### PR TITLE
Add pre-commit hook that checks for orphaned release notes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,3 +104,10 @@ repos:
           )$
         additional_dependencies:
           - pyyaml
+      - id: unreferenced-release-notes
+        name: unreferenced-release-note-check
+        language: python
+        entry: python tools/ReleaseNotes/unreferenced_release_note_check.py
+        # the whole release tree is checked at once, not just the changed files
+        pass_filenames: false
+        files: ^docs/source/release/v\d+\.\d+\.\d+/.*\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,4 +110,5 @@ repos:
         entry: python tools/ReleaseNotes/unreferenced_release_note_check.py
         # the whole release tree is checked at once, not just the changed files
         pass_filenames: false
-        files: ^docs/source/release/v\d+\.\d+\.\d+/.*\.rst$
+        # a note can be orphaned by a change to a page that the filter would not have matched, so always check
+        always_run: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,15 @@ if(BUILD_MANTIDFRAMEWORK
   add_subdirectory(Testing/SystemTests/tests)
 endif()
 
+# Tests for the developer tooling. Guarded by the same conditions as the system tests above because that is what
+# determines whether PyUnitTest has been included and enable_testing() called.
+if(BUILD_MANTIDFRAMEWORK
+   OR BUILD_MANTIDQT
+   OR ENABLE_WORKBENCH
+)
+  add_subdirectory(tools)
+endif()
+
 if(COVERAGE)
   get_property(ALL_SRCS GLOBAL PROPERTY COVERAGE_SRCS)
   set(SRCS_FILE "")

--- a/docs/source/release/v6.14.0/Framework/Python/Bugfixes/40026.rst
+++ b/docs/source/release/v6.14.0/Framework/Python/Bugfixes/40026.rst
@@ -1,2 +1,0 @@
-- Input validation errors have been corrected for numerical line edits of the :ref:`Filter Events Interface <Filter_Events_Interface>`.
-- Add horizontal and vertical range markers in lieu of sliders to simplify range filtering with the mouse.

--- a/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
+++ b/docs/source/release/v6.15.0/Framework/Algorithms/New_features/40570.rst
@@ -1,1 +1,0 @@
-- The :ref:`algm-Load` algorithm, and the file loader search process, now use a lazy file descriptor to check for the correct loading algorithm, further reducing time for :ref:`algm-Load`.

--- a/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40629.rst
+++ b/docs/source/release/v6.15.0/Framework/Nexus/Bugfixes/40629.rst
@@ -1,1 +1,0 @@
-- :ref:`LoadEventNexus <algm-LoadEventNexus>` will no longer error when loading files originating outside of ISIS that contain the ``detector_1_events`` group.

--- a/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
+++ b/docs/source/release/v6.15.0/Framework/Python/Bugfixes/40494.rst
@@ -1,1 +1,0 @@
-- The Figure Options in the :ref:`Workbench Plot Window <WorkbenchPlotWindow>` should no longer throw an error due to missing list entries.

--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40682.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40682.rst
@@ -1,1 +1,0 @@
-- In the new Instrument View, fixed a bug that caused Mantid to hang when an algorithm was run on the workspace currently open in the interface.

--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40727.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/Bugfixes/40727.rst
@@ -1,1 +1,0 @@
-- Fixed error on closing the new Instrument View due to a missing presenter.

--- a/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/40579.rst
+++ b/docs/source/release/v6.15.0/Workbench/InstrumentViewer/New_features/40579.rst
@@ -1,1 +1,0 @@
-- New Python interface to use the new Instrument View in a Jupyter Notebook

--- a/docs/source/release/v6.15.0/framework.rst
+++ b/docs/source/release/v6.15.0/framework.rst
@@ -58,6 +58,8 @@ New features
   now use a lazy file descriptor to check for the correct loading algorithm, further reducing the time taken to load files.
 - (`#40444 <https://github.com/mantidproject/mantid/pull/40444>`_) :ref:`algm-ApplyDetailedBalanceMD`
   has a new parameter, ``RescaleToTemperature``, which allows the scaling of data from one temperature to another.
+- (`#40570 <https://github.com/mantidproject/mantid/pull/40570>`_) - :ref:`algm-Load` and the file loader search process,
+  now use a lazy file descriptor to check for the correct loading algorithm, further reducing time for :ref:`algm-Load`.
 
 Bugfixes
 ########
@@ -111,6 +113,8 @@ Bugfixes
 - (`#40545 <https://github.com/mantidproject/mantid/pull/40545>`_) ``jemalloc`` has been removed from the conda
   activation scripts because it was causing crashes with unrelated applications on Linux due to ``LD_PRELOAD`` being set
   globally. Behaviour is now reverted to Mantid v6.13 where ``jemalloc`` is used only when launching ``mantidworkbench``.
+- (`#40494 <https://github.com/mantidproject/mantid/pull/40494>`_) The Figure Options in the :ref:`Workbench Plot Window <WorkbenchPlotWindow>`
+  no longer throw an error due to missing list entries.
 
 
 Dependencies
@@ -132,6 +136,14 @@ New features
   :py:obj:`IPropertyManager <mantid.kernel.IPropertyManager>` now support the application of multiple
   :py:obj:`IPropertySettings <mantid.kernel.IPropertySettings>` instances to a single property instance. From Python, a
   property's ``getSettings`` method will now return a *vector* of ``IPropertySetting`` when appropriate.
+
+Nexus
+-----
+
+Bugfixes
+########
+- (`#40629 <https://github.com/mantidproject/mantid/pull/40629>`_) :ref:`LoadEventNexus <algm-LoadEventNexus>` will
+  no longer error when loading files originating outside of ISIS that contain the ``detector_1_events`` group.
 
 
 MantidWorkbench

--- a/docs/source/release/v6.15.0/mantidworkbench.rst
+++ b/docs/source/release/v6.15.0/mantidworkbench.rst
@@ -45,6 +45,7 @@ New features
     View in a Jupyter Notebook.
   - (`#40101 <https://github.com/mantidproject/mantid/pull/40101>`_) Added a peak overlay. Peaks workspaces can be
     selected within the interface and those peaks will be plotted on both the projection and the 1D plot.
+  - (`#40579 <https://github.com/mantidproject/mantid/pull/40579>`_) Added ability to use in a Jupyter Notebook.
 
   .. figure:: ../../images/6_15_release/new-iv-features.gif
    :class: screenshot
@@ -61,6 +62,10 @@ Bugfixes
     missing presenter.
   - (`#40198 <https://github.com/mantidproject/mantid/pull/40198>`_) When deleting lots of peaks in a short space of
     time, a crash should no longer occur when erasing peaks.
+  - (`#40682 <https://github.com/mantidproject/mantid/pull/40682>`_) When an algorithm is run on the workspace currently
+    open in the interface, a hang will no longer occur.
+  - (`#40727 <https://github.com/mantidproject/mantid/pull/40727>`_) When closing, an error due to a missing presenter
+    will no longer occur.
 
 
 SliceViewer

--- a/docs/source/release/v6.16.0/Reflectometry/New_features/41353.rst
+++ b/docs/source/release/v6.16.0/Reflectometry/New_features/41353.rst
@@ -1,6 +1,0 @@
-- The :ref:`ISIS Reflectometry Interface <interface-isis-refl>` polarization input spin state order field can now be
-  used to specify the :ref:`algm-PolarizationCorrectionWildes` flipper configuration as well as the
-  :ref:`algm-PolarizationCorrectionFredrikze` input spin state order. Leaving the field empty continues to use the
-  defaults from the instrument parameter file or correction algorithm.
-- :ref:`algm-ReflectometryReductionOneAuto` now reports when a Fredrikze spin state order is supplied for a Wildes
-  correction, or a Wildes flipper configuration is supplied for a Fredrikze correction.

--- a/docs/source/release/v6.16.0/reflectometry.rst
+++ b/docs/source/release/v6.16.0/reflectometry.rst
@@ -10,6 +10,8 @@ New Features
 - (`#41415 <https://github.com/mantidproject/mantid/pull/41415>`_) The :ref:`Reduction Preview <refl_preview>` tab in the :ref:`ISIS Reflectometry Interface <interface-isis-refl>` now supports creating mask and inverted mask tables using rectangular, elliptical and polygonal selectors.
 - (`#41074 <https://github.com/mantidproject/mantid/pull/41074>`_) The :ref:`Reduction Preview <refl_preview>` tab in the :ref:`ISIS Reflectometry Interface <interface-isis-refl>` now has a checkbox to toggle the Y-axis scale between log and symlog. An input field has also been added to set the linthresh value.
 - (`#41425 <https://github.com/mantidproject/mantid/pull/41025>`_) The :ref:`Save <refl_save>` tab in the :ref:`ISIS Reflectometry Interface <interface-isis-refl>` now has an additional text box to save the model description metadata into ORSO file formats. The model description can also be optionally validated.
+- (`#41353 <https://github.com/mantidproject/mantid/pull/41353>`_) The :ref:`ISIS Reflectometry Interface <interface-isis-refl>` polarization input spin state order field can now be used to specify the :ref:`algm-PolarizationCorrectionWildes` flipper configuration as well as the :ref:`algm-PolarizationCorrectionFredrikze` input spin state order. Leaving the field empty continues to use the defaults from the instrument parameter file or correction algorithm.
+- (`#41353 <https://github.com/mantidproject/mantid/pull/41353>`_) :ref:`algm-ReflectometryReductionOneAuto` now reports when a Fredrikze spin state order is supplied for a Wildes correction, or a Wildes flipper configuration is supplied for a Fredrikze correction.
 
 Bugfixes
 --------

--- a/docs/source/release/v7.0.0/diffraction.rst
+++ b/docs/source/release/v7.0.0/diffraction.rst
@@ -13,6 +13,10 @@ Bugfixes
 ############
 .. amalgamate:: Diffraction/Powder/Bugfixes
 
+Removed
+############
+.. amalgamate:: Diffraction/Powder/Removed
+
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/release/v7.0.0/framework.rst
+++ b/docs/source/release/v7.0.0/framework.rst
@@ -76,6 +76,10 @@ Bugfixes
 ############
 .. amalgamate:: Framework/Python/Bugfixes
 
+Deprecated
+############
+.. amalgamate:: Framework/Python/Deprecated
+
 
 Dependencies
 ------------------

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Developer tooling. Only subdirectories with tests to register need to be added here.
+add_subdirectory(ReleaseNotes)

--- a/tools/ReleaseNotes/CMakeLists.txt
+++ b/tools/ReleaseNotes/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(TEST_PY_FILES test/UnreferencedReleaseNoteCheckTest.py)
+
+check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
+
+# Prefix for test=tools.ReleaseNotes
+pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} tools.ReleaseNotes ${TEST_PY_FILES})

