### PR TITLE
Updated the URL_PREFIX in ISISJournal.cpp to enable the search feature in the Reflectometry GUI on the nightly build

### DIFF
--- a/Framework/DataHandling/src/ISISJournal.cpp
+++ b/Framework/DataHandling/src/ISISJournal.cpp
@@ -30,7 +30,7 @@ using Poco::XML::NodeFilter;
 using Poco::XML::TreeWalker;
 
 namespace {
-static constexpr const char *URL_PREFIX = "http://journals.isis.cclrc.ac.uk/jv/ndx";
+static constexpr const char *URL_PREFIX = "http://data.isis.rl.ac.uk/journals/ndx";
 static constexpr const char *INDEX_FILE_NAME = "main";
 static constexpr const char *JOURNAL_PREFIX = "/journal_";
 static constexpr const char *JOURNAL_EXT = ".xml";
@@ -41,7 +41,7 @@ static constexpr const char *FILE_TAG = "file";
 
 /** Construct the URL for a journal file containing run data for a particular
  * instrument and cycle, e.g.
- *   http://journals.isis.cclrc.ac.uk/jv/ndxinter/journal_19_4.xml
+ *   http://data.isis.rl.ac.uk/journals/ndxinter/journal_19_4.xml
  * @param instrument : the ISIS instrument name (case insensitive)
  * @param name : the file name excluding the "journal_" prefix and extension,
  * e.g. "19_4" for "journal_19_4.xml"

--- a/Framework/DataHandling/test/ISISJournalTest.h
+++ b/Framework/DataHandling/test/ISISJournalTest.h
@@ -22,7 +22,7 @@ using testing::NiceMock;
 using testing::Return;
 
 namespace {
-const std::string URL_PREFIX = "http://journals.isis.cclrc.ac.uk/jv/ndx";
+const std::string URL_PREFIX = "http://data.isis.rl.ac.uk/journals/ndx";
 
 static constexpr const char *emptyFile = "";
 


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

This reverts the URL update made in #39599. It would be good to get this in as soon as possible incase someone needs to use a feature that relies on the URL. I tested the search feature on **IDAaaS** today and it was not working over there as well.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
1) Verify that this [link](http://data.isis.rl.ac.uk/journals/ndxinter/journal_19_4.xml) works.
2) Build mantid using `pixi run cmake --build .`.
3) Run `pixi run workbench`
4) Launch the `ISIS Reflectometry` interface.
5) In the **Search Runs** box on the **Runs** tab, enter Investigation Id `1120015` and Cycle `11_3`.
6) Verify that the search table populates as follows.
<img width="1147" height="714" alt="image" src="https://github.com/user-attachments/assets/be5f1da2-0386-4cdb-a72f-050ae8d52687" />


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
