### PR TITLE
Fix bug in isis sans runs summation

### DIFF
--- a/docs/source/release/v7.0.0/SANS/Bugfixes/41897.rst
+++ b/docs/source/release/v7.0.0/SANS/Bugfixes/41897.rst
@@ -1,0 +1,1 @@
+- 'AddRuns' command of the :ref:`ISIS Command Interface <ScriptingSANSReductions>` and the  `Sum Runs` tab of the :ref:`ISIS SANS GUI <ISIS_Sans_interface_contents>` now correctly use a custom save directory to save the added runs.

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -899,12 +899,12 @@ def bundle_added_event_data_as_group(out_file_path, out_file_monitors_path, _is_
 
 def get_full_path_for_added_event_data(file_name):
     path, base = os.path.split(file_name)
-    if path == "" or base not in os.listdir(path):
-        path = config["defaultsave.directory"] + path
+    if path == "" or not os.path.isfile(file_name):
+        path = os.path.join(config["defaultsave.directory"], path)
         # If the path is still an empty string check in the current working directory
         if path == "":
             path = os.getcwd()
-        assert base in os.listdir(path)
+        assert os.path.isfile(os.path.join(path, base))
     full_path_name = os.path.join(path, base)
     return full_path_name, base
 

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -853,9 +853,9 @@ def bundle_added_event_data_as_group(out_file_path, out_file_monitors_path, _is_
 
     # This is a validation and extracting name out of path
     full_data_path_name, filename = get_full_path_for_added_event_data(out_file_path)
-    full_monitor_path_name, filename_monitors = get_full_path_for_added_event_data(out_file_monitors_path)
+    full_monitor_path_name, _ = get_full_path_for_added_event_data(out_file_monitors_path)
     # Extract the file name and the extension
-    file_name, file_extension = os.path.splitext(filename)
+    file_name, _ = os.path.splitext(filename)
 
     event_data_temp = file_name + ADDED_EVENT_DATA_TAG
     Load(Filename=full_data_path_name, OutputWorkspace=event_data_temp)

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -841,37 +841,31 @@ def get_workspace_type(file_name):
     return workspace_type
 
 
-def bundle_added_event_data_as_group(out_file_name, out_file_monitors_name, is_multi_period):
+def bundle_added_event_data_as_group(out_file_path, out_file_monitors_path, _is_multi_period):
     """
     We load an added event data file and its associated monitor file. Combine
     the data in a group workspace and delete the original files.
-    @param out_file_name :: the file name of the event data file
-    @param out_file_monitors_name :: the file name of the monitors file
-    @param is_multi_period: if the data set is multiperid
+    @param out_file_path : the file path of the event data file
+    @param out_file_monitors_path : the file name path of the monitors file
+    @param _is_multi_period: if the data set is multiperiod (unused)
     @return the name fo the new group workspace file
     """
+
+    # This is a validation and extracting name out of path
+    full_data_path_name, filename = get_full_path_for_added_event_data(out_file_path)
+    full_monitor_path_name, filename_monitors = get_full_path_for_added_event_data(out_file_monitors_path)
     # Extract the file name and the extension
-    file_name, file_extension = os.path.splitext(out_file_name)
+    file_name, file_extension = os.path.splitext(filename)
+
     event_data_temp = file_name + ADDED_EVENT_DATA_TAG
-    Load(Filename=out_file_name, OutputWorkspace=event_data_temp)
+    Load(Filename=full_data_path_name, OutputWorkspace=event_data_temp)
     event_data_ws = mtd[event_data_temp]
 
     monitor_temp = file_name + "_monitors" + ADDED_EVENT_DATA_TAG
-    Load(Filename=out_file_monitors_name, OutputWorkspace=monitor_temp)
+    Load(Filename=full_monitor_path_name, OutputWorkspace=monitor_temp)
 
     monitor_ws = mtd[monitor_temp]
-
-    out_group_file_name = file_name + file_extension
     out_group_ws_name = file_name
-
-    # Delete the intermediate files
-    full_data_path_name = get_full_path_for_added_event_data(out_file_name)
-    full_monitor_path_name = get_full_path_for_added_event_data(out_file_monitors_name)
-
-    if os.path.exists(full_data_path_name):
-        os.remove(full_data_path_name)
-    if os.path.exists(full_monitor_path_name):
-        os.remove(full_monitor_path_name)
 
     # Create a grouped workspace with the data and the monitor child workspaces
     workspace_names_to_group = []
@@ -889,13 +883,18 @@ def bundle_added_event_data_as_group(out_file_name, out_file_monitors_name, is_m
     GroupWorkspaces(InputWorkspaces=workspace_names_to_group, OutputWorkspace=out_group_ws_name)
     group_ws = mtd[out_group_ws_name]
 
+    # Delete the intermediate files
+    if os.path.exists(full_data_path_name):
+        os.remove(full_data_path_name)
+    if os.path.exists(full_monitor_path_name):
+        os.remove(full_monitor_path_name)
     # Save the group
-    SaveNexusProcessed(InputWorkspace=group_ws, Filename=out_group_file_name, Append=False)
+    SaveNexusProcessed(InputWorkspace=group_ws, Filename=full_data_path_name, Append=False)
     # Delete the files and the temporary workspaces
     if out_group_ws_name in mtd:
         DeleteWorkspace(out_group_ws_name)
 
-    return out_group_file_name
+    return full_data_path_name
 
 
 def get_full_path_for_added_event_data(file_name):
@@ -907,8 +906,7 @@ def get_full_path_for_added_event_data(file_name):
             path = os.getcwd()
         assert base in os.listdir(path)
     full_path_name = os.path.join(path, base)
-
-    return full_path_name
+    return full_path_name, base
 
 
 def extract_spectra(ws, det_ids, output_ws_name):

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -89,8 +89,10 @@ def add_runs(  # noqa: C901
     if not save_directory or save_directory == "" or not os.path.isdir(save_directory):
         save_directory = config["defaultsave.directory"] if config["defaultsave.directory"] != "" else os.getcwd()
 
-    if outFile and outFile.startswith(save_directory):  # it shouldn't
-        outFile.lstrip(save_directory)
+    if outFile:
+        outFile = os.path.basename(outFile)
+    if outFile_monitors:
+        outFile_monitors = os.path.basename(outFile_monitors)
 
     user_entry = runs[0]
     counter_run = 0
@@ -104,25 +106,18 @@ def add_runs(  # noqa: C901
             is_not_allowed_instrument = inst.upper() not in {"SANS2D", "LARMOR", "ZOOM", "LOQ"}
             if is_not_allowed_instrument and is_first_dataset_event:
                 _report_error(f"Adding event data not support for {inst} for now")
-                _delete_workspaces([ADD_FILES_SUM_TEMPORARY, ADD_FILES_SUM_TEMPORARY_MONITORS])
+                _delete_workspaces()
                 return ""
 
             for run_idx in range(1, len(runs)):
                 user_entry = runs[run_idx]
-                last_path, last_file, log_file, dummy, is_data_set_event = _load_ws(
+                last_path, last_file, log_file, _, is_data_set_event = _load_ws(
                     user_entry, defType, inst, ADD_FILES_NEW_TEMPORARY, rawTypes, period
                 )
 
                 if is_data_set_event != is_first_dataset_event:
                     _report_error("Datasets added must be either ALL histogram data or ALL event data")
-                    _delete_workspaces(
-                        [
-                            ADD_FILES_SUM_TEMPORARY,
-                            ADD_FILES_SUM_TEMPORARY_MONITORS,
-                            ADD_FILES_NEW_TEMPORARY,
-                            ADD_FILES_NEW_TEMPORARY_MONITORS,
-                        ]
-                    )
+                    _delete_workspaces()
                     return ""
 
                 adder.add(
@@ -147,13 +142,13 @@ def add_runs(  # noqa: C901
                 # Increment the run number
                 counter_run += 1
         except ValueError as e:
-            _report_error(f"Error opening file {user_entry}:{str(e)}")
-            _delete_workspaces([ADD_FILES_SUM_TEMPORARY])
+            _report_error(f"Error opening file {user_entry}:{e}")
+            _delete_workspaces()
             return ""
         except Exception as e:
             # We need to catch all exceptions to ensure that a dialog box is raised with the error
-            _report_error(f"Error finding files: {str(e)}")
-            _delete_workspaces([ADD_FILES_SUM_TEMPORARY, ADD_FILES_NEW_TEMPORARY])
+            _report_error(f"Error finding files: {e}")
+            _delete_workspaces()
             return ""
 
         # In case of event file force it into a histogram workspace if this is requested
@@ -198,7 +193,7 @@ def add_runs(  # noqa: C901
             period += 1
 
     if is_first_dataset_event and saveAsEvent:
-        filename, ext = _make_filename(runs[0], defType, inst)
+        filename, _ = _make_filename(runs[0], defType, inst)
         workspace_type = get_workspace_type(filename)
         is_multi_period = True if workspace_type is WorkspaceType.MultiperiodEvent else False
         outFile = bundle_added_event_data_as_group(out_path, out_path_monitors, is_multi_period)
@@ -439,7 +434,8 @@ def _report_error(error_msg):
         sanslog.error(error_msg)
 
 
-def _delete_workspaces(names):
+def _delete_workspaces():
+    names = (ADD_FILES_SUM_TEMPORARY, ADD_FILES_SUM_TEMPORARY_MONITORS, ADD_FILES_NEW_TEMPORARY, ADD_FILES_NEW_TEMPORARY_MONITORS)
     for ws_name in names:
         if ws_name in mtd:
             DeleteWorkspace(ws_name)

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -86,45 +86,43 @@ def add_runs(  # noqa: C901
     else:
         period = _NO_INDIVIDUAL_PERIODS
 
-    userEntry = runs[0]
+    if not save_directory or save_directory == "" or not os.path.isdir(save_directory):
+        save_directory = config["defaultsave.directory"] if config["defaultsave.directory"] != "" else os.getcwd()
 
+    if outFile and outFile.startswith(save_directory):  # it shouldn't
+        outFile.lstrip(save_directory)
+
+    user_entry = runs[0]
     counter_run = 0
 
     while True:
-        isFirstDataSetEvent = False
         try:
-            lastPath, lastFile, logFile, num_periods, isFirstDataSetEvent = _load_ws(
-                userEntry, defType, inst, ADD_FILES_SUM_TEMPORARY, rawTypes, period
+            last_path, last_file, log_file, num_periods, is_first_dataset_event = _load_ws(
+                user_entry, defType, inst, ADD_FILES_SUM_TEMPORARY, rawTypes, period
             )
 
             is_not_allowed_instrument = inst.upper() not in {"SANS2D", "LARMOR", "ZOOM", "LOQ"}
-            if is_not_allowed_instrument and isFirstDataSetEvent:
-                error = "Adding event data not supported for " + inst + " for now"
-                print(error)
-                sanslog.error(error)
-                for workspaceName in (ADD_FILES_SUM_TEMPORARY, ADD_FILES_SUM_TEMPORARY_MONITORS):
-                    if workspaceName in mtd:
-                        DeleteWorkspace(workspaceName)
+            if is_not_allowed_instrument and is_first_dataset_event:
+                _report_error(f"Adding event data not support for {inst} for now")
+                _delete_workspaces([ADD_FILES_SUM_TEMPORARY, ADD_FILES_SUM_TEMPORARY_MONITORS])
                 return ""
 
-            for i in range(len(runs) - 1):
-                userEntry = runs[i + 1]
-                lastPath, lastFile, logFile, dummy, is_data_set_event = _load_ws(
-                    userEntry, defType, inst, ADD_FILES_NEW_TEMPORARY, rawTypes, period
+            for run_idx in range(1, len(runs)):
+                user_entry = runs[run_idx]
+                last_path, last_file, log_file, dummy, is_data_set_event = _load_ws(
+                    user_entry, defType, inst, ADD_FILES_NEW_TEMPORARY, rawTypes, period
                 )
 
-                if is_data_set_event != isFirstDataSetEvent:
-                    error = "Datasets added must be either ALL histogram data or ALL event data"
-                    print(error)
-                    sanslog.error(error)
-                    for workspaceName in (
-                        ADD_FILES_SUM_TEMPORARY,
-                        ADD_FILES_SUM_TEMPORARY_MONITORS,
-                        ADD_FILES_NEW_TEMPORARY,
-                        ADD_FILES_NEW_TEMPORARY_MONITORS,
-                    ):
-                        if workspaceName in mtd:
-                            DeleteWorkspace(workspaceName)
+                if is_data_set_event != is_first_dataset_event:
+                    _report_error("Datasets added must be either ALL histogram data or ALL event data")
+                    _delete_workspaces(
+                        [
+                            ADD_FILES_SUM_TEMPORARY,
+                            ADD_FILES_SUM_TEMPORARY_MONITORS,
+                            ADD_FILES_NEW_TEMPORARY,
+                            ADD_FILES_NEW_TEMPORARY_MONITORS,
+                        ]
+                    )
                     return ""
 
                 adder.add(
@@ -135,7 +133,7 @@ def add_runs(  # noqa: C901
                     estimate_logs=estimate_logs,
                 )
 
-                if isFirstDataSetEvent:
+                if is_first_dataset_event:
                     adder.add(
                         LHS_workspace=ADD_FILES_SUM_TEMPORARY_MONITORS,
                         RHS_workspace=ADD_FILES_NEW_TEMPORARY_MONITORS,
@@ -144,55 +142,51 @@ def add_runs(  # noqa: C901
                         estimate_logs=estimate_logs,
                     )
                 DeleteWorkspace(ADD_FILES_NEW_TEMPORARY)
-                if isFirstDataSetEvent:
+                if is_first_dataset_event:
                     DeleteWorkspace(ADD_FILES_NEW_TEMPORARY_MONITORS)
                 # Increment the run number
                 counter_run += 1
         except ValueError as e:
-            error = "Error opening file {}: {}".format(userEntry, str(e))
-            print(error)
-            sanslog.error(error)
-            if ADD_FILES_SUM_TEMPORARY in mtd:
-                DeleteWorkspace(ADD_FILES_SUM_TEMPORARY)
+            _report_error(f"Error opening file {user_entry}:{str(e)}")
+            _delete_workspaces([ADD_FILES_SUM_TEMPORARY])
             return ""
         except Exception as e:
             # We need to catch all exceptions to ensure that a dialog box is raised with the error
-            error = "Error finding files: {}".format(str(e))
-            print(error)
-            sanslog.error(error)
-            for workspaceName in (ADD_FILES_SUM_TEMPORARY, ADD_FILES_NEW_TEMPORARY):
-                if workspaceName in mtd:
-                    DeleteWorkspace(workspaceName)
+            _report_error(f"Error finding files: {str(e)}")
+            _delete_workspaces([ADD_FILES_SUM_TEMPORARY, ADD_FILES_NEW_TEMPORARY])
             return ""
 
         # In case of event file force it into a histogram workspace if this is requested
-        if isFirstDataSetEvent and not saveAsEvent:
+        if is_first_dataset_event and not saveAsEvent:
             handle_saving_event_workspace_when_saving_as_histogram(binning, runs, defType, inst)
 
-        lastFile = os.path.splitext(lastFile)[0]
-        # Now save the added file
-        prefix = save_directory or ""
-        if outFile is None:
-            outFile = prefix + lastFile + "-add." + "nxs"
-        if outFile_monitors is None:
-            outFile_monitors = prefix + lastFile + "-add_monitors." + "nxs"
+        # If a valid output has not been provided we pick here the latest added file name
+        if None in (outFile, outFile_monitors):
+            last_file = os.path.splitext(last_file)[0]
+            outFile = last_file + "-add." + "nxs"
+            outFile_monitors = last_file + "-add_monitors." + "nxs"
+
         sanslog.notice("Writing file: {}".format(outFile))
 
+        out_path = os.path.join(save_directory, outFile)
+        out_path_monitors = os.path.join(save_directory, outFile_monitors)
+
+        # Now save the added file
         if period == 1 or period == _NO_INDIVIDUAL_PERIODS:
             # Replace the file the first time around
-            SaveNexusProcessed(InputWorkspace=ADD_FILES_SUM_TEMPORARY, Filename=outFile, Append=False)
+            SaveNexusProcessed(InputWorkspace=ADD_FILES_SUM_TEMPORARY, Filename=out_path, Append=False)
             # If we are saving event data, then we need to save also the monitor file
-            if isFirstDataSetEvent and saveAsEvent:
-                SaveNexusProcessed(InputWorkspace=ADD_FILES_SUM_TEMPORARY_MONITORS, Filename=outFile_monitors, Append=False)
+            if is_first_dataset_event and saveAsEvent:
+                SaveNexusProcessed(InputWorkspace=ADD_FILES_SUM_TEMPORARY_MONITORS, Filename=out_path_monitors, Append=False)
 
         else:
             # Then append
-            SaveNexusProcessed(ADD_FILES_SUM_TEMPORARY, outFile, Append=True)
-            if isFirstDataSetEvent and saveAsEvent:
-                SaveNexusProcessed(ADD_FILES_SUM_TEMPORARY_MONITORS, outFile_monitors, Append=True)
+            SaveNexusProcessed(ADD_FILES_SUM_TEMPORARY, out_path, Append=True)
+            if is_first_dataset_event and saveAsEvent:
+                SaveNexusProcessed(ADD_FILES_SUM_TEMPORARY_MONITORS, out_path_monitors, Append=True)
 
         DeleteWorkspace(ADD_FILES_SUM_TEMPORARY)
-        if isFirstDataSetEvent:
+        if is_first_dataset_event:
             DeleteWorkspace(ADD_FILES_SUM_TEMPORARY_MONITORS)
 
         if period == num_periods:
@@ -203,11 +197,11 @@ def add_runs(  # noqa: C901
         else:
             period += 1
 
-    if isFirstDataSetEvent and saveAsEvent:
+    if is_first_dataset_event and saveAsEvent:
         filename, ext = _make_filename(runs[0], defType, inst)
         workspace_type = get_workspace_type(filename)
         is_multi_period = True if workspace_type is WorkspaceType.MultiperiodEvent else False
-        outFile = bundle_added_event_data_as_group(outFile, outFile_monitors, is_multi_period)
+        outFile = bundle_added_event_data_as_group(out_path, out_path_monitors, is_multi_period)
 
     # This adds the path to the filename
     path, base = os.path.split(outFile)
@@ -220,13 +214,13 @@ def add_runs(  # noqa: C901
             path = os.getcwd()
         assert base in os.listdir(path)
     path_out = path
-    if logFile:
-        _copy_log(lastPath, logFile, path_out)
+    if log_file:
+        _copy_log(last_path, log_file, path_out)
 
     return "The following file has been created:\n" + outFile
 
 
-def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, def_type, inst):
+def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, defType, inst):
     ws_in_monitor = mtd[ADD_FILES_SUM_TEMPORARY_MONITORS]
     if binning == "Monitors":
         mon_x = ws_in_monitor.x(0)
@@ -245,7 +239,7 @@ def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, def_ty
 
     # loading the nexus file using LoadNexus is necessary because it has some metadata
     # that is not in LoadEventNexus. This must be fixed.
-    filename, ext = _make_filename(runs[0], def_type, inst)
+    filename, ext = _make_filename(runs[0], defType, inst)
     workspace_type = get_workspace_type(filename)
     if workspace_type is WorkspaceType.MultiperiodEvent:
         # If we are dealing with multi-period event workspaces then there is no way of getting any other
@@ -279,7 +273,7 @@ def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, def_ty
         DeleteWorkspace("AddFilesSumTemporary_Rebin")
 
 
-def _can_load_periods(runs, def_type, raw_types):
+def _can_load_periods(runs, defType, rawTypes):
     """
     Searches through the supplied list of run file names and
     returns False if some appear to be raw files else True
@@ -287,8 +281,8 @@ def _can_load_periods(runs, def_type, raw_types):
     for i in runs:
         dummy, ext = os.path.splitext(i)
         if ext == "":
-            ext = def_type
-        if _is_type(ext, raw_types):
+            ext = defType
+        if _is_type(ext, rawTypes):
             return False
     # No raw files were found, assume we can specify the period number for each
     return True
@@ -321,7 +315,7 @@ def remove_unwanted_workspaces(workspace_name, temp_workspace_name, period):
     RenameWorkspace(InputWorkspace=workspaces_to_keep, OutputWorkspace=workspace_name)
 
 
-def _load_ws(entry, ext, inst, ws_name, raw_types, period=_NO_INDIVIDUAL_PERIODS):
+def _load_ws(entry, ext, inst, ws_name, rawTypes, period=_NO_INDIVIDUAL_PERIODS):
     filename, ext = _make_filename(entry, ext, inst)
     sanslog.notice("reading file:\t{}".format(filename))
 
@@ -378,7 +372,7 @@ def _load_ws(entry, ext, inst, ws_name, raw_types, period=_NO_INDIVIDUAL_PERIODS
         # Looks like we're on a windows system, convert the directory separators
         path = path.replace("\\", "/")
 
-    if _is_type(ext, raw_types):
+    if _is_type(ext, rawTypes):
         LoadSampleDetailsFromRaw(InputWorkspace=ws_name, Filename=path + "/" + f_name)
     else:
         height, width, thickness, shape = get_geometry_information_isis_nexus(full_path)
@@ -389,7 +383,7 @@ def _load_ws(entry, ext, inst, ws_name, raw_types, period=_NO_INDIVIDUAL_PERIODS
         sample.setThickness(thickness)
 
     # Change below when logs in Nexus files work  file types of .raw need their log files to be copied too
-    # if isType(ext, raw_types):
+    # if isType(ext, rawTypes):
     log_file = os.path.splitext(f_name)[0] + ".log"
     try:
         outWs = mtd[ws_name]
@@ -437,6 +431,18 @@ def _copy_log(last_path, log_file, path_out):
         error = "Error copying log file {} to directory {}\n".format(log_file, path_out)
         print(error)
         sanslog.error(error)
+
+
+def _report_error(error_msg):
+    if error_msg:
+        print(error_msg)
+        sanslog.error(error_msg)
+
+
+def _delete_workspaces(names):
+    for ws_name in names:
+        if ws_name in mtd:
+            DeleteWorkspace(ws_name)
 
 
 if __name__ == "__main__":

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -209,8 +209,7 @@ def add_runs(  # noqa: C901
             path = os.getcwd()
         assert base in os.listdir(path)
     path_out = path
-    if log_file:
-        _copy_log(last_path, log_file, path_out)
+    _copy_log(last_path, log_file, path_out)
 
     return "The following file has been created:\n" + outFile
 
@@ -377,8 +376,6 @@ def _load_ws(entry, ext, inst, ws_name, rawTypes, period=_NO_INDIVIDUAL_PERIODS)
         sample.setWidth(width)
         sample.setThickness(thickness)
 
-    # Change below when logs in Nexus files work  file types of .raw need their log files to be copied too
-    # if isType(ext, rawTypes):
     log_file = os.path.splitext(f_name)[0] + ".log"
     try:
         outWs = mtd[ws_name]

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -86,7 +86,7 @@ def add_runs(  # noqa: C901
     else:
         period = _NO_INDIVIDUAL_PERIODS
 
-    if not save_directory or save_directory == "" or not os.path.isdir(save_directory):
+    if not save_directory or not os.path.isdir(save_directory):
         save_directory = config["defaultsave.directory"] if config["defaultsave.directory"] != "" else os.getcwd()
 
     if outFile:
@@ -234,7 +234,7 @@ def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, defTyp
 
     # loading the nexus file using LoadNexus is necessary because it has some metadata
     # that is not in LoadEventNexus. This must be fixed.
-    filename, ext = _make_filename(runs[0], defType, inst)
+    filename, _ = _make_filename(runs[0], defType, inst)
     workspace_type = get_workspace_type(filename)
     if workspace_type is WorkspaceType.MultiperiodEvent:
         # If we are dealing with multi-period event workspaces then there is no way of getting any other
@@ -274,7 +274,7 @@ def _can_load_periods(runs, defType, rawTypes):
     returns False if some appear to be raw files else True
     """
     for i in runs:
-        dummy, ext = os.path.splitext(i)
+        _, ext = os.path.splitext(i)
         if ext == "":
             ext = defType
         if _is_type(ext, rawTypes):

--- a/scripts/test/SANS/SANSadd2Test.py
+++ b/scripts/test/SANS/SANSadd2Test.py
@@ -7,6 +7,8 @@
 
 import unittest
 from unittest.mock import patch
+import tempfile
+import os
 
 from SANS import SANSadd2
 from sans.common.enums import SampleShape
@@ -50,3 +52,15 @@ class TestSANSAddSampleMetadata(unittest.TestCase):
             mocked_get_geo_info.return_value = (8.0, 8.0, 2.0, SampleShape.DISC)
             SANSadd2.add_runs("74014", "LOQ", ".nxs", rawTypes=(".add", ".raw", ".s*"), lowMem=False)
             self.assertEqual(1, mocked_get_geo_info.call_count)
+
+    def test_save_directory_is_called_correctly_when_saving_ws(self):
+        out_name = "ZOOM00006113-add.nxs"
+        out_mon_name = "ZOOM00006113-add_monitors.nxs"
+        with tempfile.TemporaryDirectory() as save_dir:
+            with patch("SANS.SANSadd2.bundle_added_event_data_as_group") as mocked_bundle:
+                out_path = os.path.join(save_dir, out_name)
+                out_path_mon = os.path.join(save_dir, out_mon_name)
+
+                mocked_bundle.return_value = out_path
+                SANSadd2.add_runs("6113", "ZOOM", ".nxs", save_directory=save_dir, saveAsEvent=True)
+                mocked_bundle.assert_called_once_with(out_path, out_path_mon, False)

--- a/scripts/test/SANS/SANSadd2Test.py
+++ b/scripts/test/SANS/SANSadd2Test.py
@@ -7,9 +7,11 @@
 
 import unittest
 from unittest.mock import patch
+import tempfile
+import os
 
 from SANS import SANSadd2
-from SANS.sans.common.enums import SampleShape
+from sans.common.enums import SampleShape
 from mantid.simpleapi import Load
 
 
@@ -32,7 +34,7 @@ class TestSANSAddSampleMetadata(unittest.TestCase):
             SANSadd2.add_runs(("LOQ54432", "LOQ54432"), "LOQ", ".raw")
             self.assertEqual(2, mocked_load_sample.call_count)
 
-    def test_isis_neuxs_files_get_correct_sample_info(self):
+    def test_isis_nexus_files_get_correct_sample_info(self):
         result = SANSadd2.add_runs(["74014"], "LOQ", ".nxs", rawTypes=(".add", ".raw", ".s*"), lowMem=False)
         assert result.startswith("The following file has been created:")
         assert result.endswith("LOQ74014-add.nxs")
@@ -48,9 +50,17 @@ class TestSANSAddSampleMetadata(unittest.TestCase):
     def test_isis_nexus_get_sample_info_using_file_information(self):
         with patch("SANS.SANSadd2.get_geometry_information_isis_nexus") as mocked_get_geo_info:
             mocked_get_geo_info.return_value = (8.0, 8.0, 2.0, SampleShape.DISC)
-            SANSadd2.add_runs(("74014", "74014"), "LOQ", ".nxs", rawTypes=(".add", ".raw", ".s*"), lowMem=False)
+            SANSadd2.add_runs("74014", "LOQ", ".nxs", rawTypes=(".add", ".raw", ".s*"), lowMem=False)
             self.assertEqual(1, mocked_get_geo_info.call_count)
 
-    def test_is_not_allowed_instrument_branch(self):
-        result = SANSadd2.add_runs(["LOQ00113953"], "LOQ", ".nxs")
-        self.assertEqual(result, "")
+    def test_save_directory_is_called_correctly_when_saving_ws(self):
+        out_name = "ZOOM00006113-add.nxs"
+        out_mon_name = "ZOOM00006113-add_monitors.nxs"
+        with tempfile.TemporaryDirectory() as save_dir:
+            with patch("SANS.SANSadd2.bundle_added_event_data_as_group") as mocked_bundle:
+                out_path = os.path.join(save_dir, out_name)
+                out_path_mon = os.path.join(save_dir, out_mon_name)
+
+                mocked_bundle.return_value = out_path
+                SANSadd2.add_runs("6113", "ZOOM", ".nsx", save_directory=save_dir, saveAsEvent=True)
+                mocked_bundle.assert_called_once_with(out_path, out_path_mon, False)

--- a/scripts/test/SANS/SANSadd2Test.py
+++ b/scripts/test/SANS/SANSadd2Test.py
@@ -7,8 +7,6 @@
 
 import unittest
 from unittest.mock import patch
-import tempfile
-import os
 
 from SANS import SANSadd2
 from sans.common.enums import SampleShape
@@ -52,15 +50,3 @@ class TestSANSAddSampleMetadata(unittest.TestCase):
             mocked_get_geo_info.return_value = (8.0, 8.0, 2.0, SampleShape.DISC)
             SANSadd2.add_runs("74014", "LOQ", ".nxs", rawTypes=(".add", ".raw", ".s*"), lowMem=False)
             self.assertEqual(1, mocked_get_geo_info.call_count)
-
-    def test_save_directory_is_called_correctly_when_saving_ws(self):
-        out_name = "ZOOM00006113-add.nxs"
-        out_mon_name = "ZOOM00006113-add_monitors.nxs"
-        with tempfile.TemporaryDirectory() as save_dir:
-            with patch("SANS.SANSadd2.bundle_added_event_data_as_group") as mocked_bundle:
-                out_path = os.path.join(save_dir, out_name)
-                out_path_mon = os.path.join(save_dir, out_mon_name)
-
-                mocked_bundle.return_value = out_path
-                SANSadd2.add_runs("6113", "ZOOM", ".nsx", save_directory=save_dir, saveAsEvent=True)
-                mocked_bundle.assert_called_once_with(out_path, out_path_mon, False)

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -8,6 +8,7 @@ import os
 import random
 import re
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -49,6 +50,9 @@ TEST_STRING_MON2 = TEST_STRING_MON + "_2"
 
 TEST_STRING_DATA3 = TEST_STRING_DATA + "_3"
 TEST_STRING_MON3 = TEST_STRING_MON + "_3"
+DEPRECATED_TEST_MSG = (
+    "This test does not pass and was not used before 1/4/2015. SansUtilitytests was disabled. Can be removed once #35807 is closed"
+)
 
 
 def provide_group_workspace_for_added_event_data(event_ws_name, monitor_ws_name, out_ws_name):
@@ -147,53 +151,60 @@ def provide_workspace_with_x_errors(
             ws.setSharedDx(hists, x_error_array)
 
 
-# This test does not pass and was not used before 1/4/2015. SansUtilitytests was disabled.
 class SANSUtilityTest(unittest.TestCase):
-    # def checkValues(self, list1, list2):
+    def checkValues(self, list1, list2):
+        def _check_single_values(v1, v2):
+            self.assertAlmostEqual(v1, v2)
 
-    #    def _check_single_values( v1, v2):
-    #        self.assertAlmostEqual(v1, v2)
+        self.assertEqual(len(list1), len(list2))
+        for v1, v2 in zip(list1, list2):
+            start_1, stop_1 = v1
+            start_2, stop_2 = v2
+            _check_single_values(start_1, start_2)
+            _check_single_values(stop_1, stop_2)
 
-    #    self.assertEqual(len(list1), len(list2))
-    #    for v1,v2 in zip(list1, list2):
-    #        start_1,stop_1 = v1
-    #        start_2, stop_2 = v2
-    #        _check_single_values(start_1, start_2)
-    #        _check_single_values(stop_1, stop_2)
+    @unittest.skip(DEPRECATED_TEST_MSG)
+    def test_checkValues(self):
+        """sanity check to ensure that the others will work correctly"""
+        values = [
+            [
+                [1, 2],
+            ],
+            [[None, 3], [4, None]],
+        ]
+        for singlevalues in values:
+            self.checkValues(singlevalues, singlevalues)
 
-    # def test_checkValues(self):
-    #    """sanity check to ensure that the others will work correctly"""
-    #    values = [
-    #        [[1,2],],
-    #        [[None, 3],[4, None]],
-    #    ]
-    #    for singlevalues in values:
-    #        self.checkValues(singlevalues, singlevalues)
+    @unittest.skip(DEPRECATED_TEST_MSG)
+    def test_parse_strings(self):
+        inputs = {
+            "1-2": [[1, 2]],  # single period syntax  min < x < max
+            "1.3-5.6": [[1.3, 5.6]],  # float
+            "1-2,3-4": [[1, 2], [3, 4]],  # more than one slice
+            ">1": [[1, -1]],  # just lower bound
+            "<5": [[-1, 5]],  # just upper bound
+            "<5,8-9": [[-1, 5], [8, 9]],
+            "1:2:5": [[1, 3], [3, 5]],  # syntax: start, step, stop
+        }
 
-    # def test_parse_strings(self):
-    #    inputs = { '1-2':[[1,2]],         # single period syntax  min < x < max
-    #               '1.3-5.6':[[1.3,5.6]], # float
-    #               '1-2,3-4':[[1,2],[3,4]],# more than one slice
-    #               '>1':[[1, -1]],       # just lower bound
-    #               '<5':[[-1, 5]],      # just upper bound
-    #               '<5,8-9': [[-1, 5], [8,9]],
-    #               '1:2:5': [[1,3], [3,5]] # syntax: start, step, stop
-    #        }
+        for k, v in inputs.items():
+            self.checkValues(su.sliceParser(k), v)
 
-    #    for (k, v) in inputs.items():
-    #        self.checkValues(su.sliceParser(k),v)
+    @unittest.skip(DEPRECATED_TEST_MSG)
+    def test_accept_spaces(self):
+        self.checkValues(su.sliceParser("1 - 2, 3 - 4"), [[1, 2], [3, 4]])
 
-    # def test_accept_spaces(self):
-    #    self.checkValues(su.sliceParser("1 - 2, 3 - 4"), [[1,2],[3,4]])
+    @unittest.skip(DEPRECATED_TEST_MSG)
+    def test_invalid_values_raise(self):
+        invalid_strs = ["5>6", ":3:", "MAX<min"]
+        for val in invalid_strs:
+            self.assertRaises(SyntaxError, su.sliceParser, val)
 
-    # def test_invalid_values_raise(self):
-    #    invalid_strs = ["5>6", ":3:", "MAX<min"]
-    #    for val in invalid_strs:
-    #        self.assertRaises(SyntaxError, su.sliceParser, val)
+    @unittest.skip(DEPRECATED_TEST_MSG)
+    def test_empty_string_is_valid(self):
+        self.checkValues(su.sliceParser(""), [[-1, -1]])
 
-    # def test_empty_string_is_valid(self):
-    #    self.checkValues(su.sliceParser(""), [[-1,-1]])
-
+    @unittest.skip(DEPRECATED_TEST_MSG)
     def test_extract_spectra(self):
         mtd.clear()
 
@@ -217,6 +228,7 @@ class SANSUtilityTest(unittest.TestCase):
         det_ids = list(range(100, 299, 2))
         result = su.extract_spectra(ws, det_ids, "result")
 
+    @unittest.skip(DEPRECATED_TEST_MSG)
     def test_get_masked_det_ids(self):
         ws = CreateSampleWorkspace("Histogram", "Multiple Peaks")
 
@@ -229,11 +241,40 @@ class SANSUtilityTest(unittest.TestCase):
         self.assertTrue(104 in masked_det_ids)
         self.assertEqual(len(masked_det_ids), 3)
 
+    @unittest.skip(DEPRECATED_TEST_MSG)
     def test_merge_to_ranges(self):
         self.assertEqual([[1, 4]], su._merge_to_ranges([1, 2, 3, 4]))
         self.assertEqual([[1, 3], [5, 7]], su._merge_to_ranges([1, 2, 3, 5, 6, 7]))
         self.assertEqual([[1, 3], [5, 5], [7, 9]], su._merge_to_ranges([1, 2, 3, 5, 7, 8, 9]))
         self.assertEqual([[1, 1]], su._merge_to_ranges([1]))
+
+    @patch("SANSUtility.os.getcwd")
+    @patch("SANSUtility.config")
+    @patch("SANSUtility.os.path.isfile")
+    def test_get_full_path_for_added_event_data(self, mock_isfile, mock_config, mock_getcwd):
+        mock_isfile.side_effect = [True, False, True, True, True, True]
+        mock_config.__getitem__.side_effect = ["config_path", "", "", "config_path"]
+        mock_getcwd.return_value = "cwd_path"
+        # Case 1: path != "" and os.path.isfile(file_name) is True
+        path, base = su.get_full_path_for_added_event_data(os.path.join("mock_path", "event.nxs"))
+        self.assertEqual(os.path.join("mock_path", "event.nxs"), path)
+        self.assertEqual("event.nxs", base)
+        # Case 2: path != "" and os.path.isfile(file_name) is False and config["defaultsave.directory"] = "config_path"
+        path, base = su.get_full_path_for_added_event_data(os.path.join("mock_path", "event.nxs"))
+        self.assertEqual(os.path.join("config_path", "mock_path", "event.nxs"), path)
+        self.assertEqual("event.nxs", base)
+        # Case 3: path == "" and os.path.isfile(file_name) is True and config["defaultsave.directory"] = ""
+        path, base = su.get_full_path_for_added_event_data("event.nxs")
+        self.assertEqual(os.path.join("cwd_path", "event.nxs"), path)
+        self.assertEqual("event.nxs", base)
+        # Case 4: path == "" and os.path.isfile(file_name) is False and config["defaultsave.directory"] = ""
+        path, base = su.get_full_path_for_added_event_data("event.nxs")
+        self.assertEqual(os.path.join("cwd_path", "event.nxs"), path)
+        self.assertEqual("event.nxs", base)
+        # Case 5: path == "" and os.path.isfile(file_name) is False and config["defaultsave.directory"] = "config_path"
+        path, base = su.get_full_path_for_added_event_data("event.nxs")
+        self.assertEqual(os.path.join("config_path", "event.nxs"), path)
+        self.assertEqual("event.nxs", base)
 
 
 class TestBundleAddedEventDataFilesToGroupWorkspaceFile(unittest.TestCase):


### PR DESCRIPTION
### Description of work

This issue seems to reoccur from time to time but it was not very reproducible and it seems to be caused by the way in which the add_runs function handles paths, as sometimes the load/save paths can be absolute paths, or just filename paths, in which the role of finding the absolute path is to the file finder in the load algorithm, or defaulting to the default directory in the save algorithms. 

This script can reproduce the issue in any machine (if you don't have access to the ISIS archive, contact me to get the files) : 
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from SANSadd2 import add_runs

# create these two folders in your machine(or add tempfolders using tempfile)
save_dir_1 = "/save_test"
save_dir_2 = "/save_test_backup"

run_numbers = [103222,103230,103231]
instrument = "SANS2D"

config['defaultsave.directory'] = save_dir_1
add_runs(run_numbers, instrument, defType=".nxs", saveAsEvent=True)

config['defaultsave.directory'] = save_dir_2

#move save_dir_1 to top of the list so that it is found by add_runs loader first
config['datasearch.directories'] = save_dir_1 + ";" + config["datasearch.directories"]
add_runs(run_numbers, instrument, defType=".nxs", saveAsEvent=True)
```

When adding event files, if the `saveAsEvent` keyword is set to `True`, the helper function `bundle_added_event_data_as_group` will be called. At this point of the function, the added event workspace and added event monitors workspace both should be stored in the chosen save directory, both being event workspaces with the save name of the largest run selected (`SANS2D00103231-add.nxs` in the case of the example). `bundle_added..` will load these two workspaces into the ads, but the workspace name will have the tag `-added-event-data` as a suffix. The event and monitor ws loaded like this are grouped and stored back in the save directory with the same file name as before (`SANS2D00103231-add.nxs`). If for some reason (like adding search directories or changing the default save directory) the file `SANS2D00103231-add.nxs` is pulled from a different folder as the one in which the algorithm was saving them prior to this step, it can be that an added group workspace is being loaded instead of an event workspace, in which case there is a conflict with the group name, as the name that the group is tagged with is similar to one of its member (using this `-added-event-data` tag). 
Additionally, in the `Sum Runs` tab of the SANS GUI interface, the `save_directory` that is passed to the algorithm was not really being used, and only changing the default save directory could really change the storing folder. 

In this issue; I have tried to manage better the python paths, so the function should not pull from a different directory when trying to load previously saved processed summed workspace in the grouping stage. 


 
<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41897, #41898. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Build this branch and run the test script from description, it should not cause any error. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