--- a/tools/ReleaseNotes/test/UnreferencedReleaseNoteCheckTest.py
+++ b/tools/ReleaseNotes/test/UnreferencedReleaseNoteCheckTest.py
@@ -7,7 +7,7 @@
 import io
 import sys
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
@@ -42,17 +42,16 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
         note.write_text("- A release note.\n", encoding="utf-8")
         return note
 
-    def _run_main(self, argv: list) -> tuple:
-        """Run main() against the temporary release tree, returning (exit code, stdout, stderr)."""
-        stdout, stderr = io.StringIO(), io.StringIO()
+    def _run_main(self) -> tuple:
+        """Run main() against the temporary release tree, returning (exit code, stdout)."""
+        stdout = io.StringIO()
         with (
             mock.patch.object(checker, "RELEASE_ROOT", self.release_root),
-            mock.patch.object(sys, "argv", ["unreferenced_release_note_check.py"] + argv),
+            mock.patch.object(sys, "argv", ["unreferenced_release_note_check.py"]),
             redirect_stdout(stdout),
-            redirect_stderr(stderr),
         ):
             exit_code = checker.main()
-        return exit_code, stdout.getvalue(), stderr.getvalue()
+        return exit_code, stdout.getvalue()
 
     # ------------------------------------------------------------------ no problems
 
