### PR TITLE
Only write QSettings from error reporter on change

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
@@ -1,2 +1,2 @@
-- The Error Reporter Dialog now does not erase the local contact information of the user after clicking ``Don't share any information``. This information is never shared if the button
-  ``Don't share any information`` is clicked.
+- The Error Reporter Dialog no longer updates saved contact information after clicking ``Don't share any information`` or when ``Remember me`` is disabled. Submitting unchanged contact
+  information also leaves the Workbench settings file untouched.

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -33,6 +33,8 @@ class ErrorReporterPresenter(object):
         self._application = application
         self._traceback = traceback or ""
         self._cpp_traces = b""
+        self._saved_name = self._view.saved_name.strip()
+        self._saved_email = self._view.saved_email.strip()
         self._view.set_report_callback(self.error_handler)
         self._view.moreDetailsButton.clicked.connect(self.show_more_details)
 
@@ -51,22 +53,29 @@ class ErrorReporterPresenter(object):
 
     def do_not_share(self, continue_working=True, remember_contact_info=False, name="", email=""):
         self.error_log.notice("No information shared")
-        self._manage_remember_me_setting(remember_contact_info, name, email)
         self._handle_exit(continue_working)
         return -1
 
     def _manage_remember_me_setting(self, remember_contact_info=False, name: str = "", email: str = "") -> None:
-        """
-        Stores locally the name and email set by the user on the error reporter form if they choose to do so
-        when clicking on the `Remember Me` checkbox. This information is never shared if the button
-        `Don't share any information` is clicked.
-        """
+        """Store changed contact information after a report is shared with `Remember Me` selected."""
         if not remember_contact_info:
-            name = email = ""
+            return
+
+        name = name.strip()
+        email = email.strip()
+        name_changed = name != self._saved_name
+        email_changed = email != self._saved_email
+        if not name_changed and not email_changed:
+            return
+
         settings = QSettings()
         settings.beginGroup(self._view.CONTACT_INFO)
-        settings.setValue(self._view.NAME, name)
-        settings.setValue(self._view.EMAIL, email)
+        if name_changed:
+            settings.setValue(self._view.NAME, name)
+            self._saved_name = name
+        if email_changed:
+            settings.setValue(self._view.EMAIL, email)
+            self._saved_email = email
         settings.endGroup()
 
     def share_all_information(self, continue_working, remember_contact_info, new_name, new_email, text_box):

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -34,12 +34,14 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.q_settings_mock.return_value = self.q_settings_mock_instance
 
         self.view = mock.MagicMock()
+        self.view.CONTACT_INFO = "ContactInfo"
+        self.view.NAME = "Name"
+        self.view.EMAIL = "Email"
+        self.view.saved_name = "Saved User"
+        self.view.saved_email = "saved.user@example.com"
         self.exit_code = 255
         self.app_name = "ErrorReportPresenterTest"
         self.error_report_presenter = ErrorReporterPresenter(self.view, self.exit_code, application=self.app_name, workbench_pid=None)
-        self.view.CONTACT_INFO = "ContactInfo"
-        self.view.NAME = "John Smith"
-        self.view.EMAIL = "john.smith@example.com"
 
     def test_sets_logger_view_and_exit_code_upon_construction(self):
         self.assertEqual(self.error_report_presenter._exit_code, self.exit_code)
@@ -60,21 +62,63 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.logger_mock_instance.error.assert_called_once_with("Terminated by user.")
         self.assertEqual(self.view.quit.call_count, 1)
 
-    def test_remember_me_ticked_stores_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
+    def test_do_not_share_does_not_construct_qsettings_when_remember_me_is_ticked(self):
         self.error_report_presenter.do_not_share(False, True, "MantidUser", "MantidUser@mail.com")
 
-        self.q_settings_mock_instance.beginGroup.assert_called_once()
-        self.q_settings_mock_instance.endGroup.assert_called_once()
-        self.q_settings_mock_instance.setValue.assert_has_calls(
-            [mock.call(self.view.NAME, "MantidUser"), mock.call(self.view.EMAIL, "MantidUser@mail.com")]
+        self.q_settings_mock.assert_not_called()
+
+    def test_share_does_not_construct_qsettings_when_remember_me_is_unticked(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(False, False, "MantidUser", "MantidUser@mail.com", "details")
+
+        self.q_settings_mock.assert_not_called()
+
+    def test_share_does_not_construct_qsettings_when_contact_info_is_unchanged(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(False, True, self.view.saved_name, self.view.saved_email, "details")
+
+        self.q_settings_mock.assert_not_called()
+
+    def test_share_does_not_construct_qsettings_when_contact_info_changes_only_in_whitespace(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(
+            False, True, f"  {self.view.saved_name}  ", f"\t{self.view.saved_email}\n", "details"
         )
 
-    def test_remember_me_unticked_does_not_store_user_info_on_local_qsettings_when_do_not_share_is_clicked(self):
-        self.error_report_presenter.do_not_share(False, False, "MantidUser", "MantidUser@mail.com")
+        self.q_settings_mock.assert_not_called()
 
-        self.q_settings_mock_instance.beginGroup.assert_called_once()
-        self.q_settings_mock_instance.endGroup.assert_called_once()
-        self.q_settings_mock_instance.setValue.assert_has_calls([mock.call(self.view.NAME, ""), mock.call(self.view.EMAIL, "")])
+    def test_share_stores_only_changed_name_stripped(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(False, True, "  New User  ", self.view.saved_email, "details")
+
+        self.q_settings_mock_instance.beginGroup.assert_called_once_with(self.view.CONTACT_INFO)
+        self.q_settings_mock_instance.setValue.assert_called_once_with(self.view.NAME, "New User")
+        self.q_settings_mock_instance.endGroup.assert_called_once_with()
+
+    def test_share_stores_only_changed_email_stripped(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(False, True, self.view.saved_name, "  new.user@example.com\t", "details")
+
+        self.q_settings_mock_instance.beginGroup.assert_called_once_with(self.view.CONTACT_INFO)
+        self.q_settings_mock_instance.setValue.assert_called_once_with(self.view.EMAIL, "new.user@example.com")
+        self.q_settings_mock_instance.endGroup.assert_called_once_with()
+
+    def test_share_stores_both_changed_contact_values_stripped(self):
+        self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
+
+        self.error_report_presenter.share_all_information(False, True, "  New User  ", "  new.user@example.com  ", "details")
+
+        self.q_settings_mock_instance.beginGroup.assert_called_once_with(self.view.CONTACT_INFO)
+        self.q_settings_mock_instance.setValue.assert_has_calls(
+            [mock.call(self.view.NAME, "New User"), mock.call(self.view.EMAIL, "new.user@example.com")]
+        )
+        self.assertEqual(self.q_settings_mock_instance.setValue.call_count, 2)
+        self.q_settings_mock_instance.endGroup.assert_called_once_with()
 
     def test_send_error_report_to_server_calls_ErrorReport_correctly(self):
         name = "John Smith"


### PR DESCRIPTION
To reduce contention for writing qsettings information, the error reporter only writes on change. Additionally, the email and name fields are trimmed for whitespace.

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

Refs #41904 
[EWM17167](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=17167)

### To test:

Inspecting the code changes is probably the best way to do this.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
