### PR TITLE
Histogram 2.0 migration, new methods for handling `HistogramX`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertAxisByFormula.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertAxisByFormula.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidAlgorithms/ConvertUnits.h"
 #include "MantidAlgorithms/DllConfig.h"
+#include "MantidHistogramData/HistogramX.h"
 
 // forward declaration
 namespace mu {
@@ -58,7 +59,7 @@ private:
   using Variable_ptr = std::shared_ptr<Variable>;
 
   void setAxisValue(const double value, const std::vector<Variable_ptr> &variables);
-  void calculateValues(mu::Parser &p, std::vector<double> &vec, const std::vector<Variable_ptr> &variables);
+  void calculateValues(mu::Parser &p, HistogramData::HistogramX &xValues, const std::vector<Variable_ptr> &variables);
   void setGeometryValues(const API::SpectrumInfo &specInfo, const size_t index,
                          const std::vector<Variable_ptr> &variables);
   double evaluateResult(mu::Parser &p);

--- a/Framework/Algorithms/src/ConvertAxisByFormula.cpp
+++ b/Framework/Algorithms/src/ConvertAxisByFormula.cpp
@@ -163,9 +163,9 @@ void ConvertAxisByFormula::exec() {
       Progress prog(this, 0.6, 1.0, numberOfSpectra_i);
       for (size_t i = 0; i < numberOfSpectra_i; ++i) {
         try {
-          MantidVec &vec = outputWs->dataX(i);
+          auto &xValues = outputWs->mutableX(i);
           setGeometryValues(spectrumInfo, i, variables);
-          calculateValues(p, vec, variables);
+          calculateValues(p, xValues, variables);
         } catch (std::runtime_error &)
         // two possible exceptions runtime error and NotFoundError
         // both handled the same way
@@ -185,8 +185,8 @@ void ConvertAxisByFormula::exec() {
       // common bins - we only have to calculate once
 
       // Calculate the new (common) X values
-      MantidVec &vec = outputWs->dataX(0);
-      calculateValues(p, vec, variables);
+      auto &xValues = outputWs->mutableX(0);
+      calculateValues(p, xValues, variables);
 
       // copy xVals to every spectra
       auto numberOfSpectra_i = static_cast<int64_t>(outputWs->getNumberHistograms()); // cast to make openmp happy
@@ -212,8 +212,8 @@ void ConvertAxisByFormula::exec() {
   // If the units conversion has flipped the ascending direction of X, reverse
   // all the vectors
   size_t midSpectra = outputWs->getNumberHistograms() / 2;
-  if (!outputWs->dataX(0).empty() && (outputWs->dataX(0).front() > outputWs->dataX(0).back() ||
-                                      outputWs->dataX(midSpectra).front() > outputWs->dataX(midSpectra).back())) {
+  if (!outputWs->x(0).empty() && (outputWs->x(0).front() > outputWs->x(0).back() ||
+                                  outputWs->x(midSpectra).front() > outputWs->x(midSpectra).back())) {
     g_log.information("Reversing data within the workspace to keep the axes in "
                       "increasing order.");
     this->reverse(outputWs);
@@ -243,9 +243,9 @@ void ConvertAxisByFormula::setAxisValue(const double value, const std::vector<Va
   }
 }
 
-void ConvertAxisByFormula::calculateValues(mu::Parser &p, MantidVec &vec, const std::vector<Variable_ptr> &variables) {
-  MantidVec::iterator iter;
-  for (iter = vec.begin(); iter != vec.end(); ++iter) {
+void ConvertAxisByFormula::calculateValues(mu::Parser &p, HistogramData::HistogramX &xValues,
+                                           const std::vector<Variable_ptr> &variables) {
+  for (auto iter = xValues.begin(); iter != xValues.end(); ++iter) {
     setAxisValue(*iter, variables);
     *iter = evaluateResult(p);
   }

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -375,10 +375,6 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
   const std::string emodeStr = getProperty("EMode");
   DeltaEMode::Type emode = DeltaEMode::fromString(emodeStr);
 
-  // Not doing anything with the Y vector in to/fromTOF yet, so just pass
-  // empty
-  // vector
-  std::vector<double> emptyVec;
   double efixedProp = getProperty("Efixed");
   if (efixedProp == EMPTY_DBL() && emode == DeltaEMode::Type::Direct) {
     try {
@@ -405,9 +401,9 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
   auto checkXValues = inputWS->x(checkIndex).rawData();
   try {
     // Convert the input unit to time-of-flight
-    checkFromUnit->toTOF(checkXValues, emptyVec, l1, emode, upmap);
+    checkFromUnit->toTOF(checkXValues.begin(), checkXValues.end(), l1, emode, upmap);
     // Convert from time-of-flight to the desired unit
-    checkOutputUnit->fromTOF(checkXValues, emptyVec, l1, emode, upmap);
+    checkOutputUnit->fromTOF(checkXValues.begin(), checkXValues.end(), l1, emode, upmap);
   } catch (std::runtime_error &) { // if it's a detector specific problem then ignore
   }
 

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -437,9 +437,10 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
     }
     outSpectrumInfo.getDetectorValues(*fromUnit, *outputUnit, emode, signedTheta, i, pmap);
     try {
-      localFromUnit->toTOF(outputWS->dataX(i), emptyVec, l1, emode, pmap);
+      auto &xValues = outputWS->mutableX(i);
+      localFromUnit->toTOF(xValues.begin(), xValues.end(), l1, emode, pmap);
       // Convert from time-of-flight to the desired unit
-      localOutputUnit->fromTOF(outputWS->dataX(i), emptyVec, l1, emode, pmap);
+      localOutputUnit->fromTOF(xValues.begin(), xValues.end(), l1, emode, pmap);
 
       // EventWorkspace part, modifying the EventLists.
       if (m_inputEvents) {
@@ -532,8 +533,8 @@ void ConvertUnits::reverse(const API::MatrixWorkspace_sptr &WS) {
     auto reverseX = make_cow<HistogramData::HistogramX>(WS->x(0).crbegin(), WS->x(0).crend());
     for (size_t j = 0; j < numberOfSpectra; ++j) {
       WS->setSharedX(j, reverseX);
-      std::reverse(WS->dataY(j).begin(), WS->dataY(j).end());
-      std::reverse(WS->dataE(j).begin(), WS->dataE(j).end());
+      std::reverse(WS->mutableY(j).begin(), WS->mutableY(j).end());
+      std::reverse(WS->mutableE(j).begin(), WS->mutableE(j).end());
       if (j % 100 == 0)
         interruption_point();
     }

--- a/Framework/Algorithms/src/CropWorkspaceRagged.cpp
+++ b/Framework/Algorithms/src/CropWorkspaceRagged.cpp
@@ -120,9 +120,9 @@ void CropWorkspaceRagged::exec() {
   for (int64_t i = 0; i < int64_t(numSpectra); ++i) {
     PARALLEL_START_INTERRUPT_REGION
     auto points = tmp->points(i);
-    auto &dataX = outputWS->dataX(i);
-    auto &dataY = outputWS->dataY(i);
-    auto &dataE = outputWS->dataE(i);
+    const auto &xValues = outputWS->x(i);
+    const auto &yValues = outputWS->y(i);
+    const auto &eValues = outputWS->e(i);
 
     // get iterators for cropped region using points
     auto low = std::lower_bound(points.begin(), points.end(), xMin[i]);
@@ -132,19 +132,17 @@ void CropWorkspaceRagged::exec() {
     int64_t upperIndex = std::distance(points.begin(), up);
 
     // get new vectors
-    std::vector<double> newY = getSubVector(dataY, lowerIndex, upperIndex);
-    std::vector<double> newE = getSubVector(dataE, lowerIndex, upperIndex);
-    if (histogram && upperIndex + (size_t)1 <= dataX.size()) {
+    std::vector<double> newY = getSubVector(yValues.rawData(), lowerIndex, upperIndex);
+    std::vector<double> newE = getSubVector(eValues.rawData(), lowerIndex, upperIndex);
+    if (histogram && upperIndex + (size_t)1 <= xValues.size()) {
       // the offset adds one to the upper index for histograms
       // only use the offset if the end is cropped
       upperIndex += 1;
     }
-    std::vector<double> newX = getSubVector(dataX, lowerIndex, upperIndex);
+    std::vector<double> newX = getSubVector(xValues.rawData(), lowerIndex, upperIndex);
 
-    // resize the data
-    dataX.resize(newX.size());
-    dataY.resize(newY.size());
-    dataE.resize(newE.size());
+    // resize the histogram; this keeps X, Y and E consistent with the storage mode
+    outputWS->resizeHistogram(i, newY.size());
 
     // update the data
     outputWS->mutableX(i) = newX;

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -294,9 +294,8 @@ void DiffractionFocussing2::exec() {
     outSpec.setSpectrumNo(group);
 
     // Get the references to Y and E output and rebin
-    // TODO can only be changed once rebin implemented in HistogramData
-    auto &Yout = outSpec.dataY();
-    auto &Eout = outSpec.dataE();
+    auto &Yout = outSpec.mutableY();
+    auto &Eout = outSpec.mutableE();
 
     // Initialize the group's weight vector here and the dummy vector used for
     // accumulating errors.

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -85,12 +85,8 @@ MatrixWorkspace_sptr removeZeros(MatrixWorkspace_sptr &ws, const std::vector<siz
     return ws; // In case, we don't have any spectra
   }
   for (size_t spec = 0; spec < nspec; spec++) {
-    auto &dataX = ws->dataX(spec);
-    dataX.resize(itCount[spec]);
-    auto &dataY = ws->dataY(spec);
-    dataY.resize(itCount[spec]);
-    auto &dataE = ws->dataE(spec);
-    dataE.resize(itCount[spec]);
+    // the workspace holds point data, so this resizes X, Y and E alike
+    ws->resizeHistogram(spec, itCount[spec]);
   }
   return ws;
 }

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -426,15 +426,13 @@ void ResampleX::exec() {
     for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
       PARALLEL_START_INTERRUPT_REGION
       // get const references to input Workspace arrays (no copying)
-      // TODO: replace with HistogramX/Y/E when VectorHelper::rebin is updated
       Mantid::HistogramData::HistogramX const &XValues = inputWS->x(wkspIndex);
       Mantid::HistogramData::HistogramY const &YValues = inputWS->y(wkspIndex);
       Mantid::HistogramData::HistogramE const &YErrors = inputWS->e(wkspIndex);
 
       // get references to output workspace data (no copying)
-      // TODO: replace with HistogramX/Y/E when VectorHelper::rebin is updated
-      MantidVec &YValues_new = outputWS->dataY(wkspIndex);
-      MantidVec &YErrors_new = outputWS->dataE(wkspIndex);
+      auto &YValues_new = outputWS->mutableY(wkspIndex);
+      auto &YErrors_new = outputWS->mutableE(wkspIndex);
 
       // create new output X axis
       MantidVec XValues_new;

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
+#include <span>
 #include <sstream>
 
 namespace Mantid::Algorithms {
@@ -430,9 +431,9 @@ void ResampleX::exec() {
       Mantid::HistogramData::HistogramY const &YValues = inputWS->y(wkspIndex);
       Mantid::HistogramData::HistogramE const &YErrors = inputWS->e(wkspIndex);
 
-      // get references to output workspace data (no copying)
-      auto &YValues_new = outputWS->mutableY(wkspIndex);
-      auto &YErrors_new = outputWS->mutableE(wkspIndex);
+      // get writable views onto the output workspace data (no copying)
+      std::span<double> const YValues_new{outputWS->mutableY(wkspIndex)};
+      std::span<double> const YErrors_new{outputWS->mutableE(wkspIndex)};
 
       // create new output X axis
       MantidVec XValues_new;

--- a/Framework/DataHandling/src/SaveNXcanSASHelper.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASHelper.cpp
@@ -85,13 +85,13 @@ H5::DSetCreatPropList setCompression(const size_t rank, const hsize_t *chunkDims
  */
 template <typename T> class QxExtractor {
 public:
-  T *operator()(const MatrixWorkspace_sptr &ws, size_t index) {
+  T const *operator()(const MatrixWorkspace_sptr &ws, size_t index) {
     if (ws->isHistogramData()) {
       qxPointData.clear();
-      VectorHelper::convertToBinCentre(ws->dataX(index), qxPointData);
+      VectorHelper::convertToBinCentre(ws->x(index).rawData(), qxPointData);
       return qxPointData.data();
     }
-    return ws->dataX(index).data();
+    return ws->x(index).rawData().data();
   }
 
   std::vector<T> qxPointData;
@@ -111,7 +111,7 @@ public:
     const double value = isPointData ? m_spectrumAxisValues[index]
                                      : (m_spectrumAxisValues[index + 1] + m_spectrumAxisValues[index]) / 2.0;
 
-    Mantid::MantidVec tempVec(m_workspace->dataY(index).size(), value);
+    Mantid::MantidVec tempVec(m_workspace->y(index).size(), value);
     m_currentAxisValues.swap(tempVec);
     return m_currentAxisValues.data();
   }
@@ -138,9 +138,9 @@ public:
   explicit WorkspaceGroupDataExtractor(const WorkspaceGroup_sptr &workspace, bool extractError = false)
       : m_workspace(workspace), m_extractError(extractError) {}
 
-  T *operator()(size_t groupIndex, size_t spectraIndex = 0) {
+  T const *operator()(size_t groupIndex, size_t spectraIndex = 0) {
     const auto ws = std::dynamic_pointer_cast<MatrixWorkspace>(m_workspace->getItem(groupIndex));
-    return m_extractError ? ws->dataE(spectraIndex).data() : ws->dataY(spectraIndex).data();
+    return m_extractError ? ws->e(spectraIndex).rawData().data() : ws->y(spectraIndex).rawData().data();
   }
 
   void setExtractErrors(bool extractError) { m_extractError = extractError; }
@@ -759,14 +759,14 @@ void addData2D(H5::Group &data, const MatrixWorkspace_sptr &workspace) {
   // Get 2D I data and store it
   auto iAttributes = prepareUnitAttributes(workspace);
 
-  auto iExtractor = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->dataY(index).data(); };
+  auto iExtractor = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->y(index).rawData().data(); };
   write2DWorkspace(data, workspace, sasDataI, iExtractor, iAttributes);
 
   // Get 2D Idev data and store it
   AttrMap eAttributes;
   eAttributes.insert(std::make_pair(sasUnitAttr, iAttributes[sasUnitAttr])); // same units as intensity
 
-  auto iDevExtractor = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->dataE(index).data(); };
+  auto iDevExtractor = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->e(index).rawData().data(); };
   write2DWorkspace(data, workspace, sasDataIdev, iDevExtractor, eAttributes);
 }
 

--- a/Framework/DataObjects/src/RebinnedOutput.cpp
+++ b/Framework/DataObjects/src/RebinnedOutput.cpp
@@ -130,7 +130,7 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
   if (m_finalized) {
     PARALLEL_FOR_IF(Kernel::threadSafe(*this))
     for (int i = 0; i < nHist; ++i) {
-      MantidVec &err = this->dataE(i);
+      auto &err = this->mutableE(i);
       MantidVec &frac = this->dataF(i);
       if (hasSqrdErrs) {
         std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::divides<double>());
@@ -146,8 +146,8 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int i = 0; i < nHist; ++i) {
-    MantidVec &data = this->dataY(i);
-    MantidVec &err = this->dataE(i);
+    auto &data = this->mutableY(i);
+    auto &err = this->mutableE(i);
     MantidVec &frac = this->dataF(i);
     std::transform(data.begin(), data.end(), frac.begin(), data.begin(), std::divides<double>());
     std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::divides<double>());
@@ -173,8 +173,8 @@ void RebinnedOutput::unfinalize() {
   auto nHist = static_cast<int>(this->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int i = 0; i < nHist; ++i) {
-    MantidVec &data = this->dataY(i);
-    MantidVec &err = this->dataE(i);
+    auto &data = this->mutableY(i);
+    auto &err = this->mutableE(i);
     MantidVec &frac = this->dataF(i);
     std::transform(data.begin(), data.end(), frac.begin(), data.begin(), std::multiplies<double>());
     std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::multiplies<double>());

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -141,7 +141,7 @@ double SpecialWorkspace2D::getValue(const detid_t detectorID) const {
        << "  Size(Map) = " << this->detID_to_WI.size() << '\n';
     throw std::invalid_argument(os.str());
   } else {
-    return this->dataY(it->second)[0];
+    return this->y(it->second)[0];
   }
 }
 
@@ -160,7 +160,7 @@ double SpecialWorkspace2D::getValue(const detid_t detectorID, const double defau
   else {
     if (it->second < getNumberHistograms()) // don't let it generate an exception
     {
-      return this->dataY(it->second)[0];
+      return this->y(it->second)[0];
     } else {
       g_log.debug() << "getValue(" << detectorID << "->" << (it->second) << ", " << defaultValue
                     << ") index out of range\n";
@@ -271,8 +271,8 @@ void SpecialWorkspace2D::binaryOperation(const unsigned int operatortype) {
 void SpecialWorkspace2D::binaryAND(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
 
     if (y1 < 1.0E-10 || y2 < 1.0E-10) {
       this->mutableY(i)[0] = 0.0;
@@ -288,8 +288,8 @@ void SpecialWorkspace2D::binaryAND(const std::shared_ptr<const SpecialWorkspace2
 void SpecialWorkspace2D::binaryOR(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
 
     double max = y1;
     if (y2 > y1) {
@@ -313,8 +313,8 @@ if (y1 < 1.0E-10 && y2 < 1.0E-10){
 void SpecialWorkspace2D::binaryXOR(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
     if (y1 < 1.0E-10 && y2 < 1.0E-10) {
       this->mutableY(i)[0] = 0.0;
     } else if (y1 > 1.0E-10 && y2 > 1.0E-10) {
@@ -331,7 +331,7 @@ void SpecialWorkspace2D::binaryXOR(const std::shared_ptr<const SpecialWorkspace2
 void SpecialWorkspace2D::binaryNOT() {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
+    double y1 = this->y(i)[0];
     if (y1 < 1.0E-10) {
       this->mutableY(i)[0] = 1.0;
     } else {

--- a/Framework/DataObjects/src/WorkspaceSingleValue.cpp
+++ b/Framework/DataObjects/src/WorkspaceSingleValue.cpp
@@ -19,10 +19,10 @@ DECLARE_WORKSPACE(WorkspaceSingleValue)
 /// Constructor
 WorkspaceSingleValue::WorkspaceSingleValue(double value, double error) : API::HistoWorkspace() {
   initialize(1, 1, 1);
-  // Set the "histogram" to the single value
-  data.dataX().resize(1, 0.0);
-  data.setCounts(1, value);
-  data.setCountStandardDeviations(1, error);
+  // Set the "histogram" to the single value. X, Y and E must be set together: the arrays
+  // start out empty, so setting any one of them on its own fails the size check.
+  data.setHistogram(HistogramData::Points(1, 0.0), HistogramData::Counts(1, value),
+                    HistogramData::CountStandardDeviations(1, error));
   data.setPointStandardDeviations(1, 0.0);
   setDistribution(true);
   // Add a set of axes to the workspace

--- a/Framework/DataObjects/test/RebinnedOutputTest.h
+++ b/Framework/DataObjects/test/RebinnedOutputTest.h
@@ -52,11 +52,11 @@ public:
   void testRepresentation() {
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 4);
     TS_ASSERT_EQUALS(ws->blocksize(), nHist);
-    TS_ASSERT_EQUALS(ws->dataX(0).size(), 7);
-    TS_ASSERT_EQUALS(ws->dataX(0)[2], -1.);
-    TS_ASSERT_EQUALS(ws->dataY(1)[3], 1.);
+    TS_ASSERT_EQUALS(ws->x(0).size(), 7);
+    TS_ASSERT_EQUALS(ws->x(0)[2], -1.);
+    TS_ASSERT_EQUALS(ws->y(1)[3], 1.);
     // 1/sqrt(3)
-    TS_ASSERT_DELTA(ws->dataE(1)[3], 0.57735026918963, 1.e-5);
+    TS_ASSERT_DELTA(ws->e(1)[3], 0.57735026918963, 1.e-5);
     TS_ASSERT_EQUALS(ws->dataF(0).size(), nHist);
     TS_ASSERT_EQUALS(ws->dataF(1)[3], 3.);
   }

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -109,7 +109,7 @@ void sanityCheck(const Histogram &input, const Histogram &output, const size_t m
 void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
                                 const Mantid::HistogramData::Points &points, Mantid::HistogramData::Histogram &output,
                                 const bool calculateErrors = false, const bool independentErrors = true) {
-  auto xs = input.dataX();
+  const auto xs = input.x().rawData();
   // Interpolation and Error propagation follows method described in Gardner paper
   // "Uncertainties in Interpolated Spectral Data", Journal of Research of the
   // National Institute of Standards and Technology, 2003
@@ -133,7 +133,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
   double hMaxEpsilon = xsMaxEpsilon * 2 / 3;
 
   std::vector<double> d(xs.size() - 2);
-  auto ys = input.dataY();
+  const auto ys = input.y().rawData();
   for (size_t i = 0; i < xs.size() - 2; i++) {
     d[i] = (ys[i + 2] - ys[i + 1]) / (xs[i + 2] - xs[i + 1]) - (ys[i + 1] - ys[i]) / (xs[i + 1] - xs[i]);
   }
@@ -151,7 +151,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
 
   // calculate some covariances to support error propagation
   auto &enew = output.mutableE();
-  const auto &eold = input.dataE();
+  const auto &eold = input.e();
   // u_ypp_ypp - covariance of y'' vs y''
   std::vector<double> u_ypp_ypp(xs.size());
   // u_ypp_y - covariance of y'' vs y

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -12,6 +12,7 @@
 #include "MantidKernel/UnitLabel.h"
 #include <utility>
 
+#include <algorithm>
 #include <unordered_map>
 #include <vector>
 #ifndef Q_MOC_RUN
@@ -93,6 +94,28 @@ public:
   void toTOF(std::vector<double> &xdata, std::vector<double> const &ydata, const double &_l1, const int &_emode,
              const UnitParametersMap &params);
 
+  /** Convert a range of X values in place from the concrete unit to time-of-flight.
+   *  TOF is in microseconds.
+   *  This overload takes an iterator range rather than a `std::vector<double> &`, so that it can be
+   *  used with the size-checked histogram data types, which deliberately do not hand out a
+   *  modifiable `std::vector<double>`.
+   *  @param xbegin ::  Iterator to the first X value to be converted
+   *  @param xend ::    Iterator one past the last X value to be converted
+   *  @param l1 ::      The source-sample distance (in metres)
+   *  @param emode ::   The energy mode (0=elastic, 1=direct geometry, 2=indirect geometry)
+   *  @param params ::  Map containing optional parameters eg
+   *                    The sample-detector distance (in metres)
+   *                    The scattering angle (in radians)
+   *                    Fixed energy: EI (emode=1) or EF (emode=2)(in meV)
+   *                    Delta (not currently used)
+   */
+  template <typename Iterator>
+  void toTOF(Iterator const xbegin, Iterator const xend, double const l1, int const emode,
+             UnitParametersMap const &params) {
+    this->initialize(l1, emode, params);
+    std::transform(xbegin, xend, xbegin, [this](double const x) { return this->singleToTOF(x); });
+  }
+
   /// Convert from the concrete unit to time-of-flight. TOF is in microseconds.
   double convertSingleToTOF(const double xvalue, const double &l1, const int &emode, const UnitParametersMap &params);
 
@@ -114,6 +137,28 @@ public:
 
   void fromTOF(std::vector<double> &xdata, std::vector<double> const &ydata, const double &_l1, const int &_emode,
                const UnitParametersMap &params);
+
+  /** Convert a range of X values in place from time-of-flight to the concrete unit.
+   *  TOF is in microseconds.
+   *  This overload takes an iterator range rather than a `std::vector<double> &`, so that it can be
+   *  used with the size-checked histogram data types, which deliberately do not hand out a
+   *  modifiable `std::vector<double>`.
+   *  @param xbegin ::  Iterator to the first X value to be converted
+   *  @param xend ::    Iterator one past the last X value to be converted
+   *  @param l1 ::      The source-sample distance (in metres)
+   *  @param emode ::   The energy mode (0=elastic, 1=direct geometry, 2=indirect geometry)
+   *  @param params ::  Map containing optional parameters eg
+   *                    The sample-detector distance (in metres)
+   *                    The scattering angle (in radians)
+   *                    Fixed energy: EI (emode=1) or EF (emode=2)(in meV)
+   *                    Delta (not currently used)
+   */
+  template <typename Iterator>
+  void fromTOF(Iterator const xbegin, Iterator const xend, double const l1, int const emode,
+               UnitParametersMap const &params) {
+    this->initialize(l1, emode, params);
+    std::transform(xbegin, xend, xbegin, [this](double const tof) { return this->singleFromTOF(tof); });
+  }
 
   /// Convert from the time-of-flight to the concrete unit. TOF is in microseconds.
   double convertSingleFromTOF(const double xvalue, const double &l1, const int &emode, const UnitParametersMap &params);

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <functional>
 #include <numeric>
+#include <span>
 #include <stdexcept>
 #include <vector>
 
@@ -35,15 +36,17 @@ std::size_t MANTID_KERNEL_DLL createAxisFromRebinParams(
     const bool full_bins_only = false, const double xMinHint = std::nan(""), const double xMaxHint = std::nan(""),
     const bool useReverseLogarithmic = false, const double power = -1);
 
+/// The output ranges are taken as spans so that the size-checked histogram data types, which do not
+/// hand out a modifiable std::vector<double>, can be rebinned into directly. The outputs must already
+/// be sized; neither function resizes them.
 void MANTID_KERNEL_DLL rebin(const std::vector<double> &xold, const std::vector<double> &yold,
-                             const std::vector<double> &eold, const std::vector<double> &xnew,
-                             std::vector<double> &ynew, std::vector<double> &enew, bool distribution,
-                             bool addition = false);
+                             const std::vector<double> &eold, const std::vector<double> &xnew, std::span<double> ynew,
+                             std::span<double> enew, bool distribution, bool addition = false);
 
 // New method to rebin Histogram data, should be faster than previous one
 void MANTID_KERNEL_DLL rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold,
                                       const std::vector<double> &eold, const std::vector<double> &xnew,
-                                      std::vector<double> &ynew, std::vector<double> &enew, bool addition);
+                                      std::span<double> ynew, std::span<double> enew, bool addition);
 
 /// Convert an array of bin boundaries to bin center values.
 void MANTID_KERNEL_DLL convertToBinCentre(const std::vector<double> &bin_edges, std::vector<double> &bin_centres);

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -303,7 +303,7 @@ std::size_t createAxisFromRebinParams(const std::vector<double> &params, std::ve
  *  @throw invalid_argument Thrown if input to function is incorrect.
  **/
 void rebin(const std::vector<double> &xold, const std::vector<double> &yold, const std::vector<double> &eold,
-           const std::vector<double> &xnew, std::vector<double> &ynew, std::vector<double> &enew, bool distribution,
+           const std::vector<double> &xnew, std::span<double> ynew, std::span<double> enew, bool distribution,
            bool addition) {
   // Make sure y and e vectors are of correct sizes
   const size_t size_xold = xold.size();
@@ -420,8 +420,7 @@ void rebin(const std::vector<double> &xold, const std::vector<double> &yold, con
  *  @throw runtime_error Thrown if vector sizes are inconsistent
  **/
 void rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold, const std::vector<double> &eold,
-                    const std::vector<double> &xnew, std::vector<double> &ynew, std::vector<double> &enew,
-                    bool addition) {
+                    const std::vector<double> &xnew, std::span<double> ynew, std::span<double> enew, bool addition) {
   // Make sure y and e vectors are of correct sizes
   const size_t size_yold = yold.size();
   if (xold.size() != (size_yold + 1) || size_yold != eold.size())
@@ -432,8 +431,8 @@ void rebinHistogram(const std::vector<double> &xold, const std::vector<double> &
 
   // If not adding to existing vectors, make sure ynew & enew contain zeroes
   if (!addition) {
-    ynew.assign(size_ynew, 0.0);
-    enew.assign(size_ynew, 0.0);
+    std::fill(ynew.begin(), ynew.end(), 0.0);
+    std::fill(enew.begin(), enew.end(), 0.0);
   }
 
   // Find the starting points to avoid wasting time processing irrelevant bins

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -363,6 +363,48 @@ public:
                     -5.0865, 0.0001);
   }
 
+  void testWavelength_toTOF_iteratorRange() {
+    UnitParametersMap const params{{UnitParams::l2, 1.0}, {UnitParams::efixed, 1.0}};
+    std::vector<double> const input{1.5, 2.0};
+    std::vector<double> const emptyVec;
+    // Reference values from the vector overload
+    std::vector<double> expected = input;
+    lambda.toTOF(expected, emptyVec, 1.0, 1, params);
+    TS_ASSERT_DELTA(expected[0], 2665.4390, 0.0001) // matches testWavelength_toTOF
+
+    // The iterator overload must give the same answer ...
+    std::vector<double> x = input;
+    TS_ASSERT_THROWS_NOTHING(lambda.toTOF(x.begin(), x.end(), 1.0, 1, params))
+    TS_ASSERT_EQUALS(x, expected)
+
+    // ... and must convert only the values within the given range
+    std::vector<double> partial = input;
+    TS_ASSERT_THROWS_NOTHING(lambda.toTOF(partial.begin(), partial.begin() + 1, 1.0, 1, params))
+    TS_ASSERT_EQUALS(partial[0], expected[0])
+    TS_ASSERT_EQUALS(partial[1], input[1])
+  }
+
+  void testWavelength_fromTOF_iteratorRange() {
+    UnitParametersMap const params{{UnitParams::l2, 1.0}, {UnitParams::efixed, 1.0}};
+    std::vector<double> const input{1000.5, 1500.5};
+    std::vector<double> const emptyVec;
+    // Reference values from the vector overload
+    std::vector<double> expected = input;
+    lambda.fromTOF(expected, emptyVec, 1.0, 1, params);
+    TS_ASSERT_DELTA(expected[0], -5.0865, 0.0001) // matches testWavelength_fromTOF
+
+    // The iterator overload must give the same answer ...
+    std::vector<double> x = input;
+    TS_ASSERT_THROWS_NOTHING(lambda.fromTOF(x.begin(), x.end(), 1.0, 1, params))
+    TS_ASSERT_EQUALS(x, expected)
+
+    // ... and must convert only the values within the given range
+    std::vector<double> partial = input;
+    TS_ASSERT_THROWS_NOTHING(lambda.fromTOF(partial.begin(), partial.begin() + 1, 1.0, 1, params))
+    TS_ASSERT_EQUALS(partial[0], expected[0])
+    TS_ASSERT_EQUALS(partial[1], input[1])
+  }
+
   void testWavelength_quickConversions() {
     // Test it gives the same answer as going 'the long way'
     double factor, power;

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
@@ -151,7 +151,7 @@ public:
   }
 
   std::size_t getNumberBins(const std::size_t &index) const override {
-    if (index > m_vec.size())
+    if (index >= m_vec.size())
       return 0;
     return m_vec[index].dataY().size();
   }


### PR DESCRIPTION
### Description of work

The full Histogram 2.0 migration was (ten years ago) halted because certain functions like the rebin helper or unit conversions depended on the $x$-axis values being passed as a vector.

This changes those functions to allow for passing as a `HistogramX` object, directly, and changes the places needing it.

### To test:

This is a pure refactor.

Make sure existing and new unit tests pass.

This does not need release notes because it is an internal refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