@@ -93,11 +92,11 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
 
         self.assertEqual([], checker.check_version(version_dir))
 
-    def test_released_version_with_no_directives_is_skipped(self):
-        # release_editor.py replaces the directives with the collated text, so there is nothing left to check
+    def test_published_release_holding_nothing_but_pages_has_no_problems(self):
+        # release_editor.py replaces the directives with the collated text and clears the note directories out
         version_dir = self._make_version()
-        self._write_note(version_dir, "Framework/Python/Bugfixes")
         self._write_page(version_dir, "framework.rst")
+        self._write_page(version_dir, "index.rst")
 
         self.assertEqual([], checker.check_version(version_dir))
 
@@ -147,6 +146,30 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
         problems = checker.check_version(version_dir)
 
         self.assertEqual(2, len(problems))
+
+    def test_note_left_behind_in_a_published_release_is_reported(self):
+        # the notes for a published release have been collated into the pages, so a directory left holding one
+        # means it never made it into the release
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes", name="40629.rst")
+        self._write_page(version_dir, "framework.rst")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("Framework/Python/Bugfixes", problems[0])
+        self.assertIn("40629.rst", problems[0])
+
+    def test_report_for_a_published_release_does_not_suggest_adding_a_directive(self):
+        # the release has gone out, so the fix is to fold the text into the page rather than reference it
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertNotIn(".. amalgamate::", problems[0])
+        self.assertIn("already been published", problems[0])
 
     def test_note_count_is_pluralised(self):
         version_dir = self._make_version()
