### PR TITLE
Migrate Engineering Diffraction UI Manual Tests to Automated QTests

### DIFF
--- a/Framework/API/inc/MantidAPI/IFuncMinimizer.h
+++ b/Framework/API/inc/MantidAPI/IFuncMinimizer.h
@@ -32,6 +32,19 @@ inline const std::string CHANGES_IN_FUNCTION_TOO_SMALL = "Changes in function va
 /// Reported by Levenberg-Marquardt when the change in the parameter values between
 /// iterations has fallen below tolerance (an essentially-converged stop).
 inline const std::string CHANGES_IN_PARAMETER_TOO_SMALL = "Changes in parameter value are too small";
+
+/// Whether a Fit "OutputStatus" string should be treated as a converged fit.
+/// In strict mode only "success" is accepted. Otherwise the tolerance-limited stopping
+/// conditions count too: a minimiser started from an already-optimal set of parameters
+/// stops that way routinely, and treating it as a failure is wrong.
+/// Kept here beside the strings so callers do not each re-implement the comparison.
+inline bool isConverged(const std::string &status, const bool strict = false) {
+  if (status == SUCCESS)
+    return true;
+  if (strict)
+    return false;
+  return status == CHANGES_IN_FUNCTION_TOO_SMALL || status == CHANGES_IN_PARAMETER_TOO_SMALL;
+}
 } // namespace MinimizerStatus
 
 /** An interface for function minimizers. Minimizers minimize cost functions.

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1867,12 +1867,7 @@ double FitPeaks::fitIndividualPeak(size_t wi, const API::IAlgorithm_sptr &fitter
  * GSL tolerance-limited stopping conditions are also treated as converged.
  */
 bool FitPeaks::fitStatusIsConverged(const std::string &fitStatus, const bool strict) {
-  if (fitStatus == API::MinimizerStatus::SUCCESS)
-    return true;
-  if (strict)
-    return false;
-  return fitStatus == API::MinimizerStatus::CHANGES_IN_FUNCTION_TOO_SMALL ||
-         fitStatus == API::MinimizerStatus::CHANGES_IN_PARAMETER_TOO_SMALL;
+  return API::MinimizerStatus::isConverged(fitStatus, strict);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -87,6 +87,7 @@ set(EXPORT_FILES
     src/Exports/SpectrumInfoPythonIterator.cpp
     src/Exports/AnalysisDataServiceObserver.cpp
     src/Exports/Citation.cpp
+    src/Exports/MinimizerStatus.cpp
     src/Exports/IPreview.cpp
     src/Exports/PreviewManager.cpp
     src/Exports/RegionSelectorObserver.cpp

--- a/Framework/PythonInterface/mantid/api/src/Exports/MinimizerStatus.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MinimizerStatus.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/IFuncMinimizer.h"
 
+#include <boost/python/args.hpp>
 #include <boost/python/class.hpp>
 
 using namespace boost::python;

--- a/Framework/PythonInterface/mantid/api/src/Exports/MinimizerStatus.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MinimizerStatus.cpp
@@ -1,0 +1,36 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidAPI/IFuncMinimizer.h"
+
+#include <boost/python/class.hpp>
+
+using namespace boost::python;
+
+namespace {
+/// A namespace cannot be exported directly, so the canonical status strings are hung off a
+/// non-instantiable class that stands in for one on the Python side.
+struct MinimizerStatusNamespace {};
+} // namespace
+
+void export_MinimizerStatus() {
+  auto pythonClass = class_<MinimizerStatusNamespace, boost::noncopyable>(
+      "MinimizerStatus",
+      "The status strings a function minimizer reports through a fit's OutputStatus, and the test for "
+      "whether one of them means the fit converged. Mirrors Mantid::API::MinimizerStatus so Python "
+      "callers do not have to hard code the wording.",
+      no_init);
+
+  pythonClass.def("isConverged", &Mantid::API::MinimizerStatus::isConverged, (arg("status"), arg("strict") = false),
+                  "Whether a fit OutputStatus means the minimizer converged. With strict=True only 'success' "
+                  "counts; otherwise the tolerance-limited stopping conditions do too, because a minimizer "
+                  "started from an already-optimal set of parameters stops that way routinely.");
+  pythonClass.staticmethod("isConverged");
+
+  pythonClass.attr("SUCCESS") = Mantid::API::MinimizerStatus::SUCCESS;
+  pythonClass.attr("CHANGES_IN_FUNCTION_TOO_SMALL") = Mantid::API::MinimizerStatus::CHANGES_IN_FUNCTION_TOO_SMALL;
+  pythonClass.attr("CHANGES_IN_PARAMETER_TOO_SMALL") = Mantid::API::MinimizerStatus::CHANGES_IN_PARAMETER_TOO_SMALL;
+}

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/CMakeLists.txt
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Automated UI tests: system tests that drive a real Qt interface with QTest, replacing the manual test guides in
+# dev-docs/source/Testing.
+#
+# No tests are registered at this level - each interface gets its own subdirectory. The shared harness modules here
+# (automated_ui_test_base.py, qt_interaction_helpers.py) are deliberately not listed as tests; putting this directory on
+# the test PYTHONPATH is what makes them importable from the interface subdirectories, and CMake variables propagate
+# into add_subdirectory.
+set(PYUNITTEST_PYTHONPATH_EXTRA ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(EngineeringDiffraction)

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/CMakeLists.txt
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Automated UI tests for the Engineering Diffraction interface.
+#
+# eng_diff_gui_test_base.py is not listed: it holds the shared setup and the synthetic data fixture, not tests. Its base
+# class is abstract so the system test collector ignores it even in the modules that import it.
+set(SYSTEST_NAMES
+    EngDiffGuiCorrectionTest.py
+    EngDiffGuiCroppingTest.py
+    EngDiffGuiFittingTest.py
+    EngDiffGuiGsas2Test.py
+    EngDiffGuiImatTest.py
+    EngDiffGuiRunProcessingTest.py
+    EngDiffGuiTextureTest.py
+)
+
+# The parent's PYUNITTEST_PYTHONPATH_EXTRA (the shared harness directory) is inherited here, and PY_ADD_TEST puts this
+# directory on PYTHONPATH itself, so both eng_diff_gui_test_base and the cross-interface helpers are importable from the
+# test modules without adding anything further.
+pysystemtest_add_test(${CMAKE_CURRENT_SOURCE_DIR} qt.AutomatedUITest.EngineeringDiffraction ${SYSTEST_NAMES})

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
@@ -1,0 +1,740 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the Absorption Correction tab.
+
+This tab is the heaviest user of the generated-algorithm-dialog seam: the sample shape, the sample
+material and the orientation are all set by opening a real ``InterfaceManager`` dialog and reacting
+to the algorithm finishing. A real dialog would block an unattended run forever, so
+``algorithm_dialog_runs`` stands in for the user pressing Run - it executes the *real* algorithm and
+then drives the same observer callback the real dialog does, leaving everything downstream of the
+dialog unmodified. That seam is exercised here for all four algorithms the tab opens.
+
+Everything else is real: real workspaces, a real ``MonteCarloAbsorption``, real files on disk.
+
+The sample runs are the fabricated ENGIN-X pair (see ``create_synthetic_ceria_and_vanadium``). The
+tab only cares that a run loads and carries an instrument, a run number and enough spectra to
+correct, so fabricated data exercises it exactly as real data would while keeping the Monte Carlo
+calculation quick.
+"""
+
+import os
+
+from eng_diff_gui_test_base import (
+    CORRECTION_PRESENTER,
+    ENGINX_SYNTHETIC_CERIA_RUN,
+    ENGINX_SYNTHETIC_VANADIUM_RUN,
+    EngDiffGuiTestBase,
+    TAB_CORRECTION,
+    create_enginx_ceria_and_vanadium,
+)
+from qt_interaction_helpers import (
+    cell_button,
+    click,
+    combo_items,
+    figure_numbers,
+    process_events,
+    select_combo,
+    set_checkbox,
+    set_finder_text,
+    table_checkbox,
+    table_column,
+)
+
+INSTRUMENT = "ENGINX"
+CERIA = str(ENGINX_SYNTHETIC_CERIA_RUN)
+VANADIUM = str(ENGINX_SYNTHETIC_VANADIUM_RUN)
+
+# workspaces are named after the file, and the fixture writes 8-digit zero padded run numbers
+CERIA_WS = f"{INSTRUMENT}{ENGINX_SYNTHETIC_CERIA_RUN:08d}"
+VANADIUM_WS = f"{INSTRUMENT}{ENGINX_SYNTHETIC_VANADIUM_RUN:08d}"
+
+# table columns, as set up in TextureCorrectionView.table_column_headers
+COL_RUN, COL_SHAPE, COL_MATERIAL, COL_ORIENTATION, COL_SELECT = range(5)
+
+RB_NUMBER = "5551234"
+
+# the orientation and gauge volume fixtures live under Testing/Data/SystemTest/Texture
+TEXTURE_DATA = "Texture"
+
+# the CSG cuboid the manual guide asks for, as typed into the SetSampleShape dialog
+CUBOID_XML = (
+    "<cuboid id='sample'>"
+    "<height val='0.01'/>"
+    "<width val='0.01'/>"
+    "<depth val='0.01'/>"
+    "<centre x='0.0' y='0.0' z='0.0'/>"
+    "</cuboid>"
+    "<algebra val='sample'/>"
+)
+CUBOID_VOLUME = 1.0e-6  # a 1 cm cube, in m^3
+
+
+class _CorrectionTestBase(EngDiffGuiTestBase):
+    """Loads the fabricated ENGIN-X runs into the correction table."""
+
+    def requiredMemoryMB(self):
+        return 4000
+
+    def seeded_settings(self):
+        settings = super(_CorrectionTestBase, self).seeded_settings()
+        # keep the corrected and intermediate workspaces so they can be asserted on; the default is
+        # to drop them once saved, which is checked explicitly in EngDiffGuiCorrectionApplyTest
+        settings["clear_absorption_ws_after_processing"] = False
+        return settings
+
+    def pre_gui_setup(self):
+        self.data_dir = os.path.join(self.tmp_root, "enginx_data")
+        os.makedirs(self.data_dir, exist_ok=True)
+        create_enginx_ceria_and_vanadium(self.data_dir)
+        self.add_data_search_dir(self.data_dir)
+
+    # ------------------------------------------------------------------ helpers
+
+    def load_runs(self, runs=f"{CERIA}, {VANADIUM}"):
+        """Type run numbers into the tab's finder and press Load, as a user would."""
+        self.show_tab(TAB_CORRECTION)
+        set_finder_text(self.correction_view.finder_corr, runs)
+        click(self.correction_view.btn_loadFiles)
+        process_events(2)
+        return self.table_runs()
+
+    def table(self):
+        return self.correction_view.table_loaded_data
+
+    def table_runs(self):
+        return table_column(self.table(), COL_RUN)
+
+    def row_of(self, ws_name):
+        runs = self.table_runs()
+        self.assertIn(ws_name, runs, f"{ws_name} is not in the table; found {runs}")
+        return runs.index(ws_name)
+
+    def select_only(self, ws_names):
+        """Tick exactly the given rows, so a following action applies to a known set."""
+        click(self.correction_view.btn_deselectAll)
+        for name in ws_names:
+            table_checkbox(self.table(), self.row_of(name), COL_SELECT).setChecked(True)
+        process_events()
+
+    def run_alg_dialog(self, button, run_algorithm):
+        """Press a button that opens a generated algorithm dialog and accept it.
+
+        The dialog is replaced, but the algorithm it would have run is run for real and the
+        presenter's own finish handling is left alone - which is what makes the table redraw and the
+        reference information update part of what is being tested.
+        """
+        with self.algorithm_dialog_runs(CORRECTION_PRESENTER, run_algorithm):
+            click(button)
+        process_events(2)
+
+    # ------------------------------------------------------------------ fixture paths
+
+    @staticmethod
+    def cube_stl():
+        from mantid.api import FileFinder
+
+        return FileFinder.Instance().getFullPath("cube.stl")
+
+    @staticmethod
+    def texture_data_file(name):
+        """Resolve one of the shipped Texture fixtures.
+
+        The data search path holds the ``SystemTest`` root rather than each of its subdirectories,
+        so the relative path has to be given - and a miss has to fail loudly here rather than
+        returning an empty string that only fails much later.
+        """
+        from mantid.api import FileFinder
+
+        path = FileFinder.Instance().getFullPath(f"{TEXTURE_DATA}/{name}")
+        if not path:
+            raise RuntimeError(f"could not resolve the test fixture {TEXTURE_DATA}/{name}")
+        return path
+
+    def output_dir(self, name, rb_number=None):
+        if rb_number:
+            return os.path.join(self.save_dir, "User", rb_number, name)
+        return os.path.join(self.save_dir, name)
+
+
+class EngDiffGuiCorrectionTableTest(_CorrectionTestBase):
+    """Loading runs, the table, the reference workspace and every sample-definition dialog.
+
+    No correction is applied here, so this is the cheap half of the tab's coverage.
+    """
+
+    def requiredFiles(self):
+        return ["cube.stl", f"{TEXTURE_DATA}/rotation_as_euler.txt", f"{TEXTURE_DATA}/rotation_as_matrix.txt"]
+
+    def _run_checks(self):
+        self.set_rb_number(RB_NUMBER)
+        self._check_loading()
+        self._check_selection_buttons()
+        self._check_reference_workspace()
+        self._check_sample_shape()
+        self._check_sample_material()
+        self._check_orientations()
+        self._check_copy_sample()
+        self._check_deleting()
+
+    def _check_loading(self):
+        runs = self.load_runs()
+
+        with self.check("Correction / loading runs puts one row in the table per run"):
+            self.assertEqual([CERIA_WS, VANADIUM_WS], sorted(runs))
+
+        with self.check("Correction / a freshly loaded run has no shape, material or orientation"):
+            row = self.row_of(CERIA_WS)
+            self.assertIsNone(cell_button(self.table(), row, COL_SHAPE), "a run with no shape must not offer a view button")
+            self.assertEqual("Not set", self.table().item(row, COL_MATERIAL).text())
+            self.assertEqual("default", self.table().item(row, COL_ORIENTATION).text())
+
+        with self.check("Correction / newly loaded rows start unselected"):
+            # the presenter carries the previous tick state forward when it redraws, and a run that
+            # was not in the table before had none, so nothing is acted on until the user chooses
+            self.assertEqual([], self.correction_view.get_selected_workspaces())
+
+        with self.check("Correction / the loaded runs are offered as a sample to copy from"):
+            self.assertIn(CERIA_WS, combo_items(self.correction_view.combo_workspaceList))
+
+        with self.check("Correction / loading the same run again does not duplicate its row"):
+            self.load_runs(runs=CERIA)
+            self.assertEqual([CERIA_WS, VANADIUM_WS], sorted(self.table_runs()))
+
+    def _check_selection_buttons(self):
+        view = self.correction_view
+
+        click(view.btn_deselectAll)
+        with self.check("Correction / Deselect All clears every row"):
+            self.assertEqual([], view.get_selected_workspaces())
+
+        click(view.btn_selectAll)
+        with self.check("Correction / Select All ticks every row"):
+            self.assertEqual(sorted([CERIA_WS, VANADIUM_WS]), sorted(view.get_selected_workspaces()))
+
+        with self.check("Correction / a single row can be ticked on its own"):
+            self.select_only([CERIA_WS])
+            self.assertEqual([CERIA_WS], view.get_selected_workspaces())
+
+    def _check_reference_workspace(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        view = self.correction_view
+        click(view.btn_createRefWS)
+        process_events(2)
+
+        with self.check("Correction / creating a reference workspace names it for the RB number"):
+            expected = f"{RB_NUMBER}_reference_workspace"
+            self.assertTrue(ADS.doesExist(expected), f"{expected} was not created")
+            self.assertEqual(expected, view.ref_frame_status.text())
+
+        with self.check("Correction / a reference workspace with no shape cannot be viewed"):
+            self.assertFalse(view.btn_viewRefShape.isEnabled())
+            self.assertEqual("Not set", view.ref_material_status.text())
+
+        # give the reference a shape and a material through the real dialogs, which is also what
+        # makes the rest of the reference checks meaningful
+        reference = f"{RB_NUMBER}_reference_workspace"
+        self._set_shape_from_stl([reference])
+        self._set_material(["Fe"], [reference])
+
+        with self.check("Correction / the reference section updates once it has a shape and material"):
+            self.assertTrue(view.btn_viewRefShape.isEnabled())
+            self.assertEqual("Fe", view.ref_material_status.text())
+
+        with self.check("Correction / the reference shape can be viewed"):
+            before = figure_numbers()
+            click(view.btn_viewRefShape)
+            process_events(3)
+            self.assertTrue(figure_numbers() - before, "viewing the reference shape opened no figure")
+
+        click(view.btn_saveRefWS)
+        process_events(2)
+        with self.check("Correction / saving the reference writes it under ReferenceWorkspaces"):
+            saved = self.basenames_under(self.output_dir("ReferenceWorkspaces", RB_NUMBER))
+            self.assertIn(f"{RB_NUMBER}_reference_workspace.nxs", saved)
+
+        with self.check("Correction / a saved reference can be loaded back"):
+            path = os.path.join(self.output_dir("ReferenceWorkspaces", RB_NUMBER), f"{RB_NUMBER}_reference_workspace.nxs")
+            set_finder_text(view.finder_reference, path)
+            click(view.btn_loadRef)
+            process_events(2)
+            self.assertEqual(f"{RB_NUMBER}_reference_workspace", view.ref_frame_status.text())
+            self.assertEqual("Fe", view.ref_material_status.text())
+
+    def _check_sample_shape(self):
+        from mantid.api import AnalysisDataService as ADS
+        from mantid.geometry import CSGObject, MeshObject
+
+        self.select_only([CERIA_WS])
+        self._set_shape_from_stl([CERIA_WS])
+
+        with self.check("Correction / an STL shape is loaded as a mesh"):
+            shape = ADS.retrieve(CERIA_WS).sample().getShape()
+            self.assertIsInstance(shape, MeshObject)
+
+        with self.check("Correction / the table offers a view button once a shape is set"):
+            row = self.row_of(CERIA_WS)
+            self.assertIsNotNone(cell_button(self.table(), row, COL_SHAPE), "no view button appeared for a shape")
+
+        with self.check("Correction / the per-row shape button opens a figure"):
+            before = figure_numbers()
+            click(cell_button(self.table(), self.row_of(CERIA_WS), COL_SHAPE))
+            process_events(3)
+            self.assertTrue(figure_numbers() - before, "the row's shape button opened no figure")
+
+        # now the CSG route, on the other run, so both shape dialogs are covered
+        self.select_only([VANADIUM_WS])
+        self._set_shape_from_csg([VANADIUM_WS])
+
+        with self.check("Correction / a CSG shape is loaded as a constructive solid"):
+            shape = ADS.retrieve(VANADIUM_WS).sample().getShape()
+            self.assertIsInstance(shape, CSGObject)
+
+        with self.check("Correction / the CSG shape has the volume that was asked for"):
+            # the magnitude, because Mantid reports a signed volume for a centre-and-dimensions
+            # cuboid - the same form Engineering's own get_cube_xml produces - and it comes back
+            # negative. That is a geometry quirk, not something this tab controls.
+            volume = abs(ADS.retrieve(VANADIUM_WS).sample().getShape().volume())
+            self.assertAlmostEqual(CUBOID_VOLUME, volume, delta=0.01 * CUBOID_VOLUME)
+
+    def _check_sample_material(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        self.select_only([CERIA_WS])
+        self._set_material(["Fe"], [CERIA_WS])
+
+        with self.check("Correction / the material set through the dialog is on the workspace"):
+            self.assertEqual("Fe", ADS.retrieve(CERIA_WS).sample().getMaterial().name())
+
+        with self.check("Correction / and is shown in the table"):
+            self.assertEqual("Fe", self.table().item(self.row_of(CERIA_WS), COL_MATERIAL).text())
+
+        with self.check("Correction / a run with no material still reads 'Not set'"):
+            self.assertEqual("Not set", self.table().item(self.row_of(VANADIUM_WS), COL_MATERIAL).text())
+
+    def _check_orientations(self):
+        import numpy as np
+        from mantid.api import AnalysisDataService as ADS
+        from mantid.simpleapi import SetGoniometer
+
+        view = self.correction_view
+        self.select_only([CERIA_WS])
+
+        with self.check("Correction / a single orientation set through the dialog reaches the goniometer"):
+            self.run_alg_dialog(
+                view.btn_setOrientation,
+                lambda: SetGoniometer(Workspace=CERIA_WS, Axis0="90,1,0,0,1", Axis1="135,0,0,1,-1"),
+            )
+            rotation = ADS.retrieve(CERIA_WS).run().getGoniometer().getR()
+            self.assertFalse(np.allclose(rotation, np.identity(3)), "the goniometer is still the identity")
+
+        with self.check("Correction / the table reports that an orientation has been set"):
+            self.assertEqual("set", self.table().item(self.row_of(CERIA_WS), COL_ORIENTATION).text())
+
+        # from a file of flattened rotation matrices
+        self.select_only([CERIA_WS])
+        matrix_file = self.texture_data_file("rotation_as_matrix.txt")
+        self.set_engineering_setting("use_euler_angles", False)
+        set_finder_text(view.finder_orientation_file, matrix_file)
+        click(view.btn_loadOrientation)
+        process_events(2)
+
+        with self.check("Correction / an orientation file of matrices is applied verbatim"):
+            with open(matrix_file) as handle:
+                values = [float(value) for value in handle.readline().split(",")]
+            expected = np.array(values[:9]).reshape(3, 3)
+            self.assertTrue(
+                np.allclose(expected, ADS.retrieve(CERIA_WS).run().getGoniometer().getR(), atol=1e-6),
+                "the rotation matrix from the file was not the one applied",
+            )
+
+        # ... and of Euler angles, which are interpreted using the scheme in the settings
+        self.select_only([CERIA_WS])
+        self.set_engineering_setting("use_euler_angles", True)
+        self.set_engineering_setting("euler_angles_scheme", "XYZ")
+        self.set_engineering_setting("euler_angles_sense", "1,1,1")
+        set_finder_text(view.finder_orientation_file, self.texture_data_file("rotation_as_euler.txt"))
+        click(view.btn_loadOrientation)
+        process_events(2)
+        from_xyz = ADS.retrieve(CERIA_WS).run().getGoniometer().getR().copy()
+
+        with self.check("Correction / an orientation file of Euler angles gives a real rotation"):
+            self.assertFalse(np.allclose(from_xyz, np.identity(3)), "the Euler angles produced no rotation")
+            # a rotation matrix is orthonormal with determinant +1; a mis-parsed file would not be
+            self.assertTrue(np.allclose(from_xyz @ from_xyz.T, np.identity(3), atol=1e-6))
+            self.assertAlmostEqual(1.0, float(np.linalg.det(from_xyz)), places=6)
+
+        with self.check("Correction / changing the Euler scheme changes how the same file is read"):
+            self.select_only([CERIA_WS])
+            self.set_engineering_setting("euler_angles_scheme", "ZXZ")
+            click(view.btn_loadOrientation)
+            process_events(2)
+            from_zxz = ADS.retrieve(CERIA_WS).run().getGoniometer().getR()
+            self.assertFalse(np.allclose(from_xyz, from_zxz), "the Euler scheme setting had no effect")
+
+        with self.check("Correction / reversing the sense of rotation also changes the result"):
+            self.select_only([CERIA_WS])
+            self.set_engineering_setting("euler_angles_sense", "-1,-1,-1")
+            click(view.btn_loadOrientation)
+            process_events(2)
+            reversed_sense = ADS.retrieve(CERIA_WS).run().getGoniometer().getR()
+            self.assertFalse(np.allclose(from_zxz, reversed_sense), "the sense of rotation setting had no effect")
+
+    def _check_copy_sample(self):
+        from mantid.api import AnalysisDataService as ADS
+        from mantid.geometry import MeshObject
+
+        view = self.correction_view
+
+        with self.check("Correction / the reference sample can be copied onto the selected runs"):
+            self.select_only([VANADIUM_WS])
+            click(view.btn_copyRefSample)
+            process_events(2)
+            # the reference carries the STL mesh, so the CSG cuboid must have been replaced
+            self.assertIsInstance(ADS.retrieve(VANADIUM_WS).sample().getShape(), MeshObject)
+            self.assertEqual("Fe", ADS.retrieve(VANADIUM_WS).sample().getMaterial().name())
+
+        with self.check("Correction / any loaded workspace can be used as the sample to copy from"):
+            self._set_shape_from_csg([VANADIUM_WS])
+            select_combo(view.combo_workspaceList, VANADIUM_WS)
+            self.select_only([CERIA_WS])
+            click(view.btn_copySampleToAll)
+            process_events(2)
+            from mantid.geometry import CSGObject
+
+            self.assertIsInstance(ADS.retrieve(CERIA_WS).sample().getShape(), CSGObject)
+
+    def _check_deleting(self):
+        view = self.correction_view
+
+        self.select_only([VANADIUM_WS])
+        click(view.btn_deleteSelected)
+        process_events(2)
+
+        with self.check("Correction / Delete Selected removes only the ticked rows"):
+            self.assertEqual([CERIA_WS], self.table_runs())
+
+        with self.check("Correction / deleting a row does not delete the workspace"):
+            from mantid.api import AnalysisDataService as ADS
+
+            # the table is a working set, not the ADS - the guide expects the workspace to survive
+            self.assertTrue(ADS.doesExist(VANADIUM_WS))
+
+    # ------------------------------------------------------------------ dialog helpers
+
+    def _set_shape_from_stl(self, workspaces):
+        from mantid.simpleapi import LoadSampleShape
+
+        def run():
+            for ws in workspaces:
+                LoadSampleShape(InputWorkspace=ws, OutputWorkspace=ws, Filename=self.cube_stl(), Scale="mm")
+
+        self.run_alg_dialog(self.correction_view.btn_loadSampleShape, run)
+
+    def _set_shape_from_csg(self, workspaces):
+        from mantid.simpleapi import SetSample
+
+        def run():
+            for ws in workspaces:
+                SetSample(InputWorkspace=ws, Geometry={"Shape": "CSG", "Value": CUBOID_XML})
+
+        self.run_alg_dialog(self.correction_view.btn_setSampleShape, run)
+
+    def _set_material(self, materials, workspaces):
+        from mantid.simpleapi import SetSampleMaterial
+
+        def run():
+            for ws in workspaces:
+                SetSampleMaterial(InputWorkspace=ws, ChemicalFormula=materials[0])
+
+        self.run_alg_dialog(self.correction_view.btn_setSampleMaterial, run)
+
+
+class EngDiffGuiCorrectionApplyTest(_CorrectionTestBase):
+    """Applying the corrections: gauge volume, Monte Carlo parameters, divergence and the
+    attenuation table, plus where all of it is saved."""
+
+    def requiredFiles(self):
+        return ["cube.stl", f"{TEXTURE_DATA}/custom_gauge_volume.xml"]
+
+    def excludeInPullRequests(self):
+        return True
+
+    def _run_checks(self):
+        self.load_runs(runs=CERIA)
+        self._prepare_sample()
+        self._check_visibility_toggles()
+        self._check_absorption_only()
+        self._check_gauge_volume_choices()
+        self._check_divergence()
+        self._check_attenuation_table()
+        self._check_monte_carlo_parameters()
+        self._check_workspace_cleanup()
+
+    def _prepare_sample(self):
+        """A shape and a material are preconditions for any correction, so these are hard asserts."""
+        from mantid.simpleapi import LoadSampleShape, SetSampleMaterial
+
+        self.select_only([CERIA_WS])
+
+        def load_shape():
+            LoadSampleShape(InputWorkspace=CERIA_WS, OutputWorkspace=CERIA_WS, Filename=self.cube_stl(), Scale="mm")
+
+        def set_material():
+            SetSampleMaterial(InputWorkspace=CERIA_WS, ChemicalFormula="Fe")
+
+        self.run_alg_dialog(self.correction_view.btn_loadSampleShape, load_shape)
+        self.run_alg_dialog(self.correction_view.btn_setSampleMaterial, set_material)
+
+        from mantid.api import AnalysisDataService as ADS
+
+        self.assertEqual("Fe", ADS.retrieve(CERIA_WS).sample().getMaterial().name(), "the sample material was not set")
+
+    def _check_visibility_toggles(self):
+        view = self.correction_view
+
+        with self.check("Correction / the gauge volume inputs follow the absorption checkbox"):
+            set_checkbox(view.check_absorption, False)
+            self.assertFalse(view.combo_shapeMethod.isVisible())
+            set_checkbox(view.check_absorption, True)
+            self.assertTrue(view.combo_shapeMethod.isVisible())
+
+        with self.check("Correction / the divergence inputs follow the divergence checkbox"):
+            set_checkbox(view.check_divergence, True)
+            self.assertTrue(view.line_divHorz.isVisible())
+            set_checkbox(view.check_divergence, False)
+            self.assertFalse(view.line_divHorz.isVisible())
+
+        with self.check("Correction / the attenuation table inputs follow its checkbox"):
+            set_checkbox(view.check_attenTab, True)
+            self.assertTrue(view.widget_attenuationTableContainer.isVisible())
+            set_checkbox(view.check_attenTab, False)
+            self.assertFalse(view.widget_attenuationTableContainer.isVisible())
+
+        with self.check("Correction / the custom gauge volume finder appears only for a custom shape"):
+            select_combo(view.combo_shapeMethod, "4mmCube")
+            self.assertFalse(view.finder_gauge_vol.isVisible())
+            select_combo(view.combo_shapeMethod, "Custom Shape")
+            self.assertTrue(view.finder_gauge_vol.isVisible())
+            select_combo(view.combo_shapeMethod, "4mmCube")
+
+    def _check_absorption_only(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+
+        with self.check("Correction / applying absorption produces a corrected workspace"):
+            self.assertTrue(ADS.doesExist(f"Corrected_{CERIA_WS}"), "no corrected workspace was produced")
+
+        with self.check("Correction / the corrected workspace is in d-spacing"):
+            corrected = ADS.retrieve(f"Corrected_{CERIA_WS}")
+            self.assertEqual("dSpacing", corrected.getAxis(0).getUnit().unitID())
+            self.assertEqual(ADS.retrieve(CERIA_WS).getNumberHistograms(), corrected.getNumberHistograms())
+
+        with self.check("Correction / the correction actually changed the data"):
+            import numpy as np
+            from mantid.simpleapi import ConvertUnits
+
+            original = ConvertUnits(InputWorkspace=CERIA_WS, Target="dSpacing", StoreInADS=False)
+            corrected = ADS.retrieve(f"Corrected_{CERIA_WS}")
+            self.assertFalse(np.allclose(original.readY(0), corrected.readY(0)), "the corrected data is identical to the input")
+
+        with self.check("Correction / the corrected workspace is saved under AbsorptionCorrection"):
+            self.assertIn(f"Corrected_{CERIA_WS}.nxs", self.basenames_under(self.output_dir("AbsorptionCorrection")))
+
+        with self.check("Correction / the absorption calculation used the shape that was set"):
+            # MonteCarloAbsorption is never stubbed - the correction workspace it produced is left
+            # in the ADS so the factors themselves can be checked
+            import numpy as np
+
+            factors = ADS.retrieve("_abs_corr")
+            self.assertTrue(np.all(factors.readY(0) > 0.0), "absorption factors must be positive")
+            self.assertTrue(np.all(factors.readY(0) <= 1.0), "absorption factors must not exceed 1")
+
+    def _check_gauge_volume_choices(self):
+        import numpy as np
+        from mantid.api import AnalysisDataService as ADS
+        from Engineering.common.xml_shapes import get_cube_xml
+
+        def logged_gauge_volume():
+            # the algorithm strips the shape string before storing it as a run log
+            return ADS.retrieve(CERIA_WS).run().getLogData("GaugeVolume").value.strip()
+
+        with self.check("Correction / the 4mm cube preset is written to the run as a gauge volume"):
+            self.assertEqual(get_cube_xml("some-gv", 0.004).strip(), logged_gauge_volume())
+
+        preset_factors = ADS.retrieve("_abs_corr").readY(0).copy()
+
+        with self.check("Correction / a custom gauge volume file is used instead when chosen"):
+            custom_file = self.texture_data_file("custom_gauge_volume.xml")
+            select_combo(self.correction_view.combo_shapeMethod, "Custom Shape")
+            set_finder_text(self.correction_view.finder_gauge_vol, custom_file)
+            self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+
+            with open(custom_file) as handle:
+                expected = handle.read()
+            self.assertEqual(expected.strip(), logged_gauge_volume())
+
+        with self.check("Correction / the shipped custom file describes the same volume as the preset"):
+            # custom_gauge_volume.xml is itself a 4 mm cube, so this is a round trip: reading the
+            # shape from a file must give the same correction as asking for the preset directly
+            self.assertTrue(
+                np.allclose(preset_factors, ADS.retrieve("_abs_corr").readY(0)),
+                "the same gauge volume gave different absorption factors depending on how it was specified",
+            )
+
+        with self.check("Correction / a genuinely different gauge volume gives a different correction"):
+            smaller = os.path.join(self.tmp_root, "small_gauge_volume.xml")
+            with open(smaller, "w") as handle:
+                handle.write(get_cube_xml("some-gv", 0.001))
+            set_finder_text(self.correction_view.finder_gauge_vol, smaller)
+            self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+            self.assertFalse(
+                np.allclose(preset_factors, ADS.retrieve("_abs_corr").readY(0)),
+                "shrinking the gauge volume made no difference to the absorption factors",
+            )
+
+        with self.check("Correction / 'No Gauge Volume' clears the gauge volume off the run"):
+            from Engineering.texture.texture_helper import GAUGE_VOLUME_LOG
+
+            select_combo(self.correction_view.combo_shapeMethod, "No Gauge Volume")
+            self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+            # the option has to actively remove an earlier definition, otherwise the stale shape is
+            # silently reused and choosing it does nothing at all
+            self.assertFalse(
+                ADS.retrieve(CERIA_WS).run().hasProperty(GAUGE_VOLUME_LOG),
+                "the previous gauge volume was left on the workspace",
+            )
+
+        with self.check("Correction / and the correction really is the uncollimated one"):
+            uncollimated = ADS.retrieve("_abs_corr").readY(0).copy()
+            self.assertFalse(
+                np.allclose(preset_factors, uncollimated),
+                "correcting with no gauge volume gave the same factors as the 4mm cube",
+            )
+
+        select_combo(self.correction_view.combo_shapeMethod, "4mmCube")
+
+    def _check_divergence(self):
+        """The divergence factors are consumed and removed inside ``apply_corrections``, so unlike
+        the absorption factors they can only be observed through the corrected data itself."""
+        import numpy as np
+        from mantid.api import AnalysisDataService as ADS
+        from mantid.simpleapi import ConvertUnits
+
+        uncorrected = ConvertUnits(InputWorkspace=CERIA_WS, Target="dSpacing", StoreInADS=False).readY(0).copy()
+
+        self.apply_corrections(absorption=False, divergence=True, attenuation=False)
+        corrected = ADS.retrieve(f"Corrected_{CERIA_WS}").readY(0).copy()
+
+        with self.check("Correction / a divergence correction changes the data"):
+            self.assertFalse(np.allclose(uncorrected, corrected), "the divergence correction had no effect")
+            self.assertTrue(np.all(np.isfinite(corrected)), "the corrected data contains non-finite values")
+
+        with self.check("Correction / the divergence parameters typed into the tab are the ones used"):
+            # the correction is data / (scale * sin^2(theta)) with scale = vert * sqrt(horz^2 +
+            # det_horz^2), so dividing the two spectra back out must recover that factor exactly
+            view = self.correction_view
+            horz, vert, det_horz = (float(view.get_div_horz()), float(view.get_div_vert()), float(view.get_div_det_horz()))
+            scale = vert * np.sqrt(horz**2 + det_horz**2)
+            two_theta = ADS.retrieve(CERIA_WS).spectrumInfo().twoTheta(0)
+            expected = scale * np.sin(two_theta) ** 2
+            ratio = uncorrected[uncorrected != 0.0] / corrected[uncorrected != 0.0]
+            self.assertTrue(np.allclose(expected, ratio, rtol=1e-6), f"expected a divergence factor of {expected}, got {ratio[:3]}")
+
+        with self.check("Correction / changing the divergence changes the correction"):
+            self.correction_view.line_divVert.setText("0.05")
+            process_events()
+            self.apply_corrections(absorption=False, divergence=True, attenuation=False)
+            self.assertFalse(
+                np.allclose(corrected, ADS.retrieve(f"Corrected_{CERIA_WS}").readY(0)),
+                "the divergence parameters made no difference to the correction",
+            )
+            self.correction_view.line_divVert.setText("0.02")
+            process_events()
+
+    def _check_attenuation_table(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        view = self.correction_view
+        set_checkbox(view.check_attenTab, True)
+        view.line_evalVal.setText("2.0")
+        select_combo(view.combo_Units, "dSpacing")
+        process_events()
+
+        self.apply_corrections(absorption=True, divergence=False, attenuation=True)
+
+        # the table is named from the workspace's own instrument name, which is the full name in the
+        # IDF ("ENGIN-X") rather than the short name the interface's combo box uses ("ENGINX")
+        expected_name = f"ENGIN-X_{CERIA}_attenuation_coefficient_2.0_dSpacing"
+        with self.check("Correction / the attenuation table is named for the run and evaluation point"):
+            self.assertTrue(ADS.doesExist(expected_name), f"{expected_name} was not produced; found {ADS.getObjectNames()}")
+
+        with self.check("Correction / the attenuation table has one mu per spectrum"):
+            table = ADS.retrieve(expected_name)
+            self.assertEqual(["mu"], list(table.getColumnNames()))
+            self.assertEqual(ADS.retrieve(CERIA_WS).getNumberHistograms(), table.rowCount())
+
+        with self.check("Correction / the attenuation table is saved under AttenuationTables"):
+            self.assertIn(f"{expected_name}.nxs", self.basenames_under(self.output_dir("AttenuationTables")))
+
+        set_checkbox(view.check_attenTab, False)
+
+    def _check_monte_carlo_parameters(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        # the parameters are only observable through the algorithm history of the workspace
+        # MonteCarloAbsorption produced, which is why they are never stubbed
+        self.set_engineering_setting("monte_carlo_params", "SparseInstrument:True,NumberOfDetectorRows:5,NumberOfDetectorColumns:5")
+        self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+
+        with self.check("Correction / the Monte Carlo settings reach MonteCarloAbsorption"):
+            history = ADS.retrieve("_abs_corr").getHistory().getAlgorithmHistories()
+            monte_carlo = [alg for alg in history if alg.name() == "MonteCarloAbsorption"]
+            self.assertTrue(monte_carlo, "MonteCarloAbsorption is not in the history of the correction workspace")
+            properties = {prop.name(): prop.value() for prop in monte_carlo[-1].getProperties()}
+            self.assertEqual("5", properties["NumberOfDetectorRows"])
+            self.assertEqual("5", properties["NumberOfDetectorColumns"])
+
+        with self.check("Correction / different Monte Carlo settings give different factors"):
+            import numpy as np
+
+            coarse = ADS.retrieve("_abs_corr").readY(0).copy()
+            self.set_engineering_setting("monte_carlo_params", "SparseInstrument:True,NumberOfDetectorRows:9,NumberOfDetectorColumns:9")
+            self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+            self.assertFalse(
+                np.allclose(coarse, ADS.retrieve("_abs_corr").readY(0)),
+                "the Monte Carlo parameters made no difference to the absorption factors",
+            )
+
+    def _check_workspace_cleanup(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        self.set_engineering_setting("clear_absorption_ws_after_processing", True)
+        self.apply_corrections(absorption=True, divergence=True, attenuation=False)
+
+        with self.check("Correction / the intermediate workspaces are dropped when the setting asks"):
+            self.assertFalse(ADS.doesExist("_abs_corr"), "the absorption factors were left in the ADS")
+            self.assertFalse(ADS.doesExist("_div_corr"), "the divergence factors were left in the ADS")
+            self.assertFalse(ADS.doesExist(f"Corrected_{CERIA_WS}"), "the corrected workspace was left in the ADS")
+
+        with self.check("Correction / but the file is still written"):
+            self.assertIn(f"Corrected_{CERIA_WS}.nxs", self.basenames_under(self.output_dir("AbsorptionCorrection")))
+
+    # ------------------------------------------------------------------ helper
+
+    def apply_corrections(self, absorption, divergence, attenuation):
+        """Tick the wanted corrections and press Apply, waiting for the worker."""
+        view = self.correction_view
+        self.show_tab(TAB_CORRECTION)
+        self.select_only([CERIA_WS])
+        set_checkbox(view.check_absorption, absorption)
+        set_checkbox(view.check_divergence, divergence)
+        set_checkbox(view.check_attenTab, attenuation)
+        click(view.btn_applyCorrections)
+        self.wait_for_async_task(self.correction_presenter.worker, what="corrections")
+        process_events(2)

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
@@ -72,6 +72,21 @@ CUBOID_XML = (
 )
 CUBOID_VOLUME = 1.0e-6  # a 1 cm cube, in m^3
 
+# MonteCarloAbsorption defaults to 1000 events per point, which dominates the runtime of every
+# correction applied below. None of the checks here need converged factors - they ask whether the
+# settings reached the algorithm and whether changing the inputs changed the result - and the
+# algorithm is seeded, so a cheap sampling is still reproducible run to run.
+MC_EVENTS = 50
+
+
+def monte_carlo_params(rows=5, columns=10):
+    """The Monte Carlo settings string the interface takes, with a cheap event count.
+
+    ``rows`` and ``columns`` default to the algorithm's own sparse grid, so only the event count
+    differs from what a user would get.
+    """
+    return f"SparseInstrument:True,EventsPerPoint:{MC_EVENTS},NumberOfDetectorRows:{rows},NumberOfDetectorColumns:{columns}"
+
 
 class _CorrectionTestBase(EngDiffGuiTestBase):
     """Loads the fabricated ENGIN-X runs into the correction table."""
@@ -84,6 +99,9 @@ class _CorrectionTestBase(EngDiffGuiTestBase):
         # keep the corrected and intermediate workspaces so they can be asserted on; the default is
         # to drop them once saved, which is checked explicitly in EngDiffGuiCorrectionApplyTest
         settings["clear_absorption_ws_after_processing"] = False
+        # keep every Monte Carlo calculation cheap; the parameters themselves are checked explicitly
+        # in EngDiffGuiCorrectionApplyTest._check_monte_carlo_parameters
+        settings["monte_carlo_params"] = monte_carlo_params()
         return settings
 
     def pre_gui_setup(self):
@@ -689,7 +707,7 @@ class EngDiffGuiCorrectionApplyTest(_CorrectionTestBase):
 
         # the parameters are only observable through the algorithm history of the workspace
         # MonteCarloAbsorption produced, which is why they are never stubbed
-        self.set_engineering_setting("monte_carlo_params", "SparseInstrument:True,NumberOfDetectorRows:5,NumberOfDetectorColumns:5")
+        self.set_engineering_setting("monte_carlo_params", monte_carlo_params(rows=5, columns=5))
         self.apply_corrections(absorption=True, divergence=False, attenuation=False)
 
         with self.check("Correction / the Monte Carlo settings reach MonteCarloAbsorption"):
@@ -704,7 +722,7 @@ class EngDiffGuiCorrectionApplyTest(_CorrectionTestBase):
             import numpy as np
 
             coarse = ADS.retrieve("_abs_corr").readY(0).copy()
-            self.set_engineering_setting("monte_carlo_params", "SparseInstrument:True,NumberOfDetectorRows:9,NumberOfDetectorColumns:9")
+            self.set_engineering_setting("monte_carlo_params", monte_carlo_params(rows=9, columns=9))
             self.apply_corrections(absorption=True, divergence=False, attenuation=False)
             self.assertFalse(
                 np.allclose(coarse, ADS.retrieve("_abs_corr").readY(0)),

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCorrectionTest.py
@@ -386,12 +386,15 @@ class EngDiffGuiCorrectionTableTest(_CorrectionTestBase):
             self.assertTrue(np.allclose(from_xyz @ from_xyz.T, np.identity(3), atol=1e-6))
             self.assertAlmostEqual(1.0, float(np.linalg.det(from_xyz)), places=6)
 
+        self.select_only([CERIA_WS])
+        self.set_engineering_setting("euler_angles_scheme", "ZXZ")
+        click(view.btn_loadOrientation)
+        process_events(2)
+        # copied so the next load cannot change it under us, as getR() returns a view of the
+        # goniometer's own matrix
+        from_zxz = ADS.retrieve(CERIA_WS).run().getGoniometer().getR().copy()
+
         with self.check("Correction / changing the Euler scheme changes how the same file is read"):
-            self.select_only([CERIA_WS])
-            self.set_engineering_setting("euler_angles_scheme", "ZXZ")
-            click(view.btn_loadOrientation)
-            process_events(2)
-            from_zxz = ADS.retrieve(CERIA_WS).run().getGoniometer().getR()
             self.assertFalse(np.allclose(from_xyz, from_zxz), "the Euler scheme setting had no effect")
 
         with self.check("Correction / reversing the sense of rotation also changes the result"):
@@ -582,6 +585,11 @@ class EngDiffGuiCorrectionApplyTest(_CorrectionTestBase):
             # the algorithm strips the shape string before storing it as a run log
             return ADS.retrieve(CERIA_WS).run().getLogData("GaugeVolume").value.strip()
 
+        # chosen here rather than left to whatever an earlier check happened to leave selected, so
+        # the log and the factors below are known to belong to the preset
+        select_combo(self.correction_view.combo_shapeMethod, "4mmCube")
+        self.apply_corrections(absorption=True, divergence=False, attenuation=False)
+
         with self.check("Correction / the 4mm cube preset is written to the run as a gauge volume"):
             self.assertEqual(get_cube_xml("some-gv", 0.004).strip(), logged_gauge_volume())
 
@@ -661,7 +669,8 @@ class EngDiffGuiCorrectionApplyTest(_CorrectionTestBase):
             scale = vert * np.sqrt(horz**2 + det_horz**2)
             two_theta = ADS.retrieve(CERIA_WS).spectrumInfo().twoTheta(0)
             expected = scale * np.sin(two_theta) ** 2
-            ratio = uncorrected[uncorrected != 0.0] / corrected[uncorrected != 0.0]
+            usable = (uncorrected != 0.0) & (corrected != 0.0)
+            ratio = uncorrected[usable] / corrected[usable]
             self.assertTrue(np.allclose(expected, ratio, rtol=1e-6), f"expected a divergence factor of {expected}, got {ratio[:3]}")
 
         with self.check("Correction / changing the divergence changes the correction"):

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCroppingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCroppingTest.py
@@ -1,0 +1,400 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the calibration region of interest on ENGIN-X.
+
+Split out from ``EngDiffGuiRunProcessingTest`` because a class is the unit of both skipping and
+runtime, and the region-of-interest cases are the most expensive part of the suite: each one is a
+separate real ``PDCalibration``.
+
+Three classes, in increasing cost:
+
+* ``EngDiffGuiRoiOptionsTest`` drives the cropping widget without calibrating at all, so it covers
+  every option and every widget interaction cheaply and can gate pull requests.
+* ``EngDiffGuiCroppedCalibrationTest`` calibrates and focuses for a single bank and for a custom
+  spectrum range, which is where the file naming actually differs.
+* ``EngDiffGuiTextureRoiTest`` calibrates and focuses a texture grouping, which additionally has its
+  own save layout and its own rule about the RB number.
+
+The ceria and vanadium runs are fabricated - see ``create_synthetic_ceria_and_vanadium`` and the
+module docstring of ``EngDiffGuiRunProcessingTest`` for why.
+"""
+
+import os
+
+from eng_diff_gui_test_base import (
+    ENGINX_SYNTHETIC_CERIA_RUN,
+    ENGINX_SYNTHETIC_VANADIUM_RUN,
+    EngDiffGuiTestBase,
+    TAB_RUN_PROCESSING,
+    create_enginx_ceria_and_vanadium,
+)
+from qt_interaction_helpers import combo_items, process_events, select_combo
+
+INSTRUMENT = "ENGINX"
+CERIA = str(ENGINX_SYNTHETIC_CERIA_RUN)
+VANADIUM = str(ENGINX_SYNTHETIC_VANADIUM_RUN)
+
+# the region of interest options ENGIN-X offers, in the order the combo lists them
+EXPECTED_ROI_OPTIONS = (
+    "Custom Grouping File",
+    "1 (North)",
+    "2 (South)",
+    "Crop to Spectra",
+    "Texture20",
+    "Texture30",
+)
+
+CUSTOM_SPECTRA = "1200-2400"
+TEXTURE_GROUPS = 20
+
+
+class _CroppingTestBase(EngDiffGuiTestBase):
+    """Stages the fabricated ENGIN-X runs and points the interface's file finder at them."""
+
+    def requiredMemoryMB(self):
+        return 4000
+
+    def seeded_settings(self):
+        settings = super(_CroppingTestBase, self).seeded_settings()
+        # the fixture generates Gaussian peaks, so the fit has to look for the same shape
+        settings["default_peak_ENGINX"] = "Gaussian"
+        return settings
+
+    def pre_gui_setup(self):
+        self.data_dir = os.path.join(self.tmp_root, "enginx_data")
+        os.makedirs(self.data_dir, exist_ok=True)
+        create_enginx_ceria_and_vanadium(self.data_dir)
+        self.add_data_search_dir(self.data_dir)
+
+    def custom_grouping_file(self):
+        """A grouping file to feed the 'Custom Grouping File' option.
+
+        The shipped North bank grouping is used rather than a fabricated one: it is a real file of
+        the right form, and the point of the option is that an arbitrary file is accepted, not what
+        is in it. Its trailing name part is what ends up in the output file names.
+        """
+        from Engineering.EnggUtils import CALIB_DIR
+
+        return os.path.join(CALIB_DIR, "ENGINX_North_grouping.xml")
+
+    def focused_basename(self, suffix, xunit):
+        return f"{INSTRUMENT}_{CERIA}_{VANADIUM}_{suffix}_{xunit}"
+
+
+class EngDiffGuiRoiOptionsTest(_CroppingTestBase):
+    """Every region of interest option, driven through the widget but stopping short of calibrating.
+
+    Cheap enough to run everywhere - it needs no run data - so it is the regression check that the
+    combo, the conditional inputs and the grouping each option produces all stay correct.
+    """
+
+    def excludeInPullRequests(self):
+        return False
+
+    def pre_gui_setup(self):
+        # no calibration is run here, so the fabricated runs are not needed
+        pass
+
+    def _run_checks(self):
+        self.show_tab(TAB_RUN_PROCESSING)
+        self._check_combo_and_visibility()
+        self._check_selected_groups()
+        self._check_spectra_validation()
+        self._check_grouping_workspaces()
+        self._check_output_file_names()
+
+    def _check_combo_and_visibility(self):
+        view = self.run_processing_view
+
+        with self.check("Cropping / the region of interest inputs are hidden until it is ticked"):
+            self.assertFalse(self.cropping_view.isVisible())
+
+        self.set_region_of_interest("1 (North)")
+
+        with self.check("Cropping / ticking the box reveals the region of interest widget"):
+            self.assertTrue(self.cropping_view.isVisible())
+
+        with self.check("Cropping / ENGIN-X offers exactly its own grouping options"):
+            self.assertEqual(list(EXPECTED_ROI_OPTIONS), combo_items(self.cropping_view.combo_bank))
+
+        with self.check("Cropping / a bank option needs no extra input"):
+            self.assertFalse(self.cropping_view.widget_custom.isVisible())
+            self.assertFalse(self.cropping_view.widget_crop.isVisible())
+
+        select_combo(self.cropping_view.combo_bank, "Custom Grouping File")
+        with self.check("Cropping / 'Custom Grouping File' reveals the file finder only"):
+            self.assertTrue(self.cropping_view.widget_custom.isVisible())
+            self.assertFalse(self.cropping_view.widget_crop.isVisible())
+
+        select_combo(self.cropping_view.combo_bank, "Crop to Spectra")
+        with self.check("Cropping / 'Crop to Spectra' reveals the spectrum number field only"):
+            self.assertTrue(self.cropping_view.widget_crop.isVisible())
+            self.assertFalse(self.cropping_view.widget_custom.isVisible())
+
+        select_combo(self.cropping_view.combo_bank, "Texture20")
+        with self.check("Cropping / a texture option needs no extra input either"):
+            self.assertFalse(self.cropping_view.widget_custom.isVisible())
+            self.assertFalse(self.cropping_view.widget_crop.isVisible())
+
+        # unticking must put the widget away again, otherwise the next calibration would silently
+        # keep using whatever was last selected
+        self.set_region_of_interest(None)
+        with self.check("Cropping / unticking the box hides the region of interest widget"):
+            self.assertFalse(self.cropping_view.isVisible())
+            self.assertFalse(view.get_crop_checked())
+
+    def _check_selected_groups(self):
+        from Engineering.common.instrument_config import ENGINX_GROUP
+
+        expected = {
+            "Custom Grouping File": ENGINX_GROUP.CUSTOM,
+            "1 (North)": ENGINX_GROUP.NORTH,
+            "2 (South)": ENGINX_GROUP.SOUTH,
+            "Crop to Spectra": ENGINX_GROUP.CROPPED,
+            "Texture20": ENGINX_GROUP.TEXTURE20,
+            "Texture30": ENGINX_GROUP.TEXTURE30,
+        }
+        cropping = self.calibration_presenter.cropping_widget
+        for description, group in expected.items():
+            self.set_region_of_interest(description)
+            with self.check(f"Cropping / selecting '{description}' selects {group}"):
+                self.assertEqual(group, cropping.get_group())
+
+    def _check_spectra_validation(self):
+        cropping = self.calibration_presenter.cropping_widget
+        self.set_region_of_interest("Crop to Spectra")
+
+        with self.check("Cropping / a valid spectrum range is accepted and cleaned up"):
+            self.cropping_view.edit_crop.setText(CUSTOM_SPECTRA)
+            process_events()
+            self.assertTrue(cropping.is_spectra_valid())
+            self.assertEqual(CUSTOM_SPECTRA, cropping.get_custom_spectra())
+            self.assertFalse(self.cropping_view.label_cropValid.isVisible())
+
+        with self.check("Cropping / an invalid spectrum range is rejected and flagged"):
+            self.cropping_view.edit_crop.setText("not a spectrum list")
+            process_events()
+            self.assertFalse(cropping.is_spectra_valid())
+            self.assertIsNone(cropping.get_custom_spectra())
+            self.assertTrue(self.cropping_view.label_cropValid.isVisible())
+            # the reason is offered as a tooltip rather than a popup, so nothing blocks
+            self.assertTrue(self.cropping_view.label_cropValid.toolTip())
+
+        with self.check("Cropping / correcting the spectrum range clears the warning"):
+            self.cropping_view.edit_crop.setText(CUSTOM_SPECTRA)
+            process_events()
+            self.assertTrue(cropping.is_spectra_valid())
+            self.assertFalse(self.cropping_view.label_cropValid.isVisible())
+
+        with self.check("Cropping / a custom grouping file is resolved and reported valid"):
+            self.set_region_of_interest("Custom Grouping File", custom_grouping_file=self.custom_grouping_file())
+            self.assertTrue(cropping.is_groupingfile_valid())
+            self.assertEqual(
+                os.path.normcase(self.custom_grouping_file()),
+                os.path.normcase(cropping.get_custom_groupingfile()),
+            )
+
+    def _check_grouping_workspaces(self):
+        """Each option must produce a grouping workspace with the right number of groups.
+
+        This is the part of the calibration that the region of interest actually decides, so it can
+        be checked without running PDCalibration at all.
+        """
+        from Engineering.common.calibration_info import CalibrationInfo
+        from Engineering.common.instrument_config import ENGINX_GROUP
+
+        expected_groups = {
+            ENGINX_GROUP.BOTH: 2,
+            ENGINX_GROUP.NORTH: 1,
+            ENGINX_GROUP.SOUTH: 1,
+            ENGINX_GROUP.TEXTURE20: TEXTURE_GROUPS,
+            ENGINX_GROUP.TEXTURE30: 30,
+        }
+        for group, count in expected_groups.items():
+            with self.check(f"Cropping / {group} produces {count} focused group(s)"):
+                calibration = CalibrationInfo(group=group, instrument=INSTRUMENT)
+                calibration.set_calibration_paths(INSTRUMENT, CERIA, VANADIUM)
+                calibration.update_group_ws_from_group()
+                grouping = calibration.get_group_ws()
+                self.assertEqual(count, len(set(grouping.extractY().flatten())) - (0 in grouping.extractY()))
+
+    def _check_output_file_names(self):
+        """The region of interest is what names the calibration output, so check each form."""
+        from Engineering.common.calibration_info import CalibrationInfo
+        from Engineering.common.instrument_config import ENGINX_GROUP
+
+        cases = {
+            ENGINX_GROUP.BOTH: f"{INSTRUMENT}_{CERIA}_all_banks.prm",
+            ENGINX_GROUP.NORTH: f"{INSTRUMENT}_{CERIA}_bank_1.prm",
+            ENGINX_GROUP.SOUTH: f"{INSTRUMENT}_{CERIA}_bank_2.prm",
+            ENGINX_GROUP.TEXTURE20: f"{INSTRUMENT}_{CERIA}_Texture20.prm",
+            ENGINX_GROUP.TEXTURE30: f"{INSTRUMENT}_{CERIA}_Texture30.prm",
+        }
+        for group, expected in cases.items():
+            with self.check(f"Cropping / {group} names its output '{expected}'"):
+                calibration = CalibrationInfo(group=group, instrument=INSTRUMENT)
+                calibration.set_calibration_paths(INSTRUMENT, CERIA, VANADIUM)
+                self.assertEqual(expected, calibration.generate_output_file_name())
+
+        with self.check("Cropping / a cropped calibration carries the spectrum range in its name"):
+            calibration = CalibrationInfo(group=ENGINX_GROUP.CROPPED, instrument=INSTRUMENT)
+            calibration.set_calibration_paths(INSTRUMENT, CERIA, VANADIUM)
+            calibration.set_spectra_list(CUSTOM_SPECTRA)
+            calibration.set_extra_group_suffix()
+            self.assertEqual(f"{INSTRUMENT}_{CERIA}_Cropped_{CUSTOM_SPECTRA}.prm", calibration.generate_output_file_name())
+
+
+class EngDiffGuiCroppedCalibrationTest(_CroppingTestBase):
+    """A real calibrate and focus for a single bank and for a custom spectrum range."""
+
+    def excludeInPullRequests(self):
+        return True
+
+    def _run_checks(self):
+        self._check_single_bank()
+        self._check_cropped_to_spectra()
+
+    def _check_single_bank(self):
+        from Engineering.common.instrument_config import ENGINX_GROUP
+        from mantid.api import AnalysisDataService as ADS
+
+        self.set_region_of_interest("1 (North)")
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the North bank calibration reported itself invalid")
+
+        with self.check("Cropping / a North bank calibration records that group"):
+            self.assertEqual(ENGINX_GROUP.NORTH, calibration.get_group())
+
+        with self.check("Cropping / a North bank calibration writes exactly one prm and one nxs"):
+            written = self.basenames_under(self.calibration_dir())
+            self.assertEqual(
+                sorted([f"{INSTRUMENT}_{CERIA}_bank_1.prm", f"{INSTRUMENT}_{CERIA}_bank_1.nxs"]),
+                sorted(written),
+                "a cropped calibration must not write the other banks",
+            )
+
+        self.focus(runs=CERIA)
+        with self.check("Cropping / focusing a single bank gives a single spectrum"):
+            focused = self.focused_workspace_names()
+            self.assertEqual(1, len(focused), f"expected one focused workspace, got {focused}")
+            self.assertEqual(1, ADS.retrieve(focused[0]).getNumberHistograms())
+
+        with self.check("Cropping / the focused files are named for the bank"):
+            written = self.basenames_under(self.focus_dir())
+            self.assertIn(self.focused_basename("bank_1", "TOF") + ".nxs", written)
+            self.assertIn(self.focused_basename("bank_1", "TOF") + ".gss", written)
+
+    def _check_cropped_to_spectra(self):
+        from Engineering.common.instrument_config import ENGINX_GROUP
+        from mantid.api import AnalysisDataService as ADS
+
+        self.set_region_of_interest("Crop to Spectra", custom_spectra=CUSTOM_SPECTRA)
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the cropped calibration reported itself invalid")
+
+        with self.check("Cropping / a cropped calibration records the group and the spectrum range"):
+            self.assertEqual(ENGINX_GROUP.CROPPED, calibration.get_group())
+            self.assertEqual(CUSTOM_SPECTRA, calibration.spectra_list_str)
+
+        expected_stem = f"{INSTRUMENT}_{CERIA}_Cropped_{CUSTOM_SPECTRA}"
+        written = self.basenames_under(self.calibration_dir())
+
+        with self.check("Cropping / a cropped calibration names its output for the spectrum range"):
+            self.assertIn(expected_stem + ".prm", written)
+            self.assertIn(expected_stem + ".nxs", written)
+
+        with self.check("Cropping / the grouping used is saved alongside, so the crop is reproducible"):
+            # only custom and cropped groupings are saved - the bank and texture ones ship with the
+            # instrument, so there would be nothing to record
+            self.assertIn(expected_stem + ".xml", written)
+
+        self.focus(runs=CERIA)
+        with self.check("Cropping / focusing a cropped calibration gives a single spectrum"):
+            from Engineering.EnggUtils import FOCUSED_OUTPUT_WORKSPACE_NAME
+
+            # named for the region of interest, so it sits alongside the North bank output from the
+            # first half of this test rather than replacing it
+            expected_ws = f"{CERIA}_{FOCUSED_OUTPUT_WORKSPACE_NAME}Cropped_{CUSTOM_SPECTRA}"
+            self.assertIn(expected_ws, self.focused_workspace_names())
+            self.assertEqual(1, ADS.retrieve(expected_ws).getNumberHistograms())
+
+        with self.check("Cropping / the focused files carry the cropped suffix too"):
+            focused_written = self.basenames_under(self.focus_dir())
+            self.assertIn(self.focused_basename(f"Cropped_{CUSTOM_SPECTRA}", "TOF") + ".nxs", focused_written)
+
+
+class EngDiffGuiTextureRoiTest(_CroppingTestBase):
+    """A real calibrate and focus for a texture grouping, and its RB number rule.
+
+    Texture groupings save differently from every other option: the focused output goes into its own
+    subdirectory, and once an RB number is set the output goes *only* to the RB directory, to keep
+    the number of files down.
+    """
+
+    RB_NUMBER = "7654321"
+
+    def excludeInPullRequests(self):
+        return True
+
+    def _run_checks(self):
+        from Engineering.common.instrument_config import ENGINX_GROUP
+        from mantid.api import AnalysisDataService as ADS
+
+        self.set_region_of_interest("Texture20")
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the texture calibration reported itself invalid")
+
+        with self.check("Cropping / a texture calibration records the texture group"):
+            self.assertEqual(ENGINX_GROUP.TEXTURE20, calibration.get_group())
+            self.assertTrue(calibration.is_texture_group())
+
+        with self.check("Cropping / a texture calibration writes one prm and nxs named for the grouping"):
+            written = self.basenames_under(self.calibration_dir())
+            self.assertIn(f"{INSTRUMENT}_{CERIA}_Texture20.prm", written)
+            self.assertIn(f"{INSTRUMENT}_{CERIA}_Texture20.nxs", written)
+
+        with self.check("Cropping / the texture prm describes every group in the grouping"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            prm = os.path.join(self.calibration_dir(), f"{INSTRUMENT}_{CERIA}_Texture20.prm")
+            self.assertEqual(TEXTURE_GROUPS, len(read_diff_constants_from_prm(prm)))
+
+        self.focus(runs=CERIA)
+
+        with self.check("Cropping / focusing a texture calibration gives one spectrum per group"):
+            focused = self.focused_workspace_names()
+            self.assertEqual(1, len(focused), f"expected one focused workspace, got {focused}")
+            self.assertEqual(TEXTURE_GROUPS, ADS.retrieve(focused[0]).getNumberHistograms())
+
+        texture_focus_dir = os.path.join(self.focus_dir(), "Texture20")
+        with self.check("Cropping / texture focused output goes into its own subdirectory"):
+            written = self.basenames_under(texture_focus_dir)
+            self.assertIn(self.focused_basename("Texture20", "TOF") + ".gss", written)
+            for group in (1, TEXTURE_GROUPS):
+                self.assertIn(self.focused_basename(f"Texture20_{group}", "TOF") + ".nxs", written)
+
+        with self.check("Cropping / a nexus file is written for every texture group"):
+            written = self.basenames_under(texture_focus_dir, ".nxs")
+            per_group = [name for name in written if "_Texture20_" in name and "_TOF" in name]
+            self.assertEqual(TEXTURE_GROUPS, len(per_group))
+
+        self._check_rb_number_rule(texture_focus_dir)
+
+    def _check_rb_number_rule(self, texture_focus_dir):
+        before = set(self.files_under(texture_focus_dir))
+
+        self.set_rb_number(self.RB_NUMBER)
+        self.focus(runs=CERIA)
+        process_events(2)
+
+        with self.check("Cropping / with an RB number texture output goes to the RB directory"):
+            rb_dir = os.path.join(self.focus_dir(self.RB_NUMBER), "Texture20")
+            self.assertIn(self.focused_basename("Texture20", "TOF") + ".gss", self.basenames_under(rb_dir))
+
+        with self.check("Cropping / and *only* there, to limit the number of files saved"):
+            # unlike a non-texture grouping, which is written to both places
+            self.assertEqual(before, set(self.files_under(texture_focus_dir)))

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCroppingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiCroppingTest.py
@@ -58,6 +58,10 @@ class _CroppingTestBase(EngDiffGuiTestBase):
     def requiredMemoryMB(self):
         return 4000
 
+    def excludeInPullRequests(self):
+        # a subclass of this base runs a real calibration unless it says otherwise
+        return True
+
     def seeded_settings(self):
         settings = super(_CroppingTestBase, self).seeded_settings()
         # the fixture generates Gaussian peaks, so the fit has to look for the same shape
@@ -219,8 +223,9 @@ class EngDiffGuiRoiOptionsTest(_CroppingTestBase):
                 calibration = CalibrationInfo(group=group, instrument=INSTRUMENT)
                 calibration.set_calibration_paths(INSTRUMENT, CERIA, VANADIUM)
                 calibration.update_group_ws_from_group()
-                grouping = calibration.get_group_ws()
-                self.assertEqual(count, len(set(grouping.extractY().flatten())) - (0 in grouping.extractY()))
+                group_ids = set(calibration.get_group_ws().extractY().flatten())
+                group_ids.discard(0.0)  # 0 marks a detector that is in no group
+                self.assertEqual(count, len(group_ids), f"{group} did not produce {count} group(s), got {sorted(group_ids)}")
 
     def _check_output_file_names(self):
         """The region of interest is what names the calibration output, so check each form."""

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiFittingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiFittingTest.py
@@ -217,7 +217,6 @@ class EngDiffGuiFittingDataTest(_FittingTestBase):
             for row in range(self.table().rowCount()):
                 self.assertTrue(self.data_view.get_item_checked(row, COL_BGSUB), f"row {row} has no background subtraction")
 
-        bgsub_name = f"{CERIA}_{INSTRUMENT}_bank_1_TOF_bgsub"
         candidates = [name for name in ADS.getObjectNames() if name.endswith("_bgsub")]
         with self.check("Test 5 / a background subtracted workspace is created for each run"):
             self.assertEqual(2, len(candidates), f"expected two _bgsub workspaces, got {candidates}")
@@ -531,5 +530,10 @@ class EngDiffGuiSequentialFitTest(_FittingTestBase):
         for term in function_string.split(","):
             key, _, value = term.partition("=")
             if key.strip() == name:
-                return float(value)
+                try:
+                    return float(value)
+                except ValueError:
+                    # ties and constraints put the same name on the left of an expression rather
+                    # than a number, e.g. "ties=(Sigma=0.5*Height)"
+                    raise AssertionError(f"{name} is not a fitted value in '{function_string}'")
         raise AssertionError(f"{name} is not in the fitted function '{function_string}'")

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiFittingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiFittingTest.py
@@ -1,0 +1,535 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the Fitting tab.
+
+Nothing here is mocked. The tab is reached the way the guide reaches it - by calibrating and
+focusing on the Run Processing tab first - so the notifier that prefills the fitting file finder is
+exercised rather than assumed, and the workspaces being fitted are the ones focusing actually
+produced.
+
+The fits are real ``Fit`` calls against the real ``EngDiffFitPropertyBrowser``. Because the
+fabricated runs carry Gaussian peaks (see ``create_synthetic_ceria_and_vanadium``), the model fitted
+here is a Gaussian on a linear background, positioned from the calibration rather than hard coded, so
+the fit has a well conditioned answer and the assertions can be about parameter values rather than
+just "something ran".
+
+Two sample runs are fabricated and focused, purely so there are two runs to fit: that is what makes
+the serial/sequential distinction and the run ordering observable at all.
+"""
+
+import os
+
+from eng_diff_gui_test_base import (
+    ENGINX_SYNTHETIC_CERIA_RUN,
+    ENGINX_SYNTHETIC_VANADIUM_RUN,
+    EngDiffGuiTestBase,
+    TAB_FITTING,
+    TAB_RUN_PROCESSING,
+    create_enginx_ceria_and_vanadium,
+)
+from qt_interaction_helpers import (
+    click,
+    figure_numbers,
+    process_events,
+    set_checkbox,
+    wait_until,
+)
+
+INSTRUMENT = "ENGINX"
+CERIA = str(ENGINX_SYNTHETIC_CERIA_RUN)
+VANADIUM = str(ENGINX_SYNTHETIC_VANADIUM_RUN)
+
+# a second sample run carrying the same peaks as the ceria one, so there are two runs to fit. The
+# vanadium is not usable for this: it is deliberately featureless, so a peak fitted to it lands
+# somewhere arbitrary.
+SECOND_SAMPLE = str(ENGINX_SYNTHETIC_CERIA_RUN + 1)
+
+# table_selection columns, as built in FittingDataView.add_table_row
+COL_RUN, COL_BANK, COL_PLOT, COL_BGSUB, COL_NITER, COL_XWINDOW, COL_SG = range(7)
+
+# a ceria d-spacing well inside the ENGIN-X calibration window and clear of its neighbours, used to
+# place the fit range; the actual TOF is derived from the calibration at runtime
+FIT_PEAK_D = 2.7059
+
+
+class _FittingTestBase(EngDiffGuiTestBase):
+    """Calibrates and focuses so the fitting tab has something real to work with."""
+
+    def requiredMemoryMB(self):
+        return 4000
+
+    def excludeInPullRequests(self):
+        return True
+
+    def seeded_settings(self):
+        settings = super(_FittingTestBase, self).seeded_settings()
+        # the fixture generates Gaussian peaks, so both the calibration and the fit look for those
+        settings["default_peak_ENGINX"] = "Gaussian"
+        return settings
+
+    def pre_gui_setup(self):
+        self.data_dir = os.path.join(self.tmp_root, "enginx_data")
+        os.makedirs(self.data_dir, exist_ok=True)
+        create_enginx_ceria_and_vanadium(self.data_dir, extra_sample_runs=(int(SECOND_SAMPLE),))
+        self.add_data_search_dir(self.data_dir)
+
+    # ------------------------------------------------------------------ setup
+
+    def calibrate_and_focus(self):
+        """Produce the focused data the fitting tab consumes.
+
+        The North bank only: one spectrum per run keeps both the focus and every subsequent fit
+        cheap, and nothing in this tab depends on the number of banks.
+        """
+        self.show_tab(TAB_RUN_PROCESSING)
+        self.set_region_of_interest("1 (North)")
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the calibration reported itself invalid")
+        # both sample runs are focused so there are two to fit
+        self.focus(runs=f"{CERIA}, {SECOND_SAMPLE}")
+        return calibration
+
+    # ------------------------------------------------------------------ the tab
+
+    @property
+    def data_view(self):
+        return self.fitting_presenter.data_widget.view
+
+    @property
+    def data_presenter(self):
+        return self.fitting_presenter.data_widget.presenter
+
+    @property
+    def plot_presenter(self):
+        return self.fitting_presenter.plot_widget
+
+    @property
+    def plot_view(self):
+        return self.fitting_presenter.plot_widget.view
+
+    def table(self):
+        return self.data_view.table_selection
+
+    def load_focused_data(self, add_to_plot=True):
+        """Press Load on the fitting tab and wait for its worker."""
+        self.show_tab(TAB_FITTING)
+        set_checkbox(self.data_view.check_addToPlot, add_to_plot)
+        click(self.data_view.button_load)
+        self.wait_for_async_task(self.data_presenter.worker, what="fitting data load")
+        process_events(3)
+
+    def focused_files(self):
+        """The focused nexus files, as the prefill notifier offers them."""
+        return [name for name in self.basenames_under(self.focus_dir(), ".nxs") if "_TOF" in name]
+
+    def table_run_column(self):
+        return [self.table().item(row, COL_RUN).text() for row in range(self.table().rowCount())]
+
+
+class EngDiffGuiFittingDataTest(_FittingTestBase):
+    """Guide Test 5: loading focused data, the selection table and the background subtraction."""
+
+    def _run_checks(self):
+        self.calibrate_and_focus()
+        self._check_prefill_and_filters()
+        self._check_loading()
+        self._check_plot_checkbox()
+        self._check_background_subtraction()
+        self._check_plot_background_button()
+        self._check_removal()
+
+    def _check_prefill_and_filters(self):
+        self.show_tab(TAB_FITTING)
+        finder = self.data_view.finder_data
+
+        with self.check("Test 5 / focusing prefills the fitting file finder"):
+            text = finder.getText()
+            self.assertTrue(text, "the fitting finder was not prefilled after focusing")
+            for run in (CERIA, SECOND_SAMPLE):
+                self.assertIn(run, text, f"{run} is missing from the prefilled file list")
+
+        with self.check("Test 5 / the finder is prefilled with the TOF files"):
+            self.assertIn("_TOF", finder.getText())
+
+        # the browse filter is built from the two combos, and it is what decides which of the many
+        # focused outputs a user is offered
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.data_handling.data_view import (
+            _file_filter_generator,
+        )
+
+        with self.check("Test 5 / the Unit and Region filters build the expected file filter"):
+            self.assertEqual("*bank_1*_TOF*", _file_filter_generator({"Region": "1 (North)", "Unit": "TOF"}))
+            self.assertEqual("*Texture*_dSpacing*", _file_filter_generator({"Region": "Texture", "Unit": "dSpacing"}))
+            self.assertEqual("*bank_*", _file_filter_generator({"Region": "Both Banks", "Unit": "No Unit Filter"}))
+
+    def _check_loading(self):
+        self.load_focused_data(add_to_plot=True)
+
+        with self.check("Test 5 / one table row appears per focused file"):
+            self.assertEqual(2, self.table().rowCount(), f"expected two rows, got {self.table_run_column()}")
+
+        with self.check("Test 5 / the table names the run and the bank it came from"):
+            self.assertEqual(sorted([CERIA, SECOND_SAMPLE]), sorted(self.table_run_column()))
+            # the bank comes from the "bankid" log the focus writes, which has its underscores
+            # replaced with spaces so it reads as a label
+            banks = {self.table().item(row, COL_BANK).text() for row in range(self.table().rowCount())}
+            self.assertEqual({"bank 1"}, banks)
+
+        with self.check("Test 5 / the loaded workspaces are tracked by the model"):
+            loaded = self.data_presenter.get_loaded_ws_list()
+            self.assertEqual(2, len(loaded), f"expected two loaded workspaces, got {loaded}")
+
+        with self.check("Test 5 / a log workspace group is created for the loaded runs"):
+            from mantid.api import AnalysisDataService as ADS
+
+            group_name = self.data_presenter.get_log_ws_group_name()
+            self.assertTrue(ADS.doesExist(group_name), f"{group_name} was not created")
+
+    def _check_plot_checkbox(self):
+        with self.check("Test 5 / with Add To Plot ticked the rows are marked as plotted"):
+            for row in range(self.table().rowCount()):
+                self.assertTrue(self.data_view.get_item_checked(row, COL_PLOT), f"row {row} is not marked as plotted")
+
+        with self.check("Test 5 / and the lines really are on the axes"):
+            axes = self.plot_view.get_axes()[0]
+            self.assertTrue(axes.get_lines(), "nothing was plotted")
+
+        with self.check("Test 5 / unticking a row's Plot box removes its line"):
+            before = len(self.plot_view.get_axes()[0].get_lines())
+            self.data_view.set_item_checkstate(0, COL_PLOT, False)
+            process_events(3)
+            self.assertLess(len(self.plot_view.get_axes()[0].get_lines()), before)
+
+        with self.check("Test 5 / and re-ticking it puts the line back"):
+            before = len(self.plot_view.get_axes()[0].get_lines())
+            self.data_view.set_item_checkstate(0, COL_PLOT, True)
+            process_events(3)
+            self.assertGreater(len(self.plot_view.get_axes()[0].get_lines()), before)
+
+    def _check_background_subtraction(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        with self.check("Test 5 / background subtraction is on by default for a newly loaded run"):
+            for row in range(self.table().rowCount()):
+                self.assertTrue(self.data_view.get_item_checked(row, COL_BGSUB), f"row {row} has no background subtraction")
+
+        bgsub_name = f"{CERIA}_{INSTRUMENT}_bank_1_TOF_bgsub"
+        candidates = [name for name in ADS.getObjectNames() if name.endswith("_bgsub")]
+        with self.check("Test 5 / a background subtracted workspace is created for each run"):
+            self.assertEqual(2, len(candidates), f"expected two _bgsub workspaces, got {candidates}")
+
+        # work with whichever one belongs to the ceria run, without assuming the exact prefix
+        bgsub_name = next((name for name in candidates if CERIA in name), None)
+        self.assertIsNotNone(bgsub_name, f"no _bgsub workspace for run {CERIA} in {candidates}")
+
+        with self.check("Test 5 / the subtracted data really is below the raw data"):
+            import numpy as np
+
+            raw_name = bgsub_name[: -len("_bgsub")]
+            raw = ADS.retrieve(raw_name).readY(0)
+            subtracted = ADS.retrieve(bgsub_name).readY(0)
+            self.assertTrue(np.all(subtracted <= raw + 1e-9), "the background subtraction increased the counts")
+            self.assertLess(subtracted.sum(), raw.sum(), "the background subtraction removed nothing")
+
+        with self.check("Test 5 / changing the number of iterations changes the subtracted data"):
+            import numpy as np
+
+            before = ADS.retrieve(bgsub_name).readY(0).copy()
+            row = self.table_run_column().index(CERIA)
+            self.data_view.set_table_column(row, COL_NITER, 200)
+            process_events(3)
+            wait_until(
+                lambda: not np.allclose(before, ADS.retrieve(bgsub_name).readY(0)),
+                timeout=60.0,
+                msg="the background estimate to be recalculated",
+            )
+
+        with self.check("Test 5 / turning the Savitzky-Golay filter off also changes it"):
+            import numpy as np
+
+            before = ADS.retrieve(bgsub_name).readY(0).copy()
+            row = self.table_run_column().index(CERIA)
+            self.data_view.set_item_checkstate(row, COL_SG, False)
+            process_events(3)
+            wait_until(
+                lambda: not np.allclose(before, ADS.retrieve(bgsub_name).readY(0)),
+                timeout=60.0,
+                msg="the background estimate to be recalculated without the filter",
+            )
+
+        with self.check("Test 5 / unticking background subtraction puts the raw data back on the plot"):
+            row = self.table_run_column().index(CERIA)
+            self.data_view.set_item_checkstate(row, COL_BGSUB, False)
+            process_events(3)
+            raw_name = bgsub_name[: -len("_bgsub")]
+            self.assertIn(raw_name, self.data_presenter.plotted)
+            self.assertNotIn(bgsub_name, self.data_presenter.plotted)
+            # the subtracted workspace itself is deliberately kept, so re-ticking is instant rather
+            # than recalculating the background
+            self.assertTrue(ADS.doesExist(bgsub_name))
+
+    def _check_plot_background_button(self):
+        with self.check("Test 5 / the Inspect Background button needs a selected row"):
+            self.table().clearSelection()
+            process_events(2)
+            self.assertFalse(self.data_view.button_plotBG.isEnabled())
+
+        with self.check("Test 5 / selecting a row enables it"):
+            self.table().selectRow(0)
+            process_events(2)
+            self.assertTrue(self.data_view.button_plotBG.isEnabled())
+
+        with self.check("Test 5 / and pressing it opens a figure"):
+            # re-enable the subtraction on the selected row, which is what there is to inspect
+            row = 0
+            self.data_view.set_item_checkstate(row, COL_BGSUB, True)
+            process_events(3)
+            before = figure_numbers()
+            click(self.data_view.button_plotBG)
+            process_events(3)
+            self.assertTrue(figure_numbers() - before, "Inspect Background opened no figure")
+
+    def _check_removal(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        self.table().selectRow(0)
+        removed_run = self.table().item(0, COL_RUN).text()
+        removed_ws = self.data_presenter.row_numbers[0]
+
+        with self.check("Test 5 / Remove Selected drops just that row"):
+            click(self.data_view.button_removeSelected)
+            process_events(3)
+            self.assertEqual(1, self.table().rowCount())
+            self.assertNotIn(removed_run, self.table_run_column())
+
+        with self.check("Test 5 / and its workspaces leave the ADS with it"):
+            # both the focused workspace and its background subtracted partner
+            self.assertFalse(ADS.doesExist(removed_ws), f"{removed_ws} survived removal")
+            self.assertFalse(ADS.doesExist(f"{removed_ws}_bgsub"), f"{removed_ws}_bgsub survived removal")
+
+        with self.check("Test 5 / Remove All empties the table"):
+            click(self.data_view.button_removeAll)
+            process_events(3)
+            self.assertEqual(0, self.table().rowCount())
+            self.assertEqual([], self.data_presenter.get_loaded_ws_list())
+
+
+class EngDiffGuiSequentialFitTest(_FittingTestBase):
+    """Guide Test 5: fitting from the plot toolbar, and the outputs a fit produces."""
+
+    RB_NUMBER = "9876543"
+
+    def _run_checks(self):
+        self.calibrate_and_focus()
+        self.set_rb_number(self.RB_NUMBER)
+        self.load_focused_data(add_to_plot=True)
+        # the background subtraction would move the peak heights around under the fit; the fits here
+        # are about the fitting machinery, so the raw focused data is used
+        self._disable_background_subtraction()
+
+        self._prepare_fit_browser()
+        self._check_serial_fit()
+        self._check_sequential_fit()
+        self._check_fit_outputs()
+        self._check_run_ordering()
+
+    def _disable_background_subtraction(self):
+        for row in range(self.table().rowCount()):
+            self.data_view.set_item_checkstate(row, COL_BGSUB, False)
+        process_events(3)
+
+    # ------------------------------------------------------------------ the fit browser
+
+    def _peak_tof(self):
+        """Where the chosen ceria peak sits in TOF, from the calibration rather than hard coded."""
+        from mantid.api import AnalysisDataService as ADS
+        from mantid.kernel import DeltaEModeType, UnitConversion
+
+        ws_name = self.data_presenter.get_loaded_ws_list()[0]
+        diff_consts = ADS.retrieve(ws_name).spectrumInfo().diffractometerConstants(0)
+        return UnitConversion.run("dSpacing", "TOF", FIT_PEAK_D, 0, DeltaEModeType.Elastic, diff_consts)
+
+    def _prepare_fit_browser(self):
+        browser = self.plot_view.fit_browser
+        centre = self._peak_tof()
+        # the fixture writes sigma as a fixed fraction of the peak position
+        sigma = 0.002 * centre
+
+        # open the fit browser the way the toolbar does
+        self.plot_presenter.fit_toggle()
+        process_events(3)
+
+        with self.check("Test 5 / the fit browser opens once data is plotted"):
+            self.assertTrue(browser.isVisible(), "the fit browser did not open")
+
+        with self.check("Test 5 / the browser's default peak comes from the instrument setting"):
+            self.assertEqual("Gaussian", browser.defaultPeakType())
+
+        browser.loadFunction(
+            f"name=LinearBackground,A0=100,A1=0;name=Gaussian,Height=1000,PeakCentre={centre},Sigma={sigma}",
+        )
+        browser.setStartX(centre - 8.0 * sigma)
+        browser.setEndX(centre + 8.0 * sigma)
+        process_events(2)
+
+        # a precondition: without a readable fit setup neither fit below does anything at all
+        fitprop = self.plot_view.read_fitprop_from_browser()
+        self.assertIsNotNone(fitprop, "the fit browser has no usable fit setup")
+        self.assertIn("Gaussian", fitprop["properties"]["Function"])
+
+    def _do_fit_all(self, sequential):
+        if sequential:
+            self.plot_presenter.do_seq_fit()
+        else:
+            self.plot_presenter.do_serial_fit()
+        self.wait_for_async_task(self.plot_presenter.worker, what="sequential fit" if sequential else "serial fit")
+        process_events(3)
+        return self.plot_presenter.fitprop_list
+
+    def _check_serial_fit(self):
+        with self.captured_logs(level="notice") as logs:
+            fitprops = self._do_fit_all(sequential=False)
+
+        with self.check("Test 5 / a serial fit fits every loaded run"):
+            self.assertEqual(2, len(fitprops), f"expected one result per run, got {fitprops}")
+
+        with self.check("Test 5 / and reports itself as a serial fit"):
+            self.assertIn("Serial fitting finished", logs.text)
+
+        with self.check("Test 5 / each serial fit converged"):
+            for fitprop in fitprops:
+                self.assertTrue(self._converged(fitprop["status"]), f"fit status was {fitprop['status']}")
+
+        with self.check("Test 5 / the fitted peak centre is the one the fixture generated"):
+            centre = self._peak_tof()
+            for fitprop in fitprops:
+                fitted = self._fitted_parameter(fitprop["properties"]["Function"], "PeakCentre")
+                self.assertAlmostEqual(centre, fitted, delta=0.01 * centre)
+
+    def _check_sequential_fit(self):
+        with self.captured_logs(level="notice") as logs:
+            fitprops = self._do_fit_all(sequential=True)
+
+        with self.check("Test 5 / a sequential fit also fits every loaded run"):
+            self.assertEqual(2, len(fitprops), f"expected one result per run, got {fitprops}")
+
+        with self.check("Test 5 / and reports itself as a sequential fit"):
+            self.assertIn("Sequential fitting finished", logs.text)
+
+        with self.check("Test 5 / each sequential fit converged"):
+            for fitprop in fitprops:
+                self.assertTrue(self._converged(fitprop["status"]), f"fit status was {fitprop['status']}")
+
+        with self.check("Test 5 / the browser is left holding the last fitted function"):
+            self.assertIn("Gaussian", self.plot_view.read_fitprop_from_browser()["properties"]["Function"])
+
+        with self.check("Test 5 / the progress bar reports a converged fit as a success"):
+            # every run after the first starts from the previous result, so it converges on a
+            # tolerance-limited stop rather than an exact "success" - which must still read as done
+            self.assertEqual(100, self.plot_view.fit_progress_bar.value())
+            self.assertTrue(self._converged(self.plot_view.fit_progress_bar.toolTip()))
+
+    def _check_fit_outputs(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        group_name = self.data_presenter.get_log_ws_group_name().split("_log")[0] + "_fits"
+
+        with self.check("Test 5 / the fit results are grouped together"):
+            self.assertTrue(ADS.doesExist(group_name), f"{group_name} was not created")
+
+        with self.check("Test 5 / a matrix workspace is produced per fitted parameter"):
+            # named for the function the parameter belongs to, so a model with two peaks of the same
+            # type stays unambiguous
+            members = list(ADS.retrieve(group_name).getNames())
+            for parameter in ("Gaussian_PeakCentre", "Gaussian_Height", "Gaussian_Sigma", "LinearBackground_A0"):
+                self.assertIn(parameter, members, f"{parameter} is missing from {members}")
+
+        with self.check("Test 5 / the peak width is reported as an FWHM as well"):
+            self.assertIn("Gaussian_fwhm", list(ADS.retrieve(group_name).getNames()))
+
+        with self.check("Test 5 / the peak centre is also reported in d-spacing"):
+            members = list(ADS.retrieve(group_name).getNames())
+            d_parameters = [name for name in members if name.endswith("_dSpacing")]
+            self.assertTrue(d_parameters, f"no d-spacing conversion in {members}")
+
+        with self.check("Test 5 / the d-spacing conversion is of the peak that was fitted"):
+            import numpy as np
+
+            members = list(ADS.retrieve(group_name).getNames())
+            d_name = next(name for name in members if name.endswith("_dSpacing"))
+            values = ADS.retrieve(d_name).extractY()
+            finite = values[np.isfinite(values)]
+            self.assertTrue(finite.size, f"{d_name} holds no finite values")
+            self.assertTrue(np.allclose(FIT_PEAK_D, finite, rtol=0.02), f"expected d = {FIT_PEAK_D}, got {finite}")
+
+        with self.check("Test 5 / the model summary table has one row per fitted run"):
+            table = ADS.retrieve("model")
+            self.assertEqual(["Workspace", "chisq/DOF", "status", "Model"], list(table.getColumnNames()))
+            self.assertEqual(2, table.rowCount())
+            for row in range(table.rowCount()):
+                self.assertTrue(self._converged(table.cell("status", row)), f"row {row} reports {table.cell('status', row)}")
+
+        with self.check("Test 5 / a fit parameter table is saved for each run"):
+            saved = self.basenames_under(os.path.join(self.save_dir, "User", self.RB_NUMBER, "FitParameters"))
+            self.assertTrue(saved, "no fit parameter files were saved")
+            for run in (CERIA, SECOND_SAMPLE):
+                self.assertTrue(
+                    any(run in name and name.endswith("_Fit_Parameters.nxs") for name in saved),
+                    f"no fit parameter file for run {run} in {saved}",
+                )
+
+    def _check_run_ordering(self):
+        """A sequential fit feeds each result into the next, so the order it visits the runs is
+        part of the result rather than an implementation detail."""
+        from mantid.api import AnalysisDataService as ADS
+
+        # the primary log has to be one the tab actually tabulates - the combo in the settings only
+        # ever offers those, and the lookup is by name with no fallback
+        # the group also holds a run_info table, which has no per-run average and so cannot be
+        # sorted on; only the tables with an "avg" column are candidates
+        group = ADS.retrieve(self.data_presenter.get_log_ws_group_name())
+        log_tables = [name for name in group.getNames() if name.endswith("_Fitting") and "avg" in ADS.retrieve(name).getColumnNames()]
+        self.assertTrue(log_tables, f"no sortable log tables in {group.name()}")
+        primary_log = log_tables[0][: -len("_Fitting")]
+
+        self.set_engineering_setting("primary_log", primary_log)
+        self.set_engineering_setting("sort_ascending", True)
+        ascending = self.data_presenter.get_sorted_active_ws_list()
+
+        with self.check("Test 5 / sorting by a primary log keeps every run"):
+            self.assertEqual(sorted(self.data_presenter.get_active_ws_list()), sorted(ascending))
+
+        with self.check("Test 5 / unticking Ascending reverses the order the runs are fitted in"):
+            # asserted as a reversal rather than against specific log values, because two runs can
+            # legitimately share a value for a given log and then no absolute order is defined
+            self.set_engineering_setting("sort_ascending", False)
+            self.assertEqual(ascending[::-1], self.data_presenter.get_sorted_active_ws_list())
+
+        with self.check("Test 5 / with no primary log the loaded order is kept"):
+            self.set_engineering_setting("primary_log", "")
+            self.set_engineering_setting("sort_ascending", True)
+            self.assertEqual(self.data_presenter.get_active_ws_list(), self.data_presenter.get_sorted_active_ws_list())
+
+    @staticmethod
+    def _converged(status):
+        """Whether a Fit output status means the minimizer converged.
+
+        Deliberately the framework's own test rather than a substring match here, so this asserts
+        the same notion of convergence the tab itself uses.
+        """
+        from mantid.api import MinimizerStatus
+
+        return MinimizerStatus.isConverged(status)
+
+    @staticmethod
+    def _fitted_parameter(function_string, name):
+        """Pull one parameter out of the function string a fit reports back."""
+        for term in function_string.split(","):
+            key, _, value = term.partition("=")
+            if key.strip() == name:
+                return float(value)
+        raise AssertionError(f"{name} is not in the fitted function '{function_string}'")

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiGsas2Test.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiGsas2Test.py
@@ -1,0 +1,574 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the GSAS II tab, replacing the manual guide's Tests 13 and 14.
+
+GSAS-II itself is an external program, so the one thing mocked is the subprocess call that runs it;
+the canned outputs it would have produced are shipped in ``Testing/Data/UnitTest/EngDiff_gsas2_tab``
+and the mock copies them into the temporary directory the real model created. Everything on both
+sides of that seam is real: the model builds the GSAS-II command line and serialises its inputs, and
+then genuinely parses the outputs, builds the tables, moves the files to the user save location and
+plots the result.
+
+Note that mocking ``call_subprocess`` alone is not enough to avoid needing GSAS-II installed:
+``call_gsas2`` first resolves the interpreter and ``GSASIIscriptable.py`` out of the configured
+installation directory. The tests therefore stage a stub installation tree, which keeps that whole
+resolution path - and the JSON the interface would have handed to GSAS-II - under test.
+"""
+
+import json
+import os
+import shutil
+from unittest import mock
+
+import numpy as np
+
+from eng_diff_gui_test_base import EngDiffGuiTestBase, TAB_GSAS2
+from qt_interaction_helpers import click, combo_items, process_events, select_combo, set_checkbox, set_finder_text
+
+GSAS2_MODEL = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.gsas2.model"
+
+# the canned GSAS-II outputs were generated for this focused workspace, so the fabricated .gss below
+# uses the same name and bank count to stay consistent with them
+FOCUSED_BASENAME = "ENGINX_305761_307521_all_banks_TOF"
+CANNED_DIR = "EngDiff_gsas2_tab"
+PHASE_NAME = "Fe_gamma"
+PROJECT_NAME = "SysTestRefinement"
+# run_model appends the focused file's basename to the user's project name, once per data file
+FULL_PROJECT = f"{PROJECT_NAME}_{FOCUSED_BASENAME}"
+
+# a focused ENGIN-X 'all banks' file has one spectrum per bank
+N_BANKS = 2
+# diffractometer constants of roughly the right magnitude for ENGIN-X, used for the fabricated .prm
+BANK_DIFC = (18400.0, 18500.0)
+
+
+class _Gsas2TestBase(EngDiffGuiTestBase):
+    """Stages the GSAS II tab's inputs and replaces the external GSAS-II call.
+
+    Abstract - it has no ``_run_checks`` - which is also what keeps the system test collector from
+    picking it up out of the modules that import it.
+    """
+
+    def requiredFiles(self):
+        return [
+            f"{CANNED_DIR}/gsas2_output.lst",
+            f"{CANNED_DIR}/gsas2_output_1.csv",
+            f"{CANNED_DIR}/gsas2_output_cell_parameters_{PHASE_NAME}.txt",
+            f"{CANNED_DIR}/gsas2_output_inst_parameters_PWDR_{FOCUSED_BASENAME}_Bank_1.txt",
+            f"{CANNED_DIR}/gsas2_output_inst_parameters_PWDR_{FOCUSED_BASENAME}_Bank_2.txt",
+            f"{CANNED_DIR}/gsas2_output_reflections_1_{PHASE_NAME}.txt",
+            f"{CANNED_DIR}/gsas2_output_reflections_2_{PHASE_NAME}.txt",
+        ]
+
+    def pre_gui_setup(self):
+        self.inputs_dir = os.path.join(self.tmp_root, "focus_output")
+        os.makedirs(self.inputs_dir, exist_ok=True)
+        self.gss_path = _write_focused_gss(self.inputs_dir)
+        self.prm_path = _write_instrument_prm(self.inputs_dir)
+        self.gsas2_install = _stage_stub_gsas2_install(os.path.join(self.tmp_root, "gsas2"))
+
+    def seeded_settings(self):
+        settings = super(_Gsas2TestBase, self).seeded_settings()
+        # the model refuses to call GSAS-II at all without this, and the handler resolves a real
+        # interpreter out of it, hence the stub tree
+        settings["path_to_gsas2"] = self.gsas2_install
+        return settings
+
+    def setUp(self):
+        super(_Gsas2TestBase, self).setUp()
+        self.show_tab(TAB_GSAS2)
+        self.subprocess_calls = []
+        patcher = mock.patch.object(
+            type(self.gsas2_presenter.model), "call_subprocess", autospec=True, side_effect=self._fake_gsas2_subprocess
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # ------------------------------------------------------------------ the GSAS-II seam
+
+    def _fake_gsas2_subprocess(self, model, command_string_list, gsas_binary_paths):
+        """Stand in for the external GSAS-II process.
+
+        Records the command line the interface built - the third argument is the serialised inputs,
+        which is the only place several settings are observable - and drops the canned output files
+        into the temporary directory the real model has already created, renamed to whatever project
+        name the model chose. Returning them under the model's own naming rather than the canned
+        naming is what lets the checks below assert on the real ``move_output_files_to_user_save``
+        and table-building code.
+        """
+        self.subprocess_calls.append(list(command_string_list))
+        _copy_canned_outputs(model.save_directories.temporary_save_directory, model.save_directories.project_name)
+        return ("GSAS-II ran", "1.23")
+
+    def serialized_inputs(self, call_index=-1):
+        return json.loads(self.subprocess_calls[call_index][2])
+
+    # ------------------------------------------------------------------ driving the tab
+
+    def fill_in_refinement(self, project_name=PROJECT_NAME, gss_paths=None, prm_paths=None):
+        view = self.gsas2_view
+        set_finder_text(view.instrument_group_file_finder, ",".join(prm_paths or [self.prm_path]))
+        set_finder_text(view.focused_data_file_finder, ",".join(gss_paths or [self.gss_path]))
+        view.project_name_line_edit.setText(project_name)
+        process_events()
+
+    def refine(self):
+        """Click Refine and let the result settle.
+
+        Deliberately does not pause between refinements: back to back clicks are exactly the case
+        that used to collide on the second-resolution name of the model's working directory, so
+        leaving them back to back keeps that regression covered.
+        """
+        click(self.gsas2_view.refine_button)
+        process_events(3)
+
+    def gsas2_output_dir(self, project=FULL_PROJECT, rb_number=None):
+        if rb_number:
+            return os.path.join(self.save_dir, "User", rb_number, "GSAS2", project)
+        return os.path.join(self.save_dir, "GSAS2", project)
+
+
+class EngDiffGuiGsas2SingleTest(_Gsas2TestBase):
+    """One focused file with two banks - the manual guide's Test 13."""
+
+    def _run_checks(self):
+        self._check_initial_tab_state()
+        self._check_phase_selection()
+        self._check_invalid_inputs_are_reported()
+        self._check_refinement_outputs()
+        self._check_saved_files()
+        self._check_serialized_inputs()
+        self._check_plot()
+        self._check_x_limits_round_trip()
+
+    # -------------------------------------------------------------- initial state
+
+    def _check_initial_tab_state(self):
+        view = self.gsas2_view
+        with self.check("Test 13 / an empty project name is flagged as invalid"):
+            self.assertTrue(view.project_name_invalid.isVisible())
+            self.assertIn("No Project Name", view.project_name_invalid.toolTip())
+
+        view.project_name_line_edit.setText(PROJECT_NAME)
+        process_events()
+        with self.check("Test 13 / the invalid marker clears once a project name is given"):
+            self.assertFalse(view.project_name_invalid.isVisible())
+
+        with self.check("Test 13 / Rietveld is offered but disabled"):
+            self.assertIn("Rietveld", combo_items(view.refinement_method_combobox))
+            index = view.refinement_method_combobox.findText("Rietveld")
+            self.assertFalse(view.refinement_method_combobox.model().item(index).isEnabled())
+            self.assertEqual("Pawley", view.refinement_method_combobox.currentText())
+
+        # the guide calls out that refining microstrain together with both peak-shape parameters is
+        # inadvisable, and the interface warns rather than forbids
+        with self.check("Test 13 / no advisory marker until all three refinement boxes are ticked"):
+            self.assertFalse(view.checkboxes_invalid.isVisible())
+        for checkbox in (view.refine_microstrain_checkbox, view.refine_sigma_one_checkbox, view.refine_gamma_y_checkbox):
+            set_checkbox(checkbox, True)
+        with self.check("Test 13 / advisory marker appears when microstrain, Sigma-1 and Gamma(Y) are all refined"):
+            self.assertTrue(view.checkboxes_invalid.isVisible())
+            self.assertIn("may not be advisable", view.checkboxes_invalid.toolTip())
+        set_checkbox(view.refine_microstrain_checkbox, False)
+        with self.check("Test 13 / advisory marker clears when microstrain is unticked"):
+            self.assertFalse(view.checkboxes_invalid.isVisible())
+
+    def _check_phase_selection(self):
+        view = self.gsas2_view
+        options = combo_items(view.cifComboBox)
+        with self.check("Test 13 / the phase combo offers the shipped cif files plus a custom entry"):
+            self.assertGreater(len(options), 1)
+            self.assertIn("Custom", options)
+        with self.check("Test 13 / the custom phase file finder is hidden for a shipped phase"):
+            self.assertNotEqual("Custom", view.cifComboBox.currentText())
+            self.assertFalse(view.phase_file_finder.isVisible())
+        select_combo(view.cifComboBox, "Custom")
+        with self.check("Test 13 / choosing Custom reveals the phase file finder"):
+            self.assertTrue(view.phase_file_finder.isVisible())
+        # go back to a shipped phase so the refinement below has one without needing a cif on disk
+        select_combo(view.cifComboBox, options[0])
+        with self.check("Test 13 / the custom phase file finder is hidden again"):
+            self.assertFalse(view.phase_file_finder.isVisible())
+
+    # -------------------------------------------------------------- error handling
+
+    def _check_invalid_inputs_are_reported(self):
+        self.subprocess_calls = []
+        self.fill_in_refinement(project_name="")
+        with self.captured_logs(level="error") as logs:
+            self.refine()
+        with self.check("Test 13 / refining without a project name is rejected"):
+            self.assertIn("valid Project Name", logs.text)
+            self.assertEqual([], self.subprocess_calls)
+
+        # more than one instrument file is the guide's documented error case
+        self.subprocess_calls = []
+        second_prm = os.path.join(self.inputs_dir, "second.prm")
+        shutil.copy(self.prm_path, second_prm)
+        self.fill_in_refinement(prm_paths=[self.prm_path, second_prm])
+        with self.captured_logs(level="error") as logs:
+            self.refine()
+        with self.check("Test 13 / more than one instrument file is rejected"):
+            self.assertIn("exactly one instrument file", logs.text)
+            self.assertEqual([], self.subprocess_calls)
+
+        # a focused file whose bank count disagrees with the instrument file
+        self.subprocess_calls = []
+        single_bank = _write_focused_gss(self.inputs_dir, basename="ENGINX_single_bank_TOF", n_banks=1)
+        self.fill_in_refinement(gss_paths=[single_bank])
+        with self.captured_logs(level="error") as logs:
+            self.refine()
+        with self.check("Test 13 / a bank count that disagrees with the instrument file is rejected"):
+            self.assertIn("same number of banks", logs.text)
+            self.assertEqual([], self.subprocess_calls)
+
+    # -------------------------------------------------------------- a successful refinement
+
+    def _check_refinement_outputs(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        self.fill_in_refinement()
+        # forget the rejected attempts above so the counts below are about this refinement only
+        self.subprocess_calls = []
+        self.refine()
+
+        # a precondition, not an observation: nothing below means anything if GSAS-II was not called
+        self.assertEqual(1, len(self.subprocess_calls), "GSAS-II was not called exactly once")
+
+        with self.check("Test 13 / the histogram selector lists one entry per bank"):
+            self.assertEqual([str(i) for i in range(1, N_BANKS + 1)], combo_items(self.gsas2_view.number_output_histograms_combobox))
+            self.assertEqual("1", self.gsas2_view.number_output_histograms_combobox.currentText())
+
+        with self.check("Test 13 / the lattice parameter table is created from the cell parameters file"):
+            table = ADS.retrieve(f"{FULL_PROJECT}_GSASII_lattice_parameters")
+            self.assertEqual(1, table.rowCount())
+            self.assertEqual(PHASE_NAME, table.column("Phase name")[0])
+            # gamma iron is cubic, so a, b and c must agree and the angles must all be 90 degrees
+            lengths = [table.column(name)[0] for name in ("a", "b", "c")]
+            self.assertTrue(np.allclose(lengths, lengths[0]), f"cubic phase has unequal cell lengths {lengths}")
+            for angle in ("alpha", "beta", "gamma"):
+                self.assertAlmostEqual(90.0, table.column(angle)[0], places=4)
+            self.assertAlmostEqual(lengths[0] ** 3, table.column("volume")[0], places=3)
+
+        with self.check("Test 13 / the microstrain column is marked as refined only when it was refined"):
+            table = ADS.retrieve(f"{FULL_PROJECT}_GSASII_lattice_parameters")
+            self.assertIn("Microstrain", table.getColumnNames())
+            self.assertNotIn("Microstrain (Refined)", table.getColumnNames())
+
+        with self.check("Test 13 / the instrument parameter table has a row per bank with the fit range"):
+            table = ADS.retrieve(f"{FULL_PROJECT}_GSASII_instrument_parameters")
+            self.assertEqual(N_BANKS, table.rowCount())
+            names = table.column("Histogram name")
+            self.assertEqual([f"PWDR_{FOCUSED_BASENAME}_Bank_{i}" for i in range(1, N_BANKS + 1)], names)
+            for row in range(N_BANKS):
+                self.assertLess(table.column("Fit X Min")[row], table.column("Fit X Max")[row])
+            # both were left ticked by the initial-state checks, so both columns say so
+            self.assertIn("Sigma-1 (Refined)", table.getColumnNames())
+            self.assertIn("Gamma (Y) (Refined)", table.getColumnNames())
+
+        with self.check("Test 13 / the reflections table has a row per bank and phase"):
+            table = ADS.retrieve(f"{FULL_PROJECT}_GSASII_reflections")
+            self.assertEqual(N_BANKS, table.rowCount())
+            self.assertEqual([PHASE_NAME] * N_BANKS, table.column("Phase name"))
+            for reflections in table.column("Reflections"):
+                self.assertTrue(reflections.strip(), "a reflections row is empty")
+
+        with self.check("Test 13 / an 'all banks' file is expanded into its per-bank focused workspaces"):
+            # the tab loads the .nxs beside the .gss to get at the sample logs, one per bank
+            loaded = self.gsas2_presenter.model._data_workspaces.get_loaded_workpace_names()
+            expected = [FOCUSED_BASENAME.replace("all_banks", f"bank_{bank}") + "_GSASII" for bank in range(1, N_BANKS + 1)]
+            self.assertEqual(sorted(expected), sorted(loaded))
+
+        with self.check("Test 13 / the GSAS-II sample log group is built"):
+            self.assertTrue(ADS.doesExist("logs_GSASII"))
+            group_names = ADS.retrieve("logs_GSASII").getNames()
+            # a run summary table plus one table per log the interface tracks for this instrument
+            self.assertIn("run_info_GSASII", group_names)
+            self.assertGreater(len(group_names), 1, f"only got {group_names}")
+            self.assertEqual(["Instrument", "Run", "Bank", "uAmps", "Title"], ADS.retrieve("run_info_GSASII").getColumnNames())
+
+    def _check_saved_files(self):
+        output_dir = self.gsas2_output_dir()
+        saved = self.basenames_under(output_dir)
+        with self.check("Test 13 / the GSAS-II outputs are moved to the save directory"):
+            self.assertTrue(os.path.isdir(output_dir), f"{output_dir} was not created")
+            for expected in (
+                f"{FULL_PROJECT}.lst",
+                f"{FULL_PROJECT}.gpx",
+                f"{FULL_PROJECT}_1.csv",
+                f"{FULL_PROJECT}_cell_parameters_{PHASE_NAME}.txt",
+                f"{FULL_PROJECT}_reflections_1_{PHASE_NAME}.txt",
+            ):
+                self.assertIn(expected, saved)
+
+        with self.check("Test 13 / no temporary working directory is left behind"):
+            # covers the rejected refinements above as well as the successful one: each creates a
+            # working directory before validating, and all of them must clean it up again
+            leftover = [name for name in os.listdir(os.path.join(self.save_dir, "GSAS2")) if name.startswith("tmp_EngDiff_GSASII")]
+            self.assertEqual([], leftover)
+
+    def _check_serialized_inputs(self):
+        inputs = self.serialized_inputs()
+        with self.check("Test 13 / the inputs handed to GSAS-II describe the requested refinement"):
+            self.assertEqual(FULL_PROJECT, inputs["project_name"])
+            self.assertEqual("Pawley", inputs["refinement_settings"]["method"])
+            self.assertFalse(inputs["refinement_settings"]["microstrain"])
+            self.assertTrue(inputs["refinement_settings"]["sigma_one"])
+            self.assertTrue(inputs["refinement_settings"]["gamma"])
+            self.assertEqual(N_BANKS, inputs["number_of_regions"])
+
+        with self.check("Test 13 / the file paths handed to GSAS-II are the ones chosen in the tab"):
+            self.assertEqual([self.prm_path], [os.path.normpath(p) for p in inputs["file_paths"]["instrument_files"]])
+            self.assertEqual([self.gss_path], [os.path.normpath(p) for p in inputs["file_paths"]["data_files"]])
+            self.assertTrue(inputs["file_paths"]["phase_filepaths"], "no phase file was passed to GSAS-II")
+
+        with self.check("Test 13 / Pawley reflections were generated for the phase"):
+            reflections = inputs["mantid_pawley_reflections"]
+            self.assertEqual(1, len(reflections), "expected one phase")
+            self.assertTrue(reflections[0], "no reflections generated")
+            # each entry is [hkl, d, multiplicity], sorted by descending d
+            d_values = [entry[1] for entry in reflections[0]]
+            self.assertEqual(sorted(d_values, reverse=True), d_values)
+            self.assertTrue(all(d >= inputs["d_spacing_min"] for d in d_values))
+
+        with self.check("Test 13 / the command line points at the configured GSAS-II interpreter"):
+            command = self.subprocess_calls[-1]
+            self.assertTrue(command[0].startswith(self.gsas2_install), f"unexpected interpreter {command[0]}")
+            self.assertTrue(command[1].endswith("call_G2sc.py"))
+
+    def _check_plot(self):
+        axes = self.gsas2_view.get_axes()[0]
+        with self.check("Test 13 / the refinement result is plotted"):
+            labels = [line.get_label() for line in axes.get_lines()]
+            # observed, calculated, difference and background, plus the two draggable limit markers
+            self.assertGreaterEqual(len(labels), 4, f"only got {labels}")
+        with self.check("Test 13 / the four refinement curves are plotted"):
+            labels = [line.get_label() for line in axes.get_lines()]
+            for expected in ("observed", "calculated", "difference", "background"):
+                self.assertIn(expected, labels)
+        with self.check("Test 13 / reflection markers are plotted for the phase"):
+            labels = [line.get_label() for line in axes.get_lines()]
+            self.assertIn(f"reflections_{PHASE_NAME}", labels)
+        with self.check("Test 13 / the plot is titled for the refined data file"):
+            # set_x_limits runs immediately after the title is set and reaches update_figure through
+            # the range markers, so this also covers the title surviving that
+            self.assertEqual(f"GSAS-II Refinement {os.path.basename(self.gss_path)}", self.gsas2_view.plot_dock.windowTitle())
+        with self.check("Test 13 / the plot is labelled in time of flight"):
+            self.assertIn("Time-of-flight", axes.get_xlabel())
+
+    def _check_x_limits_round_trip(self):
+        view = self.gsas2_view
+        original_min = float(view.x_min_line_edit.text())
+        original_max = float(view.x_max_line_edit.text())
+        with self.check("Test 13 / the x limits are seeded from the data"):
+            self.assertLess(original_min, original_max)
+            self.assertAlmostEqual(original_min, view.initial_x_limits[0], places=2)
+            self.assertAlmostEqual(original_max, view.initial_x_limits[1], places=2)
+
+        # narrowing the range and refining again must reach the serialized inputs, but only because
+        # the load parameters are unchanged - that is what get_limits_if_same_load_parameters guards
+        narrowed_min = original_min + 0.25 * (original_max - original_min)
+        narrowed_max = original_max - 0.25 * (original_max - original_min)
+        view.set_x_limits_line_edits(narrowed_min, narrowed_max)
+        process_events()
+        self.refine()
+        with self.check("Test 13 / user x limits are passed through to GSAS-II"):
+            self.assertEqual(2, len(self.subprocess_calls), "the second refinement did not run")
+            limits = self.serialized_inputs()["limits"]
+            self.assertEqual(N_BANKS, len(limits[0]))
+            for value in limits[0]:
+                self.assertAlmostEqual(narrowed_min, value, places=2)
+            for value in limits[1]:
+                self.assertAlmostEqual(narrowed_max, value, places=2)
+
+        # choosing different input files must discard the limits rather than apply them to new data
+        other_gss = _write_focused_gss(self.inputs_dir, basename="ENGINX_other_TOF", n_banks=N_BANKS)
+        self.fill_in_refinement(gss_paths=[other_gss])
+        self.refine()
+        with self.check("Test 13 / x limits are reset when different input files are chosen"):
+            self.assertEqual(3, len(self.subprocess_calls), "the third refinement did not run")
+            limits = self.serialized_inputs()["limits"]
+            self.assertNotAlmostEqual(narrowed_min, limits[0][0], places=2)
+
+
+class EngDiffGuiGsas2MultipleTest(_Gsas2TestBase):
+    """Several focused files, and the RB-number save location - the manual guide's Test 14."""
+
+    RB_NUMBER = "9876"
+
+    def _run_checks(self):
+        self._check_multiple_files_refine_separately()
+        self._check_rb_number_save_location()
+
+    def _check_multiple_files_refine_separately(self):
+        from mantid.api import AnalysisDataService as ADS
+
+        second_gss = _write_focused_gss(self.inputs_dir, basename="ENGINX_305762_307521_all_banks_TOF", n_banks=N_BANKS)
+        self.fill_in_refinement(gss_paths=[self.gss_path, second_gss])
+        self.refine()
+
+        with self.check("Test 14 / each focused file is refined in its own GSAS-II call"):
+            self.assertEqual(2, len(self.subprocess_calls))
+            projects = [self.serialized_inputs(i)["project_name"] for i in range(2)]
+            self.assertEqual([FULL_PROJECT, f"{PROJECT_NAME}_ENGINX_305762_307521_all_banks_TOF"], projects)
+
+        with self.check("Test 14 / each refinement produces its own set of tables"):
+            for project in (FULL_PROJECT, f"{PROJECT_NAME}_ENGINX_305762_307521_all_banks_TOF"):
+                for suffix in ("reflections", "instrument_parameters", "lattice_parameters"):
+                    self.assertTrue(ADS.doesExist(f"{project}_GSASII_{suffix}"), f"{project}_GSASII_{suffix} missing")
+
+        with self.check("Test 14 / each refinement writes its own save directory"):
+            for project in (FULL_PROJECT, f"{PROJECT_NAME}_ENGINX_305762_307521_all_banks_TOF"):
+                self.assertTrue(os.path.isdir(self.gsas2_output_dir(project)), f"no output directory for {project}")
+
+        with self.check("Test 14 / the sample logs cover every bank of both focused files"):
+            self.assertTrue(ADS.doesExist("logs_GSASII"))
+            loaded = self.gsas2_presenter.model._data_workspaces.get_loaded_workpace_names()
+            self.assertEqual(2 * N_BANKS, len(loaded), f"expected both files' banks, got {loaded}")
+
+    def _check_rb_number_save_location(self):
+        self.set_rb_number(self.RB_NUMBER)
+        self.fill_in_refinement()
+        self.refine()
+
+        rb_dir = self.gsas2_output_dir(rb_number=self.RB_NUMBER)
+        with self.check("Test 14 / an RB number adds a copy under User/<RB>/GSAS2"):
+            self.assertTrue(os.path.isdir(rb_dir), f"{rb_dir} was not created")
+            self.assertIn(f"{FULL_PROJECT}.lst", self.basenames_under(rb_dir))
+        with self.check("Test 14 / the non-RB copy is still written"):
+            self.assertIn(f"{FULL_PROJECT}.lst", self.basenames_under(self.gsas2_output_dir()))
+
+
+# ---------------------------------------------------------------------- fixtures
+
+
+def _write_focused_gss(out_dir, basename=FOCUSED_BASENAME, n_banks=N_BANKS):
+    """Write a focused GSAS file of the shape the focus tab produces.
+
+    Fabricated rather than focused for real because the GSAS-II tab only ever reads the bin
+    boundaries out of it - the counts are handed straight to GSAS-II, which is mocked here. Running
+    a real calibration and focus just to obtain it would make this the slowest module in the suite
+    instead of the fastest, and that path is already covered by the run processing tests.
+
+    A matching ``_bank_<n>.nxs`` is written alongside each bank because the tab loads those for the
+    sample log group after a successful refinement, exactly as the focus tab leaves them on disk.
+    """
+    from mantid.simpleapi import AddSampleLog, CreateWorkspace, DeleteWorkspace, SaveGSS, SaveNexusProcessed
+
+    tof = np.arange(15000.0, 45000.0, 10.0)
+    counts = 500.0 + 200.0 * np.exp(-(((tof - 25000.0) / 4000.0) ** 2))
+
+    ws = CreateWorkspace(
+        DataX=np.tile(tof, n_banks),
+        DataY=np.tile(counts, n_banks),
+        DataE=np.tile(np.sqrt(counts), n_banks),
+        NSpec=n_banks,
+        UnitX="TOF",
+        OutputWorkspace="__gsas2_focused",
+        EnableLogging=False,
+    )
+    AddSampleLog(Workspace=ws, LogName="run_number", LogType="String", LogText=basename.split("_")[1], EnableLogging=False)
+
+    gss_path = os.path.join(out_dir, f"{basename}.gss")
+    SaveGSS(InputWorkspace=ws, Filename=gss_path, SplitFiles=False, EnableLogging=False)
+
+    # The tab derives the sample log file names from the .gss name: an 'all_banks' file is expanded
+    # into one per bank, anything else is taken as a single spectrum. Mirror that exactly, or the
+    # refinement succeeds but the log loading reports missing files.
+    if "all_banks" in basename:
+        nxs_names = [f"{basename.replace('all_banks', f'bank_{bank}')}.nxs" for bank in range(1, n_banks + 1)]
+    else:
+        nxs_names = [f"{basename}.nxs"]
+    for nxs_name in nxs_names:
+        single = CreateWorkspace(
+            DataX=tof,
+            DataY=counts,
+            DataE=np.sqrt(counts),
+            NSpec=1,
+            UnitX="TOF",
+            OutputWorkspace="__gsas2_focused_bank",
+            EnableLogging=False,
+        )
+        AddSampleLog(Workspace=single, LogName="run_number", LogType="String", LogText=basename.split("_")[1], EnableLogging=False)
+        SaveNexusProcessed(InputWorkspace=single, Filename=os.path.join(out_dir, nxs_name), EnableLogging=False)
+        DeleteWorkspace(single, EnableLogging=False)
+
+    DeleteWorkspace(ws, EnableLogging=False)
+    return os.path.normpath(gss_path)
+
+
+def _write_instrument_prm(out_dir, basename=FOCUSED_BASENAME):
+    """Write the .prm the focus tab writes, from the shipped ENGIN-X header template.
+
+    The tab reads the bank count out of the ``INS   BANK`` line and cross-checks it against the
+    focused data, so the template's own header is used verbatim rather than being hand written.
+    """
+    from Engineering.EnggUtils import CALIB_DIR
+
+    with open(os.path.join(CALIB_DIR, "template_ENGINX_prm_header.prm")) as template:
+        header = template.read()
+
+    lines = [header.rstrip("\n")]
+    for bank, difc in enumerate(BANK_DIFC, start=1):
+        lines.append(f"INS  {bank} ICONS  {difc:.2f}    0.00    0.00")
+    path = os.path.join(out_dir, f"{basename}.prm")
+    with open(path, "w") as prm:
+        prm.write("\n".join(lines) + "\n")
+    return os.path.normpath(path)
+
+
+def _stage_stub_gsas2_install(root):
+    """Create the minimum tree that ``GSAS2Handler`` will accept as a GSAS-II installation.
+
+    The handler searches for the interpreter within two directory levels and for
+    ``GSASIIscriptable.py`` within three, and only ever records their paths - nothing here is
+    executed, because the subprocess call itself is mocked. Staging this instead of mocking the
+    handler keeps the path resolution, the binary search and the JSON serialisation under test.
+    """
+    scriptable_dir = os.path.join(root, "GSASII")
+    os.makedirs(scriptable_dir, exist_ok=True)
+    os.makedirs(os.path.join(root, "bin"), exist_ok=True)
+    interpreter = "python.exe" if os.name == "nt" else "python"
+    for path in (os.path.join(root, interpreter), os.path.join(scriptable_dir, "GSASIIscriptable.py")):
+        with open(path, "w") as stub:
+            stub.write("")
+    return os.path.normpath(root)
+
+
+def _copy_canned_outputs(temporary_dir, project_name):
+    """Drop the canned GSAS-II outputs into the model's temporary directory under its project name.
+
+    The files shipped in ``Testing/Data/UnitTest`` were produced by a real GSAS-II run against the
+    ENGIN-X focused data, and the model finds its outputs purely by name, so renaming them to the
+    project the model chose is all that is needed for the whole output-handling path to run for
+    real. The ``.gpx`` project file is not shipped (it is a large binary and only its existence is
+    checked), so an empty placeholder stands in for it.
+    """
+    from mantid.api import FileFinder
+
+    def canned(name):
+        return FileFinder.Instance().getFullPath(f"{CANNED_DIR}/{name}")
+
+    shutil.copy(canned("gsas2_output.lst"), os.path.join(temporary_dir, f"{project_name}.lst"))
+    shutil.copy(
+        canned(f"gsas2_output_cell_parameters_{PHASE_NAME}.txt"),
+        os.path.join(temporary_dir, f"{project_name}_cell_parameters_{PHASE_NAME}.txt"),
+    )
+    for bank in range(1, N_BANKS + 1):
+        # one csv and one set of reflections per histogram; only histogram 1 is shipped, and the
+        # banks differ only in their counts, which nothing here asserts on
+        shutil.copy(canned("gsas2_output_1.csv"), os.path.join(temporary_dir, f"{project_name}_{bank}.csv"))
+        shutil.copy(
+            canned(f"gsas2_output_reflections_{bank}_{PHASE_NAME}.txt"),
+            os.path.join(temporary_dir, f"{project_name}_reflections_{bank}_{PHASE_NAME}.txt"),
+        )
+        shutil.copy(
+            canned(f"gsas2_output_inst_parameters_PWDR_{FOCUSED_BASENAME}_Bank_{bank}.txt"),
+            os.path.join(temporary_dir, f"{project_name}_inst_parameters_PWDR_{FOCUSED_BASENAME}_Bank_{bank}.txt"),
+        )
+    with open(os.path.join(temporary_dir, f"{project_name}.gpx"), "wb") as placeholder:
+        placeholder.write(b"")

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiGsas2Test.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiGsas2Test.py
@@ -386,7 +386,7 @@ class EngDiffGuiGsas2SingleTest(_Gsas2TestBase):
                 self.assertAlmostEqual(narrowed_max, value, places=2)
 
         # choosing different input files must discard the limits rather than apply them to new data
-        other_gss = _write_focused_gss(self.inputs_dir, basename="ENGINX_other_TOF", n_banks=N_BANKS)
+        other_gss = _write_focused_gss(self.inputs_dir, basename="ENGINX_305763_307521_all_banks_TOF", n_banks=N_BANKS)
         self.fill_in_refinement(gss_paths=[other_gss])
         self.refine()
         with self.check("Test 13 / x limits are reset when different input files are chosen"):
@@ -531,7 +531,6 @@ def _stage_stub_gsas2_install(root):
     """
     scriptable_dir = os.path.join(root, "GSASII")
     os.makedirs(scriptable_dir, exist_ok=True)
-    os.makedirs(os.path.join(root, "bin"), exist_ok=True)
     interpreter = "python.exe" if os.name == "nt" else "python"
     for path in (os.path.join(root, interpreter), os.path.join(scriptable_dir, "GSASIIscriptable.py")):
         with open(path, "w") as stub:

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiImatTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiImatTest.py
@@ -1,0 +1,227 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for Run Processing on IMAT.
+
+The manual guide asks for calibration and focusing "for all instrument options", but the repository
+has no IMAT ceria/vanadium pair, so this module fabricates one (see ``create_imat_ceria_and_vanadium``
+in the shared base) and puts it where the interface's own file finder will resolve it from a run
+number. The interface is therefore driven exactly as it is for ENGIN-X - nothing reaches past the
+view to inject a workspace.
+
+Because the data is fabricated, the assertions are about the *pipeline and the interface*, not the
+physics: that the IMAT-specific settings are picked up, that calibration and focusing complete, that
+the expected files appear with the expected names, and that the status bar and region-of-interest
+options are right. The one check that asks whether PDCalibration genuinely succeeded is kept soft,
+so a peak-shape regression reports as one clear line rather than aborting the class.
+"""
+
+import os
+
+from eng_diff_gui_test_base import (
+    EngDiffGuiTestBase,
+    IMAT_CERIA_RUN,
+    IMAT_VANADIUM_RUN,
+    TAB_RUN_PROCESSING,
+    create_imat_ceria_and_vanadium,
+)
+from qt_interaction_helpers import combo_items
+
+INSTRUMENT = "IMAT"
+# the IMAT grouping options offered in place of ENGIN-X's texture groupings
+EXPECTED_ROI_OPTIONS = (
+    "Custom Grouping File",
+    "1 (North)",
+    "2 (South)",
+    "Crop to Spectra",
+    "1 Group per module",
+    "4 Groups per module",
+    "1 Group per row",
+    "4 Groups per row",
+)
+
+
+class EngDiffGuiImatSettingsTest(EngDiffGuiTestBase):
+    """The instrument-specific configuration, without running a calibration.
+
+    Cheap - it needs no run data at all - so it stays useful as a fast regression check on the
+    per-instrument settings even when the calibration test below is excluded for runtime.
+    """
+
+    def _run_checks(self):
+        self.show_tab(TAB_RUN_PROCESSING)
+        self.set_instrument(INSTRUMENT)
+
+        with self.check("Run Processing / IMAT offers its own region of interest options"):
+            options = combo_items(self.cropping_view.combo_bank)
+            self.assertEqual(list(EXPECTED_ROI_OPTIONS), options)
+
+        with self.check("Run Processing / the ENGIN-X texture groupings are not offered for IMAT"):
+            options = combo_items(self.cropping_view.combo_bank)
+            self.assertNotIn("Texture20", options)
+            self.assertNotIn("Texture30", options)
+
+        with self.check("Run Processing / IMAT uses its own full instrument calibration"):
+            from Engineering.common.instrument_config import get_instr_config
+
+            config = get_instr_config(INSTRUMENT)
+            self.assertIn("IMAT", config.full_instr_calib)
+
+        with self.check("Run Processing / IMAT uses IkedaCarpenterPV with fixed peak parameters"):
+            from Engineering.common.instrument_config import get_instr_config
+
+            config = get_instr_config(INSTRUMENT)
+            self.assertEqual("IkedaCarpenterPV", config.peak_func)
+            self.assertIn("IkedaCarpenterPV", config.funcs_to_keep_fixed)
+
+        with self.check("Run Processing / IMAT uses its own TOF binning"):
+            from Engineering.common.instrument_config import get_instr_config
+
+            self.assertNotEqual(get_instr_config("ENGINX").calibration_tof_binning, get_instr_config(INSTRUMENT).calibration_tof_binning)
+
+        with self.check("Run Processing / switching back to ENGIN-X restores its texture groupings"):
+            self.set_instrument("ENGINX")
+            options = combo_items(self.cropping_view.combo_bank)
+            # The exact labels matter: the combo is repopulated from the instrument config on every
+            # instrument change, so if those labels drift from the ones the tab starts with, the
+            # same option gets two different names within one session.
+            self.assertIn("Texture20", options)
+            self.assertIn("Texture30", options)
+
+
+class EngDiffGuiImatCalibrateAndFocusTest(EngDiffGuiTestBase):
+    """A real calibration and focus on IMAT, against fabricated run data."""
+
+    def requiredMemoryMB(self):
+        return 4000
+
+    def excludeInPullRequests(self):
+        return True
+
+    def seeded_settings(self):
+        settings = super(EngDiffGuiImatCalibrateAndFocusTest, self).seeded_settings()
+        # Fit Gaussians, matching the shape the fixture generates. IMAT's real default is
+        # IkedaCarpenterPV with its parameters pinned by the instrument definition, which is both
+        # far slower to fit and impossible to satisfy with fabricated data - so this doubles as the
+        # manual guide's "changing Default Peak Function" step, asserted from the log below.
+        settings["default_peak_IMAT"] = "Gaussian"
+        return settings
+
+    def pre_gui_setup(self):
+        self.data_dir = os.path.join(self.tmp_root, "imat_data")
+        os.makedirs(self.data_dir, exist_ok=True)
+        create_imat_ceria_and_vanadium(self.data_dir)
+        # this is what lets the interface resolve the fabricated runs from a run number, exactly as
+        # it would a real one, instead of the test bypassing the file finder
+        self.add_data_search_dir(self.data_dir)
+
+    def _run_checks(self):
+        self.show_tab(TAB_RUN_PROCESSING)
+        self.set_instrument(INSTRUMENT)
+        self.set_region_of_interest(None)
+
+        with self.captured_logs(level="notice") as logs:
+            calibration = self.calibrate(ceria=str(IMAT_CERIA_RUN), vanadium=str(IMAT_VANADIUM_RUN))
+
+        # preconditions: nothing below is meaningful without a calibration
+        self.assertIsNotNone(calibration, "no calibration was produced")
+        self.assertTrue(calibration.is_valid(), "the calibration reported itself invalid")
+
+        self._check_calibration_reported(logs)
+        self._check_calibration_files()
+        self._check_calibration_succeeded()
+        self._check_focus()
+
+    def _check_calibration_reported(self, logs):
+        with self.check("Run Processing / the status bar reports the IMAT calibration"):
+            self.assertEqual(
+                f"CeO2: {IMAT_CERIA_RUN}, V: {IMAT_VANADIUM_RUN}, Instrument: {INSTRUMENT}",
+                self.statusbar_text(),
+            )
+
+        with self.check("Run Processing / the peak function from the settings is the one used"):
+            # the Default Peak Function setting is only observable through this log line
+            self.assertIn("Gaussian", logs.text)
+            # only IkedaCarpenterPV is in IMAT's funcs_to_keep_fixed, so a Gaussian fit is free
+            self.assertIn("RespectFixedPeakParameters: False", logs.text)
+
+        with self.check("Run Processing / the calibration records the peak shape it fitted"):
+            self.assertEqual("Gaussian", self.calibration_presenter.current_calibration.get_fit_peak_shape())
+
+    def _check_calibration_files(self):
+        calibration_dir = self.calibration_dir()
+        written = self.basenames_under(calibration_dir)
+        with self.check("Run Processing / a prm and nxs are written for both banks and for all banks"):
+            # calibration files are named INSTRUMENT_ceriaRun_suffix for every instrument; the
+            # vanadium run appears in the *focused* output names, not these
+            for suffix in ("all_banks", "bank_1", "bank_2"):
+                for extension in (".prm", ".nxs"):
+                    self.assertIn(f"{INSTRUMENT}_{IMAT_CERIA_RUN}_{suffix}{extension}", written)
+
+        with self.check("Run Processing / the prm is built from the IMAT header template"):
+            from Engineering.EnggUtils import CALIB_DIR
+
+            prm = os.path.join(calibration_dir, f"{INSTRUMENT}_{IMAT_CERIA_RUN}_all_banks.prm")
+            with open(prm) as written_prm:
+                contents = written_prm.read()
+            with open(os.path.join(CALIB_DIR, "template_IMAT_prm_header.prm")) as template:
+                first_line = template.readline().strip()
+            self.assertIn(first_line, contents)
+            self.assertIn("ICONS", contents)
+
+        with self.check("Run Processing / the written prm parses back into diffractometer constants"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            prm = os.path.join(calibration_dir, f"{INSTRUMENT}_{IMAT_CERIA_RUN}_all_banks.prm")
+            constants = read_diff_constants_from_prm(prm)
+            self.assertEqual(2, len(constants), f"expected one row per bank, got {constants}")
+            for row in constants:
+                for value in row:
+                    self.assertEqual(value, value, "a diffractometer constant is NaN")
+
+        # SOFT, for the same reason as the mask check: run_calibration keeps the uncalibrated DIFC
+        # when PDCalibration fails rather than raising, so a zero here means the fabricated peak
+        # shape did not fit that bank. That is a data-quality signal about this fixture, not a
+        # regression in the interface, which is what the rest of the class is testing.
+        with self.check("Run Processing / both IMAT banks got a fitted difc (data quality, soft)"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            prm = os.path.join(self.calibration_dir(), f"{INSTRUMENT}_{IMAT_CERIA_RUN}_all_banks.prm")
+            unfitted = [index for index, row in enumerate(read_diff_constants_from_prm(prm)) if row[0] <= 0.0]
+            self.assertEqual([], unfitted, f"PDCalibration produced no difc for bank(s) {unfitted}")
+
+    def _check_calibration_succeeded(self):
+        # SOFT on purpose. run_calibration only logs a warning when PDCalibration fails for a
+        # spectrum and keeps the uncalibrated DIFC, so this is the only way to notice - but the
+        # fabricated peak shape is an approximation of IMAT's real moderator pulse, so a failure
+        # here is a data-quality signal rather than a reason to abandon the rest of the class.
+        from mantid.api import AnalysisDataService as ADS
+
+        mask_name = "engggui_calibration_all_banks_mask"
+        with self.check("Run Processing / PDCalibration fitted the IMAT banks (data quality, soft)"):
+            self.assertTrue(ADS.doesExist(mask_name), f"{mask_name} was not produced")
+            mask = ADS.retrieve(mask_name)
+            total = mask.getNumberHistograms()
+            masked = sum(1 for index in range(total) if mask.readY(index)[0] != 0)
+            # The mask spans the whole instrument while the fabricated run only populates a subset
+            # of detectors, so most entries are legitimately masked. What matters is that the
+            # focused banks were fitted at all, i.e. that some spectra came through unmasked.
+            self.assertLess(masked, total, "PDCalibration failed for every spectrum")
+
+    def _check_focus(self):
+        self.focus(runs=str(IMAT_CERIA_RUN))
+
+        with self.check("Run Processing / focusing produces an output workspace named for the run"):
+            focused = self.focused_workspace_names()
+            self.assertTrue(focused, "focusing produced no output workspace")
+            for name in focused:
+                self.assertTrue(name.startswith(str(IMAT_CERIA_RUN)), f"{name} is not named for the focused run")
+
+        with self.check("Run Processing / the focused output files are written"):
+            written = self.basenames_under(self.focus_dir())
+            self.assertTrue(written, f"nothing under {self.focus_dir()}")
+            self.assertTrue(any(name.endswith(".gss") for name in written), f"no gss in {written}")
+            self.assertTrue(any(name.endswith(".nxs") for name in written), f"no nxs in {written}")

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiImatTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiImatTest.py
@@ -19,6 +19,7 @@ options are right. The one check that asks whether PDCalibration genuinely succe
 so a peak-shape regression reports as one clear line rather than aborting the class.
 """
 
+import math
 import os
 
 from eng_diff_gui_test_base import (
@@ -180,7 +181,7 @@ class EngDiffGuiImatCalibrateAndFocusTest(EngDiffGuiTestBase):
             self.assertEqual(2, len(constants), f"expected one row per bank, got {constants}")
             for row in constants:
                 for value in row:
-                    self.assertEqual(value, value, "a diffractometer constant is NaN")
+                    self.assertFalse(math.isnan(value), "a diffractometer constant is NaN")
 
         # SOFT, for the same reason as the mask check: run_calibration keeps the uncalibrated DIFC
         # when PDCalibration fails rather than raising, so a zero here means the fabricated peak

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiRunProcessingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiRunProcessingTest.py
@@ -1,0 +1,417 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the Run Processing tab on ENGIN-X.
+
+Covers the manual guide's Test 1 (calibrate and focus), its settings steps, the plot-output
+checkboxes, the RB number's effect on the save layout, and the "restart the interface" step that
+checks the last calibration is restored.
+
+The ceria and vanadium runs are **fabricated** rather than the real 305738/307521 pair, in the same
+way as the IMAT tests - see ``create_synthetic_ceria_and_vanadium``. The real runs are large and
+slow, and what these tests assert is the interface, the reported state and the on-disk save layout,
+none of which depends on the counts being real. The numerical correctness of the calibrate/focus
+chain is already covered by ``EnginXScriptTest``, so duplicating it here would only add fixtures that
+need regenerating whenever an algorithm changes.
+
+Because the fabricated peaks are Gaussian, every class here sets ENGIN-X's Default Peak Function to
+``Gaussian`` so the fitted shape matches the generated one - which doubles as coverage of that
+setting, asserted from the captured log.
+"""
+
+import os
+
+from eng_diff_gui_test_base import (
+    ENGINX_SYNTHETIC_CERIA_RUN,
+    ENGINX_SYNTHETIC_VANADIUM_RUN,
+    EngDiffGuiTestBase,
+    TAB_RUN_PROCESSING,
+    create_enginx_ceria_and_vanadium,
+)
+from qt_interaction_helpers import figure_numbers, process_events, set_checkbox
+
+INSTRUMENT = "ENGINX"
+CERIA = str(ENGINX_SYNTHETIC_CERIA_RUN)
+VANADIUM = str(ENGINX_SYNTHETIC_VANADIUM_RUN)
+
+# the two ENGIN-X banks, focused together when no region of interest is set
+N_BANKS = 2
+
+
+class _RunProcessingTestBase(EngDiffGuiTestBase):
+    """Stages the fabricated ENGIN-X runs and points the interface's file finder at them."""
+
+    def requiredMemoryMB(self):
+        return 4000
+
+    def excludeInPullRequests(self):
+        # every subclass runs at least one real PDCalibration
+        return True
+
+    def seeded_settings(self):
+        settings = super(_RunProcessingTestBase, self).seeded_settings()
+        # match the shape the fixture generates; ENGIN-X's real default is BackToBackExponential,
+        # which cannot be fitted to a symmetric Gaussian peak
+        settings["default_peak_ENGINX"] = "Gaussian"
+        return settings
+
+    def pre_gui_setup(self):
+        self.data_dir = os.path.join(self.tmp_root, "enginx_data")
+        os.makedirs(self.data_dir, exist_ok=True)
+        create_enginx_ceria_and_vanadium(self.data_dir)
+        # this is what lets the interface resolve the fabricated runs from a run number, exactly as
+        # it would a real one, instead of the test bypassing the file finder
+        self.add_data_search_dir(self.data_dir)
+
+    # ------------------------------------------------------------------ shared expectations
+
+    def focused_basename(self, suffix, xunit):
+        """Focused output files are named ``INSTRUMENT_sample_vanadium_suffix_xunit``."""
+        return f"{INSTRUMENT}_{CERIA}_{VANADIUM}_{suffix}_{xunit}"
+
+
+class EngDiffGuiCalibrateAndFocusTest(_RunProcessingTestBase):
+    """Guide Test 1: a new calibration with no region of interest, then focusing the ceria run.
+
+    The bulk of the coverage - the calibration state, the files written by both the calibration and
+    the focus, and the focused workspaces themselves.
+    """
+
+    def _run_checks(self):
+        self.show_tab(TAB_RUN_PROCESSING)
+        self._check_initial_state()
+
+        self.set_region_of_interest(None)
+        with self.captured_logs(level="notice") as logs:
+            calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+
+        # preconditions: nothing below is meaningful without a calibration
+        self.assertIsNotNone(calibration, "no calibration was produced")
+        self.assertTrue(calibration.is_valid(), "the calibration reported itself invalid")
+
+        self._check_calibration_state(calibration, logs)
+        self._check_calibration_files()
+        self._check_calibration_succeeded()
+        self._check_focus()
+
+    def _check_initial_state(self):
+        view = self.run_processing_view
+        with self.check("Test 1 / step 3 (Create New Calibration is preselected on a clean setup)"):
+            # nothing has been calibrated in this isolated settings store, so there is no last
+            # calibration to restore and the interface must offer to make one
+            self.assertTrue(view.get_new_checked())
+            self.assertFalse(view.get_load_checked())
+
+        with self.check("Test 1 / step 3 (the existing calibration path field is disabled)"):
+            self.assertFalse(view.finder_path.isEnabled())
+
+        with self.check("Test 1 / step 3 (no calibration is reported in the status bar)"):
+            self.assertEqual("No Calibration Loaded.", self.statusbar_text())
+
+        with self.check("Test 1 / step 4 (the save location reported is the one in settings)"):
+            self.assertIn(self.save_dir, self.savedir_text())
+
+    def _check_calibration_state(self, calibration, logs):
+        from Engineering.common.instrument_config import ENGINX_GROUP
+
+        with self.check("Test 1 / step 11 (the status bar reports the new calibration)"):
+            self.assertEqual(
+                f"CeO2: {CERIA}, V: {VANADIUM}, Instrument: {INSTRUMENT}",
+                self.statusbar_text(),
+            )
+
+        with self.check("Test 1 / step 11 (the calibration records both banks and both runs)"):
+            self.assertEqual(ENGINX_GROUP.BOTH, calibration.get_group())
+            self.assertEqual(CERIA, calibration.get_ceria_runno())
+            self.assertEqual(VANADIUM, calibration.get_vanadium_runno())
+            self.assertEqual(INSTRUMENT, calibration.get_instrument())
+
+        with self.check("Test 1 / steps 4-7 (the Default Peak Function setting is the one used)"):
+            # the setting is only observable through this log line and the calibration's own record
+            self.assertIn("Gaussian", logs.text)
+            self.assertEqual("Gaussian", calibration.get_fit_peak_shape())
+
+        with self.check("Test 1 / step 11 (the diffractometer constants table is produced)"):
+            from mantid.api import AnalysisDataService as ADS
+            from Engineering.EnggUtils import DIFF_CONSTS_TABLE_NAME
+
+            self.assertTrue(ADS.doesExist(DIFF_CONSTS_TABLE_NAME), f"{DIFF_CONSTS_TABLE_NAME} was not produced")
+            self.assertEqual(N_BANKS, ADS.retrieve(DIFF_CONSTS_TABLE_NAME).rowCount())
+
+    def _check_calibration_files(self):
+        calibration_dir = self.calibration_dir()
+        written = self.basenames_under(calibration_dir)
+
+        with self.check("Test 1 / step 12 (a prm and nxs are written for each bank and for both)"):
+            for suffix in ("all_banks", "bank_1", "bank_2"):
+                for extension in (".prm", ".nxs"):
+                    self.assertIn(f"{INSTRUMENT}_{CERIA}_{suffix}{extension}", written)
+
+        with self.check("Test 1 / step 12 (nothing is written under User/ without an RB number)"):
+            self.assertEqual([], self.files_under(os.path.join(self.save_dir, "User")))
+
+        with self.check("Test 1 / step 12 (the prm is built from the ENGIN-X header template)"):
+            from Engineering.EnggUtils import CALIB_DIR
+
+            with open(self._all_banks_prm()) as written_prm:
+                contents = written_prm.read()
+            with open(os.path.join(CALIB_DIR, "template_ENGINX_prm_header.prm")) as template:
+                first_line = template.readline().strip()
+            self.assertIn(first_line, contents)
+            self.assertIn("ICONS", contents)
+            # the header carries the run number of the ceria run it was made from
+            self.assertIn(CERIA, contents)
+
+        with self.check("Test 1 / step 12 (the written prm parses back into diffractometer constants)"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            constants = read_diff_constants_from_prm(self._all_banks_prm())
+            self.assertEqual(N_BANKS, len(constants), f"expected one row per bank, got {constants}")
+            for row in constants:
+                for value in row:
+                    self.assertEqual(value, value, "a diffractometer constant is NaN")
+
+        with self.check("Test 1 / step 12 (the per-bank prm files hold one bank each)"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            for bank in (1, 2):
+                prm = os.path.join(calibration_dir, f"{INSTRUMENT}_{CERIA}_bank_{bank}.prm")
+                self.assertEqual(1, len(read_diff_constants_from_prm(prm)), f"{prm} should describe one bank")
+
+        # SOFT: run_calibration keeps the uncalibrated DIFC and only logs a warning when
+        # PDCalibration fails, so a zero here means the fabricated peaks did not fit that bank.
+        # That is a signal about this fixture rather than a regression in the interface, which is
+        # what the rest of the class tests.
+        with self.check("Test 1 / both banks got a fitted difc (data quality, soft)"):
+            from Engineering.EnggUtils import read_diff_constants_from_prm
+
+            unfitted = [index for index, row in enumerate(read_diff_constants_from_prm(self._all_banks_prm())) if row[0] <= 0.0]
+            self.assertEqual([], unfitted, f"PDCalibration produced no difc for bank(s) {unfitted}")
+
+    def _check_calibration_succeeded(self):
+        # SOFT, for the same reason as the difc check above.
+        from mantid.api import AnalysisDataService as ADS
+
+        mask_name = "engggui_calibration_all_banks_mask"
+        with self.check("Test 1 / PDCalibration fitted the ENGIN-X banks (data quality, soft)"):
+            self.assertTrue(ADS.doesExist(mask_name), f"{mask_name} was not produced")
+            mask = ADS.retrieve(mask_name)
+            total = mask.getNumberHistograms()
+            masked = sum(1 for index in range(total) if mask.readY(index)[0] != 0)
+            # the mask spans the whole instrument while the fabricated run populates a subset of the
+            # detectors, so most entries are legitimately masked; what matters is that the focused
+            # banks were fitted at all
+            self.assertLess(masked, total, "PDCalibration failed for every spectrum")
+
+    def _check_focus(self):
+        self.focus(runs=CERIA)
+
+        with self.check("Test 1 / step 15 (focusing produces one workspace with one spectrum per bank)"):
+            from mantid.api import AnalysisDataService as ADS
+
+            focused = self.focused_workspace_names()
+            self.assertEqual(1, len(focused), f"expected one focused workspace, got {focused}")
+            self.assertTrue(focused[0].startswith(CERIA), f"{focused[0]} is not named for the focused run")
+            self.assertEqual(N_BANKS, ADS.retrieve(focused[0]).getNumberHistograms())
+
+        with self.check("Test 1 / step 15 (the focused output is left in TOF)"):
+            from mantid.api import AnalysisDataService as ADS
+
+            focused = ADS.retrieve(self.focused_workspace_names()[0])
+            self.assertEqual("TOF", focused.getAxis(0).getUnit().unitID())
+
+        focus_dir = self.focus_dir()
+        written = self.basenames_under(focus_dir)
+
+        with self.check("Test 1 / step 15 (ASCII output is written for the whole run in TOF)"):
+            self.assertIn(self.focused_basename("all_banks", "TOF") + ".gss", written)
+            self.assertIn(self.focused_basename("all_banks", "TOF") + ".abc", written)
+
+        with self.check("Test 1 / step 15 (ASCII output is also written in d-spacing)"):
+            self.assertIn(self.focused_basename("all_banks", "dSpacing") + ".gss", written)
+            self.assertIn(self.focused_basename("all_banks", "dSpacing") + ".abc", written)
+
+        with self.check("Test 1 / step 15 (a nexus file is written per bank, in both units)"):
+            for bank in (1, 2):
+                for xunit in ("TOF", "dSpacing"):
+                    self.assertIn(self.focused_basename(f"bank_{bank}", xunit) + ".nxs", written)
+
+        with self.check("Test 1 / step 15 (the d-spacing spectra are also saved combined)"):
+            combined = self.basenames_under(os.path.join(focus_dir, "CombinedFiles"))
+            self.assertEqual([self.focused_basename("bank", "dSpacing") + ".nxs"], combined)
+
+        with self.check("Test 1 / step 15 (the focused workspace records the vanadium it was normalised by)"):
+            from mantid.api import AnalysisDataService as ADS
+
+            run = ADS.retrieve(self.focused_workspace_names()[0]).run()
+            self.assertEqual(VANADIUM, run.getLogData("Vanadium Run").value)
+            self.assertEqual("bank", run.getLogData("Grouping").value)
+
+    def _all_banks_prm(self):
+        return os.path.join(self.calibration_dir(), f"{INSTRUMENT}_{CERIA}_all_banks.prm")
+
+
+class EngDiffGuiPlotOutputTest(_RunProcessingTestBase):
+    """Guide Test 1: the 'Plot Calibrated Workspace' and 'Plot Focused Workspace' checkboxes.
+
+    Uses the North bank only - one group instead of two makes both the calibration and the focus
+    noticeably cheaper, and the checkbox behaviour does not depend on the region of interest.
+    """
+
+    def _run_checks(self):
+        self.set_region_of_interest("1 (North)")
+
+        before = figure_numbers()
+        self.calibrate(ceria=CERIA, vanadium=VANADIUM, plot_output=False)
+        with self.check("Test 1 / step 9 (no plot appears when Plot Calibrated Workspace is off)"):
+            self.assertEqual(before, figure_numbers())
+
+        self.focus(runs=CERIA, plot_output=False)
+        with self.check("Test 1 / step 14 (no plot appears when Plot Focused Workspace is off)"):
+            self.assertEqual(before, figure_numbers())
+
+        # calibrate again with the box ticked; the calibration itself is unchanged, so any new
+        # figure can only have come from the checkbox
+        before = figure_numbers()
+        self.calibrate(ceria=CERIA, vanadium=VANADIUM, plot_output=True)
+        with self.check("Test 1 / step 9 (a plot appears when Plot Calibrated Workspace is on)"):
+            self.assertTrue(figure_numbers() - before, "no new figure was created by the calibration")
+
+        before = figure_numbers()
+        self.focus(runs=CERIA, plot_output=True)
+        with self.check("Test 1 / step 14 (a plot appears when Plot Focused Workspace is on)"):
+            self.assertTrue(figure_numbers() - before, "no new figure was created by the focus")
+
+        with self.check("Test 1 / step 9 (the checkbox state is what the view reports)"):
+            view = self.run_processing_view
+            self.assertTrue(view.get_plot_output())
+            set_checkbox(view.check_plotOutput, False)
+            self.assertFalse(view.get_plot_output())
+
+
+class EngDiffGuiLoadExistingCalibrationTest(_RunProcessingTestBase):
+    """Guide Test 1: closing and reopening the interface, then loading a calibration by path."""
+
+    def _run_checks(self):
+        self.set_region_of_interest(None)
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the calibration reported itself invalid")
+
+        all_banks_prm = calibration.get_prm_filepath()
+        self.assertTrue(os.path.exists(all_banks_prm), f"{all_banks_prm} was not written")
+
+        self.rebuild_gui()
+
+        with self.check("Test 1 / step 16 (reopening preselects Load Existing Calibration)"):
+            self.assertTrue(self.run_processing_view.get_load_checked())
+            self.assertFalse(self.run_processing_view.get_new_checked())
+
+        with self.check("Test 1 / step 16 (the path field is prefilled with the last calibration)"):
+            from qt_interaction_helpers import wait_for_file_finder
+
+            wait_for_file_finder(self.run_processing_view.finder_path, msg="restored calibration path")
+            self.assertEqual(
+                os.path.normcase(all_banks_prm),
+                os.path.normcase(self.run_processing_view.get_path_filename()),
+            )
+
+        with self.check("Test 1 / step 16 (the last vanadium run is restored too)"):
+            from qt_interaction_helpers import wait_for_file_finder
+
+            wait_for_file_finder(self.run_processing_view.finder_vanadium, msg="restored vanadium run")
+            self.assertIn(VANADIUM, self.run_processing_view.finder_vanadium.getText())
+
+        with self.check("Test 1 / step 16 (the calibrate button is relabelled for the load path)"):
+            self.assertEqual("Load", self.run_processing_view.button_calibrate.text())
+
+        # now browse to a single bank instead, which is the guide's "load a different calibration"
+        bank_2_prm = os.path.join(self.calibration_dir(), f"{INSTRUMENT}_{CERIA}_bank_2.prm")
+        loaded = self.load_calibration(bank_2_prm)
+
+        with self.check("Test 1 / step 17 (loading a bank prm reports that calibration)"):
+            from Engineering.common.instrument_config import ENGINX_GROUP
+
+            self.assertIsNotNone(loaded, "no calibration was loaded")
+            self.assertTrue(loaded.is_valid(), "the loaded calibration reported itself invalid")
+            self.assertEqual(ENGINX_GROUP.SOUTH, loaded.get_group())
+            self.assertEqual(CERIA, loaded.get_ceria_runno())
+            self.assertEqual(INSTRUMENT, loaded.get_instrument())
+
+        with self.check("Test 1 / step 17 (the status bar reports the loaded calibration)"):
+            self.assertIn(f"CeO2: {CERIA}", self.statusbar_text())
+            self.assertIn(f"Instrument: {INSTRUMENT}", self.statusbar_text())
+
+        with self.check("Test 1 / step 17 (focusing against the loaded calibration gives one spectrum)"):
+            from mantid.api import AnalysisDataService as ADS
+
+            self.focus(runs=CERIA)
+            focused = self.focused_workspace_names()
+            self.assertEqual(1, len(focused), f"expected one focused workspace, got {focused}")
+            self.assertEqual(1, ADS.retrieve(focused[0]).getNumberHistograms())
+
+
+class EngDiffGuiSaveLocationAndRbNumberTest(_RunProcessingTestBase):
+    """Guide Test 1: the RB number and changing the save location mid-session.
+
+    North bank only, for the same reason as the plot test - what is being checked is where the
+    output lands, not what is in it.
+    """
+
+    RB_NUMBER = "1234567"
+
+    def _run_checks(self):
+        self.set_rb_number(self.RB_NUMBER)
+        self.set_region_of_interest("1 (North)")
+        calibration = self.calibrate(ceria=CERIA, vanadium=VANADIUM)
+        self.assertTrue(calibration.is_valid(), "the calibration reported itself invalid")
+        self.focus(runs=CERIA)
+
+        self._check_rb_layout()
+        self._check_save_location_change()
+
+    def _check_rb_layout(self):
+        expected_prm = f"{INSTRUMENT}_{CERIA}_bank_1.prm"
+
+        with self.check("Test 1 / step 8 (with an RB number the calibration is saved in both places)"):
+            # a non-texture group is written to the plain directory *and* the RB one
+            self.assertIn(expected_prm, self.basenames_under(self.calibration_dir()))
+            self.assertIn(expected_prm, self.basenames_under(self.calibration_dir(self.RB_NUMBER)))
+
+        with self.check("Test 1 / step 8 (the focused output is saved in both places too)"):
+            expected_nxs = self.focused_basename("bank_1", "TOF") + ".nxs"
+            self.assertIn(expected_nxs, self.basenames_under(self.focus_dir()))
+            self.assertIn(expected_nxs, self.basenames_under(self.focus_dir(self.RB_NUMBER)))
+
+        with self.check("Test 1 / step 8 (the RB directory is named for the number that was entered)"):
+            self.assertTrue(
+                os.path.isdir(os.path.join(self.save_dir, "User", self.RB_NUMBER)),
+                f"no User/{self.RB_NUMBER} directory under {self.save_dir}",
+            )
+
+    def _check_save_location_change(self):
+        new_save_dir = os.path.join(self.tmp_root, "relocated_output")
+        os.makedirs(new_save_dir, exist_ok=True)
+        before = set(self.files_under(self.save_dir))
+
+        # through the real settings dialog rather than by writing QSettings, so the presenter's
+        # validation and its save-directory notification are exercised as well
+        self.apply_settings(save_location=new_save_dir)
+
+        with self.check("Test 1 / steps 4-7 (the interface reports the new save location)"):
+            self.assertIn(new_save_dir, self.savedir_text())
+
+        with self.check("Test 1 / steps 4-7 (the setting was persisted)"):
+            self.assertEqual(new_save_dir, self.get_engineering_setting("save_location"))
+
+        self.focus(runs=CERIA)
+        process_events(2)
+
+        with self.check("Test 1 / steps 4-7 (subsequent output lands under the new save location)"):
+            relocated = self.basenames_under(os.path.join(new_save_dir, "User", self.RB_NUMBER, "Focus"))
+            self.assertIn(self.focused_basename("bank_1", "TOF") + ".nxs", relocated)
+
+        with self.check("Test 1 / steps 4-7 (nothing further is written under the old save location)"):
+            self.assertEqual(before, set(self.files_under(self.save_dir)))

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiRunProcessingTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiRunProcessingTest.py
@@ -22,6 +22,7 @@ Because the fabricated peaks are Gaussian, every class here sets ENGIN-X's Defau
 setting, asserted from the captured log.
 """
 
+import math
 import os
 
 from eng_diff_gui_test_base import (
@@ -172,7 +173,7 @@ class EngDiffGuiCalibrateAndFocusTest(_RunProcessingTestBase):
             self.assertEqual(N_BANKS, len(constants), f"expected one row per bank, got {constants}")
             for row in constants:
                 for value in row:
-                    self.assertEqual(value, value, "a diffractometer constant is NaN")
+                    self.assertFalse(math.isnan(value), "a diffractometer constant is NaN")
 
         with self.check("Test 1 / step 12 (the per-bank prm files hold one bank each)"):
             from Engineering.EnggUtils import read_diff_constants_from_prm

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiTextureTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiTextureTest.py
@@ -1,0 +1,346 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""System tests for the Texture tab, replacing the manual guide's Test 12.
+
+Everything here is real: the focused workspaces and fit parameter tables are the shipped Texture30
+validation files, and the pole figures are produced by the genuine model on a worker thread. Nothing
+is mocked - the tab has no external dependency and no blocking dialog on these paths.
+
+The seven focused runs are used rather than focusing runs in the test because they are exactly the
+fixtures the manual guide names, which makes this the cheapest real-data module in the suite; the
+route from focusing into this tab is covered where a real focus already happens.
+"""
+
+import os
+
+from eng_diff_gui_test_base import EngDiffGuiTestBase, TAB_TEXTURE
+from qt_interaction_helpers import (
+    click,
+    combo_items,
+    process_events,
+    select_combo,
+    set_checkbox,
+    set_finder_text,
+    table_checkbox,
+    table_column,
+)
+
+TEXTURE_DATA = "Texture/ValidationFiles"
+RUNS = ("364901", "364911", "364920", "364926", "364929", "364935", "364944")
+FOCUS_TEMPLATE = "ENGINX_{run}_361838_Texture30_dSpacing.nxs"
+PARAM_TEMPLATE = "ENGINX_{run}_2.03_Texture30_Fit_Parameters.nxs"
+
+# columns of the loaded-data table
+COL_RUN, COL_PARAMS, COL_CRYSTAL, COL_SHAPE, COL_SELECT = 0, 1, 2, 3, 4
+
+# a body centred cubic iron crystal, as the guide's scattering correction step uses
+LATTICE = "2.87 2.87 2.87"
+SPACEGROUP = "I m -3 m"
+BASIS = "Fe 0 0 0 1.0 0.05"
+
+
+class _TextureTestBase(EngDiffGuiTestBase):
+    """Shared setup. Abstract, so the system test collector ignores it where it is imported."""
+
+    def requiredFiles(self):
+        return [f"{TEXTURE_DATA}/Focus/{FOCUS_TEMPLATE.format(run=run)}" for run in RUNS] + [
+            f"{TEXTURE_DATA}/FitParameters/{PARAM_TEMPLATE.format(run=run)}" for run in RUNS
+        ]
+
+    def focus_files(self, runs=RUNS):
+        return [self._resolve(f"{TEXTURE_DATA}/Focus/{FOCUS_TEMPLATE.format(run=run)}") for run in runs]
+
+    def param_files(self, runs=RUNS):
+        return [self._resolve(f"{TEXTURE_DATA}/FitParameters/{PARAM_TEMPLATE.format(run=run)}") for run in runs]
+
+    @staticmethod
+    def _resolve(name):
+        from mantid.api import FileFinder
+
+        path = FileFinder.Instance().getFullPath(name)
+        if not path:
+            raise RuntimeError(f"could not resolve the test fixture {name}")
+        return path
+
+    # ------------------------------------------------------------------ driving the tab
+
+    def load_workspaces(self, runs=RUNS):
+        self.show_tab(TAB_TEXTURE)
+        set_finder_text(self.texture_view.finder_texture_ws, ",".join(self.focus_files(runs)))
+        click(self.texture_view.btn_loadWSFiles)
+        process_events(2)
+
+    def load_parameters(self, runs=RUNS):
+        set_finder_text(self.texture_view.finder_texture_tables, ",".join(self.param_files(runs)))
+        click(self.texture_view.btn_loadParamFiles)
+        process_events(2)
+
+    def table(self):
+        return self.texture_view.table_loaded_data
+
+    def calculate_pole_figure(self):
+        click(self.texture_view.btn_calc_pf)
+        self.wait_for_async_task(self.texture_presenter.worker, what="pole figure")
+
+    def pole_figure_dir(self, rb_number=None):
+        if rb_number:
+            return os.path.join(self.save_dir, "User", rb_number, "PoleFigureTables")
+        return os.path.join(self.save_dir, "PoleFigureTables")
+
+    def plot_axes(self):
+        figure, _canvas = self.texture_view.get_plot_axis()
+        return figure.axes
+
+
+class EngDiffGuiTextureLoadingTest(_TextureTestBase):
+    """Loading runs and parameter files, and the table buttons."""
+
+    def _run_checks(self):
+        self._check_initial_state()
+        self._check_loading_runs()
+        self._check_loading_parameters()
+        self._check_selection_buttons()
+        self._check_delete_buttons()
+
+    def _check_initial_state(self):
+        self.show_tab(TAB_TEXTURE)
+        view = self.texture_view
+        with self.check("Test 12 / the table starts empty"):
+            self.assertEqual(0, self.table().rowCount())
+        with self.check("Test 12 / the scattering correction section is hidden until requested"):
+            self.assertFalse(view.check_scatt.isChecked())
+        with self.check("Test 12 / the parameter column selector is hidden with no parameter tables"):
+            self.assertFalse(view.combo_param.isVisible())
+        with self.check("Test 12 / the crystal buttons are disabled with nothing to apply them to"):
+            self.assertFalse(view.btn_setCrystal.isEnabled())
+            self.assertFalse(view.btn_setAllCrystal.isEnabled())
+
+    def _check_loading_runs(self):
+        self.load_workspaces()
+        # a precondition: every later check reads this table
+        self.assertEqual(len(RUNS), self.table().rowCount(), "the focused runs did not load")
+
+        with self.check("Test 12 / one row per loaded run, named for the focused workspace"):
+            names = table_column(self.table(), COL_RUN)
+            expected = [os.path.splitext(os.path.basename(path))[0] for path in self.focus_files()]
+            self.assertEqual(sorted(expected), sorted(names))
+
+        with self.check("Test 12 / runs load with no parameters, crystal or shape set"):
+            for column in (COL_PARAMS, COL_CRYSTAL):
+                self.assertEqual([("Not set")] * len(RUNS), table_column(self.table(), column))
+
+        with self.check("Test 12 / every row starts unselected"):
+            self.assertEqual([False] * len(RUNS), [table_checkbox(self.table(), row, COL_SELECT).isChecked() for row in range(len(RUNS))])
+
+        with self.check("Test 12 / the crystal workspace list offers every loaded run"):
+            self.assertEqual(sorted(table_column(self.table(), COL_RUN)), sorted(combo_items(self.texture_view.combo_workspaceListProp)))
+
+        with self.check("Test 12 / loading the same runs again does not duplicate rows"):
+            self.load_workspaces()
+            self.assertEqual(len(RUNS), self.table().rowCount())
+
+    def _check_loading_parameters(self):
+        with self.check("Test 12 / with no parameter tables only the projection option is offered"):
+            self.assertFalse(self.texture_view.combo_param.isVisible())
+
+        self.load_parameters()
+        with self.check("Test 12 / each run is paired with its own fit parameter table"):
+            params = table_column(self.table(), COL_PARAMS)
+            self.assertNotIn("Not set", params, "a run was left without parameters")
+            # the pairing is by run number, so each row's parameter table must name the same run
+            for run_name, param_name in zip(table_column(self.table(), COL_RUN), params):
+                run_number = run_name.split("_")[1]
+                self.assertIn(run_number, param_name, f"{param_name} was paired with {run_name}")
+
+        with self.check("Test 12 / the parameter column selector stays hidden while nothing is selected"):
+            # the offer is driven by the selected rows, not the loaded ones, because the readout
+            # column has to be common to everything that will go into the pole figure
+            self.assertFalse(self.texture_view.combo_param.isVisible())
+
+        click(self.texture_view.btn_selectAll)
+        with self.check("Test 12 / the parameter column selector appears once every selected run has parameters"):
+            self.assertTrue(self.texture_view.combo_param.isVisible())
+            columns = combo_items(self.texture_view.combo_param)
+            self.assertTrue(columns, "no plottable columns were offered")
+
+        with self.check("Test 12 / only numeric parameter columns are offered for plotting"):
+            from mantid.api import AnalysisDataService as ADS
+
+            table_name = table_column(self.table(), COL_PARAMS)[0]
+            parameter_table = ADS.retrieve(table_name)
+            numeric = [
+                name
+                for name, column_type in zip(parameter_table.getColumnNames(), parameter_table.columnTypes())
+                if column_type in ("double", "float", "int", "long64", "size_t")
+            ]
+            for offered in combo_items(self.texture_view.combo_param):
+                self.assertIn(offered, numeric, f"'{offered}' is not a numeric column")
+
+    def _check_selection_buttons(self):
+        view = self.texture_view
+        click(view.btn_selectAll)
+        with self.check("Test 12 / Select All ticks every row"):
+            self.assertEqual([True] * len(RUNS), [table_checkbox(self.table(), row, COL_SELECT).isChecked() for row in range(len(RUNS))])
+            selected, _params = view.get_selected_workspaces()
+            self.assertEqual(len(RUNS), len(selected))
+
+        click(view.btn_deselectAll)
+        with self.check("Test 12 / Deselect All unticks every row"):
+            self.assertEqual([False] * len(RUNS), [table_checkbox(self.table(), row, COL_SELECT).isChecked() for row in range(len(RUNS))])
+            selected, _params = view.get_selected_workspaces()
+            self.assertEqual([], selected)
+
+    def _check_delete_buttons(self):
+        view = self.texture_view
+        # remove the parameters from the first two rows only
+        for row in (0, 1):
+            table_checkbox(self.table(), row, COL_SELECT).setChecked(True)
+        process_events()
+        click(view.btn_deleteSelectedParams)
+        with self.check("Test 12 / Remove Selected Parameters clears only the selected rows"):
+            params = table_column(self.table(), COL_PARAMS)
+            self.assertEqual(["Not set", "Not set"], params[:2])
+            self.assertNotIn("Not set", params[2:])
+
+        with self.check("Test 12 / the column selector hides again once a run has no parameters"):
+            self.assertFalse(view.combo_param.isVisible())
+
+        remaining_before = table_column(self.table(), COL_RUN)
+        click(view.btn_deleteSelected)
+        with self.check("Test 12 / Delete Selected removes the selected rows"):
+            self.assertEqual(len(RUNS) - 2, self.table().rowCount())
+            self.assertEqual(sorted(remaining_before[2:]), sorted(table_column(self.table(), COL_RUN)))
+
+        click(view.btn_selectAll)
+        click(view.btn_deleteSelected)
+        with self.check("Test 12 / deleting every selected row empties the table"):
+            self.assertEqual(0, self.table().rowCount())
+            self.assertEqual([], combo_items(view.combo_workspaceListProp))
+
+
+class EngDiffGuiTexturePoleFigureTest(_TextureTestBase):
+    """Creating pole figures: projections, parameter readout and the scattering correction."""
+
+    RB_NUMBER = "5432"
+
+    def _run_checks(self):
+        self._check_pole_figure_without_parameters()
+        self._check_projection_methods()
+        self._check_pole_figure_with_parameters()
+        self._check_scattering_correction()
+        self._check_rb_number_save_location()
+
+    def _check_pole_figure_without_parameters(self):
+        self.load_workspaces()
+        click(self.texture_view.btn_selectAll)
+
+        with self.check("Test 12 / a pole figure needs no parameter table"):
+            self.assertFalse(self.texture_view.combo_param.isVisible())
+
+        self.calculate_pole_figure()
+        # a precondition for everything below
+        self.assertTrue(self.plot_axes(), "no pole figure axes were created")
+
+        with self.check("Test 12 / the pole figure is plotted"):
+            axes = self.plot_axes()[0]
+            self.assertTrue(axes.collections or axes.get_lines(), "nothing was drawn on the pole figure")
+
+        with self.check("Test 12 / a pole figure table is written to the save directory"):
+            saved = self.basenames_under(self.pole_figure_dir())
+            self.assertTrue(saved, f"nothing under {self.pole_figure_dir()}")
+
+    def _check_projection_methods(self):
+        view = self.texture_view
+        methods = combo_items(view.combo_projMethod)
+        with self.check("Test 12 / both projections are offered"):
+            self.assertGreaterEqual(len(methods), 2, f"only got {methods}")
+
+        offsets = {}
+        for method in methods:
+            select_combo(view.combo_projMethod, method)
+            self.calculate_pole_figure()
+            axes = self.plot_axes()[0]
+            if axes.collections:
+                offsets[method] = axes.collections[0].get_offsets().data.copy()
+
+        with self.check("Test 12 / each projection produces a different point set"):
+            self.assertEqual(len(methods), len(offsets), "a projection produced no scatter points")
+            first, second = (offsets[method] for method in methods[:2])
+            self.assertEqual(first.shape, second.shape, "the projections disagree on the number of points")
+            self.assertFalse((first == second).all(), "the two projections produced identical points")
+
+        select_combo(view.combo_projMethod, methods[0])
+
+    def _check_pole_figure_with_parameters(self):
+        self.load_parameters()
+        view = self.texture_view
+        with self.check("Test 12 / every numeric parameter column becomes plottable"):
+            self.assertTrue(view.combo_param.isVisible())
+            self.assertTrue(combo_items(view.combo_param))
+
+        columns = combo_items(view.combo_param)
+        colours = {}
+        for column in columns[:2]:
+            select_combo(view.combo_param, column)
+            self.calculate_pole_figure()
+            axes = self.plot_axes()[0]
+            if axes.collections:
+                colours[column] = axes.collections[0].get_array()
+
+        with self.check("Test 12 / the chosen parameter column drives the plotted colour data"):
+            self.assertEqual(len(colours), min(2, len(columns)), "a parameter column produced no colour data")
+            values = list(colours.values())
+            if len(values) == 2 and values[0] is not None and values[1] is not None:
+                self.assertFalse((values[0] == values[1]).all(), "two different columns plotted identical values")
+
+    def _check_scattering_correction(self):
+        view = self.texture_view
+        with self.check("Test 12 / the crystal inputs are hidden until the correction is requested"):
+            self.assertFalse(view.lattice_lineedit.isVisible())
+
+        set_checkbox(view.check_scatt, True)
+        with self.check("Test 12 / ticking the correction reveals the crystal inputs"):
+            self.assertTrue(view.lattice_lineedit.isVisible())
+            self.assertTrue(view.finder_cif_file.isEnabled())
+
+        view.lattice_lineedit.setText(LATTICE)
+        view.spacegroup_lineedit.setText(SPACEGROUP)
+        view.basis_lineedit.setText(BASIS)
+        process_events()
+        with self.check("Test 12 / entering lattice parameters disables the CIF finder"):
+            self.assertFalse(view.finder_cif_file.isEnabled())
+        with self.check("Test 12 / the crystal buttons enable once a crystal and a run are chosen"):
+            self.assertTrue(view.btn_setCrystal.isEnabled())
+            self.assertTrue(view.btn_setAllCrystal.isEnabled())
+
+        click(view.btn_setAllCrystal)
+        with self.check("Test 12 / the crystal structure is recorded against every selected run"):
+            self.assertNotIn("Not set", table_column(self.table(), COL_CRYSTAL))
+
+        for line_edit, value in zip((view.h_lineedit, view.k_lineedit, view.l_lineedit), ("1", "1", "0")):
+            line_edit.setText(value)
+        process_events()
+        self.calculate_pole_figure()
+        with self.check("Test 12 / a corrected pole figure is still produced"):
+            axes = self.plot_axes()[0]
+            self.assertTrue(axes.collections or axes.get_lines(), "nothing was drawn after the scattering correction")
+
+    def _check_rb_number_save_location(self):
+        self.set_rb_number(self.RB_NUMBER)
+        with self.check("Test 12 / the RB number reaches the texture presenter"):
+            self.assertEqual(self.RB_NUMBER, self.texture_presenter.rb_num)
+
+        self.calculate_pole_figure()
+        written = self.files_under(self.save_dir)
+        with self.check("Test 12 / pole figure tables are written under PoleFigureTables"):
+            # repeated calculations overwrite rather than accumulate, so this asserts the layout
+            # rather than a delta
+            self.assertTrue(written, "nothing was written to the save directory")
+            self.assertTrue(
+                any(path.startswith("PoleFigureTables") for path in written),
+                f"no PoleFigureTables output in {sorted(written)}",
+            )

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiTextureTest.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/EngDiffGuiTextureTest.py
@@ -131,7 +131,7 @@ class EngDiffGuiTextureLoadingTest(_TextureTestBase):
 
         with self.check("Test 12 / runs load with no parameters, crystal or shape set"):
             for column in (COL_PARAMS, COL_CRYSTAL):
-                self.assertEqual([("Not set")] * len(RUNS), table_column(self.table(), column))
+                self.assertEqual(["Not set"] * len(RUNS), table_column(self.table(), column))
 
         with self.check("Test 12 / every row starts unselected"):
             self.assertEqual([False] * len(RUNS), [table_checkbox(self.table(), row, COL_SELECT).isChecked() for row in range(len(RUNS))])
@@ -152,7 +152,7 @@ class EngDiffGuiTextureLoadingTest(_TextureTestBase):
             params = table_column(self.table(), COL_PARAMS)
             self.assertNotIn("Not set", params, "a run was left without parameters")
             # the pairing is by run number, so each row's parameter table must name the same run
-            for run_name, param_name in zip(table_column(self.table(), COL_RUN), params):
+            for run_name, param_name in zip(table_column(self.table(), COL_RUN), params, strict=True):
                 run_number = run_name.split("_")[1]
                 self.assertIn(run_number, param_name, f"{param_name} was paired with {run_name}")
 
@@ -174,7 +174,7 @@ class EngDiffGuiTextureLoadingTest(_TextureTestBase):
             parameter_table = ADS.retrieve(table_name)
             numeric = [
                 name
-                for name, column_type in zip(parameter_table.getColumnNames(), parameter_table.columnTypes())
+                for name, column_type in zip(parameter_table.getColumnNames(), parameter_table.columnTypes(), strict=True)
                 if column_type in ("double", "float", "int", "long64", "size_t")
             ]
             for offered in combo_items(self.texture_view.combo_param):
@@ -321,7 +321,7 @@ class EngDiffGuiTexturePoleFigureTest(_TextureTestBase):
         with self.check("Test 12 / the crystal structure is recorded against every selected run"):
             self.assertNotIn("Not set", table_column(self.table(), COL_CRYSTAL))
 
-        for line_edit, value in zip((view.h_lineedit, view.k_lineedit, view.l_lineedit), ("1", "1", "0")):
+        for line_edit, value in zip((view.h_lineedit, view.k_lineedit, view.l_lineedit), ("1", "1", "0"), strict=True):
             line_edit.setText(value)
         process_events()
         self.calculate_pole_figure()

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/eng_diff_gui_test_base.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/eng_diff_gui_test_base.py
@@ -1,0 +1,489 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Shared setup for the Engineering Diffraction interface system tests.
+
+These tests replace ``dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst``.
+They build the real ``EngineeringDiffractionGui`` and click it with ``QTest``; the model, the
+presenters, the algorithms and the files written to disk are all real. The only things mocked are
+the ones that would block waiting for a user: the generated algorithm dialogs, the error popups,
+and (in the GSAS-II tests) the external GSAS-II process.
+
+This module holds the setup, the interaction helpers that are specific to this interface, and the
+fixture that fabricates IMAT run data. It is not itself a test - the base class is abstract, which
+is also what keeps the system test collector from picking it up out of the modules that import it.
+"""
+
+import os
+import sys
+from abc import ABCMeta
+
+import numpy as np
+
+_PARENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PARENT_DIR not in sys.path:
+    sys.path.insert(0, _PARENT_DIR)
+
+from automated_ui_test_base import AutomatedUITestBase  # noqa: E402
+from qt_interaction_helpers import (  # noqa: E402
+    click,
+    process_events,
+    select_combo,
+    set_checkbox,
+    set_finder_text,
+    wait_until,
+)
+
+TAB_PREFIX = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs"
+CALIBRATION_PRESENTER = f"{TAB_PREFIX}.calibration.presenter"
+FOCUS_PRESENTER = f"{TAB_PREFIX}.focus.presenter"
+CORRECTION_PRESENTER = f"{TAB_PREFIX}.correction.presenter"
+DATA_PRESENTER = f"{TAB_PREFIX}.common.data_handling.data_presenter"
+
+# modules that import the blocking error popup by name, so each needs patching individually
+ERROR_MESSAGE_MODULES = (CALIBRATION_PRESENTER, FOCUS_PRESENTER, DATA_PRESENTER)
+
+# tab titles, as added in EngineeringDiffractionPresenter.setup_*
+TAB_RUN_PROCESSING = "Run Processing"
+TAB_CORRECTION = "Absorption Correction"
+TAB_FITTING = "Fitting"
+TAB_TEXTURE = "Texture"
+TAB_GSAS2 = "GSAS II"
+
+# ENGINX runs used by the guide, all present in Testing/Data/DocTest
+ENGINX_CERIA = "305738"
+ENGINX_VANADIUM = "307521"
+ENGINX_FOCUS_RUN = "305761"
+ENGINX_FOCUS_RUNS = "305793-305795"
+
+# fabricated runs (see create_synthetic_ceria_and_vanadium). Run numbers well outside the range of
+# anything shipped, so a fabricated file can never shadow a real one in the search path.
+IMAT_CERIA_RUN = 99001
+IMAT_VANADIUM_RUN = 99002
+ENGINX_SYNTHETIC_CERIA_RUN = 99101
+ENGINX_SYNTHETIC_VANADIUM_RUN = 99102
+
+
+class EngDiffGuiTestBase(AutomatedUITestBase, metaclass=ABCMeta):
+    """Builds the Engineering Diffraction interface and exposes its tabs.
+
+    Subclasses implement ``_run_checks``. Anything they need before the interface exists (extra
+    data directories, pre-seeded settings) goes in an override of ``setUp`` *before*
+    ``super().setUp()``, via the ``pre_gui_setup`` hook.
+    """
+
+    def __init__(self):
+        super(EngDiffGuiTestBase, self).__init__()
+        self.gui = None
+        self.save_dir = None
+
+    # ------------------------------------------------------------------ hooks
+
+    def pre_gui_setup(self):
+        """Runs after settings isolation but before the interface is constructed, and before
+        ``seeded_settings`` is read.
+
+        Override to stage data files the interface will need - including any that a seeded setting
+        has to point at, such as a fabricated calibration or an external program's install tree.
+        """
+
+    def seeded_settings(self):
+        """Settings to write before the interface is built, as a plain dict.
+
+        Defaults to pointing the save location at this test's temporary directory. A test that
+        wants to drive the settings dialog itself (guide Test 1, steps 4-7) can return ``{}`` and
+        set it through the real dialog instead.
+        """
+        return {"save_location": self.save_dir}
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def setUp(self):
+        super(EngDiffGuiTestBase, self).setUp()
+        self.save_dir = os.path.join(self.tmp_root, "output")
+        os.makedirs(self.save_dir, exist_ok=True)
+
+        # stage files first: seeded settings routinely point at something pre_gui_setup created
+        self.pre_gui_setup()
+        for name, value in self.seeded_settings().items():
+            self.set_engineering_setting(name, value)
+
+        # error popups are modal and would hang an unattended run; the focus tab additionally asks
+        # for confirmation before focusing many runs, and that answer decides whether it proceeds
+        self.patch_error_messages(ERROR_MESSAGE_MODULES)
+        self.patch_confirmation_box(FOCUS_PRESENTER, answer=True)
+
+        self._build_gui()
+
+    def rebuild_gui(self):
+        """Close the interface and open a fresh one, leaving the settings store and the ADS alone.
+
+        This is how the guide's "restart the interface" steps are reproduced: what they are really
+        checking is that state which should survive a restart (the last calibration, the last
+        vanadium run, the RB number) was written to settings and is read back on construction.
+        """
+        self.gui.close()
+        process_events(2)
+        self._build_gui()
+
+    def _build_gui(self):
+        # imported here rather than at module scope so a build without the interface skips cleanly
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.engineering_diffraction import EngineeringDiffractionGui
+
+        self.gui = EngineeringDiffractionGui()
+        self.gui.show()
+        process_events(2)
+
+        self.presenter = self.gui.presenter
+        self.calibration_presenter = self.presenter.calibration_presenter
+        self.focus_presenter = self.presenter.focus_presenter
+        self.correction_presenter = self.presenter.correction_presenter
+        self.fitting_presenter = self.presenter.fitting_presenter
+        self.texture_presenter = self.presenter.texture_presenter
+        self.gsas2_presenter = self.presenter.gsas2_presenter
+        self.settings_presenter = self.presenter.settings_presenter
+
+        # the Run Processing tab hosts both the calibration and focus presenters, so they share it
+        self.run_processing_view = self.calibration_presenter.view
+        self.cropping_view = self.calibration_presenter.cropping_widget.view
+        self.correction_view = self.correction_presenter.view
+        self.fitting_view = self.fitting_presenter.view
+        self.texture_view = self.texture_presenter.view
+        self.gsas2_view = self.gsas2_presenter.view
+        self.settings_view = self.settings_presenter.view
+
+    def tearDown(self):
+        gui = getattr(self, "gui", None)
+        if gui is not None:
+            # Clear the ADS while the interface is still alive. The fitting, texture and GSAS-II
+            # tabs all hold ADS observers that repopulate their tables on a clear, so clearing after
+            # the window has gone drives those handlers into deleted C++ widgets.
+            self._clear_ads()
+            process_events(2)
+            # the window is WA_DeleteOnClose, so the reference must not be touched after this
+            gui.close()
+            process_events(2)
+            self.gui = None
+        super(EngDiffGuiTestBase, self).tearDown()
+
+    # ------------------------------------------------------------------ settings
+
+    @staticmethod
+    def set_engineering_setting(name, value):
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.settings_helper import set_setting
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
+
+        set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, name, value)
+
+    @staticmethod
+    def get_engineering_setting(name, return_type=str):
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
+        from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
+
+        return get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, name, return_type=return_type)
+
+    def open_settings(self):
+        """Open the settings dialog the way a user does, via the cog in the bottom left.
+
+        The dialog is not modal-blocking (the presenter calls ``show()``, not ``exec_()``), so it
+        can be driven directly once open.
+        """
+        click(self.gui.btn_settings)
+        return self.settings_view
+
+    def apply_settings(self, **fields):
+        """Change settings through the real dialog and press OK.
+
+        ``fields`` names map onto the dialog's own setters, e.g.
+        ``apply_settings(save_location=..., peak_function="Gaussian")``. Going through the dialog
+        rather than writing QSettings directly is the point: it is the path the guide describes,
+        and it exercises the presenter's validation and its save-directory notification.
+        """
+        view = self.open_settings()
+        for name, value in fields.items():
+            setter = getattr(view, f"set_{name}")
+            setter(value)
+        # the save-location and full-calibration fields are file finders, so let their background
+        # search settle before OK reads the resolved path back out
+        for finder in (view.finder_save, view.finder_fullCalib):
+            finder.findFiles(True)
+        wait_until(
+            lambda: not view.finder_save.isSearching() and not view.finder_fullCalib.isSearching(),
+            msg="settings dialog file finders",
+        )
+        click(view.btn_ok)
+        process_events(2)
+
+    # ------------------------------------------------------------------ interface state
+
+    def show_tab(self, title):
+        """Make a tab current. Widgets only report ``isVisible()`` on the current tab, so any
+        visibility check has to select the tab first."""
+        tabs = self.gui.tabs
+        for index in range(tabs.count()):
+            if tabs.tabText(index) == title:
+                tabs.setCurrentIndex(index)
+                process_events()
+                return tabs.widget(index)
+        raise AssertionError(f"no tab titled '{title}'; found {[tabs.tabText(i) for i in range(tabs.count())]}")
+
+    def statusbar_text(self):
+        """The 'info bar' at the bottom of the interface, which reports the loaded calibration."""
+        return self.gui.status_label.text()
+
+    def savedir_text(self):
+        return self.gui.savedir_label.text()
+
+    def set_instrument(self, instrument):
+        select_combo(self.gui.comboBox_instrument, instrument)
+
+    def set_rb_number(self, rb_number):
+        self.gui.lineEdit_RBNumber.setText(rb_number)
+        process_events()
+
+    # ------------------------------------------------------------------ run processing
+
+    def set_region_of_interest(self, description, custom_spectra=None, custom_grouping_file=None):
+        """Tick 'Set Calibration Region of Interest' and choose an option by its combo text.
+
+        ``description`` is the label the user sees, e.g. "1 (North)", "Crop to Spectra",
+        "Texture (20 spec)". Passing ``None`` unticks the checkbox, which is the guide's
+        "no region of interest" case and makes the calibration fall back to both banks.
+        """
+        self.show_tab(TAB_RUN_PROCESSING)
+        if description is None:
+            set_checkbox(self.run_processing_view.check_roiCalib, False)
+            return
+        set_checkbox(self.run_processing_view.check_roiCalib, True)
+        select_combo(self.cropping_view.combo_bank, description)
+        if custom_spectra is not None:
+            self.cropping_view.edit_crop.setText(custom_spectra)
+            process_events()
+        if custom_grouping_file is not None:
+            set_finder_text(self.cropping_view.finder_custom, custom_grouping_file)
+        process_events()
+
+    def calibrate(self, ceria=ENGINX_CERIA, vanadium=ENGINX_VANADIUM, plot_output=False):
+        """Run a new calibration through the interface and wait for it to finish."""
+        self.show_tab(TAB_RUN_PROCESSING)
+        view = self.run_processing_view
+        view.radio_newCalib.setChecked(True)
+        process_events()
+        set_finder_text(view.finder_vanadium, vanadium)
+        set_finder_text(view.finder_sample, ceria)
+        set_checkbox(view.check_plotOutput, plot_output)
+
+        click(view.button_calibrate)
+        self.wait_for_async_task(self.calibration_presenter.worker, what="calibration")
+        return self.calibration_presenter.current_calibration
+
+    def load_calibration(self, prm_path):
+        """Load an existing calibration from a .prm file, as the guide's 'Load Existing
+        Calibration' radio button does. This path is synchronous - no worker is started."""
+        self.show_tab(TAB_RUN_PROCESSING)
+        view = self.run_processing_view
+        view.radio_loadCalib.setChecked(True)
+        process_events()
+        set_finder_text(view.finder_path, prm_path)
+        click(view.button_calibrate)  # the button is relabelled "Load" in this mode
+        process_events(2)
+        return self.calibration_presenter.current_calibration
+
+    def focus(self, runs=ENGINX_FOCUS_RUN, plot_output=False):
+        """Focus one or more sample runs and wait for the worker."""
+        self.show_tab(TAB_RUN_PROCESSING)
+        view = self.run_processing_view
+        set_finder_text(view.finder_focus, runs)
+        set_checkbox(view.check_focusPlotOutput, plot_output)
+
+        click(view.button_focus)
+        self.wait_for_async_task(self.focus_presenter.worker, what="focus")
+
+    # ------------------------------------------------------------------ output locations
+
+    def calibration_dir(self, rb_number=None):
+        return self._output_dir("Calibration", rb_number)
+
+    def focus_dir(self, rb_number=None):
+        return self._output_dir("Focus", rb_number)
+
+    def _output_dir(self, name, rb_number):
+        if rb_number:
+            return os.path.join(self.save_dir, "User", rb_number, name)
+        return os.path.join(self.save_dir, name)
+
+    def focused_workspace_names(self):
+        """Focused output workspaces currently in the ADS, in spectrum order."""
+        from mantid.api import AnalysisDataService as ADS
+        from Engineering.EnggUtils import FOCUSED_OUTPUT_WORKSPACE_NAME
+
+        return sorted(name for name in ADS.getObjectNames() if FOCUSED_OUTPUT_WORKSPACE_NAME in name)
+
+
+# ---------------------------------------------------------------------- IMAT data fixture
+
+# Subsample the instrument. Enough detectors that every shipped grouping still has a healthy number
+# in each group - the finest is ENGIN-X's Texture30, at 30 groups - but small enough to keep the
+# file and the focusing quick. Taken as an even stride so the sample is spread across every bank.
+_TARGET_SPECTRA = 960
+
+# d range the expected ceria peaks are drawn from (they span 0.781 - 3.141 A)
+_D_MIN, _D_MAX = 0.5, 3.6
+
+# peak area, scaled with d so the long wavelength peaks are not swamped once the vanadium division
+# has flattened the spectrum. Well above PDCalibration's MinimumPeakHeight at every d.
+_PEAK_INTENSITY_PER_D = 4.0e4
+
+# peak width as a fraction of the peak's TOF position. Wide enough that the closest expected pair
+# (0.9019 / 0.9147 A) stays many sigma apart, narrow enough to sit inside PDCalibration's windows.
+_REL_SIGMA = 0.002
+
+
+def create_imat_ceria_and_vanadium(out_dir):
+    """Fabricate an IMAT ceria and vanadium run. See ``create_synthetic_ceria_and_vanadium``."""
+    return create_synthetic_ceria_and_vanadium("IMAT", out_dir, IMAT_CERIA_RUN, IMAT_VANADIUM_RUN)
+
+
+def create_enginx_ceria_and_vanadium(out_dir, extra_sample_runs=()):
+    """Fabricate an ENGIN-X ceria and vanadium run. See ``create_synthetic_ceria_and_vanadium``."""
+    return create_synthetic_ceria_and_vanadium(
+        "ENGINX", out_dir, ENGINX_SYNTHETIC_CERIA_RUN, ENGINX_SYNTHETIC_VANADIUM_RUN, extra_sample_runs
+    )
+
+
+def create_synthetic_ceria_and_vanadium(instrument, out_dir, ceria_run, vanadium_run, extra_sample_runs=()):
+    """Fabricate a ceria and vanadium run that survive the real calibrate/focus path.
+
+    Used for both instruments. For IMAT there is no choice - the repository has no ceria/vanadium
+    pair at all. For ENGIN-X it is a deliberate trade: the real runs are large and slow to load and
+    focus, and what the Run Processing tests are actually checking is the interface, the output file
+    layout and the reported state, none of which depend on the counts being real. The numerical
+    correctness of the calibration chain is already covered by ``EnginXScriptTest``.
+
+    The files are written with the run-number naming the file finder expects, so the interface loads
+    them exactly as it would a real run rather than the test reaching past the view to inject a
+    workspace.
+
+    Counts are written directly in TOF, with each detector's peaks placed at ``difc * d`` using its
+    own entry in the full instrument calibration, so they stay aligned through
+    ``DiffractionFocussing`` and give ``PDCalibration`` a problem whose answer is difa = tzero = 0.
+    The peaks are Gaussian, so the calibration must be run with the peak function set to
+    ``Gaussian`` - see ``_fill_ceria_peaks``.
+
+    :param instrument: "ENGINX" or "IMAT"
+    :param out_dir: directory to write the two nexus files into
+    :param ceria_run: run number to give the fabricated ceria run
+    :param vanadium_run: run number to give the fabricated vanadium run
+    :param extra_sample_runs: further run numbers to write with the same peaks as the ceria run, for
+        tests that need more than one sample to focus or fit
+    :return: (ceria_path, vanadium_path)
+    """
+    from mantid.simpleapi import CreateSimulationWorkspace, ExtractSpectra, Load
+    from Engineering.EnggUtils import CALIB_DIR
+    from Engineering.common.instrument_config import get_instr_config
+
+    config = get_instr_config(instrument)
+    tof_min, _tof_step, tof_max = config.calibration_tof_binning
+    # name it as the interface would, so CalibrationModel.load_full_instrument_calibration reuses
+    # this very workspace instead of reloading and risking a mismatch with the fabricated data
+    full_calib = Load(
+        Filename=os.path.join(CALIB_DIR, config.full_instr_calib),
+        OutputWorkspace=f"full_inst_calib_{instrument}",
+    )
+
+    # a coarse template keeps this tiny; Rebin then subdivides it, so the fine grid is only ever
+    # materialised for the subsampled spectra. Two bins is the minimum the algorithm accepts.
+    template_name = f"__{instrument.lower()}_template"
+    template = CreateSimulationWorkspace(
+        Instrument=instrument,
+        BinParams=f"{tof_min},{0.5 * (tof_max - tof_min)},{tof_max}",
+        UnitX="TOF",
+        OutputWorkspace=template_name,
+    )
+    stride = max(1, template.getNumberHistograms() // _TARGET_SPECTRA)
+    indices = list(range(0, template.getNumberHistograms(), stride))
+    template = ExtractSpectra(InputWorkspace=template, WorkspaceIndexList=indices, OutputWorkspace=template_name)
+
+    ceria_path = _write_synthetic_run(instrument, template, full_calib, ceria_run, out_dir, ceria=True)
+    vanadium_path = _write_synthetic_run(instrument, template, full_calib, vanadium_run, out_dir, ceria=False)
+    for run in extra_sample_runs:
+        _write_synthetic_run(instrument, template, full_calib, run, out_dir, ceria=True)
+    return ceria_path, vanadium_path
+
+
+def _write_synthetic_run(instrument, template, full_calib, run_number, out_dir, ceria):
+    from mantid.simpleapi import AddSampleLog, Rebin, SaveNexusProcessed
+    from Engineering.EnggUtils import default_ceria_expected_peaks
+    from Engineering.common.instrument_config import get_instr_config
+
+    name = f"__{instrument.lower()}_{'ceria' if ceria else 'vanadium'}"
+    tof_min, tof_step, tof_max = get_instr_config(instrument).calibration_tof_binning
+    ws = Rebin(InputWorkspace=template, Params=f"{tof_min},{tof_step},{tof_max}", OutputWorkspace=name)
+
+    edges = ws.readX(0)
+    tof = 0.5 * (edges[1:] + edges[:-1])
+    tof_centre = 0.5 * (tof_min + tof_max)
+
+    if not ceria:
+        # featureless and strictly positive, so the vanadium background estimate returns
+        # essentially the input and the subsequent division never divides by zero
+        y = 800.0 + 400.0 * np.exp(-(((tof - tof_centre) / (0.5 * (tof_max - tof_min))) ** 2))
+        e = np.sqrt(y)
+        for index in range(ws.getNumberHistograms()):
+            ws.setY(index, y)
+            ws.setE(index, e)
+    else:
+        _fill_ceria_peaks(ws, tof, full_calib, default_ceria_expected_peaks(final=True))
+
+    AddSampleLog(Workspace=ws, LogName="run_number", LogType="String", LogText=str(run_number))
+    # without a proton charge the interface's loader silently rejects the run (NormaliseByCurrent)
+    AddSampleLog(Workspace=ws, LogName="gd_prtn_chrg", LogType="Number", NumberType="Double", LogText="1.0")
+
+    # both instruments zero pad their run numbers to 8 digits, which is what
+    # path_handling.get_run_number_from_path strips back off
+    path = os.path.join(out_dir, f"{instrument}{run_number:08d}.nxs")
+    SaveNexusProcessed(InputWorkspace=ws, Filename=path)
+    return path
+
+
+def _fill_ceria_peaks(ws, tof, full_calib, expected_d_values):
+    """Write one Gaussian per expected ceria peak into every spectrum.
+
+    Gaussians rather than the instrument's own ``IkedaCarpenterPV``, and the calibration is run with
+    the peak function set to ``Gaussian`` to match (see ``EngDiffGuiImatCalibrateAndFocusTest``).
+    Generating from ``IkedaCarpenterPV`` is more faithful, but it is slow on both sides - the
+    function has to be evaluated once per peak per spectrum rather than as one vectorised
+    expression, and fitting it with ``RespectFixedPeakParameters`` is far more expensive than a
+    Gaussian - which made this the longest running class in the suite by a wide margin.
+
+    What matters here is that the *generated* and *fitted* shapes agree, which is what gives
+    PDCalibration a well conditioned problem with a known answer of difa = tzero = 0. IMAT's real
+    default peak function is still asserted, at the configuration level, in
+    ``EngDiffGuiImatSettingsTest``.
+    """
+    # detector id -> difc, so each detector's peaks land where its own calibration puts them
+    difc_by_detid = {int(row["detid"]): float(row["difc"]) for row in full_calib}
+
+    # a smooth, strictly positive background; the peaks sit far above it
+    background = 100.0 + 20.0 * np.exp(-(((tof - 40000.0) / 25000.0) ** 2))
+    d_values = [d for d in expected_d_values if _D_MIN <= d <= _D_MAX]
+
+    for index in range(ws.getNumberHistograms()):
+        difc = difc_by_detid.get(ws.getDetector(index).getID())
+        if difc is None:
+            # no calibration entry for this detector, so leave it as background only
+            ws.setY(index, background)
+            ws.setE(index, np.sqrt(background))
+            continue
+        y = background.copy()
+        for d in d_values:
+            centre = difc * d
+            if not tof[0] < centre < tof[-1]:
+                continue
+            sigma = _REL_SIGMA * centre
+            y += (_PEAK_INTENSITY_PER_D * d / (sigma * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * ((tof - centre) / sigma) ** 2)
+        ws.setY(index, y)
+        ws.setE(index, np.sqrt(y))

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/eng_diff_gui_test_base.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction/eng_diff_gui_test_base.py
@@ -18,6 +18,7 @@ is also what keeps the system test collector from picking it up out of the modul
 """
 
 import os
+import re
 import sys
 from abc import ABCMeta
 
@@ -34,7 +35,7 @@ from qt_interaction_helpers import (  # noqa: E402
     select_combo,
     set_checkbox,
     set_finder_text,
-    wait_until,
+    wait_for_file_finder,
 )
 
 TAB_PREFIX = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs"
@@ -210,10 +211,7 @@ class EngDiffGuiTestBase(AutomatedUITestBase, metaclass=ABCMeta):
         # search settle before OK reads the resolved path back out
         for finder in (view.finder_save, view.finder_fullCalib):
             finder.findFiles(True)
-        wait_until(
-            lambda: not view.finder_save.isSearching() and not view.finder_fullCalib.isSearching(),
-            msg="settings dialog file finders",
-        )
+            wait_for_file_finder(finder, msg="settings dialog file finder")
         click(view.btn_ok)
         process_events(2)
 
@@ -320,7 +318,13 @@ class EngDiffGuiTestBase(AutomatedUITestBase, metaclass=ABCMeta):
         from mantid.api import AnalysisDataService as ADS
         from Engineering.EnggUtils import FOCUSED_OUTPUT_WORKSPACE_NAME
 
-        return sorted(name for name in ADS.getObjectNames() if FOCUSED_OUTPUT_WORKSPACE_NAME in name)
+        # the spectrum/group number is a trailing suffix, so a plain sort puts _10 before _2
+        def spectrum_order(name):
+            match = re.search(r"(\d+)$", name)
+            return (int(match.group(1)) if match else -1, name)
+
+        names = [name for name in ADS.getObjectNames() if FOCUSED_OUTPUT_WORKSPACE_NAME in name]
+        return sorted(names, key=spectrum_order)
 
 
 # ---------------------------------------------------------------------- IMAT data fixture
@@ -466,6 +470,10 @@ def _fill_ceria_peaks(ws, tof, full_calib, expected_d_values):
     """
     # detector id -> difc, so each detector's peaks land where its own calibration puts them
     difc_by_detid = {int(row["detid"]): float(row["difc"]) for row in full_calib}
+    if not difc_by_detid:
+        # otherwise every spectrum would come out as background only and the fixture would produce
+        # peakless data that fails much later, in the calibration, for no obvious reason
+        raise AssertionError("the full calibration table has no difc entries, so no peaks can be generated")
 
     # a smooth, strictly positive background; the peaks sit far above it
     background = 100.0 + 20.0 * np.exp(-(((tof - 40000.0) / 25000.0) ** 2))

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/automated_ui_test_base.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/automated_ui_test_base.py
@@ -1,0 +1,385 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Base class for system tests that drive a real Qt interface.
+
+These tests replace manual test guides: they build the genuine view/presenter/model, click real
+widgets with ``QTest`` and run real algorithms, mocking only what would otherwise block on user
+input. This module holds the parts that are not specific to any one interface, so a suite for a
+second interface can subclass ``AutomatedUITestBase`` and only supply its own setup.
+
+Four framework details shape everything here, and each of them contradicts the obvious approach:
+
+1. ``AsyncTask`` invokes its success/error callbacks *on the worker thread*, and Mantid's
+   ``Observable.notify_subscribers`` marshals back to the GUI thread with a **blocking** queued
+   connection. A plain ``worker.join()`` therefore deadlocks - the worker waits for the GUI thread
+   to pump events while the GUI thread waits in ``join()``. See ``wait_for_async_task``.
+2. Every test class in a module runs in the *same* Python process (``systestrunner.py`` uses
+   ``TestRunner.start_in_current_process``), so isolation has to happen per class in
+   ``setUp``/``tearDown``, and module scope must stay cheap and free of side effects - in
+   particular there must be no module-level ``QApplication``.
+3. ``MantidSystemTest`` gives one ``runTest()`` per class, but a manual test guide is dozens of
+   small observations. ``runTest`` is therefore a template method and subclasses implement
+   ``_run_checks``; see ``check`` for how a failure in one observation avoids hiding the rest.
+4. The system test collector picks up *every* ``MantidSystemTest`` subclass visible in a module,
+   including imported ones. This class stays uncollected only because it is abstract.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+import traceback
+from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
+from unittest import mock
+
+import systemtesting
+
+# make the shared helpers importable when this file is run by hand rather than through CMake, which
+# puts this directory on PYTHONPATH via PYUNITTEST_PYTHONPATH_EXTRA
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+# offscreen rendering must be requested before the first QApplication is built, and this module is
+# imported before any test constructs one
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def qt_is_available():
+    """Whether this build can construct widgets at all. Used by ``skipTests`` so a framework-only
+    build reports a clean skip instead of an import error during collection."""
+    try:
+        import qtpy.QtWidgets  # noqa: F401
+        import mantidqt  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def ensure_qapp():
+    """Return the process-wide QApplication, creating it on first use.
+
+    Deliberately lazy. Creating it at module scope - as some older Qt system tests do - builds a
+    QApplication inside the collector process too, because the runner imports every test module
+    before running anything.
+
+    Built through ``mantidqt``'s helper rather than ``QApplication(sys.argv)`` because that helper
+    calls ``setup_library_paths()`` first; without it Qt's plugin path is unset and constructing a
+    Mantid C++ widget such as ``FileFinderWidget`` fails with a bare ``RuntimeError``.
+    """
+    from mantidqt.utils.qt.testing import get_application
+
+    return get_application()
+
+
+class AutomatedUITestBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
+    """Harness for a Qt interface system test.
+
+    Subclasses implement ``_run_checks`` and, usually, override ``setUp`` to build their interface
+    after calling ``super().setUp()``.
+    """
+
+    # organisation/application used for the isolated settings store. Deliberately unlike
+    # workbench's ("mantidproject"/"mantidworkbench") so a test can never reach the real ini file.
+    SETTINGS_ORG = "mantidproject-systemtests"
+    SETTINGS_APP = "AutomatedUITest"
+
+    def __init__(self):
+        super(AutomatedUITestBase, self).__init__()
+        self._failures = []
+        self._saved_qsettings_state = None
+        self._saved_data_dirs = None
+        self.tmp_root = None
+
+    # ------------------------------------------------------------------ test protocol
+
+    @abstractmethod
+    def _run_checks(self) -> None:
+        """Perform the checks for this test.
+
+        Write this as a readable sequence of ``self._check_*`` calls following the manual test
+        guide, so a reader can line the two up.
+        """
+
+    def skipTests(self):
+        return not qt_is_available()
+
+    def runTest(self):
+        self._failures = []
+        self._run_checks()
+        if self._failures:
+            raise AssertionError(
+                f"{len(self._failures)} UI check(s) failed in {type(self).__name__}:\n  - " + "\n  - ".join(self._failures)
+            )
+
+    @contextmanager
+    def check(self, label):
+        """Record an assertion failure instead of raising, so the rest of the checks still run.
+
+        A manual test guide is a long list of largely independent observations, and a suite that
+        stopped at the first one would need as many CI runs as there are regressions. ``label``
+        should name the step being checked, e.g. "Test 1 / Calibration step 12 (three prm files)".
+
+        Use plain ``self.assertX`` instead for preconditions - "the run number resolved", "the
+        worker finished" - where continuing would only produce a cascade of meaningless failures.
+        """
+        try:
+            yield
+        except AssertionError as exc:
+            self._failures.append(f"{label}: {exc}")
+        except Exception as exc:
+            self._failures.append(f"{label}: unexpected {type(exc).__name__}: {exc}\n{traceback.format_exc()}")
+
+    def record_failure(self, label, message):
+        """Record a failure directly, for checks that are not expressed as an assertion."""
+        self._failures.append(f"{label}: {message}")
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def setUp(self):
+        ensure_qapp()
+        self._isolate_qsettings()
+        self.tmp_root = tempfile.mkdtemp(prefix="automated_ui_test_")
+        self.addCleanup(shutil.rmtree, self.tmp_root, True)
+
+    def tearDown(self):
+        # setUp may have failed part way through, so nothing here may assume it completed
+        from qt_interaction_helpers import close_all_figures, process_events
+
+        try:
+            close_all_figures()
+            process_events(2)
+        finally:
+            self._restore_data_search_dirs()
+            self._restore_qsettings()
+            self._clear_ads()
+
+    def cleanup(self):
+        # called by the framework after validation, outside the setUp/tearDown pair
+        self._clear_ads()
+
+    @staticmethod
+    def _clear_ads():
+        """Clear the ADS between classes.
+
+        Necessary rather than tidy: the interfaces keep hidden ``__``-prefixed workspaces that
+        would otherwise be silently reused by the next class in the same process.
+        """
+        from mantid.api import AnalysisDataService as ADS
+
+        ADS.clear()
+
+    # ------------------------------------------------------------------ settings isolation
+
+    def _isolate_qsettings(self):
+        """Redirect every bare ``QSettings()`` in this process into a temporary ini file.
+
+        Must run before the interface is constructed - interfaces typically read and write their
+        stored settings during ``__init__``.
+
+        Patching the interface's own settings helper is not enough: helpers are normally imported
+        by name into many modules, so one patch intercepts none of them, and it would still miss
+        the settings that Qt widgets (e.g. a file finder's last-used directory) write for
+        themselves. Redirecting at the QSettings level catches all of it.
+        """
+        from qtpy.QtCore import QCoreApplication, QSettings
+
+        self._settings_dir = tempfile.mkdtemp(prefix="automated_ui_qsettings_")
+        self._saved_qsettings_state = (
+            QSettings.defaultFormat(),
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        # on Windows the default format is the registry, which setPath cannot redirect
+        QSettings.setDefaultFormat(QSettings.IniFormat)
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, self._settings_dir)
+        QCoreApplication.setOrganizationName(self.SETTINGS_ORG)
+        QCoreApplication.setApplicationName(self.SETTINGS_APP)
+
+    def _restore_qsettings(self):
+        if self._saved_qsettings_state is None:
+            return
+        from qtpy.QtCore import QCoreApplication, QSettings
+
+        fmt, org, app = self._saved_qsettings_state
+        QSettings.setDefaultFormat(fmt)
+        QCoreApplication.setOrganizationName(org)
+        QCoreApplication.setApplicationName(app)
+        self._saved_qsettings_state = None
+        shutil.rmtree(self._settings_dir, ignore_errors=True)
+
+    def settings_file(self):
+        """Path of the isolated ini file, for asserting on what an interface stored."""
+        return os.path.join(self._settings_dir, self.SETTINGS_ORG, f"{self.SETTINGS_APP}.ini")
+
+    # ------------------------------------------------------------------ data search directories
+
+    def add_data_search_dir(self, directory):
+        """Add a directory to Mantid's data search path for the duration of this test.
+
+        This is how a test gets the interface's own file finder to resolve fabricated run files:
+        the interface then loads them exactly as it would a real run, rather than the test reaching
+        past the view to inject a workspace.
+        """
+        from mantid.kernel import config
+
+        if self._saved_data_dirs is None:
+            self._saved_data_dirs = config["datasearch.directories"]
+        config.appendDataSearchDir(directory)
+
+    def _restore_data_search_dirs(self):
+        if self._saved_data_dirs is None:
+            return
+        from mantid.kernel import config
+
+        config["datasearch.directories"] = self._saved_data_dirs
+        self._saved_data_dirs = None
+
+    # ------------------------------------------------------------------ waiting
+
+    def wait_for_async_task(self, worker, timeout=1800.0, what="worker"):
+        """Block until an ``AsyncTask`` finishes, pumping the event loop throughout.
+
+        ``AsyncTask.run`` calls its success/error callback on the worker thread. Mantid presenters
+        typically notify their observers from that callback, and ``Observable.notify_subscribers``
+        goes through ``QAppThreadCall(..., blocking=True)``, i.e. a ``BlockingQueuedConnection``.
+        The worker is therefore parked until the GUI thread runs its event loop - so a plain
+        ``worker.join()`` here would deadlock both threads. Short joins interleaved with
+        ``processEvents`` are what make it terminate.
+        """
+        from qt_interaction_helpers import process_events
+
+        if worker is None:
+            raise RuntimeError(f"no {what} was started - was the click rejected by validation?")
+        deadline = time.time() + timeout
+        while worker.is_alive():
+            process_events()
+            worker.join(0.01)
+            if time.time() > deadline:
+                raise RuntimeError(f"{what} did not finish within {timeout}s")
+        # drain the callbacks the worker queued on its way out (e.g. re-enabling controls)
+        process_events(3)
+
+    # ------------------------------------------------------------------ modal dialogs
+
+    def patch_error_messages(self, modules, helper_name="create_error_message"):
+        """Stop a module's error popup from blocking, and record what it would have said.
+
+        An unattended test that pops a modal message box hangs until the suite times out, so every
+        module that can raise one must be neutralised before the first click. The recorded text
+        goes to ``self.message_box_messages``, which turns "the interface rejected this input" from
+        a hang into something a check can assert on.
+
+        ``modules`` are module paths that import the popup helper *by name*, so each one needs its
+        own patch - patching the definition would not affect any of them.
+        """
+        self.message_box_messages = []
+
+        def record(_parent, message):
+            self.message_box_messages.append(str(message))
+
+        for module in modules:
+            patcher = mock.patch(f"{module}.{helper_name}", side_effect=record)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def patch_confirmation_box(self, module, answer):
+        """Answer a blocking ``QMessageBox.warning`` confirmation prompt with ``answer``.
+
+        Distinct from ``patch_error_messages`` because the interface *uses* the return value to
+        decide whether to continue, so the test has to choose which button the user pressed.
+        """
+        if not hasattr(self, "message_box_messages"):
+            self.message_box_messages = []
+
+        def record(*args, **_kwargs):
+            # QMessageBox.warning(parent, title, text, buttons, default_button)
+            self.message_box_messages.append(str(args[2]) if len(args) > 2 else "")
+            return answer
+
+        patcher = mock.patch(f"{module}.QMessageBox")
+        mocked = patcher.start()
+        mocked.warning.side_effect = record
+        mocked.Ok = answer
+        mocked.Cancel = object()
+        self.addCleanup(patcher.stop)
+        return mocked
+
+    @contextmanager
+    def algorithm_dialog_runs(self, presenter_module, run_algorithm):
+        """Emulate a user accepting one of the ``InterfaceManager`` algorithm dialogs.
+
+        Several tabs open a generated algorithm dialog (``SetGoniometer``, ``LoadSampleShape``,
+        ``SetSampleMaterial``, ...) and then react to the algorithm finishing. Showing a real
+        dialog would block, so ``InterfaceManager`` is replaced and its dialog is told that, when
+        shown, it should run ``run_algorithm`` for real and then notify the observer the presenter
+        registered - which is exactly the sequence the real dialog drives on accept. Everything
+        downstream of that (the presenter's ``finishHandle``, the queued redraw) runs unmodified.
+        """
+        from qt_interaction_helpers import process_events
+
+        with mock.patch(f"{presenter_module}.InterfaceManager") as manager:
+            dialog = manager.return_value.createDialogFromName.return_value
+
+            def show_dialog():
+                run_algorithm()
+                dialog.addAlgorithmObserver.call_args.args[0].finishHandle()
+
+            dialog.show.side_effect = show_dialog
+            yield dialog
+        # finishHandle emits a queued signal so the redraw happens on the GUI thread
+        process_events(3)
+
+    # ------------------------------------------------------------------ log capture
+
+    @contextmanager
+    def captured_logs(self, level="notice"):
+        """Capture Mantid log output, for the checks that assert on what was reported.
+
+        Yields a holder whose ``text`` attribute is filled in when the block exits, rather than the
+        underlying buffer: ``mantid.utils.logging.capture_logs`` closes its buffer on the way out,
+        so reading it afterwards - which is the natural way to write the assertion - raises
+        "I/O operation on closed file". Reading ``text`` after the block is the supported use.
+        """
+        from mantid.utils.logging import capture_logs
+
+        class _CapturedLogs:
+            text = ""
+
+            def getvalue(self):
+                return self.text
+
+        holder = _CapturedLogs()
+        with capture_logs(level=level) as logs:
+            try:
+                yield holder
+            finally:
+                holder.text = logs.getvalue()
+
+    # ------------------------------------------------------------------ filesystem assertions
+
+    @staticmethod
+    def files_under(directory, extension=None):
+        """Every file below ``directory``, as paths relative to it, sorted.
+
+        Used for the save-layout checks, where the point is both which files appear and which
+        directories they appear in.
+        """
+        if not os.path.isdir(directory):
+            return []
+        found = []
+        for root, _dirs, files in os.walk(directory):
+            for name in files:
+                if extension is None or name.endswith(extension):
+                    found.append(os.path.relpath(os.path.join(root, name), directory))
+        return sorted(found)
+
+    @staticmethod
+    def basenames_under(directory, extension=None):
+        return sorted(os.path.basename(p) for p in AutomatedUITestBase.files_under(directory, extension))

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/automated_ui_test_base.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/automated_ui_test_base.py
@@ -94,6 +94,7 @@ class AutomatedUITestBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
         super(AutomatedUITestBase, self).__init__()
         self._failures = []
         self._saved_qsettings_state = None
+        self._settings_dir = None
         self._saved_data_dirs = None
         self.tmp_root = None
 
@@ -212,10 +213,16 @@ class AutomatedUITestBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
         QCoreApplication.setOrganizationName(org)
         QCoreApplication.setApplicationName(app)
         self._saved_qsettings_state = None
+        # point the ini path somewhere that still exists before the temporary directory goes, so a
+        # later bare QSettings() in this process does not write into a deleted directory
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, tempfile.gettempdir())
         shutil.rmtree(self._settings_dir, ignore_errors=True)
+        self._settings_dir = None
 
     def settings_file(self):
         """Path of the isolated ini file, for asserting on what an interface stored."""
+        if self._settings_dir is None:
+            raise RuntimeError("settings are not isolated - settings_file() is only valid between setUp and tearDown")
         return os.path.join(self._settings_dir, self.SETTINGS_ORG, f"{self.SETTINGS_APP}.ini")
 
     # ------------------------------------------------------------------ data search directories
@@ -298,16 +305,19 @@ class AutomatedUITestBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
         if not hasattr(self, "message_box_messages"):
             self.message_box_messages = []
 
+        patcher = mock.patch(f"{module}.QMessageBox")
+        mocked = patcher.start()
+        # Ok and Cancel must be distinct sentinels: callers decide by comparing the returned value
+        # against QMessageBox.Ok, so a shared value would make a rejection read as an acceptance.
+        mocked.Ok = object()
+        mocked.Cancel = object()
+
         def record(*args, **_kwargs):
             # QMessageBox.warning(parent, title, text, buttons, default_button)
             self.message_box_messages.append(str(args[2]) if len(args) > 2 else "")
-            return answer
+            return mocked.Ok if answer else mocked.Cancel
 
-        patcher = mock.patch(f"{module}.QMessageBox")
-        mocked = patcher.start()
         mocked.warning.side_effect = record
-        mocked.Ok = answer
-        mocked.Cancel = object()
         self.addCleanup(patcher.stop)
         return mocked
 

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/qt_interaction_helpers.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/qt_interaction_helpers.py
@@ -18,9 +18,10 @@ because the naive Qt call does not do what you want in a headless test:
 
 import time
 
-from qtpy.QtCore import QEventLoop, QPoint, Qt
-from qtpy.QtTest import QTest
-from qtpy.QtWidgets import QApplication, QCheckBox, QStyle
+# Qt is imported inside the functions that need it, never at module scope: this module is imported
+# by test modules that the system test collector loads on every build, including framework-only
+# builds with no Qt, and an import error there would break collection before ``skipTests`` could
+# report a clean skip.
 
 # a click that has to travel through the event loop is delivered by processEvents; 20 ms is long
 # enough to drain a burst of queued signals without making the polling loops feel sluggish
@@ -30,12 +31,18 @@ _EVENT_SLICE_MS = 20
 def process_events(rounds=1):
     """Drain the Qt event queue. Several rounds are sometimes needed because handlers post further
     events (a queued signal whose slot emits another queued signal)."""
+    from qtpy.QtCore import QEventLoop
+    from qtpy.QtWidgets import QApplication
+
     for _ in range(rounds):
         QApplication.processEvents(QEventLoop.AllEvents, _EVENT_SLICE_MS)
 
 
 def click(widget):
     """Left-click the centre of a widget."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
     QTest.mouseClick(widget, Qt.LeftButton)
     process_events()
 
@@ -47,6 +54,10 @@ def click_checkbox(checkbox):
     styles but not reliably in the offscreen platform plugin. The indicator at the left edge is the
     dependable hot-spot, and it is also where the checkboxes embedded in table cells live.
     """
+    from qtpy.QtCore import QPoint, Qt
+    from qtpy.QtTest import QTest
+    from qtpy.QtWidgets import QStyle
+
     indicator_w = checkbox.style().pixelMetric(QStyle.PM_IndicatorWidth)
     QTest.mouseClick(checkbox, Qt.LeftButton, pos=QPoint(max(indicator_w // 2, 4), checkbox.height() // 2))
     process_events()
@@ -57,6 +68,8 @@ def set_checkbox(checkbox, checked):
     to know the current state to end up in a known one."""
     if checkbox.isChecked() != checked:
         click_checkbox(checkbox)
+    if checkbox.isChecked() != checked:
+        raise AssertionError(f"checkbox '{checkbox.text()}' is {checkbox.isChecked()} after asking for {checked}")
     return checkbox.isChecked()
 
 
@@ -85,6 +98,8 @@ def table_checkbox(table, row, col):
     Both the correction and texture tables put their select box inside a QWidget/QHBoxLayout so it
     can be centred, so the checkbox is a grandchild of the cell rather than the cell widget itself.
     """
+    from qtpy.QtWidgets import QCheckBox
+
     cell_widget = table.cellWidget(row, col)
     if cell_widget is None:
         raise AssertionError(f"no cell widget at row {row}, column {col}")
@@ -133,6 +148,9 @@ def set_finder_text(finder, text, expect_valid=True):
     logic bug rather than a race.
     """
     finder.setFileTextWithSearch(text)
+    # the search is started from a queued signal, so isSearching() can still be false for the
+    # *previous* text on the next line; wait for the widget to take the new text first
+    wait_until(lambda: finder.getText() == text, msg=f"file finder accepting '{text}'")
     wait_for_file_finder(finder, msg=f"file finder resolving '{text}'")
     if expect_valid and not finder.isValid():
         raise AssertionError(f"file finder could not resolve '{text}'")
@@ -156,4 +174,6 @@ def close_all_figures():
 def top_level_widget_names():
     """Object names of the currently open top-level widgets, for asserting that a button opened a
     new window."""
+    from qtpy.QtWidgets import QApplication
+
     return [w.objectName() for w in QApplication.topLevelWidgets() if w.isVisible()]

--- a/Testing/SystemTests/tests/qt/AutomatedUITest/qt_interaction_helpers.py
+++ b/Testing/SystemTests/tests/qt/AutomatedUITest/qt_interaction_helpers.py
@@ -1,0 +1,159 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Widget-level helpers for driving a Qt interface from a test.
+
+These are free functions with no dependency on the system test framework, so they can be used from
+an ordinary unit test as readily as from an ``AutomatedUITestBase`` subclass. Most of them exist
+because the naive Qt call does not do what you want in a headless test:
+
+* a ``QCheckBox`` only toggles when the click lands on its *indicator*, not its label,
+* ``FileFinderWidget`` searches on a background thread, so its result is not available on the next
+  line, and
+* anything that waits must keep pumping the Qt event loop (see ``wait_until``).
+"""
+
+import time
+
+from qtpy.QtCore import QEventLoop, QPoint, Qt
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QApplication, QCheckBox, QStyle
+
+# a click that has to travel through the event loop is delivered by processEvents; 20 ms is long
+# enough to drain a burst of queued signals without making the polling loops feel sluggish
+_EVENT_SLICE_MS = 20
+
+
+def process_events(rounds=1):
+    """Drain the Qt event queue. Several rounds are sometimes needed because handlers post further
+    events (a queued signal whose slot emits another queued signal)."""
+    for _ in range(rounds):
+        QApplication.processEvents(QEventLoop.AllEvents, _EVENT_SLICE_MS)
+
+
+def click(widget):
+    """Left-click the centre of a widget."""
+    QTest.mouseClick(widget, Qt.LeftButton)
+    process_events()
+
+
+def click_checkbox(checkbox):
+    """Toggle a checkbox by clicking its indicator.
+
+    A click on the centre of a wide checkbox lands on the label, which does toggle it in most
+    styles but not reliably in the offscreen platform plugin. The indicator at the left edge is the
+    dependable hot-spot, and it is also where the checkboxes embedded in table cells live.
+    """
+    indicator_w = checkbox.style().pixelMetric(QStyle.PM_IndicatorWidth)
+    QTest.mouseClick(checkbox, Qt.LeftButton, pos=QPoint(max(indicator_w // 2, 4), checkbox.height() // 2))
+    process_events()
+
+
+def set_checkbox(checkbox, checked):
+    """Click a checkbox only if it is not already in the wanted state, so the caller does not have
+    to know the current state to end up in a known one."""
+    if checkbox.isChecked() != checked:
+        click_checkbox(checkbox)
+    return checkbox.isChecked()
+
+
+def combo_items(combo):
+    return [combo.itemText(i) for i in range(combo.count())]
+
+
+def select_combo(combo, text):
+    """Select a combo entry by its visible text, failing loudly rather than silently leaving the
+    selection unchanged (which is what ``setCurrentText`` does for a non-editable combo)."""
+    index = combo.findText(text)
+    if index < 0:
+        raise AssertionError(f"'{text}' is not in the combo box; available: {combo_items(combo)}")
+    combo.setCurrentIndex(index)
+    process_events()
+
+
+def table_column(table, col):
+    """Text of every cell in a column, top to bottom."""
+    return [table.item(row, col).text() if table.item(row, col) else None for row in range(table.rowCount())]
+
+
+def table_checkbox(table, row, col):
+    """The QCheckBox inside a table cell.
+
+    Both the correction and texture tables put their select box inside a QWidget/QHBoxLayout so it
+    can be centred, so the checkbox is a grandchild of the cell rather than the cell widget itself.
+    """
+    cell_widget = table.cellWidget(row, col)
+    if cell_widget is None:
+        raise AssertionError(f"no cell widget at row {row}, column {col}")
+    checkbox = cell_widget.findChild(QCheckBox)
+    if checkbox is None:
+        raise AssertionError(f"no checkbox inside the cell widget at row {row}, column {col}")
+    return checkbox
+
+
+def cell_button(table, row, col):
+    """The QPushButton inside a table cell, e.g. the '[View Shape]' buttons."""
+    from qtpy.QtWidgets import QPushButton
+
+    cell_widget = table.cellWidget(row, col)
+    if cell_widget is None:
+        return None
+    return cell_widget if isinstance(cell_widget, QPushButton) else cell_widget.findChild(QPushButton)
+
+
+def wait_until(predicate, timeout=120.0, msg=""):
+    """Block until ``predicate()`` is true, pumping the event loop while waiting.
+
+    Never use a bare ``sleep`` or ``thread.join()`` in a GUI test: work that finishes on a
+    background thread usually reports back through a queued - sometimes *blocking* queued - Qt
+    connection, which cannot be delivered unless this thread is running its event loop.
+    """
+    deadline = time.time() + timeout
+    while not predicate():
+        process_events()
+        if time.time() > deadline:
+            raise RuntimeError(f"timed out after {timeout}s waiting for {msg or 'condition'}")
+        time.sleep(0.005)
+    process_events()
+
+
+def wait_for_file_finder(finder, msg=""):
+    """Wait for a FileFinderWidget to finish its background search."""
+    wait_until(lambda: not finder.isSearching(), msg=msg or "file finder search")
+
+
+def set_finder_text(finder, text, expect_valid=True):
+    """Type a run number or path into a FileFinderWidget and wait for the search to resolve.
+
+    The Engineering presenters refuse to act (and pop a modal warning) while a finder is still
+    searching or is invalid, so a test that does not wait here fails in a way that looks like a
+    logic bug rather than a race.
+    """
+    finder.setFileTextWithSearch(text)
+    wait_for_file_finder(finder, msg=f"file finder resolving '{text}'")
+    if expect_valid and not finder.isValid():
+        raise AssertionError(f"file finder could not resolve '{text}'")
+    return finder
+
+
+def figure_numbers():
+    """Open matplotlib figure numbers. Used to assert that a 'plot output' checkbox really did (or
+    really did not) create a plot."""
+    import matplotlib.pyplot as plt
+
+    return set(plt.get_fignums())
+
+
+def close_all_figures():
+    import matplotlib.pyplot as plt
+
+    plt.close("all")
+
+
+def top_level_widget_names():
+    """Object names of the currently open top-level widgets, for asserting that a button opened a
+    new window."""
+    return [w.objectName() for w in QApplication.topLevelWidgets() if w.isVisible()]

--- a/Testing/SystemTests/tests/qt/CMakeLists.txt
+++ b/Testing/SystemTests/tests/qt/CMakeLists.txt
@@ -6,4 +6,5 @@ set(SYSTEST_NAMES CppInterfacesStartupTest.py FitScriptGeneratorStartupTest.py P
 
 if(ENABLE_WORKBENCH)
   pysystemtest_add_test(${CMAKE_CURRENT_SOURCE_DIR} qt ${SYSTEST_NAMES})
+  add_subdirectory(AutomatedUITest)
 endif()

--- a/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
+++ b/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
@@ -32,8 +32,8 @@ The automated suite
 ^^^^^^^^^^^^^^^^^^^
 
 The tests live in ``Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction`` and are
-registered with CTest under the ``qt.AutomatedUITest.EngineeringDiffraction`` prefix, so the whole
-suite is::
+registered with CTest under the ``qt.AutomatedUITest.EngineeringDiffraction`` prefix (only when the
+build has ``ENABLE_WORKBENCH`` on), so the whole suite is::
 
     ctest -R qt.AutomatedUITest.EngineeringDiffraction
 

--- a/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
+++ b/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst
@@ -3,470 +3,130 @@
 Engineering Diffraction Testing
 =================================
 
-
-Preamble
-^^^^^^^^^
-- This document is tailored towards developers intending to test the Engineering Diffraction interface.
-- Runs can be loaded from the archive, however it is possible that different run numbers will be needed as older runs may be deleted.
-- The nexus files for all the runs used below are available from ``<mantidBuildDir>/ExternalData/Testing/Data/DocTest`` path
-- Data loading time from the archive can be reduced by adding the above path at ``File`` -> ``Manage User Directories`` -> ``Data Search Directories`` before starting the tests.
-
+.. contents::
+  :local:
 
 Overview
 ^^^^^^^^
-The Engineering Diffraction interface allows scientists using the EnginX instrument to interactively
-process their data. There are 5 tabs in total. These are:
 
-- ``Run Processing`` - This is where a cerium oxide run is entered to calibrate the subsequent data, which can also be
-  focussed into a single spectrum.
-- ``Absorption Correction`` - This is where the experimental can be corrected for beam attenuation
-- ``Fitting`` - Where peaks can be fitted on focused data
-- ``Texture`` - Where pole figure's can be generated for experimental runs and their fitted peaks
-- ``GSAS II`` - Run a basic refinement on the `GSASIIscriptable API <https://gsas-ii.readthedocs.io/en/latest/GSASIIscriptable.html>`_
-
-Especially to aide ``GSASII`` testing, please test on an ENGINX IDAaaS instance.
-
-The tests are designed to be run from a starting point where no settings relating to the Engineering Diffraction Gui
-have been saved in the Mantid Workbench ini file. This file is in ``C:\Users\<fed id>\AppData\Roaming\mantidproject`` on
-Windows and ``~/.config/mantidproject/`` on linux. To ensure there are no saved settings open up the file mantidworkbench.ini
-and delete the settings with names starting with EngineeringDiffraction2 from the CustomInterfaces section
-
-Test 1 - Calibration and focussing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This test follows the simple steps for calibrating and focusing in the Engineering Diffraction Gui.
-
-Calibration
------------
-
-1. Ensure you can access the ISIS data archive.
-
-2. Open the Engineering Diffraction gui: ``Interfaces`` -> ``Diffraction`` -> ``Engineering Diffraction``
-
-3. On opening the gui the ``Create New Calibration`` option should be selected.
-
-4. Open the settings dialog from the cog in the bottom left of the gui.
-
-5. Set the ``Save Location`` to a directory of your choice.
-
-6. Check that the ``Full Calibration`` setting has a default path to a `.nxs` file (currently ``ENGINX_full_instrument_calibration_193749.nxs``)
-
-7. Close the settings window
-
-8. For the ``Vanadium #`` enter ``307521``.
-
-9. For the ``Calibration Sample #`` enter ``305738``.
-
-10. Tick the ``Plot Calibrated Workspace`` option.
-
-11. Click ``Calibrate``, after completing calibration it should produce the following plot.
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffExpectedLinear.png
-    :width: 900px
-
-12. Check that in your save location there is a Calibration folder containing three `.prm` files
-    `ENGINX_305738` with the suffixes `_all_banks`, `_bank_1`, `_bank_2`.
-
-13. Close the Engineering Diffraction gui and reopen it. The ``Load Existing Calibration`` radio
-    button should be checked on the ``Calibration`` tab and the path should be populated with the
-    `_all_banks.prm` file generated earlier in this test.
-
-14. In the ``Load Existing Calibration`` box browse to the `_bank_2.prm` file and click the ``Load`` button.
-
-Focus
------
-
-1. Now let's look at the ``Focus`` group.
-
-2. For the ``Sample Run #`` use ``305761`` and leave ``Vanadium #`` set to ``307521``.
-
-3. Tick the ``Plot Focused Workspace`` option and click ``Focus``. It should produce a plot of a single spectrum for bank 2.
-
-4. In the ``Calibration`` group select an existing calibration file for both banks e.g. `ENGINX_305738_all_banks.prm` and click ``Load``.
-
-5. Click the ``Focus`` button, after completing calibration it should produce a plot.
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffExampleFocusOutput.png
-    :width: 900px
-
-6. Check that in your save location there is a Focus folder containing the following files:
-
-    - ENGINX_305738_305721_all_banks_dSpacing.abc
-    - ENGINX_305738_305721_all_banks_dSpacing.gss
-    - ENGINX_305738_305721_all_banks_TOF.abc
-    - ENGINX_305738_305721_all_banks_TOF.gss
-    - ENGINX_305738_305721_bank_1_dSpacing.nxs
-    - ENGINX_305738_305721_bank_1_TOF.nxs
-    - ENGINX_305738_305721_bank_2_dSpacing.nxs
-    - ENGINX_305738_305721_bank_2_TOF.nxs
-    - CombinedFiles/ENGINX_305761_236516_bank_dSpacing.nxs
-
-7. There should also be a ``CombinedFiles`` folder which should contain:
-
-   - ENGINX_305761_307521_bank_dSpacing.nxs
-   - ENGINX_305761_307521_bank_2_dSpacing.nxs
-
-Test 2 - RB Number
-^^^^^^^^^^^^^^^^^^
-
-This test covers the RB number.
-
-1. Enter a string into the ``RB Number`` box.
-
-2. Follow the steps of `Test 1`, any output files (for non-texture ROI) should now be located in both
-   [Save location]/User/[RB number] and [Save location] (for texture ROI the files will be saved in the first location
-   if an RB number is specified, otherwise they will be saved in the latter - this is to reduce the number of files being written).
-
-
-Test 3 - Cropping
-^^^^^^^^^^^^^^^^^
-
-This test covers the Cropping functionality in the ``Run Processing`` tab.
-
-1. Change the ``RB Number`` to ``North``, this is purely to separate the cropped output files into their own space.
-
-2. Go to the ``Run Processing`` tab, select ``Create New Calibration`` and tick the ``Set Calibration Region of Interest`` option. In the drop down ``Region of Interest`` select ``1 (North)``.
-
-3. Check the ``Plot Calibrated Workspace`` checkbox and click ``Calibrate``.
-
-4. The generated figure should show a plot of TOF vs d-spacing and plot showing residuals of the quadratic fit.
-
-5. Check that only one `.prm` and one `.nxs` output file was generated.
-
-6. Click the ``Focus`` button.
-
-7. Change the ``RB number`` to `Custom`.
-
-8. Set the ``Region Of Interest`` to ``Crop to Spectra`` and using ``Custom Spectra`` ``1200-2400`` (these spectrum numbers correspond to the South Bank).
-   Please note that some custom spectra values may cause the algorithms to fail. Click ``Calibrate`` and a similar plot to before should appear but with only 2 subplots.
-
-9. Set the ``Region of Interest`` to ``Texture (20 spec)`` and click ``Calibrate`` - there should be 20 spectra per run (5 tiled plot windows, 4 spectra per window).
-
-
-Test 4 - Absorption Correction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This test covers the sample setting functionality in the ``Absorption Correction`` tab.
-
-1. Change the ``RB Number`` to ``ManualTesting``.
-
-2. Go to the ``Absorption Correction`` tab, in ``Sample Run(s)`` enter ``305738`` and click ``Load Files``
-
-3. A row should have been added to the table with ``Run: ENGINX00305738``, ``Shape: Not Set``, ``Material: Not set``, and ``Orientation: default``
-
-4. Click ``Create Reference Workspace``, ``ManualTesting_reference_workspace`` should now be listed as ``Reference Frame``
-
-5. In the ``Sample Shape`` section click ``Load Shape onto single WS``
-
-6. Make sure ``InputWorkspace`` and ``OutputWorkspace`` are set to ``ManualTesting_reference_workspace``
-
-7. Set ``Filename`` to a suitable file (``<mantidBuildDir>/ExternalData/Testing/Data/UnitTest/cube.stl``) and ``Scale`` to ``mm``
-
-8. There should now be a ``View`` button next to ``Shape`` in the ``Reference Workspace Information``
-
-9. Click this ``View`` button
-
-10. If you have used the example STL you should get the following:
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffSamplePlot.png
-    :width: 600px
-
-11. Now click ``Set Shape onto single WS`` and set ``InputWorkspace`` again to ``ManualTesting_reference_workspace``
-
-12. Set ``ShapeXML`` to:
-
-..testcode::
-
-   <cuboid id='some-cuboid'> \
-   <height val='0.015'  /> \
-   <width val='0.012' />  \
-   <depth  val='0.012' />  \
-   <centre x='0.0' y='0.0' z='0.0'  />  \
-   </cuboid>  \
-   <algebra val='some-cuboid' /> \
-
-13. Click ``Set Sample Material``, set ``InputWorkspace`` to ``ManualTesting_reference_workspace`` and ``ChemicalFormula`` to ``Fe`` and click ``Run``
-
-14. Click ``Set Single Orientation`` and set the ``Workspace`` as ``ENGINX00305738`` and set ``Axis0`` to ``90,1,0,0,1`` and ``Axis1`` to ``135,0,0,1,-1``, then click ``Run``
-
-15. Click either the checkbox in the table or ``Select All`` beneath the table to select the workspace and click ``Copy Reference Sample``
-
-16. The table should now be updated to ``Run: ENGINX00305738``, ``Shape: [View Shape]``, ``Material: Fe``, and ``Orientation: set``
-
-17. Open the settings menu (gear icon, bottom left)
-
-18. Set Texture Directions to be ``D1  0  1  0``, ``D2  1  0  0``, and ``D3  0  0  1`` and click ``OK``
-
-19. Down under the ``Include Absorption Correction`` change ``4mmCube`` to ``Custom Shape``
-
-20. A new ``Custom Gauge Volume File`` field should have appeared, click ``Browse`` and navigate to ``<mantidBuildDir>/ExternalData/Testing/Data/SystemTest/Texture/custom_gauge_volume.xml``
-
-21. Clicking ``View Shape`` again, the shape should now look like:
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffSamplePlot2.png
-    :width: 600px
-
-22. Click ``Apply Correction`` at the bottom of the tab
-
-23. In the save directories, you should see an ``AbsorptionCorrection`` folder with ``Corrected_ENGINX00305738.nxs``
-
-24. Play around with other functionality (tool tips or Technique reference might be helpful) in this tab some things you can try:
-
-   - Load a collection of runs using the search ``305793-305795``
-   - Load runs from browsing (some more ENGINX data can be found in ``ExternalData/Testing/Data/SystemTest``)
-   - Load Orientation File (some orientation files can be found in ``ExternalData/Testing/Data/SystemTest/Texture``)
-
-Test 5 - Focused data
-^^^^^^^^^^^^^^^^^^^^^
-
-This test covers the loading and plotting focused data in the fitting tab.
-
-.. note:: Sometimes it will be tricky to load ENGINX files from the archive and the red ``*`` next to the ``Browse`` button won't disappear. Proceeding with the red ``*`` will raise an error saying ``Check run numbers/path is valid.`` or ``Mantid is searching for data files. Please wait``. In such cases, please try re-entering the text and wait till the red ``*`` is cleared before proceeding. If the log level is set to Information, found path = 1 will be visible in the message log when the runs are found from the archive.
-
-1. Ensure you can access the ISIS data archive. In the ``Run Processing`` tab, select ``Create New Calibration`` and enter ``Calibration sample`` # ``305738`` and ``Vanadium #`` to ``307521``. Before proceeding, make sure the red ``*`` next to the ``Browse`` button is disappeared when clicked somewhere outside that text box.
-   Untick ``Set Calibration Region of Interest`` option and click on ``Calibrate`` button.
-
-2.  Set ``Sample Run #`` to ``305793-305795``. These sample runs have different stress and strain log values. Make sure the red ``*`` s next to the two ``Browse`` buttons are cleared when clicked outside the text boxes or wait otherwise. Then click ``Focus``.
-
-3. In the ``Fitting`` tab, load multiple of these newly focused TOF `.nxs` files in the ``Load Focused Data`` section. The path to the focused files should be auto populated.
-
-4. Click the ``Load`` button. A row should be added to the UI table for each focused run.
-   There should be a grouped workspace with the suffix `_logs_Fitting` in the ADS with tables corresponding to each log value specified in the settings (to open the settings use the cog in the bottom left corner of the UI).
-   In the same grouped workspace there should be an additional table called `run_info_Fitting` that provides some of the metadata for each run.
-   Each row in these tables should correspond to the equivalent row in the UI table.
-
-5. The log values that are averaged can be selected in the settings (cog button in the bottom left corner of the UI). Change which sample log checkboxes are selected. Close settings and then close and re-open the Engineering Diffraction interface.
-   Reopen settings to check these selected sample logs have been remembered. Note that any change to the selected logs won't take effect until the interface is reopened.
-
-6. Clear the runs by clicking ``Remove All`` below the table. Repeat steps 1-2 above but this time try checking the ``Add To Plot`` checkbox, when loading the run(s) the data should now be plotted and the checkbox in the ``Plot`` column of the UI table should be checked.
-
-7. Clear the runs by clicking ``Remove All`` below the table. Repeat steps 1-2 again but load the d-spacing .nxs file(s) instead.
-
-8. Plot some data and un-dock the plot in the UI by dragging or double-clicking the bar at the top of the plot labelled ``Fit Plot``. The plot can now be re-sized.
-
-9. To dock it double click the ``Fit Plot`` bar (or drag to the bottom of the toolbar). You may want to un-dock it again for subsequent tests.
-
-Test 6 - Browse Filters
-^^^^^^^^^^^^^^^^^^^^^^^
-
-This tests the ``Browse Filters`` functionality to filter the focused data in the ``Load Focused Data`` section at the top of ``Fitting`` tab.
-
-1. The tests so far have enabled you to produce many different focussed data files. In the ``Load Focused Data`` section at the top of ``Fitting`` tab,
-   when clicked on ``Browse`` button, check that the ``Unit Filter`` and ``Region Filter`` combo boxes help you to find ``dSpacing`` data for Texture regions and ``TOF`` data for North bank.
-
-Test 7 - Run removal
-^^^^^^^^^^^^^^^^^^^^
-
-This tests the removal of focused runs from the ``Fitting`` tab.
-
-1. Load multiple runs using the ``Browse`` button. This should take you to a folder called "`Focus`" containing `.nxs` files that have been previously generated from the ``Focus`` group of the ``Run Processing`` tab. Select multiple files and click on ``Open``
-
-2. Having loaded multiple runs, select a row in the UI table and then click the ``Remove Selected`` button below the table.
-   The row should be removed, if the run was plotted it will disappear from the plot and there should be one less row in each of the table workspaces inside the "_logs_Fitting" workspace group with each row corresponding to the run in the same row of the UI table.
-   The workspaces called "ENGINX\_...._TOF" and "ENGINX\_...._TOG_bgsub" will be deleted from the ADS
-
-3. Try clicking the ``Remove All`` button, the UI table should be empty and the workspace group with name ending "_logs_Fitting" should no longer be present.
-
-4. Try loading in a run again, the UI should still be able to access the workspace and remember the log values - check there are no calls to ``AverageLogData`` in the log (should be visible when log level is ``Notice``).
-
-5. Try removing a workspace by deleting it in the ADS, the corresponding row in the log tables and the UI table should have been removed.
-
-6. Delete a ``_bgsub`` workspace in the ADS, the corresponding row will not be deleted, but the ``Subtract BG`` checkbox will be unchecked.
-
-Test 8 - Background subtraction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This tests that the background subtraction works.
-
-1. Load in a run - the ``Subtract BG`` box should be checked in the UI table by default. This should generate a workspace with suffix `_bgsub` and the data should look like the background is flat and roughly zero on the plot using the default parameters (other columns in the UI table).
-
-2. Select the row in the table and check the ``Inspect Background`` button should now be enabled regardless of whether the ``Subtract BG`` box is checked.
-
-3. Click  ``Inspect Background`` to open a new figure which shows the raw data, the background and the subtracted data. Changing the values of ``Niter``, ``BG``, ``XWindow`` and ``SG`` (input to ``EnggEstimateFocussedBackground``, hover over a cell in the table to see a tool tip for explanation) should produce a change in the background on the external plot and in the UI plot.
-
-Test 9 - Fit browser
-^^^^^^^^^^^^^^^^^^^^
-
-This tests the operation of the fit browser.
-
-1. Check that when no data are plotted the ``Fit`` button on the toolbar does nothing.
-
-2. Check the ``Unit Filter`` combobox for ``Browse Filters`` is set to ``TOF`` and click Browse. In the ``Focus`` folder of the save directory, there should be output focussed TOF files.
-   Select multiple focussed files and click Open. Back on the main interface, check the box ``Add to Plot`` and click ``Load``.
-
-3. Click the ``Fit`` button in the plot toolbar. A simplified version of the standard mantid fit property browser should now be visible.
-
-4. In the fit property browser, all the plotted spectra should be available in the ``Settings > Workspace`` combo box.
-   In the central ``Run Selection`` table, remove one spectrum from the plot by unticking the ``Plot`` checkbox for one row.
-   The ``Settings > Workspace`` combo box should now update and not include the removed spectrum.
-
-5. Right-click on the plot image and select ``Add Peak`` and add a peak to the plot. Change the peak type by right clicking on the plot and selecting ``Select peak type`` and add another peak. Also add a Linear background by right clicking on the plot to select ``Add background`` and selecting ``LinearBackground`` as the function.
-   Make sure to add a ``BackToBackExponential`` peak if you have not already. For ``BackToBackExponential`` peaks, the ``A`` and ``B`` parameters should be fixed automatically for ENGIN-X data.
-
-6. Perform a fit by clicking ``Fit > Fit`` in the fit browser. On completion of the fit, a group workspace with suffix `_fits` should have appeared in the Workspaces Toolbox(ADS).
-   In this group of workspaces there should be a matrix workspace for each parameter fitted (named by convention ``FunctionName_ParameterName`` e.g `BackToBackExponential_I`), to view this right-click on the workspace
-   and ``Show Data``. If there are more than 1 fitting function of the same type, the fitting values for each parameter would appear in the columns where each workspace is listed in the rows. Any runs not fit will have a `NaN` value in the `Y` and `E` fields. In addition there is a workspace that has converted any peak centres from TOF to d-spacing (suffix `_dSpacing`).
-   There should be an additional table called `model` that summarises the `chisq` value and the function string including the best-fit parameters.
-
-7. In the Fit property browser, go to ``Setup > Custom Setup``. The function string, including the best-fit parameters, should also have been automatically saved
-   as a custom setup. Select ``Setup > Clear Model``, then select this new custom setup model. Inspect the fit by clicking ``Fit > Evaluate`` Function.
-
-Test 10 - Sequential fitting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This tests the sequential fitting capability of the UI (where the result of a fit to one workspace is used as the initial guess for the next).
-This test uses data generated in `Test 4`.
-
-0. In the main workbench window, right-click on the Message log and set the ``Log Level`` to ``Notice``.
-
-1. Close and re-open the Engineering Diffraction interface.
-
-2. Enter the Engineering Diffraction settings menu by clicking the cog wheel in the bottom left. In the ``Sample Logs - Fitting / GSAS II`` section,
-   you can select which sample logs to output to table workspaces by ticking in the list of boxes, and select the `Primary Log` from the combo box underneath the checkboxes for Sequential fit ordering,
-   and whether this should be in ``Ascending`` or ``Descending`` order by ticking the corresponding box to the right.
-   In the `Primary Log` combobox, select ``ADC1_0`` and tick ``Ascending``.
-
-3. On the ``Fitting`` tab, Load in several focused runs e.g. ``305793-305795`` from `Test 4`.
-
-4. Plot just one run, click ``Fit`` to open the fit property browser and input a valid fit function including a peak and a background.
-
-5. Click the ``Sequential Fit`` button in the plot toolbar. A group of fit workspaces should appear in the Workspaces Toolbox (ADS),
-   each with a row for each of the runs in the table. All the runs should have been fitted.
-
-6. The order of the runs in the sequential fit should be obtainable from the log at notice level -
-   check that this corresponds to the order of the average value of the primary log - ``ADC1_0``
-   You can check the value of this sample log for each run in the output GroupWorkspace with the suffix ``_logs_Fitting``. Note this order down.
-
-7. Try changing the primary log to blank and re-run the ``Sequential Fit`` This should make the Sequential fit use the order of the runs in the central ``Run Selection`` table.
-
-8. In the Engineering Diffraction settings, set the `Primary Log` back to ``ADC1_0`` and tick ``Descending``.
-   Re-run the ``Sequential Fit`` and check that the order of runs in the output workspaces has reversed compared to `Step 6`.
-
-9. Close and re-open the Engineering Diffraction interface. Reopen the Engineering Diffraction settings menu, it should remember the `Primary Log` and the order.
-
-Test 11 - Serial fitting
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-This tests the serial fitting capability of the UI (where all loaded workspaces are fitted from the same starting parameters).
-This test uses data generated in `Test 4`.
-
-1. Repeat steps 1-4 in the previous test (`Test 9`).
-
-2. Now click the ``Serial Fit`` button in the plot toolbar and the group of fit workspaces should appear in the ADS,
-   each with a row for each of the runs in the table. All the runs should have been fitted.
-
-3. The order of the runs in the serial fit should be obtainable from the log at notice level - check that this
-   corresponds to the order of the runs in the table.
-
-
-Test 12 - Pole Figures
-^^^^^^^^^^^^^^^^^^^^^^
-
-This test will check the Pole Figure plotting in the Texture Tab
-
-1. Click on the ``Texture Tab``
-
-2. Click ``Browse`` next to ``Load Workspace Files`` and navigate to ``<mantidBuildDir>/ExternalData/Testing/Data/SystemTest/Texture/ValidationFiles/Focus``
-
-3. Select all the files within that folder and click ``Load Workspace Files``
-
-4. You should see seven rows populate the table
-
-5. Click ``Select All Files``
-
-6. In settings, ensure the texture directions are set to  ``D1  1  0  0``, ``D2  0  1  0``, and ``D3  0  0  1``, and the ``Scatter Plot Experimental Pole Figure`` is checked, then click ``OK``
-
-7. Click ``Calculate Pole Figure``, you should get a plot like the one below (the colours may be different, they should correspond to the order of the files in the table, for this example the files are in ascending run number order)
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffPF1.png
-    :width: 600px
-
-8. Now click ``Browse`` next to ``Load Parameter Files`` and navigate to ``<mantidBuildDir>/ExternalData/Testing/Data/SystemTest/Texture/ValidationFiles/FitParameters``
-
-9. Select all the files within that folder and click ``Load Parameter Files``
-
-10. The ``Fit Parameters`` column should now be populated in the table, as well as a readout column option having appeared above ``Calculate Pole Figure``
-
-11. Click ``Calculate Pole Figure``, you should get a plot like the one below
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffPF2.png
-    :width: 600px
-
-12. Open the settings menu and set ``Scatter Plot Experimental Pole Figure`` to unchecked
-
-13. This should enable ``Contour Kernel Size``, set this to ``6.0`` and click ``OK``
-
-14. Click ``Calculate Pole Figure``, you should get a plot like the one below
-
-.. image:: /images/EngineeringDiffractionTest/EnggDiffPF3.png
-    :width: 600px
-
-15. Try changing options around in the interface, see if you can break it (some things you can try if you are short ideas):
-
-   - Try different sample axes
-   - Try changing the projection
-   - Try including scattering power (HKL for this peak is 1,1,0 if you set the crystal to the ``Fe.cif``)
-   - Try disabling some of the rows
-   - Try having a mixture of runs with/without parameter files
-
-
-Test 13 - GSASII
-^^^^^^^^^^^^^^^^
-
-Note this test will only work if ``GSASII`` is also installed.
-Please test this on IDAaaS: an ENGINX instance should have MantidWorkbenchNightly and ``GSASII`` installed in the expected location.
-
-1. Close and re-open the Engineering Diffraction interface.
-
-2. Go to the ``Run Processing`` tab, select ``Create New Calibration`` and un-tick the ``Set Calibration Region of Interest`` option.
-
-3. For the ``Calibration Sample #`` enter ``305738`` and ``Vanadium #`` ``307521`` and click the ``Calibrate`` button.
-
-4. In the ``Focus`` group, enter ``Sample Run #`` ``305761`` and click the ``Focus`` button.
-
-.. image:: figure:: /../../../../../docs/source/images/EngDiff_GSASII.png
-    :align: center
-    :width: 600px
-
-5. Change to the ``GSASII`` tab. The ``Instrument Group`` path should be pre-filled to a `.prm` file output by the calibration
-   and the ``Focused Data`` path should be pre-filled to the `.gss` file output from the ``Focus`` group.
-
-6. For the ``Phase`` filepath, select ``FE_GAMMA`` from the list. For the ``Project Name`` at the top, enter a string of your choice.
-
-7. Now, click ``Refine in GSAS II``. After a few seconds, the output fit should be plotted. In the top right of the plot widget, the refined spectrum can be changed using the combo-box.
-
-8. Change the fitting range by dragging the limits, or by editing the ``Min``, ``Max`` line edit boxes. Again, click ``Refine in GSAS II`` and this should only fit to the user defined range.
-
-9. Back in the file loading section, Browse for files for the inputs ``Instrument Group`` and ``Focused Data``,
-   and select files with ``bank_1`` in the name, which were produced by the ``Calibration`` and ``Focus`` in `Test 3`.
-
-10. Now, click ``Refine in GSAS II``. The previously set fitting range should be ignored as new input files were selected. There should now only be one spectrum available in the output spectrum combobox.
-
-11. Set the ``Override Unit Cell Length`` to ``3.65`` and click ``Refine in GSAS II``, the fit should be better.
-
-12. Tick all the checkboxes: ``Microstrain``, ``Sigma-1`` and ``Gamma (Y)``. An asterisk should appear with an advice tooltip.
-
-Test 14 - GSASII multiple files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This test covers the multiple data files functionality with multiple banks per file in the ``GSAS II`` tab.
-
-Note this test will only work if ``GSASII`` is also installed.
-Please test this on IDAaaS: an ENGINX instance should have ``MantidWorkbenchNightly`` and ``GSASII`` installed in the expected location.
-
-1. Close and re-open the Engineering Diffraction interface.
-
-2. Go to the ``Run Processing`` tab, select ``Create New Calibration`` and un-tick the ``Set Calibration Region of Interest`` option.
-
-3. For the ``Calibration Sample`` # enter ``305738`` and ``Vanadium #`` enter ``307521`` and click the ``Calibrate`` button.
-
-4. Enter Sample Run # ``305793-305795`` and click the ``Focus`` button. This will generate multiple focused data files.
-Change to the ``GSAS II`` tab. Clear any pre-filled paths.
-
-5. For the ``Instrument Group`` filepath, browse and select the single `.prm` file output by the calibration (should be `ENGINX_305738_all_banks.prm`).
-
-6. For the ``Focused Data`` filepath, browse and select multiple `.gss` files that each contain multiple banks. Ensure all selected files have the same number of banks (e.g., select the all_banks files: E`NGINX_305738_305793_all_banks_dSpacing.gss`, `ENGINX_305738_305794_all_banks_dSpacing.gss`, `ENGINX_305738_305795_all_banks_dSpacing.gss`).
-
-7. For the ``Phase`` filepath, select ``FE_GAMMA`` from the list. For the ``Project Name`` at the top, enter a string of your choice.
-
-8. Click Refine in ``GSAS II``. After a few seconds, the output fit should be plotted. In the top right of the plot widget, verify that the refined spectrum combobox shows entries for the banks of the last refined data file.
-
-9. Test Error Cases: Try selecting multiple instrument `.prm` files (should show error message about requiring exactly one instrument file). Try selecting `.gss` files with different numbers of banks (should show error about inconsistent bank counts). Try selecting single-bank `.gss` files (should show error about requiring multiple banks per file).
+The Engineering Diffraction interface allows scientists using the EnginX and IMAT instruments to
+interactively process their data. There are 5 tabs in total:
+
+- ``Run Processing`` - where a cerium oxide run is entered to calibrate the subsequent data, which
+  can also be focussed into a single spectrum.
+- ``Absorption Correction`` - where the experimental data can be corrected for beam attenuation.
+- ``Fitting`` - where peaks can be fitted on focused data.
+- ``Texture`` - where pole figures can be generated for experimental runs and their fitted peaks.
+- ``GSAS II`` - run a basic refinement on the
+  `GSASIIscriptable API <https://gsas-ii.readthedocs.io/en/latest/GSASIIscriptable.html>`_.
+
+**This interface is now covered by an automated UI test suite.** What used to be fourteen manual
+tests here is driven by ``QTest`` against the real interface - real view, real presenter, real model,
+real algorithms and real files on disk. Only what would block waiting for a user is stood in for: the
+generated algorithm dialogs, the error popups, and the external GSAS-II process.
+
+The sections below cover what is automated (and where), and the short list of checks that still have
+to be done by hand.
+
+The automated suite
+^^^^^^^^^^^^^^^^^^^
+
+The tests live in ``Testing/SystemTests/tests/qt/AutomatedUITest/EngineeringDiffraction`` and are
+registered with CTest under the ``qt.AutomatedUITest.EngineeringDiffraction`` prefix, so the whole
+suite is::
+
+    ctest -R qt.AutomatedUITest.EngineeringDiffraction
+
+A single module can be run on its own with::
+
+    python Testing/SystemTests/scripts/systestrunner.py <path-to-the-module>.py False
+
++--------------------------------------+------------------------------------------------------------+
+| Module                               | Replaces                                                   |
++======================================+============================================================+
+| ``EngDiffGuiRunProcessingTest.py``   | Test 1 (calibration, focusing, settings, plot output,      |
+|                                      | reopening the interface) and Test 2 (RB number).           |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiCroppingTest.py``        | Test 3 (cropping), plus every region-of-interest option    |
+|                                      | and the texture grouping save layout.                      |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiImatTest.py``            | Running the calibration and focus on IMAT, and the         |
+|                                      | per-instrument configuration.                              |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiCorrectionTest.py``      | Test 4 (absorption correction), including the sample       |
+|                                      | shape, material, orientation and gauge volume dialogs.     |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiFittingTest.py``         | Tests 5-11 (focused data, browse filters, run removal,     |
+|                                      | background subtraction, fit browser, sequential and        |
+|                                      | serial fitting).                                           |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiTextureTest.py``         | Test 12 (pole figures).                                    |
++--------------------------------------+------------------------------------------------------------+
+| ``EngDiffGuiGsas2Test.py``           | Tests 13 and 14 (GSAS-II, single and multiple files).      |
++--------------------------------------+------------------------------------------------------------+
+
+Two conventions are worth knowing before changing them:
+
+- Each class checks a long list of largely independent observations, so a failing assertion is
+  *recorded* rather than raised (see ``AutomatedUITestBase.check``). One run therefore reports every
+  regression rather than only the first. Preconditions - "the run resolved", "the worker finished" -
+  are still plain assertions, so a broken precondition fails fast instead of cascading.
+- The ENGIN-X and IMAT run data is **fabricated in-test** rather than loaded from the archive (see
+  ``create_synthetic_ceria_and_vanadium``). IMAT has no ceria/vanadium pair in the repository at all,
+  and for ENGIN-X the real runs are large and slow while what these tests assert - the interface, the
+  reported state and the on-disk save layout - does not depend on the counts being real. The
+  numerical correctness of the calibrate/focus chain is covered separately by ``EnginXScriptTest``.
+
+What still has to be tested manually
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These cannot be automated in the system test suite, and should be checked on an ENGIN-X IDAaaS
+instance running ``MantidWorkbenchNightly`` before a release.
+
+GSAS-II against a real installation
+-----------------------------------
+
+``EngDiffGuiGsas2Test`` replaces the call into the GSAS-II subprocess with canned output, so it
+verifies everything the interface does around GSAS-II but not GSAS-II itself. On an IDAaaS ENGIN-X
+instance, with GSAS-II installed in the expected location:
+
+1. On ``Run Processing``, un-tick ``Set Calibration Region of Interest``, enter ``305738`` as the
+   ``Calibration Sample #`` and ``307521`` as the ``Vanadium #``, and click ``Calibrate``.
+2. Enter ``305761`` as the ``Sample Run #`` and click ``Focus``.
+3. On the ``GSAS II`` tab, check the ``Instrument Group`` and ``Focused Data`` paths were pre-filled
+   from the calibration and focus. Select ``FE_GAMMA`` as the ``Phase`` and enter a ``Project Name``.
+4. Click ``Refine in GSAS II`` and confirm a real refinement runs and is plotted.
+5. Repeat with the fitting range narrowed, and with the ``bank_1`` files, and confirm the refined
+   parameters are sensible for the data rather than merely present.
+
+Data from the ISIS archive
+--------------------------
+
+The automated suite fabricates its run data and never touches the archive, so archive loading is not
+exercised. Load a recent ENGIN-X run through ``Run Processing`` and confirm the file finder resolves
+it from a run number. Note that run numbers quoted in older documentation may have been deleted.
+
+Visual inspection
+-----------------
+
+The suite asserts that figures are created and that the data behind them is right, but not what they
+look like. Worth a glance by eye:
+
+- the calibration plot (``Plot Calibrated Workspace``) and the focused output plot,
+- the pole figures on the ``Texture`` tab, for the projection, the axes labels and the colour scale,
+- the sample shape viewer, for the shape and the orientation of the sample axes,
+- the GSAS-II refinement plot.
+
+Adding to the suite
+^^^^^^^^^^^^^^^^^^^
+
+New interface behaviour should get a check in the relevant module rather than a step here. The
+shared harness is in ``Testing/SystemTests/tests/qt/AutomatedUITest``:
+
+- ``qt_interaction_helpers.py`` - widget-level helpers with no dependency on the system test
+  framework, so they can be used from ordinary unit tests too.
+- ``automated_ui_test_base.py`` - the cross-interface harness: settings isolation, waiting on
+  asynchronous tasks without deadlocking, neutralising modal dialogs, and the soft-assertion
+  ``check`` context manager. A suite for another interface should subclass this.
+- ``EngineeringDiffraction/eng_diff_gui_test_base.py`` - the Engineering-specific setup and the
+  synthetic data fixture.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -58,7 +58,11 @@ class CalibrationPresenter(object):
         if self.view.get_load_checked():
             # loading calibration from path to .prm
             self.current_calibration.set_calibration_from_prm_fname(self.view.get_path_filename(), self.instrument)
-            self.current_calibration.van_file = van_file
+            # the .prm file name only carries the instrument and the ceria run, so the vanadium has
+            # to come from the view. It must be set on vanadium_path, which is what is_valid and the
+            # focus path read - assigning to a van_file attribute silently created a new one, so a
+            # loaded calibration reported itself invalid until the focus tab filled the gap in.
+            self.current_calibration.vanadium_path = van_file or None
         else:
             # update current calibration with new data
             sample_file = self.view.get_sample_filename()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_widget.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_widget.ui
@@ -50,12 +50,12 @@
        </item>
        <item>
         <property name="text">
-         <string>Texture (20 spec)</string>
+         <string>Texture20</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Texture (30 spec)</string>
+         <string>Texture30</string>
         </property>
        </item>
       </widget>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/view.py
@@ -333,7 +333,10 @@ class TextureCorrectionView(QtWidgets.QWidget, Ui_texture):
 
     def set_absorption_section_visibility(self, vis: bool) -> None:
         self.combo_shapeMethod.setVisible(vis)
-        self.finder_gauge_vol.setVisible(vis)
+        # the file finder belongs to the "Custom Shape" option only, so revealing the whole section
+        # must not reveal it for a preset - the combo's own handler would otherwise not correct this
+        # until the selection changed
+        self.set_finder_gauge_vol_visible(vis and self.get_shape_method() == "Custom Shape")
 
     def set_divergence_section_visibility(self, vis: bool) -> None:
         self.label_divHorz.setVisible(vis)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -8,7 +8,7 @@ from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, Gener
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_model import FittingPlotModel
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_view import FittingPlotView
 from mantid.simpleapi import Fit, logger
-from mantid.api import MatrixWorkspace
+from mantid.api import MatrixWorkspace, MinimizerStatus
 from mantidqt.utils.asynchronous import AsyncTask, AsyncTaskSuccess, AsyncTaskFailure
 from copy import deepcopy
 from typing import List, Dict
@@ -187,7 +187,7 @@ class FittingPlotPresenter(object):
             fitprop["status"] = fit_output.OutputStatus
             funcstr = str(fit_output.Function.fun)
             fitprop["properties"]["Function"] = funcstr
-            if "success" in fitprop["status"].lower() and do_sequential:
+            if MinimizerStatus.isConverged(fitprop["status"]) and do_sequential:
                 # update function in prev fitprop to use for next workspace
                 prev_fitprop["properties"]["Function"] = funcstr
             # append a deep copy to output list (will be initial parameters if not successful)
@@ -221,8 +221,12 @@ class FittingPlotPresenter(object):
 
     def set_final_state_progress_bar(self, output_list: List[Dict[str, str]] | None, status: str | None = None) -> None:
         if not status:
-            status = output_list[-1]["status"].lower()
-        if "success" in status:
+            status = output_list[-1]["status"]
+        # MinimizerStatus rather than a substring test for "success": a minimizer started from an
+        # already-optimal set of parameters - which is the normal case for every run after the first
+        # in a sequential fit - stops with "Changes in function value are too small", and reporting
+        # that as a failed fit is wrong
+        if MinimizerStatus.isConverged(status):
             self.set_progress_bar_success(status)
         else:
             self.set_progress_bar_failed(status)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -17,7 +17,7 @@ from workbench.plotting.toolbar import ToolbarStateManager
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_toolbar import FittingPlotToolbar
 from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, GenericObserver
 from matplotlib.backend_bases import MouseEvent, ResizeEvent
-from mantid.api import MatrixWorkspace
+from mantid.api import MatrixWorkspace, MinimizerStatus
 from matplotlib.axes import Axes
 
 
@@ -258,8 +258,9 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         if status:
             self.fit_browser.fitResultsChanged.emit(status)
             self.fit_browser.changeWindowTitle.emit(status)
-            # update browser with output function and save setup if successful
-            if "success" in status.lower():
+            # update browser with output function and save setup if the fit converged - which
+            # includes the tolerance-limited stopping conditions, not just an exact "success"
+            if MinimizerStatus.isConverged(status):
                 self.fit_browser.loadFunction(func_str)
                 self.fit_browser.save_current_setup(setup_name)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -97,6 +97,28 @@ class FittingPlotPresenterTest(unittest.TestCase):
             _, _, kwargs = mock_fit.mock_calls[iws]
             self.assertEqual(kwargs, {"Function": fun_str_list[0], "InputWorkspace": ws, "Output": ws})
 
+    @mock.patch(dir_path + ".AsyncTask", wraps=BlockingAsyncTaskWithCallback)
+    @mock.patch(dir_path + ".Fit")
+    def test_do_sequential_fit_carries_on_tolerance_limited_stop(self, mock_fit, mock_async):
+        # a fit started from an already-optimal set of parameters stops this way rather than
+        # reporting "success", and its result must still seed the next workspace's fit
+        ws_list = ["ws1", "ws2"]
+        fun_str_list = [
+            "name=Gaussian,Height=11,PeakCentre=30000,Sigma=40",  # initial
+            "name=Gaussian,Height=10,PeakCentre=35000,Sigma=50",  # fit result of ws1
+        ]
+        self.view.read_fitprop_from_browser.return_value = {"properties": {"Function": fun_str_list[0]}}  # initial
+        mock_fit_output = mock.MagicMock()
+        mock_fit_output.OutputStatus = MinimizerStatus.CHANGES_IN_FUNCTION_TOO_SMALL
+        mock_fit_output.Function.fun = fun_str_list[1]
+        mock_fit.return_value = mock_fit_output
+
+        self.presenter.do_fit_all(self.view.read_fitprop_from_browser(), ws_list, do_sequential=True)
+
+        self.assertEqual(mock_fit.call_count, len(ws_list))
+        _, _, kwargs = mock_fit.mock_calls[1]
+        self.assertEqual(kwargs, {"Function": fun_str_list[1], "InputWorkspace": "ws2", "Output": "ws2"})
+
     def fit_all_helper(self, mock_fit, do_sequential):
         ws_list = ["ws1", "ws2"]
         fun_str_list = [

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -8,6 +8,7 @@ import unittest
 
 from unittest import mock
 
+from mantid.api import MinimizerStatus
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting import plot_model, plot_view, plot_presenter
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 
@@ -163,6 +164,17 @@ class FittingPlotPresenterTest(unittest.TestCase):
     def test_final_state_success_status(self):
         self.presenter.set_final_state_progress_bar(output_list=None, status="success")
         self.view.set_progress_bar.assert_has_calls([self.call_success])
+
+    def test_final_state_treats_tolerance_limited_stops_as_success(self):
+        # a minimizer started from an already-optimal set of parameters - the normal case for every
+        # run after the first in a sequential fit - stops this way rather than reporting "success"
+        for status in (MinimizerStatus.CHANGES_IN_FUNCTION_TOO_SMALL, MinimizerStatus.CHANGES_IN_PARAMETER_TOO_SMALL):
+            with self.subTest(status=status):
+                self.view.reset_mock()
+                self.presenter.set_final_state_progress_bar([{"status": status}])
+                self.view.set_progress_bar.assert_has_calls(
+                    [mock.call(status=status, minimum=0, maximum=100, value=100, style_sheet=plot_presenter.SUCCESS_STYLE_SHEET)]
+                )
 
     def test_setup_toolbar(self):
         # Get's called during setup, so let's begin with a blank slate.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -217,7 +217,7 @@ class GSAS2Model:
 
         # Checked here rather than only in initial_validation because the per-file project name
         # below is never empty, so that check could never fire for a missing project name.
-        if not project_name:
+        if not project_name or not project_name.strip(" \t"):
             logger.error("* There must be a valid Project Name for GSASII refinement")
             return None
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -10,6 +10,7 @@ import os
 import platform
 import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Tuple, TypeAlias
@@ -214,6 +215,12 @@ class GSAS2Model:
         data_files = load_parameters[2]  # Extract data files list
         num_hist = None
 
+        # Checked here rather than only in initial_validation because the per-file project name
+        # below is never empty, so that check could never fire for a missing project name.
+        if not project_name:
+            logger.error("* There must be a valid Project Name for GSASII refinement")
+            return None
+
         for data_file in data_files:
             # Create unique project name for each file
             file_basename = os.path.splitext(os.path.basename(data_file))[0]
@@ -246,39 +253,54 @@ class GSAS2Model:
         self.clear_input_components()
         if not self.initial_validation(project_name, load_parameters):
             return None
+        # From here on a temporary working directory exists, so every exit has to tidy it up. On the
+        # success path load_basic_outputs empties and removes it, and the cleanup below is a no-op.
         self.set_components_from_inputs(load_parameters, refinement_parameters, project_name, rb_num)
-        self.read_phase_files()
-        self.generate_reflections_from_space_group()
+        try:
+            self.read_phase_files()
+            self.generate_reflections_from_space_group()
 
-        formatted_limits: List[List[float]] | None = None
-        # Ensure both elements are lists of floats and pass formatted limits to validate_x_limits
-        if isinstance(user_x_limits, list) and len(user_x_limits) == 2:
-            formatted_limits = [
-                user_x_limits[0] if isinstance(user_x_limits[0], list) else [user_x_limits[0]],
-                user_x_limits[1] if isinstance(user_x_limits[1], list) else [user_x_limits[1]],
-            ]
+            formatted_limits: List[List[float]] | None = None
+            # Ensure both elements are lists of floats and pass formatted limits to validate_x_limits
+            if isinstance(user_x_limits, list) and len(user_x_limits) == 2:
+                formatted_limits = [
+                    user_x_limits[0] if isinstance(user_x_limits[0], list) else [user_x_limits[0]],
+                    user_x_limits[1] if isinstance(user_x_limits[1], list) else [user_x_limits[1]],
+                ]
 
-        if not self.validate_x_limits(formatted_limits):
-            return None
-        if not self.further_validation():
-            return None
+            if not self.validate_x_limits(formatted_limits):
+                return None
+            if not self.further_validation():
+                return None
 
-        runtime = self.call_gsas2()
-        if not runtime:
-            return None
-        runtime_str = runtime[1]  # Extract the string part of the runtime tuple
-        report_result = self.report_on_outputs(runtime_str)
-        if report_result is not None:
-            gsas_result_filepath, _ = report_result  # Unpack the tuple
-        else:
-            logger.error("Failed to unpack the result from report_on_outputs.")
-            return None
-        gsas_result = gsas_result_filepath
-        if not gsas_result:
-            return None
-        self.load_basic_outputs(gsas_result)
+            runtime = self.call_gsas2()
+            if not runtime:
+                return None
+            runtime_str = runtime[1]  # Extract the string part of the runtime tuple
+            report_result = self.report_on_outputs(runtime_str)
+            if report_result is not None:
+                gsas_result_filepath, _ = report_result  # Unpack the tuple
+            else:
+                logger.error("Failed to unpack the result from report_on_outputs.")
+                return None
+            gsas_result = gsas_result_filepath
+            if not gsas_result:
+                return None
+            self.load_basic_outputs(gsas_result)
 
-        return self.state.number_of_regions
+            return self.state.number_of_regions
+        finally:
+            self._remove_temporary_save_directory()
+
+    def _remove_temporary_save_directory(self) -> None:
+        """Remove the working directory, if it is still there.
+
+        A refinement that is rejected by validation, or that GSAS-II fails, would otherwise leave an
+        empty tmp_EngDiff_GSASII_* directory in the user's save location on every attempt.
+        """
+        temporary_directory = self.save_directories.temporary_save_directory
+        if temporary_directory and os.path.isdir(temporary_directory):
+            shutil.rmtree(temporary_directory, ignore_errors=True)
 
     # ===============
     # Prepare Inputs
@@ -761,10 +783,12 @@ class GSAS2Model:
             # if calibration.group == GROUP.TEXTURE20 or calibration.group == GROUP.TEXTURE30:
             #     calib_dirs.pop(0)  # only save to RB directory to limit number files saved
         self.user_save_directory = os.path.join(save_directory, self.save_directories.project_name)
-        self.save_directories.temporary_save_directory = os.path.join(
-            save_directory, datetime.datetime.now().strftime("tmp_EngDiff_GSASII_%Y-%m-%d_%H-%M-%S")
+        # mkdtemp rather than a bare timestamp: the name is only resolved to the second, so two
+        # refinements started within the same second would otherwise collide and raise FileExistsError
+        os.makedirs(save_directory, exist_ok=True)
+        self.save_directories.temporary_save_directory = tempfile.mkdtemp(
+            prefix=datetime.datetime.now().strftime("tmp_EngDiff_GSASII_%Y-%m-%d_%H-%M-%S_"), dir=save_directory
         )
-        os.makedirs(self.save_directories.temporary_save_directory)
 
     def move_output_files_to_user_save_location(self) -> str:
         for new_directory in self.file_paths.gsas2_save_dirs:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -392,7 +392,12 @@ class TestGSAS2Model(unittest.TestCase):
             rb_num = "valid_rb_number"
             self.model.organize_save_directories(rb_num)
             self.assertEqual(self.model.user_save_directory, mock_user_directory)
-            self.assertEqual(self.model.save_directories.temporary_save_directory[:-20], expected_temp_directory)
+            # the name carries a timestamp and a unique suffix, so only the stem is fixed
+            self.assertTrue(
+                self.model.save_directories.temporary_save_directory.startswith(expected_temp_directory),
+                f"{self.model.save_directories.temporary_save_directory} does not start with {expected_temp_directory}",
+            )
+            self.assertTrue(os.path.isdir(self.model.save_directories.temporary_save_directory))
             self.assertEqual(self.model.file_paths.gsas2_save_dirs[0], os.path.join(current_directory, "GSAS2", ""))
             self.assertEqual(len(self.model.file_paths.gsas2_save_dirs), 2)
             self.assertEqual(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -293,10 +293,13 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
         self.y_bounds = None
 
     def update_figure(self, plot_window_title: str | None = None) -> None:
-        window_title = "GSAS-II Plot"
+        # Keep the existing title when called without one. update_figure is also reached from the
+        # range markers and the toolbar's home button, both of which run straight after the title
+        # has been set for the refined file, and which would otherwise discard it.
         if plot_window_title:
-            window_title = plot_window_title
-        self.plot_dock.setWindowTitle(window_title)
+            self.plot_dock.setWindowTitle(plot_window_title)
+        elif not self.plot_dock.windowTitle():
+            self.plot_dock.setWindowTitle("GSAS-II Plot")
         self.toolbar.update()
         self.update_legend(self.get_axes()[0])
         self.update_axes_position()

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -8,7 +8,7 @@ from numpy import array, degrees, isfinite, reshape, nan, diff, ndarray
 from os import path, makedirs
 from shutil import copy2
 
-from mantid.api import AnalysisDataService as ADS, AlgorithmManager, MatrixWorkspace
+from mantid.api import AnalysisDataService as ADS, AlgorithmManager, FunctionFactory, MatrixWorkspace
 from mantid.kernel import IntArrayProperty, UnitConversion, DeltaEModeType, logger, UnitParams
 import mantid.simpleapi as mantid  # required to call EnggUtils funcs from algorithms to avoid simpleapi error
 from mantid.dataobjects import EventWorkspace, Workspace2D, TableWorkspace
@@ -52,8 +52,13 @@ def plot_tof_vs_d_from_calibration(
     fiterror = ADS.retrieve(diag_ws.name() + "_fiterror").toDict()
     d_table = ADS.retrieve(diag_ws.name() + "_dspacing").toDict()
     dspacing = array(sorted(dspacing))  # PDCal sorts the dspacing list passed
-    x0 = array(fitparam["X0"])
-    x0_er = array(fiterror["X0"])
+    # PDCalibration names the fitted centre column after the peak function's own centre parameter,
+    # so this cannot be hard coded to "X0" - that is BackToBackExponential's name for it, and a
+    # Gaussian (say) calls it "PeakCentre", which used to raise a KeyError here when the Default
+    # Peak Function had been changed and the output was plotted.
+    centre_param = FunctionFactory.createPeakFunction(calibration.get_fit_peak_shape()).getCentreParameterName()
+    x0 = array(fitparam[centre_param])
+    x0_er = array(fiterror[centre_param])
     ws_index = array(fitparam["wsindex"])
     nspec = len(set(ws_index))
     si = ws_foc.spectrumInfo()

--- a/scripts/Engineering/common/instrument_config.py
+++ b/scripts/Engineering/common/instrument_config.py
@@ -154,6 +154,9 @@ CONFIGS: Dict[str, InstrumentConfig] = {
             (ENGINX_GROUP.NORTH, "1 (North)", False, False),
             (ENGINX_GROUP.SOUTH, "2 (South)", False, False),
             (ENGINX_GROUP.CROPPED, "Crop to Spectra", False, True),
+            # these labels are what the user sees in the region of interest combo, and the .ui
+            # file's own default items must match them: the combo is repopulated from here whenever
+            # the instrument changes, so a mismatch renames the option mid-session
             (ENGINX_GROUP.TEXTURE20, "Texture20", False, False),
             (ENGINX_GROUP.TEXTURE30, "Texture30", False, False),
         ),

--- a/scripts/Engineering/texture/correction/correction_model.py
+++ b/scripts/Engineering/texture/correction/correction_model.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import (
     CopySample,
     SetSampleMaterial,
     DefineGaugeVolume,
+    DeleteLog,
     ConvertUnits,
     MonteCarloAbsorption,
     CloneWorkspace,
@@ -28,7 +29,7 @@ from Engineering.common.texture_sample_viewer import has_valid_shape
 from typing import Sequence, Tuple
 from mantid.dataobjects import Workspace2D
 from Engineering.common.calibration_info import CalibrationInfo
-from Engineering.texture.texture_helper import get_gauge_vol_str, load_all_orientations
+from Engineering.texture.texture_helper import GAUGE_VOLUME_LOG, NO_GAUGE_VOLUME, get_gauge_vol_str, load_all_orientations
 
 
 class TextureCorrectionModel:
@@ -267,7 +268,10 @@ class TextureCorrectionModel:
 
     @staticmethod
     def _get_material_name(ws_name: str) -> str:
-        return ADS.retrieve(ws_name).sample().getMaterial().name()
+        # stripped because a workspace that has been through a processed nexus round trip - which
+        # is how every run reaches this tab - comes back with a material name of " " rather than the
+        # "" it was saved with, and an unstripped comparison then reports a blank material as set
+        return ADS.retrieve(ws_name).sample().getMaterial().name().strip()
 
     def _has_no_valid_material(self, ws_name: str) -> bool:
         return self._get_material_name(ws_name) == ""
@@ -279,6 +283,14 @@ class TextureCorrectionModel:
         gauge_str = get_gauge_vol_str(preset, custom)
         if gauge_str:
             DefineGaugeVolume(ws, gauge_str)
+        elif preset == NO_GAUGE_VOLUME:
+            # DefineGaugeVolume only ever adds, so without this a workspace that was already
+            # corrected with a gauge volume would silently keep using it and the option would do
+            # nothing. Only the explicit "no gauge volume" choice clears it - failing to read a
+            # custom shape also yields no xml, and that must not discard a valid definition.
+            # Guarded because DeleteLog warns when the log is not there, which it usually is not.
+            if (ADS.retrieve(ws) if isinstance(ws, str) else ws).run().hasProperty(GAUGE_VOLUME_LOG):
+                DeleteLog(Workspace=ws, Name=GAUGE_VOLUME_LOG)
 
     # ~~~~~ `Parameter Dictionary as String` Functions ~~~~~~~~~~~~~
 

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -36,6 +36,15 @@ from Engineering.common.xml_shapes import get_cube_xml
 ##### Utility Gauge Volume Setup Functions ################
 # ---------------------------------------------------------#
 
+# the gauge volume presets, as offered in the interface's combo box. Named here because callers have
+# to tell "the user asked for no gauge volume" apart from "the shape could not be read", which both
+# produce no xml but mean different things.
+CUBE_4MM_GAUGE_VOLUME = "4mmCube"
+NO_GAUGE_VOLUME = "No Gauge Volume"
+
+# run log DefineGaugeVolume writes the shape into
+GAUGE_VOLUME_LOG = "GaugeVolume"
+
 
 def get_gauge_vol_str(preset: str, custom_file: Optional[str] = None) -> str:
     """
@@ -45,9 +54,9 @@ def get_gauge_vol_str(preset: str, custom_file: Optional[str] = None) -> str:
     custom: if preset is not one of the defaults, the custom file will be read
 
     """
-    if preset == "4mmCube":
+    if preset == CUBE_4MM_GAUGE_VOLUME:
         gauge_str = get_cube_xml("some-gv", 0.004)
-    elif preset == "No Gauge Volume":
+    elif preset == NO_GAUGE_VOLUME:
         gauge_str = None
     else:
         try:

--- a/scripts/test/Engineering/test_EnggUtils.py
+++ b/scripts/test/Engineering/test_EnggUtils.py
@@ -13,9 +13,11 @@ from Engineering.EnggUtils import (
     process_vanadium,
     focus_run,
     convert_TOFerror_to_derror,
+    plot_tof_vs_d_from_calibration,
 )
 from Engineering.common.instrument_config import ENGINX_GROUP
 from mantid.kernel import UnitConversion, DeltaEModeType, UnitParams, UnitParametersMap
+from mantid.simpleapi import CreateSampleWorkspace
 
 enggutils_path = "Engineering.EnggUtils"
 
@@ -416,6 +418,34 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
 
         expected_dirs = [path.join("/mock", "User", "RB123", "Focus", "Texture20")]
         mock_save.assert_called_with(expected_dirs, ws, calib, "123456", "RB123")
+
+    @patch("matplotlib.pyplot.subplots")
+    @patch(f"{enggutils_path}.ADS")
+    def test_plot_tof_vs_d_reads_centres_using_peak_function_centre_parameter(self, mock_ads, mock_subplots):
+        # Gaussian calls its centre parameter "PeakCentre" rather than BackToBackExponential's "X0"
+        self.calibration.get_fit_peak_shape.return_value = "Gaussian"
+        centre_param = "PeakCentre"
+        ws_foc = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=1, OutputWorkspace="ws_foc_centre_param")
+        detid = ws_foc.getSpectrum(0).getDetectorIDs()[0]
+        centres, errors, dspacing = [1.0e4, 2.0e4], [10.0, 20.0], [1.0, 2.0]
+        tables = {
+            "diag_fitparam": {"wsindex": [0, 0], centre_param: centres},
+            "diag_fiterror": {centre_param: errors},
+            "diag_dspacing": {"detid": [detid], "@1.0": [1.0], "@2.0": [2.0]},
+        }
+        mock_ads.retrieve.side_effect = lambda name: MagicMock(toDict=MagicMock(return_value=tables[name]))
+        diag_ws = MagicMock()
+        diag_ws.name.return_value = "diag"
+        mock_ax = MagicMock()
+        mock_ax.ndim = 2
+        mock_subplots.return_value = (MagicMock(), mock_ax)
+
+        plot_tof_vs_d_from_calibration(diag_ws, ws_foc, dspacing, self.calibration)  # would raise KeyError if hard coded to X0
+
+        # first errorbar call plots the fitted centres and their errors against d-spacing
+        args, kwargs = mock_ax.__getitem__.return_value.errorbar.call_args_list[0]
+        self.assertTrue((args[1] == array(centres)).all())
+        self.assertTrue((kwargs["yerr"] == array(errors)).all())
 
     def test_convert_centres_and_error_from_TOF_to_d(self):
         params = UnitParametersMap()

--- a/scripts/test/Engineering/texture/correction/test_correction_model.py
+++ b/scripts/test/Engineering/texture/correction/test_correction_model.py
@@ -12,6 +12,7 @@ from unittest.mock import patch, MagicMock, mock_open, call
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace, SetGoniometer, SetSample
 from Engineering.common.xml_shapes import get_cube_xml
+from Engineering.texture.texture_helper import GAUGE_VOLUME_LOG, NO_GAUGE_VOLUME
 
 from Engineering.texture.correction.correction_model import TextureCorrectionModel, read_attenuation_coefficient_at_value
 
@@ -217,6 +218,46 @@ class TextureCorrectionModelTest(unittest.TestCase):
         mock_read_xml.return_value = expected_str
         self.model.define_gauge_volume(self.ws_name, preset=preset, custom="gv.xml")
         mock_def_gauge_vol.assert_called_once_with(self.ws_name, expected_str)
+
+    @patch(correction_model_path + ".DefineGaugeVolume")
+    def test_define_gauge_vol_for_none_clears_any_previous_definition(self, mock_def_gauge_vol):
+        # a real workspace, because the point of this is what is left on the run
+        ws = CreateSampleWorkspace(OutputWorkspace="test_no_gauge_volume")
+        ws.mutableRun().addProperty(GAUGE_VOLUME_LOG, get_cube_xml("some-gv", 0.004), True)
+
+        self.model.define_gauge_volume("test_no_gauge_volume", preset=NO_GAUGE_VOLUME, custom=None)
+
+        # nothing new is defined, and - crucially - the earlier gauge volume does not survive to be
+        # silently reused by the next correction
+        mock_def_gauge_vol.assert_not_called()
+        self.assertFalse(ws.run().hasProperty(GAUGE_VOLUME_LOG))
+        ADS.remove("test_no_gauge_volume")
+
+    @patch(correction_model_path + ".DefineGaugeVolume")
+    def test_define_gauge_vol_for_none_is_harmless_when_none_was_set(self, mock_def_gauge_vol):
+        ws = CreateSampleWorkspace(OutputWorkspace="test_no_gauge_volume_unset")
+
+        self.model.define_gauge_volume("test_no_gauge_volume_unset", preset=NO_GAUGE_VOLUME, custom=None)
+
+        mock_def_gauge_vol.assert_not_called()
+        self.assertFalse(ws.run().hasProperty(GAUGE_VOLUME_LOG))
+        ADS.remove("test_no_gauge_volume_unset")
+
+    @patch(correction_model_path + ".DefineGaugeVolume")
+    @patch(texture_helper_path + "._read_xml")
+    def test_define_gauge_vol_keeps_previous_definition_when_custom_file_is_unreadable(self, mock_read_xml, mock_def_gauge_vol):
+        # an unreadable custom shape also yields no xml, but it means "this went wrong" rather than
+        # "the user wants no gauge volume", so it must not discard a valid definition
+        ws = CreateSampleWorkspace(OutputWorkspace="test_bad_gauge_volume")
+        expected = get_cube_xml("some-gv", 0.004)
+        ws.mutableRun().addProperty(GAUGE_VOLUME_LOG, expected, True)
+        mock_read_xml.side_effect = RuntimeError("no such file")
+
+        self.model.define_gauge_volume("test_bad_gauge_volume", preset="Custom Shape", custom="missing.xml")
+
+        mock_def_gauge_vol.assert_not_called()
+        self.assertEqual(expected, ws.run().getLogData(GAUGE_VOLUME_LOG).value)
+        ADS.remove("test_bad_gauge_volume")
 
     @patch(correction_model_path + ".LoadSampleShape")
     @patch(correction_model_path + ".SetSampleMaterial")

--- a/scripts/test/Engineering/texture/correction/test_correction_model.py
+++ b/scripts/test/Engineering/texture/correction/test_correction_model.py
@@ -160,6 +160,13 @@ class TextureCorrectionModelTest(unittest.TestCase):
         CreateSampleWorkspace(OutputWorkspace=self.ws_name)
         self.assertTrue(self.model._has_no_valid_material(self.ws_name))
 
+    @patch(correction_model_path + ".ADS")
+    def test_has_no_valid_material_returns_true_on_whitespace(self, mock_ads):
+        # a processed nexus round trip returns a blank material name as " " rather than ""
+        self.mock_ws.sample().getMaterial().name.return_value = " "
+        mock_ads.retrieve.return_value = self.mock_ws
+        self.assertTrue(self.model._has_no_valid_material(self.ws_name))
+
     def test_param_str_to_dict_converts_simple_values(self):
         param_str = "NumberOfWavelengthPoints:50,NumberOfDetectorRows:10,SparseInstrument:True"
         result = self.model._param_str_to_dict(param_str)


### PR DESCRIPTION
### Description of work

As outlined in the issue, this is an AI generated automated replacement for the onerous EngDiff Manual Testing suite. Code was written using Claude Opus over about 4 hours.

In the process of creating the tests a few bugs were identified and patched:

- Sequential Fitting only reports success when Fit reports converged, not when step size gets too small
- Texture20/ Texture30 labels change slightly when instrument goes ENGINX->IMAT->ENGINX
- Set Gauge Volume Finder should only ever be shown when Custom Shape option is chosen
- No Gauge Volume now clears existing gauge volumes saved on workspaces
- Clean up directories made by GSAS-II if the fit fails
- Plot Focused Data expected peak centre to be explicitly `X0` so could fail for peak shapes without that parameter

below I provide an AI summary of the new test coverage which far exceeds what was being covered before and the whole suite runs in about 4 minutes on my local machine 

### Prompt (aka the "work" I actually did for this)

```
I would like you to migrate and extend the Engineering Diffraction manual testing suite to an automated set of tests using QTest (see Texture Planner UI test_view_functional for an example implementation although moving from a unit test suite to a system test suite may make sense based on data and runtimes). Functionality which must be covered are the existing tests, everything provided in the below list, and any other functionality that you can identify as requiring testing (NOTE the existing tests can be split up into separate smaller tests if needed).

You should validate as much as possible, I have given minimum validations with the "->" below, but explicitly validating as fully as possible should be done. Use full system with minimal mocking (GSASII interaction may be mocked)

Tests:
`Run Processing` for all instrument options (currently ENGINX and IMAT)
- Test running a calibration and focus with example data, vanadium and ceria and {no region of interest, each of the region of interest options} -> validate the correct number of spectra are output, info bar at the bottom of the UI is updated correctly
- Test the plot calibrated workspace checkbox -> plots appear/ don't appear
- Test the plot focused workspace checkbox -> plots appear/ don't appear
- Test loading existing calibration -> info bar correct
- Test changing Default Peak Function in the settings -> logger reports correct peak being used
- Test changing Save Location in the settings -> calibration file save location changed
`Absorption Correction`
- Test loading files both with and without shape, orientation and material set -> table populated with expected files and fields populated
- Test select all, deselect all and delete selected files -> expected behaviour
- Test Create Reference Workspace -> Reference Workspace Info is updated correctly
- Test Save Reference Workspace -> files correctly saved to save dir
- Test Load reference workspace (with and without shape/material) -> reference workspace info updated correctly
- Test both shape loaders -> expected reference shape present
- Test shape view buttons create pop up windows
- Test setting sample material
- Test setting orientations by single or from euler/ matrix file
- Test changing euler settings, changes set orientations from euler file
- Test copy reference sample and copy ws sample
- Test using 4mmCube gauge volume as well as a custom shape
- Test writing an attenuation value table 
- Test including/ not including beam divergence
- Test monte-carlo parameters setting is used in the correction
`Fitting`
- Test load prepopulated from focusing
- Test the filters work as expected
- Test Add to Plot checkbox
- Test Remove Selected, Remove all and Inspect Background
- Test Fit, Serial Fit and Sequential Fit -> Expected files created in save dir
`Texture` for all instrument options (currently ENGINX and IMAT)
- Test loading runs prepopulated from focusing
- Test loading runs from file paths -> table populated correctly with correct info
- Test loading parameters
- Test table buttons
- Test shape viewer
- Test creating pole figure with no parameter table only has projection option
- Test different projections
- Test creating pole figure with parameter table has all numeric parameter options for plotting
- Test including scattering correction
- Test changing the settings of {texture directions, scatter plot, thresholds, kernel size}
`GSAS`
- Test manual testing behaviour 
```

### New Test Coverage:

## Automated UI test coverage — Engineering Diffraction

Replaces the 14 manual tests in `dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst`.
Each row below is one `check()` block — the suite's unit of assertion, since a class runs many
independent observations and records failures rather than stopping at the first.

**Totals:** 7 modules, 15 test classes, ~266 distinct checks.

---

## `EngDiffGuiRunProcessingTest.py` — ENGIN-X Run Processing (replaces guide Tests 1–2)

### Initial state, calibrate and focus, no ROI (`EngDiffGuiCalibrateAndFocusTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| new_calibration_preselected | clean settings store | `radio_newCalib` checked, `radio_loadCalib` not |
| existing_path_field_disabled | clean settings store | `finder_path.isEnabled()` False |
| status_bar_reports_no_calibration | clean settings store | status label == "No Calibration Loaded." |
| save_location_reported_from_settings | clean settings store | `savedir_label` contains the seeded save dir |
| status_bar_reports_new_calibration | after calibrate | `CeO2: <ceria>, V: <van>, Instrument: ENGINX` |
| calibration_records_group_and_runs | after calibrate | `get_group()==BOTH`, ceria/vanadium run nos, instrument |
| default_peak_function_is_used | after calibrate | "Gaussian" in notice log; `get_fit_peak_shape()` |
| diff_consts_table_produced | after calibrate | `diffractometer_consts_table` exists, 2 rows |
| prm_and_nxs_per_bank_and_all | after calibrate | 6 files `ENGINX_<ceria>_{all_banks,bank_1,bank_2}.{prm,nxs}` |
| nothing_under_user_without_rb | after calibrate | `<save>/User` has no files |
| prm_built_from_header_template | after calibrate | template first line, `ICONS`, ceria run all in prm |
| prm_parses_back_to_diff_constants | after calibrate | `read_diff_constants_from_prm` → 2 rows, no NaN |
| per_bank_prm_holds_one_bank | after calibrate | 1 constants row in each of bank_1/bank_2 prm |
| both_banks_got_fitted_difc *(soft)* | after calibrate | no difc ≤ 0 in the all_banks prm |
| pdcalibration_fitted_banks *(soft)* | after calibrate | mask ws exists, masked spectra < total |
| focus_gives_one_ws_per_bank | after focus | 1 focused ws named for run, 2 histograms |
| focused_output_in_tof | after focus | x-axis unit == TOF |
| ascii_written_tof | after focus | `*_all_banks_TOF.gss` and `.abc` |
| ascii_written_dspacing | after focus | `*_all_banks_dSpacing.gss` and `.abc` |
| nexus_per_bank_both_units | after focus | bank_1/bank_2 × TOF/dSpacing `.nxs` |
| dspacing_saved_combined | after focus | `CombinedFiles/` == exactly `*_bank_dSpacing.nxs` |
| focused_run_records_vanadium | after focus | `Vanadium Run` log, `Grouping` log == "bank" |

### Plot output checkboxes, North bank (`EngDiffGuiPlotOutputTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| no_plot_when_calib_plot_off | calibrate, box unticked | `plt.get_fignums()` unchanged |
| no_plot_when_focus_plot_off | focus, box unticked | figure set unchanged |
| plot_when_calib_plot_on | calibrate, box ticked | new figure created |
| plot_when_focus_plot_on | focus, box ticked | new figure created |
| checkbox_state_matches_view | toggle box | `view.get_plot_output()` follows the widget |

### Load existing calibration across a restart (`EngDiffGuiLoadExistingCalibrationTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| reopening_preselects_load | GUI rebuilt after calibrating | `get_load_checked()` True, `get_new_checked()` False |
| path_prefilled_with_last_calibration | GUI rebuilt | `get_path_filename()` == the all_banks prm |
| last_vanadium_restored | GUI rebuilt | vanadium finder text contains the run |
| button_relabelled_load | load mode | `button_calibrate.text()` == "Load" |
| loading_bank_prm_reports_calibration | load bank_2 prm | valid, `group==SOUTH`, ceria run, instrument |
| status_bar_reports_loaded_calibration | load bank_2 prm | status label carries ceria run + instrument |
| focus_against_loaded_gives_one_spectrum | focus after load | 1 focused ws, 1 histogram |

### RB number and save location (`EngDiffGuiSaveLocationAndRbNumberTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| rb_calibration_saved_both_places | RB set, North calibrate | prm in `<save>/Calibration` **and** `<save>/User/<RB>/Calibration` |
| rb_focus_saved_both_places | RB set, focus | focused `.nxs` in both locations |
| rb_directory_named_for_number | RB set | `<save>/User/<RB>` exists |
| new_save_location_reported | save dir changed via real settings dialog | `savedir_label` shows the new path |
| save_location_persisted | dialog OK pressed | `save_location` setting == new path |
| output_lands_under_new_location | focus after change | focused `.nxs` under new dir |
| nothing_further_under_old_location | focus after change | old dir file set unchanged |

---

## `EngDiffGuiCroppingTest.py` — region of interest (replaces guide Test 3)

### Every ROI option, no calibration (`EngDiffGuiRoiOptionsTest` — PR-gating, needs no run data)
| Test | Scenario | Asserted on |
|---|---|---|
| roi_inputs_hidden_until_ticked | tab opened | cropping widget not visible |
| ticking_reveals_roi_widget | box ticked | cropping widget visible |
| enginx_offers_own_grouping_options | ENGIN-X selected | combo items == the 6 expected labels, in order |
| bank_option_needs_no_extra_input | "1 (North)" | neither custom-file nor spectra widget visible |
| custom_grouping_reveals_file_finder | "Custom Grouping File" | file finder visible, spectra field not |
| crop_to_spectra_reveals_spectrum_field | "Crop to Spectra" | spectra field visible, file finder not |
| texture_option_needs_no_extra_input | "Texture20" | neither extra input visible |
| unticking_hides_roi_widget | box unticked | widget hidden, `get_crop_checked()` False |
| option_selects_expected_group ×6 | each combo entry | `get_group()` == CUSTOM/NORTH/SOUTH/CROPPED/TEXTURE20/TEXTURE30 |
| valid_spectrum_range_accepted | "1200-2400" | `is_spectra_valid()`, cleaned value, no warning icon |
| invalid_spectrum_range_flagged | free text | not valid, value None, warning icon visible **with tooltip** (no modal) |
| corrected_range_clears_warning | valid text re-entered | valid again, icon hidden |
| custom_grouping_file_resolved | shipped grouping xml | `is_groupingfile_valid()`, resolved path matches |
| group_produces_expected_groups ×5 | BOTH/NORTH/SOUTH/TEXTURE20/TEXTURE30 | grouping ws group count == 2/1/1/20/30 |
| group_names_its_output ×5 | same groups | `generate_output_file_name()` == expected prm name |
| cropped_name_carries_spectrum_range | CROPPED + spectra list | `ENGINX_<ceria>_Cropped_1200-2400.prm` |

### Single bank and custom spectra, real calibration (`EngDiffGuiCroppedCalibrationTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| north_calibration_records_group | North calibrate | `get_group()==NORTH` |
| north_writes_exactly_one_prm_nxs | North calibrate | calibration dir == exactly bank_1 prm + nxs (no other banks) |
| focus_single_bank_one_spectrum | focus | 1 focused ws, 1 histogram |
| focused_files_named_for_bank | focus | `*_bank_1_TOF.nxs` and `.gss` |
| cropped_records_group_and_range | Crop to Spectra calibrate | `group==CROPPED`, `spectra_list_str` preserved |
| cropped_output_named_for_range | calibrate | `ENGINX_<ceria>_Cropped_1200-2400.{prm,nxs}` |
| grouping_saved_alongside | calibrate | matching `.xml` written, so the crop is reproducible |
| focus_cropped_one_spectrum | focus | named output ws with 1 histogram |
| focused_files_carry_cropped_suffix | focus | `*_Cropped_1200-2400_TOF.nxs` |

### Texture grouping and its RB rule (`EngDiffGuiTextureRoiTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| texture_calibration_records_group | Texture20 calibrate | `group==TEXTURE20`, `is_texture_group()` |
| texture_writes_prm_nxs | calibrate | `ENGINX_<ceria>_Texture20.{prm,nxs}` |
| texture_prm_describes_every_group | calibrate | 20 constants rows in the prm |
| focus_one_spectrum_per_group | focus | 1 focused ws with 20 histograms |
| output_in_own_subdirectory | focus | `Focus/Texture20/` holds the `.gss` and per-group `.nxs` |
| nexus_per_texture_group | focus | exactly 20 per-group TOF `.nxs` |
| rb_texture_goes_to_rb_directory | RB set, re-focus | `User/<RB>/Focus/Texture20/` gets the `.gss` |
| rb_texture_only_there | RB set, re-focus | non-RB texture dir file set unchanged |

---

## `EngDiffGuiImatTest.py` — IMAT

### Per-instrument configuration, no run data (`EngDiffGuiImatSettingsTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| imat_offers_own_roi_options | instrument → IMAT | combo == the 8 IMAT grouping labels |
| enginx_texture_groups_not_offered | instrument → IMAT | "Texture20"/"Texture30" absent |
| imat_uses_own_full_calibration | IMAT config | `full_instr_calib` names IMAT |
| imat_uses_ikeda_carpenter_fixed | IMAT config | `peak_func=="IkedaCarpenterPV"`, in `funcs_to_keep_fixed` |
| imat_uses_own_tof_binning | IMAT vs ENGIN-X | binning tuples differ |
| switching_back_restores_texture | IMAT → ENGIN-X | Texture20/30 back in the combo (label stability across a session) |

### Calibrate and focus on synthesised IMAT data (`EngDiffGuiImatCalibrateAndFocusTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| status_bar_reports_imat_calibration | after calibrate | `CeO2: …, V: …, Instrument: IMAT` |
| settings_peak_function_is_used | after calibrate | "Gaussian" and `RespectFixedPeakParameters: False` in log |
| calibration_records_peak_shape | after calibrate | `get_fit_peak_shape()=="Gaussian"` |
| prm_and_nxs_for_both_banks | after calibrate | `IMAT_<ceria>_{all_banks,bank_1,bank_2}.{prm,nxs}` |
| prm_built_from_imat_template | after calibrate | IMAT header template first line + `ICONS` |
| prm_parses_back | after calibrate | 2 constants rows, no NaN |
| both_banks_got_fitted_difc *(soft)* | after calibrate | no difc ≤ 0 |
| pdcalibration_fitted_banks *(soft)* | after calibrate | mask ws exists, masked < total |
| focus_output_named_for_run | after focus | focused ws names start with the run number |
| focused_files_written | after focus | `.gss` and `.nxs` under the focus dir |

---

## `EngDiffGuiCorrectionTest.py` — Absorption Correction (replaces guide Test 4)

### Table, reference workspace and every sample dialog (`EngDiffGuiCorrectionTableTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| loading_puts_one_row_per_run | 2 runs loaded via finder | table rows == the 2 workspace names |
| fresh_run_has_nothing_set | freshly loaded | no shape view button; material "Not set"; orientation "default" |
| newly_loaded_rows_start_unselected | freshly loaded | `get_selected_workspaces()` empty |
| loaded_runs_offered_as_copy_source | freshly loaded | run appears in `combo_workspaceList` |
| reloading_does_not_duplicate | same run loaded twice | still 2 rows |
| deselect_all_clears_every_row | `btn_deselectAll` | no selected workspaces |
| select_all_ticks_every_row | `btn_selectAll` | both selected |
| single_row_can_be_ticked | one checkbox set | exactly that workspace selected |
| reference_named_for_rb_number | `btn_createRefWS` | `<RB>_reference_workspace` in ADS and in status label |
| reference_without_shape_not_viewable | just created | `btn_viewRefShape` disabled, material "Not set" |
| reference_updates_with_shape_material | STL + `Fe` via dialogs | view button enabled, material label "Fe" |
| reference_shape_can_be_viewed | `btn_viewRefShape` | a new figure is created |
| reference_saved_under_referenceworkspaces | `btn_saveRefWS` | `<save>/User/<RB>/ReferenceWorkspaces/<name>.nxs` |
| saved_reference_loads_back | `btn_loadRef` on that file | both status labels restored |
| stl_shape_loaded_as_mesh | `LoadSampleShape` dialog, `cube.stl`, Scale=mm | `sample().getShape()` is a `MeshObject` |
| table_offers_view_button_with_shape | after shape set | per-row shape button exists |
| row_shape_button_opens_figure | click that button | a new figure is created |
| csg_shape_loaded_as_solid | `SetSampleShape` dialog, cuboid XML | shape is a `CSGObject` |
| csg_volume_is_as_requested | 1 cm cuboid | \|volume\| == 1e-6 m³ within 1% |
| material_reaches_workspace | `SetSampleMaterial` dialog, `Fe` | `sample().getMaterial().name()=="Fe"` |
| material_shown_in_table | same | Material cell == "Fe" |
| run_without_material_reads_not_set | other run | Material cell == "Not set" *(regression guard for the `' '` round-trip bug)* |
| single_orientation_reaches_goniometer | `SetGoniometer` dialog, two axes | goniometer R ≠ identity |
| table_reports_orientation_set | same | Orientation cell == "set" |
| matrix_orientation_file_applied_verbatim | `rotation_as_matrix.txt` | R == the first 9 values from the file |
| euler_orientation_file_gives_real_rotation | `rotation_as_euler.txt`, XYZ | R ≠ identity, orthonormal, det == +1 |
| euler_scheme_setting_changes_result | XYZ → ZXZ, same file | R differs |
| euler_sense_setting_changes_result | sense reversed | R differs again |
| reference_sample_copied_to_selected | `btn_copyRefSample` | target gets the reference mesh **and** material |
| any_workspace_can_be_copy_source | `combo_workspaceList` + `btn_copySampleToAll` | target gets the chosen run's CSG shape |
| delete_selected_removes_only_ticked | `btn_deleteSelected` | one row left, the other gone |
| deleting_row_keeps_workspace | same | workspace still in ADS (table is a working set) |

### Applying corrections (`EngDiffGuiCorrectionApplyTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| gauge_inputs_follow_absorption_box | toggle `check_absorption` | `combo_shapeMethod` visibility |
| divergence_inputs_follow_box | toggle `check_divergence` | `line_divHorz` visibility |
| attenuation_inputs_follow_box | toggle `check_attenTab` | container visibility |
| custom_finder_only_for_custom_shape | preset vs "Custom Shape" | `finder_gauge_vol` visibility *(regression guard for the reveal-on-tick bug)* |
| absorption_produces_corrected_workspace | apply absorption | `Corrected_<ws>` in ADS |
| corrected_workspace_in_dspacing | apply | unit == dSpacing, histogram count preserved |
| correction_changed_the_data | apply | corrected Y ≠ converted input Y |
| corrected_saved_under_absorptioncorrection | apply | `<save>/AbsorptionCorrection/Corrected_<ws>.nxs` |
| absorption_factors_are_physical | apply | all `_abs_corr` Y in (0, 1] |
| preset_written_as_gauge_volume | 4mmCube | `GaugeVolume` log == `get_cube_xml("some-gv", 0.004)` |
| custom_file_used_when_chosen | `custom_gauge_volume.xml` | `GaugeVolume` log == the file contents |
| shipped_custom_matches_preset | that file is itself a 4 mm cube | factors identical to the preset run |
| different_volume_gives_different_factors | 1 mm cube written in-test | factors differ from the 4 mm run |
| no_gauge_volume_clears_the_log | "No Gauge Volume" after a preset run | `run().hasProperty("GaugeVolume")` False *(the fix)* |
| no_gauge_volume_is_uncollimated | same | factors differ from the 4 mm run |
| divergence_changes_the_data | apply divergence only | corrected Y ≠ input, all finite |
| divergence_parameters_are_the_ones_used | ratio of raw/corrected | == `vert·√(horz²+det_horz²)·sin²θ` to 1e-6 |
| changing_divergence_changes_correction | vert 0.02 → 0.05 | corrected data differs |
| attenuation_table_named_for_run_and_point | eval 2.0 dSpacing | `ENGIN-X_<run>_attenuation_coefficient_2.0_dSpacing` |
| attenuation_table_one_mu_per_spectrum | same | columns == `["mu"]`, rows == histogram count |
| attenuation_table_saved | same | `<save>/AttenuationTables/<name>.nxs` |
| monte_carlo_settings_reach_algorithm | settings string changed | `_abs_corr` algorithm history shows the two properties |
| different_mc_settings_give_different_factors | 5×5 → 9×9 detectors | factors differ |
| intermediates_dropped_when_setting_asks | clear-after-processing True | `_abs_corr`, `_div_corr`, `Corrected_*` gone from ADS |
| file_still_written_when_cleared | same | the `.nxs` is on disk regardless |

---

## `EngDiffGuiFittingTest.py` — Fitting (replaces guide Tests 5–11)

### Data loading, table and background subtraction (`EngDiffGuiFittingDataTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| focusing_prefills_finder | focus on Run Processing | finder text contains both run numbers |
| finder_prefilled_with_tof_files | same | "_TOF" in the text |
| browse_filters_build_expected_glob | Unit × Region combos | `*bank_1*_TOF*`, `*Texture*_dSpacing*`, `*bank_*` |
| one_row_per_focused_file | Load pressed | 2 table rows |
| table_names_run_and_bank | same | Run column == run numbers; Bank column == "bank 1" |
| loaded_workspaces_tracked | same | model reports 2 loaded workspaces |
| log_workspace_group_created | same | log group exists in ADS |
| add_to_plot_marks_rows_plotted | box ticked | Plot column checked on every row |
| lines_really_on_the_axes | same | axes have lines |
| unticking_plot_removes_line | row Plot unticked | line count drops |
| reticking_puts_line_back | row Plot re-ticked | line count rises |
| bgsub_on_by_default | freshly loaded | BGSub column checked on every row |
| bgsub_workspace_per_run | same | 2 `_bgsub` workspaces |
| subtracted_below_raw | same | subtracted Y ≤ raw Y everywhere, sum strictly lower |
| niter_change_recalculates | Niter → 200 | `_bgsub` data changes |
| sg_filter_off_recalculates | SG unticked | `_bgsub` data changes |
| unticking_bgsub_replots_raw | BGSub unticked | raw ws plotted, `_bgsub` not; `_bgsub` deliberately kept in ADS |
| inspect_bg_needs_selection | no row selected | `button_plotBG` disabled |
| selecting_row_enables_inspect | row selected | button enabled |
| inspect_bg_opens_figure | button pressed | new figure created |
| remove_selected_drops_that_row | `button_removeSelected` | 1 row left, removed run gone |
| removed_workspaces_leave_ads | same | focused ws and its `_bgsub` both gone |
| remove_all_empties_table | `button_removeAll` | 0 rows, no loaded workspaces |

### Serial and sequential fitting (`EngDiffGuiSequentialFitTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| fit_browser_opens_with_data | toolbar Fit toggled | `fit_browser.isVisible()` |
| default_peak_from_instrument_setting | browser opened | `defaultPeakType()=="Gaussian"` |
| serial_fit_fits_every_run | Serial Fit | 2 fit results |
| serial_fit_reports_itself | same | "Serial fitting finished" in notice log |
| each_serial_fit_converged | same | `MinimizerStatus.isConverged(status)` per result |
| fitted_centre_matches_fixture | same | fitted `PeakCentre` == calibration-derived TOF within 1% |
| sequential_fit_fits_every_run | Sequential Fit | 2 fit results |
| sequential_fit_reports_itself | same | "Sequential fitting finished" in notice log |
| each_sequential_fit_converged | same | `isConverged` per result *(tolerance-limited stops included)* |
| browser_holds_last_fitted_function | same | function string still contains Gaussian |
| progress_bar_reports_converged_as_success | same | bar value 100, tooltip status converged *(the fix)* |
| fit_results_grouped | after fits | `<log group>_fits` exists |
| matrix_ws_per_fitted_parameter | after fits | `Gaussian_PeakCentre`, `_Height`, `_Sigma`, `LinearBackground_A0` |
| fwhm_also_reported | after fits | `Gaussian_fwhm` in the group |
| peak_centre_converted_to_dspacing | after fits | a `*_dSpacing` member exists |
| dspacing_conversion_is_the_fitted_peak | after fits | finite values == 2.7059 Å within 2% |
| model_table_one_row_per_run | after fits | columns exact, 2 rows, every status converged |
| fit_parameter_table_saved_per_run | after fits | `User/<RB>/FitParameters/*_Fit_Parameters.nxs` per run |
| primary_log_sort_keeps_every_run | primary log set, ascending | sorted list is a permutation of the active list |
| unticking_ascending_reverses_order | ascending → descending | list is exactly the reverse |
| no_primary_log_keeps_loaded_order | primary log cleared | sorted == active list |

---

## `EngDiffGuiTextureTest.py` — Texture (replaces guide Test 12)

### Loading and the table (`EngDiffGuiTextureLoadingTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| table_starts_empty | tab opened | 0 rows |
| scattering_section_hidden | tab opened | correction inputs not visible |
| param_column_selector_hidden | no parameter tables | `combo_param` not visible |
| crystal_buttons_disabled | nothing loaded | buttons disabled |
| one_row_per_loaded_run | 7 Texture30 focus files | 7 rows named for the focused workspaces |
| runs_load_with_nothing_set | same | no parameters, crystal or shape |
| every_row_starts_unselected | same | no selected workspaces |
| crystal_list_offers_every_run | same | workspace combo lists all 7 |
| reloading_does_not_duplicate | same files again | still 7 rows |
| only_projection_offered_without_params | no parameter tables | single plot option |
| each_run_paired_with_its_params | 7 FitParameters files | Fit Parameters column populated per run |
| selector_hidden_while_nothing_selected | params loaded, none ticked | `combo_param` still hidden *(driven by selection, not load)* |
| selector_appears_when_all_selected_have_params | rows ticked | `combo_param` visible |
| only_numeric_columns_offered | same | non-numeric parameter columns excluded |
| select_all_ticks_every_row | button | all selected |
| deselect_all_unticks_every_row | button | none selected |
| remove_selected_params_clears_those_rows | button | only the ticked rows lose their parameters |
| selector_hides_when_a_run_has_no_params | after that removal | `combo_param` hidden again |
| delete_selected_removes_rows | button | ticked rows gone |
| deleting_all_empties_table | button | 0 rows |

### Pole figures (`EngDiffGuiTexturePoleFigureTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| pole_figure_without_parameter_table | runs only | figure produced from the fabricated `I` column |
| pole_figure_is_plotted | same | axes carry the plotted data |
| pole_figure_table_written | same | table saved to the save directory |
| both_projections_offered | projection combo | stereographic and azimuthal listed |
| projections_give_different_points | switch projection | point sets differ (`ster_proj` vs `azim_proj`) |
| every_numeric_column_plottable | parameter tables loaded | each numeric column offered |
| chosen_column_drives_colour_data | column switched | plotted colour data follows the selection |
| crystal_inputs_hidden_by_default | correction unticked | inputs not visible |
| ticking_correction_reveals_inputs | ticked | inputs visible |
| lattice_entry_disables_cif_finder | lattice params typed | CIF finder disabled |
| crystal_buttons_enable_with_crystal_and_run | both chosen | buttons enabled |
| crystal_recorded_against_each_run | applied | Crystal Structure column populated per selected run |
| corrected_pole_figure_produced | scattering correction on | figure still produced |
| rb_number_reaches_presenter | RB set | presenter `rb_num` |
| pole_figure_tables_under_polefiguretables | RB set | files written to `PoleFigureTables` |

---

## `EngDiffGuiGsas2Test.py` — GSAS II (replaces guide Tests 13–14)

> `GSAS2Model.call_subprocess` is the only mock in the suite: it copies the shipped canned outputs
> into the model's temporary directory. Everything else — validation, table construction, plotting,
> file moves — is real.

### Single focused file (`EngDiffGuiGsas2SingleTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| empty_project_name_flagged | project name cleared | invalid marker shown |
| marker_clears_with_project_name | name typed | marker gone |
| rietveld_offered_but_disabled | tab opened | option present, not selectable |
| no_advisory_until_all_three_ticked | 0–2 of the boxes | no asterisk |
| advisory_when_all_three_refined | microstrain + Sigma-1 + Gamma(Y) | asterisk with tooltip |
| advisory_clears_when_one_unticked | microstrain off | asterisk gone |
| phase_combo_lists_shipped_cifs | tab opened | shipped phases + "Custom" |
| phase_finder_hidden_for_shipped | shipped phase | finder hidden |
| custom_phase_reveals_finder | "Custom" | finder visible |
| phase_finder_hidden_again | back to shipped | finder hidden |
| refine_without_project_name_rejected | Refine pressed | error recorded, no subprocess call *(product fix: the guard could never fire before)* |
| multiple_instrument_files_rejected | 2 `.prm` | error recorded |
| bank_count_mismatch_rejected | inconsistent banks | error recorded |
| histogram_selector_lists_banks | after refinement | one entry per bank |
| lattice_table_from_cell_parameters | after refinement | `<project>_GSASII_lattice_parameters` contents |
| microstrain_column_marked_when_refined | with/without | column flag matches |
| instrument_table_row_per_bank | after refinement | rows + fit range columns |
| reflections_table_row_per_bank_and_phase | after refinement | expected row count |
| all_banks_file_expanded_per_bank | `all_banks` input | per-bank focused workspaces created |
| gsas2_log_group_built | after refinement | `logs_GSASII` group |
| outputs_moved_to_save_directory | after refinement | `<save>/GSAS2/<project>/` populated |
| no_temporary_directory_left | after refinement | temp working dir removed *(product fix)* |
| inputs_describe_requested_refinement | command inspection | refinement flags passed through |
| file_paths_are_the_ones_chosen | command inspection | prm and gss paths match the tab |
| pawley_reflections_generated | after refinement | reflections present for the phase |
| command_points_at_configured_interpreter | command inspection | GSAS-II interpreter path from settings |
| result_is_plotted | after refinement | figure produced |
| four_refinement_curves_plotted | after refinement | 4 lines |
| reflection_markers_plotted | after refinement | markers for the phase |
| plot_titled_for_data_file | after refinement | dock title *(product fix: title no longer cleared)* |
| plot_labelled_in_tof | after refinement | x label |
| x_limits_seeded_from_data | first refinement | limits match the data range |
| user_x_limits_passed_through | limits edited | serialized inputs carry them |
| x_limits_reset_on_new_inputs | new files chosen | limits cleared |

### Multiple focused files (`EngDiffGuiGsas2MultipleTest`)
| Test | Scenario | Asserted on |
|---|---|---|
| each_file_refined_separately | 2 `.gss` | one subprocess call each |
| each_refinement_has_own_tables | same | per-project table sets |
| each_refinement_writes_own_directory | same | separate save directories *(product fix: `tempfile.mkdtemp` removed a same-second collision)* |
| logs_cover_every_bank | same | log group spans both files' banks |
| rb_number_adds_user_copy | RB set | `User/<RB>/GSAS2/` copy |
| non_rb_copy_still_written | RB set | plain `GSAS2/` copy also present |



Closes https://github.com/mantidproject/mantid/issues/41936

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