@@ -216,7 +239,7 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
         self._write_note(version_dir, "Framework/Python/Bugfixes")
         self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
 
-        exit_code, stdout, _ = self._run_main([])
+        exit_code, stdout = self._run_main()
 
         self.assertEqual(0, exit_code)
         self.assertEqual("", stdout)
@@ -227,12 +250,12 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
         self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
         self._write_note(version_dir, "Framework/Python/New_features")
 
-        exit_code, stdout, _ = self._run_main([])
+        exit_code, stdout = self._run_main()
 
         self.assertEqual(1, exit_code)
         self.assertIn("Framework/Python/Deprecated", stdout)
 
-    def test_main_checks_every_release_directory_by_default(self):
+    def test_main_checks_every_release_directory(self):
         clean = self._make_version("v1.0.0")
         self._write_note(clean, "Framework/Python/Bugfixes")
         self._write_page(clean, "framework.rst", "Framework/Python/Bugfixes")
@@ -241,36 +264,20 @@ class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
         self._write_page(broken, "framework.rst", "Framework/Python/New_features")
         self._write_note(broken, "Framework/Python/New_features")
 
-        exit_code, stdout, _ = self._run_main([])
+        exit_code, stdout = self._run_main()
 
         self.assertEqual(1, exit_code)
         self.assertIn("v2.0.0", stdout)
         self.assertNotIn("v1.0.0", stdout)
 
-    def test_main_can_be_limited_to_a_single_release(self):
-        broken = self._make_version("v2.0.0")
-        self._write_note(broken, "Framework/Python/Deprecated")
-        self._write_page(broken, "framework.rst", "Framework/Python/New_features")
-        self._write_note(broken, "Framework/Python/New_features")
-        clean = self._make_version("v1.0.0")
-        self._write_note(clean, "Framework/Python/Bugfixes")
-        self._write_page(clean, "framework.rst", "Framework/Python/Bugfixes")
-
-        self.assertEqual(0, self._run_main(["--release", "v1.0.0"])[0])
-        self.assertEqual(1, self._run_main(["--release", "v2.0.0"])[0])
-
-    def test_main_accepts_a_release_without_the_v_prefix(self):
-        version_dir = self._make_version("v1.0.0")
+    def test_main_ignores_anything_in_the_release_root_that_is_not_a_version_directory(self):
+        version_dir = self._make_version()
         self._write_note(version_dir, "Framework/Python/Bugfixes")
         self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+        (self.release_root / "index.rst").write_text("=====\nTitle\n=====\n", encoding="utf-8")
+        (self.release_root / "templates").mkdir()
 
-        self.assertEqual(0, self._run_main(["--release", "1.0.0"])[0])
-
-    def test_main_returns_one_for_an_unknown_release(self):
-        exit_code, _, stderr = self._run_main(["--release", "v9.9.9"])
-
-        self.assertEqual(1, exit_code)
-        self.assertIn("No such release directory", stderr)
+        self.assertEqual(0, self._run_main()[0])
 
 
 if __name__ == "__main__":

--- a/tools/ReleaseNotes/test/UnreferencedReleaseNoteCheckTest.py
+++ b/tools/ReleaseNotes/test/UnreferencedReleaseNoteCheckTest.py
@@ -1,0 +1,277 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import unreferenced_release_note_check as checker
+
+
+class UnreferencedReleaseNoteCheckTest(unittest.TestCase):
+    def setUp(self):
+        temp_dir = TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        self.release_root = Path(temp_dir.name)
+
+    # ------------------------------------------------------------------ helpers
+
+    def _make_version(self, name: str = "v1.0.0") -> Path:
+        version_dir = self.release_root / name
+        version_dir.mkdir()
+        return version_dir
+
+    def _write_page(self, version_dir: Path, name: str, *targets: str) -> Path:
+        """Write a top level release page referencing zero or more note directories."""
+        directives = "".join(f"\n.. amalgamate:: {target}\n" for target in targets)
+        page = version_dir / name
+        page.write_text(f"=====\nTitle\n=====\n{directives}", encoding="utf-8")
+        return page
+
+    def _write_note(self, version_dir: Path, relative_dir: str, name: str = "12345.rst") -> Path:
+        note_dir = version_dir / relative_dir
+        note_dir.mkdir(parents=True, exist_ok=True)
+        note = note_dir / name
+        note.write_text("- A release note.\n", encoding="utf-8")
+        return note
+
+    def _run_main(self, argv: list) -> tuple:
+        """Run main() against the temporary release tree, returning (exit code, stdout, stderr)."""
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with (
+            mock.patch.object(checker, "RELEASE_ROOT", self.release_root),
+            mock.patch.object(sys, "argv", ["unreferenced_release_note_check.py"] + argv),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = checker.main()
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    # ------------------------------------------------------------------ no problems
+
+    def test_release_with_every_directory_referenced_has_no_problems(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features", "Framework/Python/Bugfixes")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_top_level_pages_are_not_reported_as_unreferenced(self):
+        # the version index toctree picks these up, they are not read through a directive
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "index.rst")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_directory_holding_no_notes_is_not_reported(self):
+        # release.py creates the full directory tree up front and marks empty directories with .gitkeep
+        version_dir = self._make_version()
+        empty_dir = version_dir / "Framework" / "Python" / "Bugfixes"
+        empty_dir.mkdir(parents=True)
+        (empty_dir / ".gitkeep").touch()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_notes_already_moved_to_used_are_ignored(self):
+        # release_editor.py moves notes into Used/ once they have been collated into the page
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes/Used")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/New_features")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_released_version_with_no_directives_is_skipped(self):
+        # release_editor.py replaces the directives with the collated text, so there is nothing left to check
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    # ------------------------------------------------------------------ unreferenced notes
+
+    def test_unreferenced_directory_is_reported(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/Deprecated", name="41756.rst")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn("Framework/Python/Deprecated", problems[0])
+        self.assertIn("41756.rst", problems[0])
+
+    def test_report_names_the_directive_that_should_be_added(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/Deprecated")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertIn(".. amalgamate:: Framework/Python/Deprecated", problems[0])
+
+    def test_unreferenced_directory_nested_below_a_new_sub_topic_is_reported(self):
+        # the case that motivated the check: a new sub topic reusing a standard category name
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Diffraction/Powder/New_features")
+        self._write_note(version_dir, "Diffraction/TotalScattering/New_features", name="41234.rst")
+        self._write_page(version_dir, "diffraction.rst", "Diffraction/Powder/New_features")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn(".. amalgamate:: Diffraction/TotalScattering/New_features", problems[0])
+
+    def test_every_unreferenced_directory_is_reported(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/Deprecated")
+        self._write_note(version_dir, "Framework/Python/Removed")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(2, len(problems))
+
+    def test_note_count_is_pluralised(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/New_features")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+
+        single = checker.check_version(version_dir)
+        self.assertIn("1 release note that", single[0])
+
+        self._write_note(version_dir, "Framework/Python/New_features", name="99999.rst")
+        plural = checker.check_version(version_dir)
+        self.assertIn("2 release notes that", plural[0])
+
+    # ------------------------------------------------------------------ directive targets
+
+    def test_directive_pointing_at_a_missing_directory_is_reported_with_page_and_line(self):
+        version_dir = self._make_version()
+        page = version_dir / "framework.rst"
+        # the directive is deliberately on the fifth line
+        page.write_text("=====\nTitle\n=====\n\n.. amalgamate:: Framework/Typo/Bugfixes\n", encoding="utf-8")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(1, len(problems))
+        self.assertIn(f"{page.name}:5:", problems[0])
+        self.assertIn("does not exist", problems[0])
+
+    def test_missing_directory_is_reported_once_per_referencing_line(self):
+        version_dir = self._make_version()
+        self._write_page(version_dir, "framework.rst", "Framework/Typo/Bugfixes")
+        self._write_page(version_dir, "diffraction.rst", "Framework/Typo/Bugfixes")
+
+        problems = checker.check_version(version_dir)
+
+        self.assertEqual(2, len(problems))
+
+    def test_leading_slash_in_directive_resolves_against_the_version_directory(self):
+        # amalgamate.py prepends a slash before joining, so both spellings mean the same directory
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "/Framework/Python/Bugfixes")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_indented_directive_is_recognised(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        (version_dir / "framework.rst").write_text(
+            "=====\nTitle\n=====\n\n   .. amalgamate:: Framework/Python/Bugfixes\n", encoding="utf-8"
+        )
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    def test_directories_may_be_referenced_from_more_than_one_page(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "diffraction.rst", "Framework/Python/Bugfixes")
+
+        self.assertEqual([], checker.check_version(version_dir))
+
+    # ------------------------------------------------------------------ command line
+
+    def test_main_returns_zero_when_every_release_is_clean(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+
+        exit_code, stdout, _ = self._run_main([])
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual("", stdout)
+
+    def test_main_returns_one_and_reports_when_a_release_has_problems(self):
+        version_dir = self._make_version()
+        self._write_note(version_dir, "Framework/Python/Deprecated")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/New_features")
+        self._write_note(version_dir, "Framework/Python/New_features")
+
+        exit_code, stdout, _ = self._run_main([])
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("Framework/Python/Deprecated", stdout)
+
+    def test_main_checks_every_release_directory_by_default(self):
+        clean = self._make_version("v1.0.0")
+        self._write_note(clean, "Framework/Python/Bugfixes")
+        self._write_page(clean, "framework.rst", "Framework/Python/Bugfixes")
+        broken = self._make_version("v2.0.0")
+        self._write_note(broken, "Framework/Python/Deprecated")
+        self._write_page(broken, "framework.rst", "Framework/Python/New_features")
+        self._write_note(broken, "Framework/Python/New_features")
+
+        exit_code, stdout, _ = self._run_main([])
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("v2.0.0", stdout)
+        self.assertNotIn("v1.0.0", stdout)
+
+    def test_main_can_be_limited_to_a_single_release(self):
+        broken = self._make_version("v2.0.0")
+        self._write_note(broken, "Framework/Python/Deprecated")
+        self._write_page(broken, "framework.rst", "Framework/Python/New_features")
+        self._write_note(broken, "Framework/Python/New_features")
+        clean = self._make_version("v1.0.0")
+        self._write_note(clean, "Framework/Python/Bugfixes")
+        self._write_page(clean, "framework.rst", "Framework/Python/Bugfixes")
+
+        self.assertEqual(0, self._run_main(["--release", "v1.0.0"])[0])
+        self.assertEqual(1, self._run_main(["--release", "v2.0.0"])[0])
+
+    def test_main_accepts_a_release_without_the_v_prefix(self):
+        version_dir = self._make_version("v1.0.0")
+        self._write_note(version_dir, "Framework/Python/Bugfixes")
+        self._write_page(version_dir, "framework.rst", "Framework/Python/Bugfixes")
+
+        self.assertEqual(0, self._run_main(["--release", "1.0.0"])[0])
+
+    def test_main_returns_one_for_an_unknown_release(self):
+        exit_code, _, stderr = self._run_main(["--release", "v9.9.9"])
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("No such release directory", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ReleaseNotes/unreferenced_release_note_check.py
+++ b/tools/ReleaseNotes/unreferenced_release_note_check.py
@@ -16,11 +16,11 @@ any toctree" warning. This script closes that gap by checking both directions:
 - an ``.. amalgamate::`` directive pointing at a directory that does not exist (the directive silently
   does nothing in that case).
 
-Releases that have already been published are skipped: release_editor.py replaces the directives with the
-collated note text, so a version directory with no directives left has nothing to check.
+Releases that have already been published are checked too. release_editor.py replaces the directives with
+the collated note text, so a version directory with no directives left should hold nothing but its pages;
+anything still sitting in a subdirectory is a note that was left out of the published release.
 """
 
-import sys
 from argparse import ArgumentParser
 from pathlib import Path
 import re
@@ -78,20 +78,30 @@ def find_note_directories(version_dir: Path) -> set[Path]:
 def check_version(version_dir: Path) -> list[str]:
     """Return a problem description for every unreferenced note directory and every dangling directive."""
     targets = find_amalgamate_targets(version_dir)
-    if not targets:
-        # already released, the directives have been replaced by the collated notes
-        return []
+    # release_editor.py strips the directives out as it collates the notes, so a version directory with none
+    # left is one that has already been published and can no longer pick anything up
+    published = not targets
 
     problems = []
     for directory in sorted(find_note_directories(version_dir) - set(targets)):
         notes = sorted(note.name for note in directory.glob("*.rst"))
         plural = "note" if len(notes) == 1 else "notes"
+        if published:
+            advice = (
+                f"  {version_dir.name} has already been published, so these notes were left out of it. Fold\n"
+                f"  their text into the relevant page in {display_path(version_dir)}/ and delete them, or move\n"
+                f"  them to the release being prepared."
+            )
+        else:
+            advice = (
+                f"  These notes will be missing from the published release notes. Add\n"
+                f"    .. amalgamate:: {directory.relative_to(version_dir).as_posix()}\n"
+                f"  under a heading in the relevant page in {display_path(version_dir)}/."
+            )
         problems.append(
             f"{display_path(directory)} holds {len(notes)} release {plural} that no page references:\n"
             + "".join(f"    {name}\n" for name in notes)
-            + f"  These notes will be missing from the published release notes. Add\n"
-            f"    .. amalgamate:: {directory.relative_to(version_dir).as_posix()}\n"
-            f"  under a heading in the relevant page in {display_path(version_dir)}/."
+            + advice
         )
 
     for target, references in sorted(targets.items()):
@@ -107,24 +117,16 @@ def check_version(version_dir: Path) -> list[str]:
     return problems
 
 
-def find_version_directories(release: str | None) -> list[Path]:
-    if release is not None:
-        if not release.startswith("v"):
-            release = "v" + release
-        return [RELEASE_ROOT / release]
+def find_version_directories() -> list[Path]:
+    """Every release directory, published or not."""
     return sorted(path for path in RELEASE_ROOT.glob("v*") if path.is_dir())
 
 
 def main() -> int:
-    parser = ArgumentParser(description="Find release notes that no amalgamate directive references")
-    parser.add_argument("--release", help="only check this release, e.g. v7.0.0. Defaults to every release.")
-    args = parser.parse_args()
+    ArgumentParser(description="Find release notes that no amalgamate directive references").parse_args()
 
     problems = []
-    for version_dir in find_version_directories(args.release):
-        if not version_dir.is_dir():
-            print(f"No such release directory: {display_path(version_dir)}", file=sys.stderr)
-            return 1
+    for version_dir in find_version_directories():
         problems += check_version(version_dir)
 
     for problem in problems:

--- a/tools/ReleaseNotes/unreferenced_release_note_check.py
+++ b/tools/ReleaseNotes/unreferenced_release_note_check.py
@@ -36,8 +36,15 @@ RELEASE_ROOT = REPO_ROOT / "docs" / "source" / "release"
 
 
 def display_path(path: Path) -> str:
-    """Path relative to the repository root, using forward slashes on every platform."""
-    return path.relative_to(REPO_ROOT).as_posix()
+    """Path relative to the repository root, using forward slashes on every platform.
+
+    Anything outside the repository is reported in full, which keeps the checker usable against the
+    throwaway release trees built by the tests.
+    """
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
 
 
 def find_amalgamate_targets(version_dir: Path) -> dict[Path, list[tuple[Path, int]]]:

--- a/tools/ReleaseNotes/unreferenced_release_note_check.py
+++ b/tools/ReleaseNotes/unreferenced_release_note_check.py
@@ -1,0 +1,130 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Check that every release note is reachable from an ``.. amalgamate::`` directive.
+
+Individual release notes are not pulled into the documentation by a toctree, they are read by the
+``amalgamate`` directive (docs/sphinxext/mantiddoc/directives/amalgamate.py) from the directory named as
+its argument. Notes sitting in a directory that no page names are therefore silently dropped from the
+published release notes, and conf.py deliberately excludes them from Sphinx's "document isn't included in
+any toctree" warning. This script closes that gap by checking both directions:
+
+- a directory of notes that no ``.. amalgamate::`` directive points at, and
+- an ``.. amalgamate::`` directive pointing at a directory that does not exist (the directive silently
+  does nothing in that case).
+
+Releases that have already been published are skipped: release_editor.py replaces the directives with the
+collated note text, so a version directory with no directives left has nothing to check.
+"""
+
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+import re
+
+# Matches the directive as written in the release pages, e.g. ".. amalgamate:: Diffraction/Powder/Bugfixes"
+AMALGAMATE_RE = re.compile(r"^\s*\.\.\s+amalgamate::\s+(\S+)\s*$")
+
+# release_editor.py moves notes here once they have been collated into the top level page
+PUBLISHED_DIR_NAME = "Used"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_ROOT = REPO_ROOT / "docs" / "source" / "release"
+
+
+def display_path(path: Path) -> str:
+    """Path relative to the repository root, using forward slashes on every platform."""
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def find_amalgamate_targets(version_dir: Path) -> dict[Path, list[tuple[Path, int]]]:
+    """Map each directory named by an ``.. amalgamate::`` directive to the pages and lines referencing it."""
+    targets: dict[Path, list[tuple[Path, int]]] = {}
+    for page in sorted(version_dir.glob("*.rst")):
+        for line_number, line in enumerate(page.read_text(encoding="utf-8").splitlines(), start=1):
+            match = AMALGAMATE_RE.match(line)
+            if match is None:
+                continue
+            # the directive treats a leading slash as relative to the version directory too
+            target = version_dir.joinpath(*match.group(1).strip("/").split("/"))
+            targets.setdefault(target, []).append((page, line_number))
+    return targets
+
+
+def find_note_directories(version_dir: Path) -> set[Path]:
+    """All directories below ``version_dir`` holding notes that still need to be picked up by a directive."""
+    directories = set()
+    for note in version_dir.rglob("*.rst"):
+        parent = note.parent
+        if parent == version_dir:
+            # the top level pages are reached through the index toctree, not through a directive
+            continue
+        if PUBLISHED_DIR_NAME in parent.relative_to(version_dir).parts:
+            continue
+        directories.add(parent)
+    return directories
+
+
+def check_version(version_dir: Path) -> list[str]:
+    """Return a problem description for every unreferenced note directory and every dangling directive."""
+    targets = find_amalgamate_targets(version_dir)
+    if not targets:
+        # already released, the directives have been replaced by the collated notes
+        return []
+
+    problems = []
+    for directory in sorted(find_note_directories(version_dir) - set(targets)):
+        notes = sorted(note.name for note in directory.glob("*.rst"))
+        plural = "note" if len(notes) == 1 else "notes"
+        problems.append(
+            f"{display_path(directory)} holds {len(notes)} release {plural} that no page references:\n"
+            + "".join(f"    {name}\n" for name in notes)
+            + f"  These notes will be missing from the published release notes. Add\n"
+            f"    .. amalgamate:: {directory.relative_to(version_dir).as_posix()}\n"
+            f"  under a heading in the relevant page in {display_path(version_dir)}/."
+        )
+
+    for target, references in sorted(targets.items()):
+        if target.is_dir():
+            continue
+        for page, line_number in references:
+            problems.append(
+                f"{display_path(page)}:{line_number}: amalgamate directive points at "
+                f"{display_path(target)}, which does not exist. Any notes intended for it will be missing "
+                f"from the published release notes."
+            )
+
+    return problems
+
+
+def find_version_directories(release: str | None) -> list[Path]:
+    if release is not None:
+        if not release.startswith("v"):
+            release = "v" + release
+        return [RELEASE_ROOT / release]
+    return sorted(path for path in RELEASE_ROOT.glob("v*") if path.is_dir())
+
+
+def main() -> int:
+    parser = ArgumentParser(description="Find release notes that no amalgamate directive references")
+    parser.add_argument("--release", help="only check this release, e.g. v7.0.0. Defaults to every release.")
+    args = parser.parse_args()
+
+    problems = []
+    for version_dir in find_version_directories(args.release):
+        if not version_dir.is_dir():
+            print(f"No such release directory: {display_path(version_dir)}", file=sys.stderr)
+            return 1
+        problems += check_version(version_dir)
+
+    for problem in problems:
+        print(problem)
+
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
If someone puts release note files in a new directory, then that directory must be referenced with e.g. an `::amalgamate::` directive in the index file, otherwise the release notes in that directory will not be included in the final release notes, unless someone spots the problem manually.

I've added a pre-commit hook that detects such problems and gives a useful error, it always runs (it only takes 0.5s on my laptop) to make sure we catch cases around release.

I've also added some tests. In order to run the tests I've had to add the folder to `cmake`, but only to add the unit test file.

When doing this I detected a number of 'lost' release notes, which I've now added to the appropriate release note page.

Does this need a release note? Maybe it does because I've fixed old release notes.

Closes #39982 <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Try adding a new folder with a release note in `docs/release/source/v7.0.0/`, you should get a pre-commit error. Then add a reference to it in the corresponding index file, e.g. `diffraction.rst`, pre-commit should work now. Check that the unit tests ran.

Check that the new test `UnreferencedReleaseNoteCheckTest` ran in the CI.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
