### PR TITLE
Histogram 2.0 migration: `dataX` changes

### DIFF
--- a/Framework/API/src/WorkspaceFactory.cpp
+++ b/Framework/API/src/WorkspaceFactory.cpp
@@ -61,7 +61,7 @@ MatrixWorkspace_sptr WorkspaceFactoryImpl::create(const MatrixWorkspace_const_sp
   if (NVectors == size_t(-1))
     NVectors = parent->getNumberHistograms();
   if (XLength == size_t(-1))
-    XLength = parent->dataX(0).size();
+    XLength = parent->x(0).size();
   if (YLength == size_t(-1)) {
     differentSize = false;
     YLength = parent->blocksize();

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1197,8 +1197,8 @@ public:
 
     MatrixWorkspace_sptr ws(new CompositeFunctionTest_MocMatrixWorkspace(10, 11, 10));
 
-    MantidVec &x = ws->dataX(3);
-    MantidVec &y = ws->dataY(3);
+    auto &x = ws->mutableX(3);
+    auto &y = ws->mutableY(3);
     for (size_t i = 0; i < y.size(); ++i) {
       x[i] = 0.1 * static_cast<double>(i);
       y[i] = static_cast<double>(i);

--- a/Framework/API/test/IMDWorkspaceTest.h
+++ b/Framework/API/test/IMDWorkspaceTest.h
@@ -43,9 +43,9 @@ public:
 
     for (int i = 0; i < 3; ++i) {
       workspace.mutableY(0)[i] = i * 10;
-      workspace.mutableE(0)[i] = sqrt(workspace.dataY(0)[i]);
+      workspace.mutableE(0)[i] = sqrt(workspace.y(0)[i]);
       workspace.mutableY(1)[i] = i * 100;
-      workspace.mutableE(1)[i] = sqrt(workspace.dataY(1)[i]);
+      workspace.mutableE(1)[i] = sqrt(workspace.y(1)[i]);
     }
   }
 

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -769,7 +769,7 @@ public:
     TS_ASSERT_EQUALS(ws->maskedBins(0).begin()->second, 0.75);
     // flagMasked() shouldn't change the y-value maskBins() tested below does
     // that
-    TS_ASSERT_EQUALS(ws->dataY(0)[1], 1.0);
+    TS_ASSERT_EQUALS(ws->y(0)[1], 1.0);
 
     // Now mask a bin earlier than above and check it's sorting properly
     TS_ASSERT_THROWS_NOTHING(ws->flagMasked(1, 1))
@@ -805,17 +805,17 @@ public:
     TS_ASSERT_EQUALS(ws2->maskedBins(0).size(), 1);
     TS_ASSERT_EQUALS(ws2->maskedBins(0).begin()->first, 1);
     TS_ASSERT_EQUALS(ws2->maskedBins(0).begin()->second, 0.5);
-    TS_ASSERT_EQUALS(ws2->dataY(0)[1], 0.5);
+    TS_ASSERT_EQUALS(ws2->y(0)[1], 0.5);
 
     // Now mask a bin earlier than above and check it's sorting properly
     TS_ASSERT_THROWS_NOTHING(ws2->maskBin(0, 0));
     TS_ASSERT_EQUALS(ws2->maskedBins(0).begin()->first, 0);
     TS_ASSERT_EQUALS(ws2->maskedBins(0).begin()->second, 1.0);
-    TS_ASSERT_EQUALS(ws2->dataY(0)[0], 0.0);
+    TS_ASSERT_EQUALS(ws2->y(0)[0], 0.0);
     // Check the previous masking is still OK
     TS_ASSERT_EQUALS(ws2->maskedBins(0).rbegin()->first, 1);
     TS_ASSERT_EQUALS(ws2->maskedBins(0).rbegin()->second, 0.5);
-    TS_ASSERT_EQUALS(ws2->dataY(0)[1], 0.5);
+    TS_ASSERT_EQUALS(ws2->y(0)[1], 0.5);
   }
 
   void testMaskingNaNInf() {
@@ -1266,7 +1266,7 @@ public:
   void test_getXIndex() {
     WorkspaceTester ws;
     ws.initialize(1, 4, 3);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     X[2] = 3.0;
@@ -1380,7 +1380,7 @@ public:
   void test_getImage_0_width() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     const size_t start = 0;
@@ -1394,7 +1394,7 @@ public:
   void test_getImage_wrong_start() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     size_t start = 10;
@@ -1410,7 +1410,7 @@ public:
   void test_getImage_wrong_stop() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     size_t start = 0;
@@ -1426,7 +1426,7 @@ public:
   void test_getImage_empty_set() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     size_t start = 1;
@@ -1440,7 +1440,7 @@ public:
   void test_getImage_non_rectangular() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     size_t start = 0;
@@ -1452,7 +1452,7 @@ public:
   void test_getImage_wrong_indexStart() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     const size_t start = 0;
@@ -1472,7 +1472,7 @@ public:
   void test_getImage_wrong_indexEnd() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     const size_t start = 0;
@@ -1484,7 +1484,7 @@ public:
 
     WorkspaceTester wsh;
     wsh.initialize(9, 2, 2);
-    auto &X1 = ws.dataX(0);
+    auto &X1 = ws.mutableX(0);
     X1[0] = 1.0;
     X1[1] = 2.0;
     startX = 1.0;
@@ -1495,7 +1495,7 @@ public:
   void test_getImage_single_bin_histo() {
     WorkspaceTester ws;
     ws.initialize(9, 2, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     for (size_t i = 0; i < ws.getNumberHistograms(); ++i) {
@@ -1529,7 +1529,7 @@ public:
   void test_getImage_single_bin_points() {
     WorkspaceTester ws;
     ws.initialize(9, 1, 1);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     for (size_t i = 0; i < ws.getNumberHistograms(); ++i) {
       ws.mutableY(i)[0] = static_cast<double>(i + 1);
@@ -1562,7 +1562,7 @@ public:
   void test_getImage_multi_bin_histo() {
     WorkspaceTester ws;
     ws.initialize(9, 4, 3);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     X[2] = 3.0;
@@ -1598,7 +1598,7 @@ public:
   void test_getImage_multi_bin_points() {
     WorkspaceTester ws;
     ws.initialize(9, 3, 3);
-    auto &X = ws.dataX(0);
+    auto &X = ws.mutableX(0);
     X[0] = 1.0;
     X[1] = 2.0;
     X[2] = 3.0;
@@ -2228,7 +2228,7 @@ private:
                                              std::size_t const &yLength, std::vector<double> const &xValues) {
     WorkspaceTester workspace;
     workspace.initialize(nVectors, xLength, yLength);
-    auto &X = workspace.dataX(0);
+    auto &X = workspace.mutableX(0);
 
     std::copy(xValues.begin(), xValues.end(), X.begin());
     return workspace;

--- a/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Framework/API/test/WorkspaceFactoryTest.h
@@ -82,7 +82,7 @@ public:
     TS_ASSERT_EQUALS(child->id(), "Workspace1DTest");
     TS_ASSERT_EQUALS(child->getSpectrum(0).getSpectrumNo(), 123);
     TS_ASSERT_EQUALS(*child->getSpectrum(1).getDetectorIDs().begin(), 456);
-    TS_ASSERT_DIFFERS(child->getSpectrum(2).dataY()[0], 789);
+    TS_ASSERT_DIFFERS(child->getSpectrum(2).y()[0], 789);
 
     // run/logs
     double ei(0.0);

--- a/Framework/Algorithms/src/RingProfile.cpp
+++ b/Framework/Algorithms/src/RingProfile.cpp
@@ -149,7 +149,7 @@ void RingProfile::exec() {
       API::WorkspaceFactory::Instance().create(inputWS, 1, output_bins.size() + 1, output_bins.size());
   m_progress->report("Preparing the output");
   // populate Y data getting the values from the output_bins
-  MantidVec &refY = outputWS->dataY(0);
+  auto &refY = outputWS->mutableY(0);
   if (clockwise) {
     for (size_t j = 0; j < output_bins.size(); j++)
       refY[j] = output_bins[output_bins.size() - j - 1];
@@ -160,7 +160,7 @@ void RingProfile::exec() {
 
   // prepare the output for the angles:
   // populate X data
-  MantidVec &refX = outputWS->dataX(0);
+  auto &refX = outputWS->mutableX(0);
 
   std::vector<double> angles(output_bins.size() + 1);
   // we always keep the angle in relative from where it starts and growing in
@@ -399,7 +399,7 @@ void RingProfile::processInstrumentRingProfile(const API::MatrixWorkspace_sptr &
 
     g_log.debug() << "Bin for the index " << i << " = " << bin_n << " Pos = " << spectrumInfo.position(i) << '\n';
 
-    const MantidVec &refY = inputWS->getSpectrum(i).dataY();
+    const auto &refY = inputWS->getSpectrum(i).y();
     // accumulate the values of this spectrum inside this bin
     for (double sp_ind : refY)
       output_bins[bin_n] += sp_ind;
@@ -462,7 +462,7 @@ int RingProfile::getBinForPixel(const Kernel::V3D &position) {
 void RingProfile::processNumericImageRingProfile(const API::MatrixWorkspace_sptr &inputWS,
                                                  std::vector<double> &output_bins) {
   // allocate the bin positions vector
-  std::vector<int> bin_n(inputWS->dataY(0).size(), -1);
+  std::vector<int> bin_n(inputWS->y(0).size(), -1);
 
   // consider that each spectrum is a row in the image
   for (int i = 0; i < static_cast<int>(inputWS->getNumberHistograms()); i++) {
@@ -473,7 +473,7 @@ void RingProfile::processNumericImageRingProfile(const API::MatrixWorkspace_sptr
 
     // accumulate the values from the spectrum to the target bin
     // each column has it correspondend bin_position inside bin_n
-    const MantidVec &refY = inputWS->dataY(i);
+    const auto &refY = inputWS->y(i);
     for (size_t j = 0; j < bin_n.size(); j++) {
 
       // is valid bin? No -> skip
@@ -515,7 +515,7 @@ void RingProfile::processNumericImageRingProfile(const API::MatrixWorkspace_sptr
  */
 void RingProfile::getBinForPixel(const API::MatrixWorkspace_sptr &ws, int spectrum_index, std::vector<int> &bins_pos) {
 
-  if (bins_pos.size() != ws->dataY(spectrum_index).size())
+  if (bins_pos.size() != ws->y(spectrum_index).size())
     throw std::runtime_error("Invalid bin positions vector");
 
   API::NumericAxis *oldAxis2 = dynamic_cast<API::NumericAxis *>(ws->getAxis(1));
@@ -532,7 +532,7 @@ void RingProfile::getBinForPixel(const API::MatrixWorkspace_sptr &ws, int spectr
 
   // the reference to X bins (the limits for each pixel in the horizontal
   // direction)
-  auto xvec = ws->dataX(spectrum_index);
+  const auto &xvec = ws->x(spectrum_index);
 
   // for each pixel inside this row
   for (size_t i = 0; i < xvec.size() - 1; i++) {

--- a/Framework/Algorithms/test/ChangeBinOffsetTest.h
+++ b/Framework/Algorithms/test/ChangeBinOffsetTest.h
@@ -49,8 +49,8 @@ public:
     MatrixWorkspace_sptr output =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(alg2D.getProperty("OutputWorkspace"));
 
-    Mantid::MantidVec &Xold = input->dataX(0);
-    Mantid::MantidVec &Xnew = output->dataX(0);
+    const auto &Xold = input->x(0);
+    const auto &Xnew = output->x(0);
 
     //		for (int i=0; i < Xnew.size(); ++i)
     //		{
@@ -71,13 +71,13 @@ public:
     output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output2D_lims");
 
     // check hist 0 is unchanged
-    Mantid::MantidVec &Xold0 = input->dataX(0);
-    Mantid::MantidVec &Xnew0 = output->dataX(0);
+    const auto &Xold0 = input->x(0);
+    const auto &Xnew0 = output->x(0);
     TS_ASSERT(Xold0[0] == Xnew0[0]);
     TS_ASSERT(Xold0[1] == Xnew0[1]);
     // check hist 2 is changed
-    Mantid::MantidVec &Xold2 = input->dataX(2);
-    Mantid::MantidVec &Xnew2 = output->dataX(2);
+    const auto &Xold2 = input->x(2);
+    const auto &Xnew2 = output->x(2);
     TS_ASSERT(Xold2[0] + offset == Xnew2[0]);
     TS_ASSERT(Xold2[1] + offset == Xnew2[1]);
 
@@ -138,7 +138,7 @@ public:
     std::size_t wkspIndex = 4348; // a good workspace index (with events)
     TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).getEvents()[0].tof() + 100,
                     WSO->getSpectrum(wkspIndex).getEvents()[0].tof(), 0.001);
-    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).dataX()[1] + 100., WSO->getSpectrum(wkspIndex).dataX()[1], 0.001);
+    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).x()[1] + 100., WSO->getSpectrum(wkspIndex).x()[1], 0.001);
 
     alg.setPropertyValue("IndexMin", "4349");
     alg.setPropertyValue("IndexMax", "4350");
@@ -148,12 +148,12 @@ public:
     TS_ASSERT(WSO);
     TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).getEvents()[0].tof(), WSO->getSpectrum(wkspIndex).getEvents()[0].tof(),
                     0.001); // should be unchanged
-    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).dataX()[1], WSO->getSpectrum(wkspIndex).dataX()[1],
+    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex).x()[1], WSO->getSpectrum(wkspIndex).x()[1],
                     0.001); // should be unchanged
     TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex + 1).getEvents()[0].tof() + 100,
                     WSO->getSpectrum(wkspIndex + 1).getEvents()[0].tof(),
                     0.001); // should change
-    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex + 1).dataX()[1] + 100., WSO->getSpectrum(wkspIndex + 1).dataX()[1],
+    TS_ASSERT_DELTA(WSI->getSpectrum(wkspIndex + 1).x()[1] + 100., WSO->getSpectrum(wkspIndex + 1).x()[1],
                     0.001); // should change
   }
 

--- a/Framework/Algorithms/test/ConvertFromDistributionTest.h
+++ b/Framework/Algorithms/test/ConvertFromDistributionTest.h
@@ -47,9 +47,9 @@ public:
     MatrixWorkspace_const_sptr output;
     TS_ASSERT_THROWS_NOTHING(output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(dist))
 
-    const Mantid::MantidVec &X = output->dataX(0);
-    const Mantid::MantidVec &Y = output->dataY(0);
-    const Mantid::MantidVec &E = output->dataE(0);
+    const auto &X = output->x(0);
+    const auto &Y = output->y(0);
+    const auto &E = output->e(0);
     for (size_t i = 0; i < Y.size(); ++i) {
       TS_ASSERT_EQUALS(X[i], static_cast<double>(i) / 2.0)
       TS_ASSERT_EQUALS(Y[i], 1)

--- a/Framework/Algorithms/test/ConvertToDistributionTest.h
+++ b/Framework/Algorithms/test/ConvertToDistributionTest.h
@@ -51,9 +51,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(conv.execute());
     TS_ASSERT(conv.isExecuted());
     auto output = std::dynamic_pointer_cast<MatrixWorkspace>(dist);
-    const Mantid::MantidVec &X = output->dataX(0);
-    const Mantid::MantidVec &Y = output->dataY(0);
-    const Mantid::MantidVec &E = output->dataE(0);
+    const auto &X = output->x(0);
+    const auto &Y = output->y(0);
+    const auto &E = output->e(0);
     for (size_t i = 0; i < Y.size(); ++i) {
       TS_ASSERT_EQUALS(X[i], static_cast<double>(i) / 2.0)
       TS_ASSERT_EQUALS(Y[i], 4)

--- a/Framework/Algorithms/test/ConvertToEventWorkspaceTest.h
+++ b/Framework/Algorithms/test/ConvertToEventWorkspaceTest.h
@@ -202,7 +202,7 @@ public:
     Workspace2D_sptr inWS = WorkspaceCreationHelper::create2DWorkspace(1, 10);
 
     // Clear the vector
-    inWS->dataY(0).assign(10, 0.0);
+    inWS->mutableY(0).assign(10, 0.0);
 
     // Name of the output workspace.
     std::string outWSName("ConvertToEventWorkspaceTest_OutputWS");

--- a/Framework/Algorithms/test/CreateGroupingWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreateGroupingWorkspaceTest.h
@@ -41,9 +41,9 @@ public:
 
     TS_ASSERT_EQUALS(ws->blocksize(), 1);
     // All zero.
-    TS_ASSERT_EQUALS(ws->dataY(0)[0], 0.0);
-    TS_ASSERT_EQUALS(ws->dataY(100)[0], 0.0);
-    TS_ASSERT_EQUALS(ws->dataY(10000)[0], 0.0);
+    TS_ASSERT_EQUALS(ws->y(0)[0], 0.0);
+    TS_ASSERT_EQUALS(ws->y(100)[0], 0.0);
+    TS_ASSERT_EQUALS(ws->y(10000)[0], 0.0);
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
@@ -104,11 +104,11 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 51200);
     TS_ASSERT_EQUALS(ws->blocksize(), 1);
     for (int i = 1; i <= 4; ++i) {
-      TS_ASSERT_EQUALS(ws->dataY((i - 1) * 1024)[0], double(i) * 1.0);
-      TS_ASSERT_EQUALS(ws->dataY((i - 1) * 1024 + 1023)[0], double(i) * 1.0);
+      TS_ASSERT_EQUALS(ws->y((i - 1) * 1024)[0], double(i) * 1.0);
+      TS_ASSERT_EQUALS(ws->y((i - 1) * 1024 + 1023)[0], double(i) * 1.0);
     }
     // The rest is zero
-    TS_ASSERT_EQUALS(ws->dataY(5 * 1024)[0], 0.0);
+    TS_ASSERT_EQUALS(ws->y(5 * 1024)[0], 0.0);
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
@@ -183,15 +183,15 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     const auto groupingWorkspace = ads.retrieveWS<GroupingWorkspace>(outputWS);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(0)[0], 1.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(1)[0], 1.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(2)[0], 1.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(3)[0], 2.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(4)[0], 2.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(5)[0], 3.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(6)[0], 4.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(7)[0], 5.0, 0.000001);
-    TS_ASSERT_DELTA(groupingWorkspace->dataY(8)[0], 0.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(0)[0], 1.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(1)[0], 1.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(2)[0], 1.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(3)[0], 2.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(4)[0], 2.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(5)[0], 3.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(6)[0], 4.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(7)[0], 5.0, 0.000001);
+    TS_ASSERT_DELTA(groupingWorkspace->y(8)[0], 0.0, 0.000001);
 
     ads.remove(outputWS);
   }
@@ -261,7 +261,7 @@ public:
     TS_ASSERT_EQUALS(ws->blocksize(), 1);
     // Check one entry in each group
     for (int i = 0; i < 15; ++i) {
-      TS_ASSERT_EQUALS(ws->dataY(i * 65536)[0],
+      TS_ASSERT_EQUALS(ws->y(i * 65536)[0],
                        double(i + 1) * 1.0); // Groups start at 1.0
     }
   }

--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -665,7 +665,7 @@ public:
         TS_ASSERT_EQUALS(outputEvent->sharedX(workspace_index)->size(), 16);
         // There should be some data in the bins
         for (int i = 0; i < 15; i++)
-          events_after_binning += outputEvent->dataY(workspace_index)[i];
+          events_after_binning += outputEvent->y(workspace_index)[i];
       }
       // The count sums up to the same as the number of events
       TS_ASSERT_DELTA(events_after_binning,

--- a/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
+++ b/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
@@ -518,7 +518,7 @@ public:
     // S(Q) zero everywhere apart from spike at Q=1, w=1
     for (size_t i = 0; i < 3; i++)
       for (size_t j = 0; j < 3; j++) {
-        if ((SofQWorkspace->dataX(i)[j] == deltaE) && (SofQWorkspace->getAxis(1)->getValue(i) == qSpike))
+        if ((SofQWorkspace->x(i)[j] == deltaE) && (SofQWorkspace->getAxis(1)->getValue(i) == qSpike))
           SofQWorkspace->mutableY(i)[j] = 1000.;
         else
           SofQWorkspace->mutableY(i)[j] = 0.;
@@ -839,7 +839,7 @@ public:
       for (size_t i = 0; i < output->size(); i++) {
         TS_ASSERT_THROWS_NOTHING(wsPtr = output->getItem(i));
         auto matrixWsPtr = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(wsPtr);
-        auto eData = matrixWsPtr->dataE(0);
+        auto eData = matrixWsPtr->e(0);
         TS_ASSERT(std::all_of(eData.cbegin(), eData.cend(), [](double i) { return i > 0; }));
       }
     }

--- a/Framework/Algorithms/test/ExponentialCorrectionTest.h
+++ b/Framework/Algorithms/test/ExponentialCorrectionTest.h
@@ -74,9 +74,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = 2.0 * exp(-1.0 * (j + 1.0));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j])
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] / factor, 0.0001)
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] / factor, 0.0001)
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j])
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] / factor, 0.0001)
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] / factor, 0.0001)
       }
     }
 
@@ -106,9 +106,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = 2.0 * exp(-1.0 * (j + 1.0));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j])
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] * factor, 0.0001)
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] * factor, 0.0001)
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j])
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] * factor, 0.0001)
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] * factor, 0.0001)
       }
     }
 

--- a/Framework/Algorithms/test/ExponentialTest.h
+++ b/Framework/Algorithms/test/ExponentialTest.h
@@ -87,22 +87,22 @@ private:
   void checkData(const MatrixWorkspace_sptr &work_in1, const MatrixWorkspace_sptr &work_out1) {
 
     for (size_t i = 0; i < work_out1->size(); i++) {
-      double sig1 = work_in1->dataY(i / work_in1->blocksize())[i % work_in1->blocksize()];
-      double sig3 = work_out1->dataY(i / work_in1->blocksize())[i % work_in1->blocksize()];
-      TS_ASSERT_DELTA(work_in1->dataX(i / work_in1->blocksize())[i % work_in1->blocksize()],
-                      work_out1->dataX(i / work_in1->blocksize())[i % work_in1->blocksize()], 1.e-10);
+      double sig1 = work_in1->y(i / work_in1->blocksize())[i % work_in1->blocksize()];
+      double sig3 = work_out1->y(i / work_in1->blocksize())[i % work_in1->blocksize()];
+      TS_ASSERT_DELTA(work_in1->x(i / work_in1->blocksize())[i % work_in1->blocksize()],
+                      work_out1->x(i / work_in1->blocksize())[i % work_in1->blocksize()], 1.e-10);
       double expsig3 = exp(sig1);
       TS_ASSERT_DELTA(expsig3, sig3, 1e-10 * sig3);
-      double err1 = work_in1->dataE(i / work_in1->blocksize())[i % work_in1->blocksize()];
+      double err1 = work_in1->e(i / work_in1->blocksize())[i % work_in1->blocksize()];
       double err3 = err1 * expsig3;
-      TS_ASSERT_DELTA(err3, work_out1->dataE(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
+      TS_ASSERT_DELTA(err3, work_out1->e(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
     }
   }
   // loopOrientation 0=Horizontal, 1=Vertical
   void setError(const MatrixWorkspace_sptr &work_in1) {
 
     for (size_t i = 0; i < work_in1->size(); i++) {
-      double sig1 = work_in1->dataY(i / work_in1->blocksize())[i % work_in1->blocksize()];
+      double sig1 = work_in1->y(i / work_in1->blocksize())[i % work_in1->blocksize()];
       work_in1->mutableE(i / work_in1->blocksize())[i % work_in1->blocksize()] = sqrt(sig1);
     }
   }

--- a/Framework/Algorithms/test/ExtractSpectraTest.h
+++ b/Framework/Algorithms/test/ExtractSpectraTest.h
@@ -480,7 +480,7 @@ public:
   void test_slices_dx() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 2, 1);
     Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3}, Counts{4, 9});
-    workspace->mutableY(0) = histogram.dataY();
+    workspace->mutableY(0) = histogram.y();
     workspace->setPointStandardDeviations(0, 2);
     histogram.setPointStandardDeviations(2);
 
@@ -496,8 +496,8 @@ public:
   void test_slice_single_bin_at_start() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 1;
@@ -513,8 +513,8 @@ public:
   void test_slice_single_bin() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 2;
@@ -530,8 +530,8 @@ public:
   void test_slice_single_bin_at_end() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 3;
@@ -547,8 +547,8 @@ public:
   void test_points_slice_single_bin_at_start() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 1;
@@ -564,8 +564,8 @@ public:
   void test_points_slice_single_bin() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 2;
@@ -581,8 +581,8 @@ public:
   void test_points_slice_single_bin_at_end() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 3, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3}, Counts{4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 3;
@@ -598,8 +598,8 @@ public:
   void test_slice_two_bins_at_start() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 1;
@@ -615,8 +615,8 @@ public:
   void test_slice_two_bins() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 2;
@@ -632,8 +632,8 @@ public:
   void test_slice_two_bins_at_end() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(BinEdges{1, 2, 3, 4, 5}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 3;
@@ -649,8 +649,8 @@ public:
   void test_points_slice_two_bins_at_start() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 1;
@@ -666,8 +666,8 @@ public:
   void test_points_slice_two_bins() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 2;
@@ -683,8 +683,8 @@ public:
   void test_points_slice_two_bins_at_end() {
     auto workspace = WorkspaceCreationHelper::create2DWorkspacePoints(1, 4, 1);
     const Mantid::HistogramData::Histogram histogram(Points{1, 2, 3, 4}, Counts{1, 4, 9, 16});
-    workspace->mutableY(0) = histogram.dataY();
-    workspace->mutableE(0) = histogram.dataE();
+    workspace->mutableY(0) = histogram.y();
+    workspace->mutableE(0) = histogram.e();
 
     Parameters params;
     params.XMin = 3;

--- a/Framework/Algorithms/test/FindCenterOfMassPositionTest.h
+++ b/Framework/Algorithms/test/FindCenterOfMassPositionTest.h
@@ -41,9 +41,9 @@ public:
     for (int ix = 0; ix < SANSInstrumentCreationHelper::nBins; ix++) {
       for (int iy = 0; iy < SANSInstrumentCreationHelper::nBins; iy++) {
         int i = ix * SANSInstrumentCreationHelper::nBins + iy + SANSInstrumentCreationHelper::nMonitors;
-        MantidVec &X = ws->dataX(i);
-        MantidVec &Y = ws->dataY(i);
-        MantidVec &E = ws->dataE(i);
+        auto &X = ws->mutableX(i);
+        auto &Y = ws->mutableY(i);
+        auto &E = ws->mutableE(i);
         X[0] = 1;
         X[1] = 2;
         double dx = (center_x - (double)ix);

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -2190,7 +2190,7 @@ public:
         window_ws->mutableX(i)[j * 2] = peak_center - halfwidth;
         window_ws->mutableX(i)[j * 2 + 1] = peak_center + halfwidth;
       }
-      TS_ASSERT(window_ws->dataX(i).size() == num_peaks * 2);
+      TS_ASSERT(window_ws->x(i).size() == num_peaks * 2);
     }
 
     AnalysisDataService::Instance().addOrReplace(workspace_name, window_ws);

--- a/Framework/Algorithms/test/IntegrationTest.h
+++ b/Framework/Algorithms/test/IntegrationTest.h
@@ -98,9 +98,9 @@ public:
     TS_ASSERT_EQUALS(max = output2D->getNumberHistograms(), 3);
     double yy[3] = {36, 51, 66};
     for (size_t i = 0; i < max; ++i) {
-      Mantid::MantidVec &x = output2D->dataX(i);
-      Mantid::MantidVec &y = output2D->dataY(i);
-      Mantid::MantidVec &e = output2D->dataE(i);
+      const auto &x = output2D->x(i);
+      const auto &y = output2D->y(i);
+      const auto &e = output2D->e(i);
 
       TS_ASSERT_EQUALS(x.size(), 2);
       TS_ASSERT_EQUALS(y.size(), 1);
@@ -135,11 +135,11 @@ public:
 
     Workspace2D_sptr output2D = std::dynamic_pointer_cast<Workspace2D>(output);
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 5);
-    TS_ASSERT_EQUALS(output2D->dataX(0)[0], 0);
-    TS_ASSERT_EQUALS(output2D->dataX(0)[1], 5);
-    TS_ASSERT_EQUALS(output2D->dataY(0)[0], 10);
-    TS_ASSERT_EQUALS(output2D->dataY(4)[0], 110);
-    TS_ASSERT_DELTA(output2D->dataE(2)[0], 7.746, 0.001);
+    TS_ASSERT_EQUALS(output2D->x(0)[0], 0);
+    TS_ASSERT_EQUALS(output2D->x(0)[1], 5);
+    TS_ASSERT_EQUALS(output2D->y(0)[0], 10);
+    TS_ASSERT_EQUALS(output2D->y(4)[0], 110);
+    TS_ASSERT_DELTA(output2D->e(2)[0], 7.746, 0.001);
   }
 
   void testRangeWithPartialBins() {
@@ -258,8 +258,8 @@ public:
 
     double tol = 1.e-5;
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), expectedNumHists);
-    TS_ASSERT_DELTA(outputWS->dataY(1)[0], expectedVals[0], tol);
-    TS_ASSERT_DELTA(outputWS->dataE(1)[0], expectedVals[1], tol);
+    TS_ASSERT_DELTA(outputWS->y(1)[0], expectedVals[0], tol);
+    TS_ASSERT_DELTA(outputWS->e(1)[0], expectedVals[1], tol);
 
     AnalysisDataService::Instance().remove(inName);
     AnalysisDataService::Instance().remove(outName);
@@ -350,12 +350,12 @@ public:
     TS_ASSERT_EQUALS(inWs->getNumberHistograms(), outWs->getNumberHistograms());
 
     if (checkRanges) {
-      TS_ASSERT_LESS_THAN_EQUALS(std::stod(rangeLower), outWs->dataX(0).front());
+      TS_ASSERT_LESS_THAN_EQUALS(std::stod(rangeLower), outWs->x(0).front());
 
-      TS_ASSERT_LESS_THAN_EQUALS(outWs->dataX(0).back(), std::stod(rangeUpper));
+      TS_ASSERT_LESS_THAN_EQUALS(outWs->x(0).back(), std::stod(rangeUpper));
     }
     // At last, check numerical results
-    TS_ASSERT_DELTA(outWs->dataY(0)[0], expectedVal, 1e-8);
+    TS_ASSERT_DELTA(outWs->y(0)[0], expectedVal, 1e-8);
   }
 
   void testProperHandlingOfIntegrationBoundaries() {
@@ -756,9 +756,9 @@ private:
     TS_ASSERT_EQUALS(max = output2D->getNumberHistograms(), 3);
 
     for (size_t i = 0; i < max; ++i) {
-      Mantid::MantidVec &x = output2D->dataX(i);
-      Mantid::MantidVec &y = output2D->dataY(i);
-      Mantid::MantidVec &e = output2D->dataE(i);
+      const auto &x = output2D->x(i);
+      const auto &y = output2D->y(i);
+      const auto &e = output2D->e(i);
 
       TS_ASSERT_EQUALS(x.size(), 2);
       TS_ASSERT_EQUALS(y.size(), 1);

--- a/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
+++ b/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
@@ -285,8 +285,8 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
-    auto eData = outputWS->getSpectrum(0).dataE();
+    auto yData = outputWS->getSpectrum(0).y();
+    auto eData = outputWS->getSpectrum(0).e();
     // recreate the sd of the set of simulated paths from the sd on the mean
     double attenuationFactorsSD1 = eData[0] * sqrt(NEVENTS);
 
@@ -334,8 +334,8 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
-    auto eData = outputWS->getSpectrum(0).dataE();
+    auto yData = outputWS->getSpectrum(0).y();
+    auto eData = outputWS->getSpectrum(0).e();
 
     constexpr double delta(1e-03);
     const double calculatedAttFactor = (1 - 2 * exp(-2) + exp(-4)) / 4;
@@ -371,8 +371,8 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
-    auto eData = outputWS->getSpectrum(0).dataE();
+    auto yData = outputWS->getSpectrum(0).y();
+    auto eData = outputWS->getSpectrum(0).e();
 
     constexpr double delta(1e-03);
     const double calculatedAttFactor = (1 - 2 * exp(-2) + exp(-4)) / 4;
@@ -395,7 +395,7 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
+    auto yData = outputWS->getSpectrum(0).y();
 
     constexpr double delta(1e-03);
     const double calculatedAttFactor = exp(-2);
@@ -418,7 +418,7 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
+    auto yData = outputWS->getSpectrum(0).y();
 
     constexpr double delta(1e-03);
     // pass straight through - all path lengths are exactly 2cm
@@ -444,7 +444,7 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
+    auto yData = outputWS->getSpectrum(0).y();
 
     constexpr double delta(1e-02);
     // calculated theoretical absoprtion for this cylinder, using https://doi.org/10.1107/S0567739471000652
@@ -479,7 +479,7 @@ public:
     auto outputWS = getOutputWorkspace(mcAbsorb);
 
     verifyDimensions(wsProps, outputWS);
-    auto yData = outputWS->getSpectrum(0).dataY();
+    auto yData = outputWS->getSpectrum(0).y();
 
     constexpr double delta(1e-03);
     const double calculatedAttFactor1 = 2 * (2 * exp(-1) - 3 * exp(-2)) / 3;
@@ -662,7 +662,7 @@ public:
     // zero
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 5);
     TS_ASSERT_EQUALS(outputWS->spectrumInfo().isMasked(0), true);
-    auto yData = outputWS->getSpectrum(0).dataY();
+    auto yData = outputWS->getSpectrum(0).y();
     bool allZero = std::all_of(yData.begin(), yData.end(), [](double i) { return i == 0; });
     TS_ASSERT_EQUALS(allZero, true);
   }

--- a/Framework/Algorithms/test/OneMinusExponentialCorTest.h
+++ b/Framework/Algorithms/test/OneMinusExponentialCorTest.h
@@ -75,9 +75,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = 1.0 - exp(-1.0 * 2.0 * (j + 1.0));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j]);
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] / factor, 0.0001);
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] / factor, 0.0001);
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j]);
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] / factor, 0.0001);
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] / factor, 0.0001);
       }
     }
 
@@ -107,9 +107,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = prefactor * (1.0 - exp(-1.0 * 2.0 * (j + 1.0)));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j]);
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] / factor, 0.0001);
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] / factor, 0.0001);
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j]);
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] / factor, 0.0001);
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] / factor, 0.0001);
       }
     }
 
@@ -138,9 +138,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = 1.0 - exp(-1.0 * 2.0 * (j + 1.0));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j]);
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] * factor, 0.0001);
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] * factor, 0.0001);
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j]);
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] * factor, 0.0001);
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] * factor, 0.0001);
       }
     }
 
@@ -171,9 +171,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = prefactor * (1.0 - exp(-1.0 * 2.0 * (j + 1.0)));
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j]);
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] * factor, 0.0001);
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] * factor, 0.0001);
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j]);
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] * factor, 0.0001);
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] * factor, 0.0001);
       }
     }
 

--- a/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -974,13 +974,13 @@ public:
       {
         if (DO_PLUS)
         {
-          TS_ASSERT_DELTA(  work_out1->dataY(pix)[i], 4.00, 1e-5);
-          TS_ASSERT_DELTA(  work_out1->dataE(pix)[i], sqrt(4.00), 1e-5);
+          TS_ASSERT_DELTA(  work_out1->y(pix)[i], 4.00, 1e-5);
+          TS_ASSERT_DELTA(  work_out1->e(pix)[i], sqrt(4.00), 1e-5);
         }
         else
         {
-          TS_ASSERT_DELTA(  work_out1->dataY(pix)[i], 0.00, 1e-5);
-          TS_ASSERT_DELTA(  work_out1->dataE(pix)[i], sqrt(4.00), 1e-5);
+          TS_ASSERT_DELTA(  work_out1->y(pix)[i], 0.00, 1e-5);
+          TS_ASSERT_DELTA(  work_out1->e(pix)[i], sqrt(4.00), 1e-5);
         }
 
         //Incoming event workspace should still have 2.0 for values

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -123,8 +123,8 @@ public:
     MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
-    auto const &outY = outWs->dataY(0);
-    auto const &outE = outWs->dataE(0);
+    auto const &outY = outWs->y(0);
+    auto const &outE = outWs->e(0);
     auto const numBins = outY.size();
     for (size_t i = 0; i < numBins; ++i) {
       TS_ASSERT_EQUALS(1.0, outY[i])
@@ -141,8 +141,8 @@ public:
     MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
-    auto const &outY = outWs->dataY(0);
-    auto const &outE = outWs->dataE(0);
+    auto const &outY = outWs->y(0);
+    auto const &outE = outWs->e(0);
     auto const numBins = outY.size();
     for (size_t i = 0; i < numBins; ++i) {
       TS_ASSERT_EQUALS(1.0, outY[i])
@@ -161,8 +161,8 @@ public:
     alg->execute();
     MatrixWorkspace_sptr const outWsP = alg->getProperty("OutputWorkspace");
 
-    auto const &outYA = outWsA->dataY(0);
-    auto const &outYP = outWsP->dataY(0);
+    auto const &outYA = outWsA->y(0).rawData();
+    auto const &outYP = outWsP->y(0).rawData();
     TS_ASSERT_DELTA(outYA, outYP, 1e-8);
   }
 
@@ -176,8 +176,8 @@ public:
     MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
-    auto const &outY = outWs->dataY(0);
-    auto const &outE = outWs->dataE(0);
+    auto const &outY = outWs->y(0);
+    auto const &outE = outWs->e(0);
     auto const numBins = outY.size();
     for (size_t i = 0; i < numBins; ++i) {
       TS_ASSERT_DELTA(0.9710144925, outY[i], 1e-8);

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationEfficienciesWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationEfficienciesWildesTest.h
@@ -514,8 +514,8 @@ private:
     TS_ASSERT(outWs != nullptr);
     TS_ASSERT_EQUALS(expectedNumHistograms, outWs->getNumberHistograms())
     for (size_t i = 0; i < outWs->blocksize(); i++) {
-      const double yVal = outWs->dataY(0)[i];
-      const double eVal = outWs->dataE(0)[i];
+      const double yVal = outWs->y(0)[i];
+      const double eVal = outWs->e(0)[i];
       TS_ASSERT_DELTA(expectedValue.first, yVal, 1e-6);
       TS_ASSERT_DELTA(expectedValue.second, eVal, 1e-6);
     }

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -107,7 +107,7 @@ public:
         polariserEfficiency->getProperty("OutputWorkspace"));
     // The T_para(00,11) and T_anti(01,10)) curves are 4 and 2 (constant wrt wavelength) respectively, and the analyser
     // efficiency is 1 for all wavelengths, which should give us a polarizer efficiency of 2/3
-    for (const double &y : calculatedPolariserEfficiency->dataY(0)) {
+    for (const double &y : calculatedPolariserEfficiency->y(0)) {
       TS_ASSERT_DELTA(2.0 / 3.0, y, 1e-8);
     }
   }
@@ -122,7 +122,7 @@ public:
 
     // The T_para and T_anti curves are 4 and 2 (constant wrt wavelength) respectively, and the analyser
     // efficiency is 1 for all wavelengths, which should give us a polarizer efficiency of 2/3
-    for (const double &y : calculatedPolariserEfficiency->dataY(0)) {
+    for (const double &y : calculatedPolariserEfficiency->y(0)) {
       TS_ASSERT_DELTA(2.0 / 3.0, y, 1e-8);
     }
   }
@@ -134,7 +134,7 @@ public:
     polarizerEfficiency->execute();
     MatrixWorkspace_sptr eff = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         polarizerEfficiency->getProperty("OutputWorkspace"));
-    const auto &errors = eff->dataE(0);
+    const auto &errors = eff->e(0);
     const std::vector<double> expectedErrors{0.23570, 0.14142, 0.10101, 0.07856, 0.06428, 0.05439, 0.047140};
     for (size_t i = 0; i < expectedErrors.size(); ++i) {
       TS_ASSERT_DELTA(expectedErrors[i], errors[i], 1e-5);

--- a/Framework/Algorithms/test/PolynomialCorrectionTest.h
+++ b/Framework/Algorithms/test/PolynomialCorrectionTest.h
@@ -71,9 +71,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 1; j < 4; ++j) {
         double factor = 3.0 + j * 2.0 + j * j * 1.0;
-        TS_ASSERT_EQUALS(result->dataX(i)[j - 1], inputWS->dataX(i)[j - 1]);
-        TS_ASSERT_EQUALS(result->dataY(i)[j - 1], factor * inputWS->dataY(i)[j - 1]);
-        TS_ASSERT_EQUALS(result->dataE(i)[j - 1], factor * inputWS->dataE(i)[j - 1]);
+        TS_ASSERT_EQUALS(result->x(i)[j - 1], inputWS->x(i)[j - 1]);
+        TS_ASSERT_EQUALS(result->y(i)[j - 1], factor * inputWS->y(i)[j - 1]);
+        TS_ASSERT_EQUALS(result->e(i)[j - 1], factor * inputWS->e(i)[j - 1]);
       }
     }
 
@@ -104,9 +104,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 1; j < 4; ++j) {
         double factor = 3.0 + j * 2.0 + j * j * 1.0;
-        TS_ASSERT_EQUALS(result->dataX(i)[j - 1], inputWS->dataX(i)[j - 1]);
-        TS_ASSERT_EQUALS(result->dataY(i)[j - 1], inputWS->dataY(i)[j - 1] / factor);
-        TS_ASSERT_EQUALS(result->dataE(i)[j - 1], inputWS->dataE(i)[j - 1] / factor);
+        TS_ASSERT_EQUALS(result->x(i)[j - 1], inputWS->x(i)[j - 1]);
+        TS_ASSERT_EQUALS(result->y(i)[j - 1], inputWS->y(i)[j - 1] / factor);
+        TS_ASSERT_EQUALS(result->e(i)[j - 1], inputWS->e(i)[j - 1] / factor);
       }
     }
 

--- a/Framework/Algorithms/test/PowerLawCorrectionTest.h
+++ b/Framework/Algorithms/test/PowerLawCorrectionTest.h
@@ -72,9 +72,9 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 3; ++j) {
         double factor = 3.0 * pow(j + 1, 2.0);
-        TS_ASSERT_EQUALS(result->dataX(i)[j], inputWS->dataX(i)[j]);
-        TS_ASSERT_DELTA(result->dataY(i)[j], inputWS->dataY(i)[j] * factor, 0.0001);
-        TS_ASSERT_DELTA(result->dataE(i)[j], inputWS->dataE(i)[j] * factor, 0.0001);
+        TS_ASSERT_EQUALS(result->x(i)[j], inputWS->x(i)[j]);
+        TS_ASSERT_DELTA(result->y(i)[j], inputWS->y(i)[j] * factor, 0.0001);
+        TS_ASSERT_DELTA(result->e(i)[j], inputWS->e(i)[j] * factor, 0.0001);
       }
     }
 

--- a/Framework/Algorithms/test/RemoveBackgroundTest.h
+++ b/Framework/Algorithms/test/RemoveBackgroundTest.h
@@ -182,7 +182,7 @@ public:
 
     auto clone = cloneSourceWS();
     // set negative values to signal
-    auto &Y = clone->dataY(0);
+    auto &Y = clone->mutableY(0);
     for (double &i : Y) {
       i = -1000;
     }

--- a/Framework/Algorithms/test/RemovePromptPulseTest.h
+++ b/Framework/Algorithms/test/RemovePromptPulseTest.h
@@ -38,7 +38,7 @@ private:
         WorkspaceCreationHelper::createEventWorkspace(NUMPIXELS, NUMBINS, NUMEVENTS, 1000., BIN_DELTA, 2);
     // Fake a TOF unit in the data.
     test_in->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
-    for (size_t i = 0; i < test_in->dataX(0).size(); ++i) {
+    for (size_t i = 0; i < test_in->x(0).size(); ++i) {
       test_in->mutableX(0)[i] += shift;
     }
     test_in->setInstrument(ComponentCreationHelper::createTestInstrumentCylindrical(NUMPIXELS / 9));

--- a/Framework/Algorithms/test/RingProfileTest.h
+++ b/Framework/Algorithms/test/RingProfileTest.h
@@ -123,20 +123,20 @@ public:
     goodWS->replaceAxis(0, std::move(xAxis));
 
     // 0 values
-    goodWS->mutableY(0)[0] = goodWS->dataY(0)[2] = goodWS->mutableY(0)[4] = 0;
-    goodWS->mutableY(1)[1] = goodWS->dataY(1)[3] = 0;
-    goodWS->mutableY(2)[0] = goodWS->dataY(2)[2] = goodWS->mutableY(2)[4] = 0;
-    goodWS->mutableY(3)[1] = goodWS->dataY(3)[3] = 0;
-    goodWS->mutableY(4)[0] = goodWS->dataY(4)[2] = goodWS->mutableY(4)[4] = 0;
+    goodWS->mutableY(0)[0] = goodWS->mutableY(0)[2] = goodWS->mutableY(0)[4] = 0;
+    goodWS->mutableY(1)[1] = goodWS->mutableY(1)[3] = 0;
+    goodWS->mutableY(2)[0] = goodWS->mutableY(2)[2] = goodWS->mutableY(2)[4] = 0;
+    goodWS->mutableY(3)[1] = goodWS->mutableY(3)[3] = 0;
+    goodWS->mutableY(4)[0] = goodWS->mutableY(4)[2] = goodWS->mutableY(4)[4] = 0;
 
     // 2 values
-    goodWS->mutableY(0)[1] = goodWS->dataY(1)[0] = goodWS->mutableY(1)[2] = 2;
+    goodWS->mutableY(0)[1] = goodWS->mutableY(1)[0] = goodWS->mutableY(1)[2] = 2;
     // 1 values
-    goodWS->mutableY(0)[3] = goodWS->dataY(1)[4] = goodWS->mutableY(2)[3] = 1;
+    goodWS->mutableY(0)[3] = goodWS->mutableY(1)[4] = goodWS->mutableY(2)[3] = 1;
     // 3 values
-    goodWS->mutableY(2)[1] = goodWS->dataY(3)[0] = goodWS->mutableY(4)[1] = 3;
+    goodWS->mutableY(2)[1] = goodWS->mutableY(3)[0] = goodWS->mutableY(4)[1] = 3;
     // 4 values
-    goodWS->mutableY(3)[2] = goodWS->dataY(3)[4] = goodWS->mutableY(4)[3] = 4;
+    goodWS->mutableY(3)[2] = goodWS->mutableY(3)[4] = goodWS->mutableY(4)[3] = 4;
 
     return goodWS;
   }
@@ -322,20 +322,20 @@ public:
     MatrixWorkspace_sptr goodWS = WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(1, 5, 1);
 
     // 0 values
-    goodWS->mutableY(0)[0] = goodWS->dataY(2)[0] = goodWS->mutableY(4)[0] = 0;
-    goodWS->mutableY(6)[0] = goodWS->dataY(8)[0] = 0;
-    goodWS->mutableY(10)[0] = goodWS->dataY(12)[0] = goodWS->mutableY(14)[0] = 0;
-    goodWS->mutableY(16)[0] = goodWS->dataY(18)[0] = 0;
-    goodWS->mutableY(20)[0] = goodWS->dataY(22)[0] = goodWS->mutableY(24)[0] = 0;
+    goodWS->mutableY(0)[0] = goodWS->mutableY(2)[0] = goodWS->mutableY(4)[0] = 0;
+    goodWS->mutableY(6)[0] = goodWS->mutableY(8)[0] = 0;
+    goodWS->mutableY(10)[0] = goodWS->mutableY(12)[0] = goodWS->mutableY(14)[0] = 0;
+    goodWS->mutableY(16)[0] = goodWS->mutableY(18)[0] = 0;
+    goodWS->mutableY(20)[0] = goodWS->mutableY(22)[0] = goodWS->mutableY(24)[0] = 0;
 
     // 2 values
-    goodWS->mutableY(1)[0] = goodWS->dataY(5)[0] = goodWS->mutableY(7)[0] = 2;
+    goodWS->mutableY(1)[0] = goodWS->mutableY(5)[0] = goodWS->mutableY(7)[0] = 2;
     // 1 values
-    goodWS->mutableY(3)[0] = goodWS->dataY(9)[0] = goodWS->mutableY(13)[0] = 1;
+    goodWS->mutableY(3)[0] = goodWS->mutableY(9)[0] = goodWS->mutableY(13)[0] = 1;
     // 3 values
-    goodWS->mutableY(11)[0] = goodWS->dataY(15)[0] = goodWS->mutableY(21)[0] = 3;
+    goodWS->mutableY(11)[0] = goodWS->mutableY(15)[0] = goodWS->mutableY(21)[0] = 3;
     // 4 values
-    goodWS->mutableY(17)[0] = goodWS->dataY(19)[0] = goodWS->mutableY(23)[0] = 4;
+    goodWS->mutableY(17)[0] = goodWS->mutableY(19)[0] = goodWS->mutableY(23)[0] = 4;
 
     return goodWS;
   }

--- a/Framework/Algorithms/test/UnwrapMonitorsInTOFTest.h
+++ b/Framework/Algorithms/test/UnwrapMonitorsInTOFTest.h
@@ -59,7 +59,7 @@ public:
     for (const auto &index : indicesToCheck) {
       auto histogram = outputWorkspace->histogram(index);
       auto binEdges = histogram.binEdges();
-      auto counts = histogram.dataY();
+      auto counts = histogram.y();
       TSM_ASSERT_EQUALS("Should have 21 bin edges.", binEdges.size(), 21);
       TSM_ASSERT_EQUALS("Should have 20 counts.", counts.size(), 20);
 
@@ -86,7 +86,7 @@ public:
 
       auto histogramDetector = outputWorkspace->histogram(0);
       auto binEdgesDetector = histogramDetector.binEdges();
-      auto countsDetector = histogramDetector.dataY();
+      auto countsDetector = histogramDetector.y();
       TSM_ASSERT_EQUALS("Should have 11 bin edges.", binEdgesDetector.size(), 11);
       TSM_ASSERT_EQUALS("Should have 10 counts.", countsDetector.size(), 10);
 

--- a/Framework/Algorithms/test/WorkspaceCreationHelperTest.h
+++ b/Framework/Algorithms/test/WorkspaceCreationHelperTest.h
@@ -23,7 +23,7 @@ public:
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
     TS_ASSERT(ws->getSpectrum(0).hasDetectorID(100));
     TS_ASSERT(ws->getSpectrum(1).hasDetectorID(101));
-    TS_ASSERT_DELTA(ws->dataY(5)[0], 2.0, 1e-5);
+    TS_ASSERT_DELTA(ws->y(5)[0], 2.0, 1e-5);
   }
 
   void test_createEventWorkspaceWithFullInstrument() {

--- a/Framework/Algorithms/test/WorkspaceGroupTest.h
+++ b/Framework/Algorithms/test/WorkspaceGroupTest.h
@@ -66,17 +66,17 @@ private:
 
   void checkDataItem(const MatrixWorkspace_sptr &work_in1, const MatrixWorkspace_sptr &work_in2,
                      const MatrixWorkspace_sptr &work_out1, size_t i, size_t ws2Index) {
-    double sig1 = work_in1->dataY(i / work_in1->blocksize())[i % work_in1->blocksize()];
-    double sig2 = work_in2->dataY(ws2Index / work_in1->blocksize())[ws2Index % work_in2->blocksize()];
-    double sig3 = work_out1->dataY(i / work_in1->blocksize())[i % work_in1->blocksize()];
-    TS_ASSERT_DELTA(work_in1->dataX(i / work_in1->blocksize())[i % work_in1->blocksize()],
-                    work_out1->dataX(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
+    double sig1 = work_in1->y(i / work_in1->blocksize())[i % work_in1->blocksize()];
+    double sig2 = work_in2->y(ws2Index / work_in1->blocksize())[ws2Index % work_in2->blocksize()];
+    double sig3 = work_out1->y(i / work_in1->blocksize())[i % work_in1->blocksize()];
+    TS_ASSERT_DELTA(work_in1->x(i / work_in1->blocksize())[i % work_in1->blocksize()],
+                    work_out1->x(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
 
     TS_ASSERT_DELTA(sig1 + sig2, sig3, 0.0001);
-    double err1 = work_in1->dataE(i / work_in1->blocksize())[i % work_in1->blocksize()];
-    double err2 = work_in2->dataE(ws2Index / work_in2->blocksize())[ws2Index % work_in2->blocksize()];
+    double err1 = work_in1->e(i / work_in1->blocksize())[i % work_in1->blocksize()];
+    double err2 = work_in2->e(ws2Index / work_in2->blocksize())[ws2Index % work_in2->blocksize()];
     double err3(sqrt((err1 * err1) + (err2 * err2)));
-    TS_ASSERT_DELTA(err3, work_out1->dataE(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
+    TS_ASSERT_DELTA(err3, work_out1->e(i / work_in1->blocksize())[i % work_in1->blocksize()], 0.0001);
   }
 
 public:

--- a/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
@@ -674,12 +674,12 @@ void Fit1D::exec() {
     ws->getAxis(0)->unit() = inputWorkspace->getAxis(0)->unit(); //    UnitFactory::Instance().create("TOF");
 
     for (int i = 0; i < 3; i++)
-      ws->dataX(i).assign(inputX.begin() + m_minX, inputX.begin() + m_maxX + histN);
+      ws->mutableX(i).assign(inputX.begin() + m_minX, inputX.begin() + m_maxX + histN);
 
-    ws->dataY(0).assign(inputY.begin() + m_minX, inputY.begin() + m_maxX);
+    ws->mutableY(0).assign(inputY.begin() + m_minX, inputY.begin() + m_maxX);
 
-    MantidVec &Y = ws->dataY(1);
-    MantidVec &E = ws->dataY(2);
+    auto &Y = ws->mutableY(1);
+    auto &E = ws->mutableY(2);
 
     auto lOut = new double[l_data.n];                 // to capture output from call to function()
     modifyInitialFittedParameters(m_fittedParameter); // does nothing except if

--- a/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
+++ b/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
@@ -2848,7 +2848,7 @@ Workspace2D_sptr FitPowderDiffPeaks::buildPartialWorkspace(const API::MatrixWork
   // 4. Put data there
   // TODO: Try to use vector copier
   for (size_t iw = 0; iw < partws->getNumberHistograms(); ++iw) {
-    MantidVec &nX = partws->dataX(iw);
+    auto &nX = partws->mutableX(iw);
     for (size_t i = 0; i < wssize; ++i) {
       nX[i] = X[i + ileft];
     }

--- a/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
+++ b/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
@@ -296,8 +296,8 @@ private:
       const size_t nSpec = 1;
       size_t dn = isHisto ? 1 : 0;
       auto space = WorkspaceFactory::Instance().create("Workspace2D", nSpec, nData + dn, nData);
-      space->dataX(0).assign(xBins.begin(), xBins.end());
-      space->dataE(0).assign(nData, 10.0);
+      space->mutableX(0).assign(xBins.begin(), xBins.end());
+      space->mutableE(0).assign(nData, 10.0);
       workspace = space;
     }
 
@@ -305,7 +305,7 @@ private:
       size_t dn = isHisto ? 1 : 0;
       auto space = WorkspaceFactory::Instance().create("Workspace2D", nSpec, nData + dn, nData);
       for (size_t spec = 0; spec < nSpec; ++spec) {
-        space->dataX(spec).assign(xBins.begin(), xBins.end());
+        space->mutableX(spec).assign(xBins.begin(), xBins.end());
         for (size_t i = 0; i < nData; ++i) {
           const double x = space->x(0)[i];
           space->mutableY(spec)[i] = (1.1 + 0.1 * double(spec)) * (1.0 + x + x * x);
@@ -317,10 +317,10 @@ private:
 
     void set1DSpectrumValuesInvalid() {
       set1DSpectrumValues();
-      auto &yValues = dynamic_cast<MatrixWorkspace &>(*workspace).dataY(workspaceIndex);
+      auto &yValues = dynamic_cast<MatrixWorkspace &>(*workspace).mutableY(workspaceIndex);
       yValues[2] = std::numeric_limits<double>::infinity();
       yValues[4] = std::numeric_limits<double>::quiet_NaN();
-      auto &eValues = dynamic_cast<MatrixWorkspace &>(*workspace).dataE(workspaceIndex);
+      auto &eValues = dynamic_cast<MatrixWorkspace &>(*workspace).mutableE(workspaceIndex);
       eValues[6] = -1;
     }
 
@@ -335,8 +335,8 @@ private:
       xValues = xBins;
       set1DSpectrumEmpty();
       auto space = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(workspace);
-      space->dataY(0).assign(yarray, yarray + ndata);
-      space->dataE(0).assign(ndata, 1.0);
+      space->mutableY(0).assign(yarray, yarray + ndata);
+      space->mutableE(0).assign(ndata, 1.0);
       outputName = "out";
     }
 

--- a/Framework/CurveFitting/test/Algorithms/CalculateCostFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/CalculateCostFunctionTest.h
@@ -50,7 +50,7 @@ public:
     alg.initialize();
     auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction([](double, int) { return 0.0; }, 1, 0.0, 1.0, 0.1);
     double w = 0.0;
-    std::generate(ws->dataE(0).begin(), ws->dataE(0).end(), [&w] {
+    std::generate(ws->mutableE(0).begin(), ws->mutableE(0).end(), [&w] {
       w += 1.0;
       return w;
     });
@@ -72,7 +72,7 @@ public:
     alg.initialize();
     auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction([](double, int) { return 1.0; }, 1, 0.0, 1.0, 0.1);
     double w = 0.0;
-    std::generate(ws->dataE(0).begin(), ws->dataE(0).end(), [&w] {
+    std::generate(ws->mutableE(0).begin(), ws->mutableE(0).end(), [&w] {
       w += 1.0;
       return w;
     });

--- a/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
@@ -201,7 +201,7 @@ private:
     void makeWorkspace() {
       size_t dn = isHisto ? 1 : 0;
       workspace = WorkspaceFactory::Instance().create("Workspace2D", nSpec, nData + dn, nData);
-      workspace->dataX(workspaceIndex).assign(xBins.begin(), xBins.end());
+      workspace->mutableX(workspaceIndex).assign(xBins.begin(), xBins.end());
     }
 
     void makeFunction() {

--- a/Framework/CurveFitting/test/Algorithms/LeBailFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/LeBailFitTest.h
@@ -597,9 +597,9 @@ public:
     TS_ASSERT_EQUALS(outws->getNumberHistograms(), 11);
 
     /*
-    for (size_t i = 0; i < outws->dataY(0).size(); ++i)
-      std::cout << outws->dataX(0)[i] << "\t\t" << outws->dataY(0)[i] << "\t\t"
-    << outws->dataY(1)[i] << '\n';
+    for (size_t i = 0; i < outws->y(0).size(); ++i)
+      std::cout << outws->x(0)[i] << "\t\t" << outws->y(0)[i] << "\t\t"
+    << outws->y(1)[i] << '\n';
     */
 
     // 4. Calcualte data
@@ -700,9 +700,9 @@ public:
     return;
 
     /*
-    for (size_t i = 0; i < outws->dataY(0).size(); ++i)
-      std::cout << outws->dataX(0)[i] << "\t\t" << outws->dataY(0)[i] << "\t\t"
-    << outws->dataY(1)[i] << '\n';
+    for (size_t i = 0; i < outws->y(0).size(); ++i)
+      std::cout << outws->x(0)[i] << "\t\t" << outws->y(0)[i] << "\t\t"
+    << outws->y(1)[i] << '\n';
     */
 
     // 4. Calcualte data

--- a/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
@@ -377,8 +377,8 @@ private:
     MatrixWorkspace_sptr ws2(new WorkspaceTester);
     ws2->initialize(1, 20, 20);
 
-    Mantid::MantidVec &x = ws2->dataX(0);
-    Mantid::MantidVec &y = ws2->dataY(0);
+    auto &x = ws2->mutableX(0);
+    auto &y = ws2->mutableY(0);
     for (size_t i = 0; i < ws2->blocksize(); ++i) {
       x[i] = 0.1 * double(i);
       y[i] = 10.0 * exp(-(x[i]) / 0.5);
@@ -391,8 +391,8 @@ private:
     MatrixWorkspace_sptr ws2(new WorkspaceTester);
     ws2->initialize(1, 20, 20);
 
-    Mantid::MantidVec &x = ws2->dataX(0);
-    Mantid::MantidVec &y = ws2->dataY(0);
+    auto &x = ws2->mutableX(0);
+    auto &y = ws2->mutableY(0);
     for (size_t i = 0; i < ws2->blocksize(); ++i) {
       double xx = 2. * M_PI * double(i) / 20.;
       x[i] = xx;

--- a/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
@@ -410,7 +410,7 @@ private:
       temp_ws->mutableE(0)[i] = 0.1 * dataYvalues.getCalculated(i); // assume the error is 10% of the actual value
     }
     const double dw = xView[1] - xView[0]; // bin width
-    temp_ws->mutableX(0)[M] = temp_ws->dataX(0)[M - 1] + dw;
+    temp_ws->mutableX(0)[M] = temp_ws->x(0)[M - 1] + dw;
     //  save workspace to file.
     auto save = Mantid::API::AlgorithmFactory::Instance().create("SaveNexus", 1);
     if (!save)
@@ -534,7 +534,7 @@ private:
     for (size_t i = 0; i < M; i++) {
       ws->mutableX(0)[i] = dataX[i] - dw / 2; // bin boundaries are shifted by half the bind width
       ws->mutableY(0)[i] = dataYvalues.getCalculated(i);
-      ws->dataE(0)[i] =
+      ws->mutableE(0)[i] =
           fractional_error * dataYvalues.getCalculated(i); // assume the error is a small percent of the actual value
     }
     ws->mutableX(0)[M] = dataX[M - 1] + dw / 2; // recall number of bin boundaries is 1 + #bins

--- a/Framework/CurveFitting/test/Functions/DiffSphereTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffSphereTest.h
@@ -469,7 +469,7 @@ private:
     for (size_t i = 0; i < M; i++) {
       ws->mutableX(0)[i] = dataX[i] - dw / 2; // bin boundaries are shifted by half the bind width
       ws->mutableY(0)[i] = dataYvalues.getCalculated(i);
-      ws->dataE(0)[i] =
+      ws->mutableE(0)[i] =
           fractional_error * dataYvalues.getCalculated(i); // assume the error is a small percent of the actual value
     }
     ws->mutableX(0)[M] = dataX[M - 1] + dw / 2; // recall number of bin boundaries is 1 + #bins

--- a/Framework/CurveFitting/test/Functions/UserFunction1DTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunction1DTest.h
@@ -72,9 +72,9 @@ private:
     Mantid::DataObjects::Workspace2D_sptr ws = std::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
         WorkspaceFactory::Instance().create("Workspace2D", 3, 10, 10));
     for (int i = 0; i < 3; i++) {
-      Mantid::MantidVec &X = ws->dataX(i);
-      Mantid::MantidVec &Y = ws->dataY(i);
-      Mantid::MantidVec &E = ws->dataE(i);
+      auto &X = ws->mutableX(i);
+      auto &Y = ws->mutableY(i);
+      auto &E = ws->mutableE(i);
       for (int j = 0; j < 10; j++) {
         X[j] = 1. * j;
         Y[j] = (i + 1) * (2. + 4. * X[j]);

--- a/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
+++ b/Framework/DataHandling/src/AlignAndFocusPowderSlim.cpp
@@ -733,7 +733,7 @@ AlignAndFocusPowderSlim::initializeSpectraProcessingData(const API::MatrixWorksp
   for (size_t i = 0; i < numSpectra; ++i) {
     const auto &spectrum = outputWS->getSpectrum(i);
     processingData.binedges.emplace_back(&spectrum.x().rawData());
-    processingData.counts.emplace_back(spectrum.dataY().size());
+    processingData.counts.emplace_back(spectrum.y().size());
   }
   return processingData;
 }
@@ -743,11 +743,11 @@ void AlignAndFocusPowderSlim::storeSpectraProcessingData(const SpectraProcessing
   const size_t numSpectra = outputWS->getNumberHistograms();
   for (size_t i = 0; i < numSpectra; ++i) {
     auto &spectrum = outputWS->getSpectrum(i);
-    auto &y_values = spectrum.dataY();
+    auto &y_values = spectrum.mutableY();
     std::transform(
         processingData.counts[i].cbegin(), processingData.counts[i].cend(), y_values.begin(),
         [](const std::atomic_uint32_t &val) { return static_cast<double>(val.load(std::memory_order_relaxed)); });
-    auto &e_values = spectrum.dataE();
+    auto &e_values = spectrum.mutableE();
     std::transform(processingData.counts[i].cbegin(), processingData.counts[i].cend(), e_values.begin(),
                    [](const std::atomic_uint32_t &val) {
                      return std::sqrt(static_cast<double>(val.load(std::memory_order_relaxed)));

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -300,9 +300,9 @@ void LoadILLIndirect2::loadDiffractionData(Nexus::NXEntry &entry) {
   // First, Monitor
   // Assign Y
   int *monitor_p = &dataMon(0, 0);
-  m_localWorkspace->dataY(0).assign(monitor_p, monitor_p + m_numberOfChannels);
+  m_localWorkspace->mutableY(0).assign(monitor_p, monitor_p + m_numberOfChannels);
   // Assign Error
-  MantidVec &dataE = m_localWorkspace->dataE(0);
+  auto &dataE = m_localWorkspace->mutableE(0);
   std::transform(monitor_p, monitor_p + m_numberOfChannels, dataE.begin(), [](const double v) { return std::sqrt(v); });
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_localWorkspace))
@@ -322,9 +322,9 @@ void LoadILLIndirect2::loadDiffractionData(Nexus::NXEntry &entry) {
       }
       // Assign Y
       int *data_p = &data(static_cast<int>(i), static_cast<int>(j), 0);
-      m_localWorkspace->dataY(index).assign(data_p, data_p + m_numberOfChannels);
+      m_localWorkspace->mutableY(index).assign(data_p, data_p + m_numberOfChannels);
       // Assign Error
-      MantidVec &E = m_localWorkspace->dataE(index);
+      auto &E = m_localWorkspace->mutableE(index);
       std::transform(data_p, data_p + m_numberOfChannels, E.begin(), [](const double v) { return std::sqrt(v); });
     }
   }

--- a/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Framework/DataHandling/src/LoadRKH.cpp
@@ -366,7 +366,7 @@ const MatrixWorkspace_sptr LoadRKH::read2D(const std::string &firstLine) {
     outWrksp->setSharedX(i, toPass);
 
     // now read in the Y values
-    MantidVec &YOut = outWrksp->dataY(i);
+    auto &YOut = outWrksp->mutableY(i);
     for (double &value : YOut) {
       m_fileIn >> value;
     }
@@ -375,7 +375,7 @@ const MatrixWorkspace_sptr LoadRKH::read2D(const std::string &firstLine) {
 
   // the error values form one big block after the Y-values
   for (size_t i = 0; i < nAxis1Values; ++i) {
-    MantidVec &EOut = outWrksp->dataE(i);
+    auto &EOut = outWrksp->mutableE(i);
     for (double &value : EOut) {
       m_fileIn >> value;
     }

--- a/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
@@ -115,12 +115,12 @@ public:
     DataObjects::GroupingWorkspace_sptr gws2 = std::dynamic_pointer_cast<DataObjects::GroupingWorkspace>(
         API::AnalysisDataService::Instance().retrieve("GroupPowder"));
 
-    TS_ASSERT_DELTA(gws2->dataY(0)[0], 14.0, 1.0E-5);     // 130.6 degrees
-    TS_ASSERT_DELTA(gws2->dataY(10000)[0], 10.0, 1.0E-5); // 97.4 degrees
-    TS_ASSERT_DELTA(gws2->dataY(20000)[0], 7.0, 1.0E-5);  // 62.9 degrees
-    TS_ASSERT_DELTA(gws2->dataY(30000)[0], 3.0, 1.0E-5);  // 27.8 degrees
-    TS_ASSERT_DELTA(gws2->dataY(40000)[0], 2.0, 1.0E-5);  // 14.5 degrees
-    TS_ASSERT_DELTA(gws2->dataY(50000)[0], 5.0, 1.0E-5);  // 49.7 degrees
+    TS_ASSERT_DELTA(gws2->y(0)[0], 14.0, 1.0E-5);     // 130.6 degrees
+    TS_ASSERT_DELTA(gws2->y(10000)[0], 10.0, 1.0E-5); // 97.4 degrees
+    TS_ASSERT_DELTA(gws2->y(20000)[0], 7.0, 1.0E-5);  // 62.9 degrees
+    TS_ASSERT_DELTA(gws2->y(30000)[0], 3.0, 1.0E-5);  // 27.8 degrees
+    TS_ASSERT_DELTA(gws2->y(40000)[0], 2.0, 1.0E-5);  // 14.5 degrees
+    TS_ASSERT_DELTA(gws2->y(50000)[0], 5.0, 1.0E-5);  // 49.7 degrees
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(GROUP_WS);
@@ -346,7 +346,7 @@ public:
     // ensure each pixel angle is inside the range correspondng to its group ID
     for (size_t i = 0; i < nHist; ++i) {
       auto const twoTheta = spectrumInfo.twoTheta(i);
-      auto const groupID = outputWS->dataY(i)[0];
+      auto const groupID = outputWS->y(i)[0];
       TS_ASSERT_LESS_THAN_EQUALS(angleStepRad * (groupID - 1), twoTheta);
       TS_ASSERT_LESS_THAN(twoTheta, angleStepRad * (groupID));
     }

--- a/Framework/DataHandling/test/GenerateGroupingPowderTest.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowderTest.h
@@ -116,12 +116,12 @@ public:
     DataObjects::GroupingWorkspace_sptr gws2 = std::dynamic_pointer_cast<DataObjects::GroupingWorkspace>(
         API::AnalysisDataService::Instance().retrieve("GroupPowder"));
 
-    TS_ASSERT_DELTA(gws2->dataY(0)[0], 13.0, 1.0E-5);    // 130.6 degrees
-    TS_ASSERT_DELTA(gws2->dataY(10000)[0], 9.0, 1.0E-5); // 97.4 degrees
-    TS_ASSERT_DELTA(gws2->dataY(20000)[0], 6.0, 1.0E-5); // 62.9 degrees
-    TS_ASSERT_DELTA(gws2->dataY(30000)[0], 2.0, 1.0E-5); // 27.8 degrees
-    TS_ASSERT_DELTA(gws2->dataY(40000)[0], 1.0, 1.0E-5); // 14.5 degrees
-    TS_ASSERT_DELTA(gws2->dataY(50000)[0], 4.0, 1.0E-5); // 49.7 degrees
+    TS_ASSERT_DELTA(gws2->y(0)[0], 13.0, 1.0E-5);    // 130.6 degrees
+    TS_ASSERT_DELTA(gws2->y(10000)[0], 9.0, 1.0E-5); // 97.4 degrees
+    TS_ASSERT_DELTA(gws2->y(20000)[0], 6.0, 1.0E-5); // 62.9 degrees
+    TS_ASSERT_DELTA(gws2->y(30000)[0], 2.0, 1.0E-5); // 27.8 degrees
+    TS_ASSERT_DELTA(gws2->y(40000)[0], 1.0, 1.0E-5); // 14.5 degrees
+    TS_ASSERT_DELTA(gws2->y(50000)[0], 4.0, 1.0E-5); // 49.7 degrees
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(GROUP_WS);
@@ -350,7 +350,7 @@ public:
     // ensure each pixel angle is inside the range correspondng to its group ID
     for (size_t i = 0; i < nHist; ++i) {
       auto const twoTheta = spectrumInfo.twoTheta(i);
-      auto const groupID = outputWS->dataY(i)[0];
+      auto const groupID = outputWS->y(i)[0];
       TS_ASSERT_LESS_THAN_EQUALS(angleStepRad * (groupID - 1), twoTheta);
       TS_ASSERT_LESS_THAN(twoTheta, angleStepRad * (groupID));
     }

--- a/Framework/DataHandling/test/LoadCanSAS1dTest.h
+++ b/Framework/DataHandling/test/LoadCanSAS1dTest.h
@@ -61,28 +61,28 @@ public:
 
     // Test the size of the data vectors (there should be 102 data points so x
     // have 103)
-    TS_ASSERT_EQUALS((ws2d->dataX(0).size()), 102);
-    TS_ASSERT_EQUALS((ws2d->dataY(0).size()), 102);
-    TS_ASSERT_EQUALS((ws2d->dataE(0).size()), 102);
+    TS_ASSERT_EQUALS((ws2d->x(0).size()), 102);
+    TS_ASSERT_EQUALS((ws2d->y(0).size()), 102);
+    TS_ASSERT_EQUALS((ws2d->e(0).size()), 102);
 
     double tolerance(1e-06);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[0], 0.0604703, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[1], 0.0620232, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[2], 0.0635737, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[0], 0.0604703, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[1], 0.0620232, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[2], 0.0635737, tolerance);
     ////Test a couple of random ones
-    TS_ASSERT_DELTA(ws2d->dataX(0)[20], 0.0991537, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[64], 0.293873, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[20], 0.0991537, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[64], 0.293873, tolerance);
 
-    TS_ASSERT_DELTA(ws2d->dataX(0)[100], 0.714858, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[101], 0.732729, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[100], 0.714858, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[101], 0.732729, tolerance);
 
-    TS_ASSERT_DELTA(ws2d->dataY(0)[0], 12, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataY(0)[25], 4674, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataY(0)[99], 1, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[0], 12, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[25], 4674, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[99], 1, tolerance);
 
-    TS_ASSERT_DELTA(ws2d->dataE(0)[0], 3.4641, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataE(0)[25], 68.3667, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataE(0)[99], 1, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[0], 3.4641, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[25], 68.3667, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[99], 1, tolerance);
   }
 
   void testMultipleEntries() {
@@ -123,7 +123,7 @@ public:
     TS_ASSERT_EQUALS(ws2d->getInstrument()->getName(), "LOQ")
 
     TS_ASSERT_EQUALS(ws2d->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws2d->dataX(0).size(), 143);
+    TS_ASSERT_EQUALS(ws2d->x(0).size(), 143);
 
     // some of the data is only stored to 3 decimal places
     double tolerance(1e-04);
@@ -131,9 +131,9 @@ public:
     // has all its values check below
     const int testIndices[] = {0, 70, 142};
     for (int i = 0; i < 3; ++i) {
-      TS_ASSERT_DELTA(ws2d->dataX(0)[testIndices[i]], xs99631[i], tolerance);
-      TS_ASSERT_DELTA(ws2d->dataY(0)[testIndices[i]], ys99631[i], tolerance);
-      TS_ASSERT_DELTA(ws2d->dataE(0)[testIndices[i]], es99631[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->x(0)[testIndices[i]], xs99631[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->y(0)[testIndices[i]], ys99631[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->e(0)[testIndices[i]], es99631[i], tolerance);
     }
 
     ws = Mantid::API::AnalysisDataService::Instance().retrieve(wNames[1]);
@@ -147,13 +147,13 @@ public:
     TS_ASSERT_EQUALS(ws2d->getInstrument()->getName(), "SANS2D")
 
     TS_ASSERT_EQUALS(ws2d->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws2d->dataX(0).size(), 23);
+    TS_ASSERT_EQUALS(ws2d->x(0).size(), 23);
 
     // testing all workspace data, as there isn't much
     for (int i = 0; i < 23; ++i) {
-      TS_ASSERT_DELTA(ws2d->dataX(0)[i], xs808[i], tolerance);
-      TS_ASSERT_DELTA(ws2d->dataY(0)[i], ys808[i], tolerance);
-      TS_ASSERT_DELTA(ws2d->dataE(0)[i], es808[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->x(0)[i], xs808[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->y(0)[i], ys808[i], tolerance);
+      TS_ASSERT_DELTA(ws2d->e(0)[i], es808[i], tolerance);
     }
   }
 
@@ -178,25 +178,25 @@ public:
 
     TS_ASSERT_EQUALS(ws2d->getNumberHistograms(), 1);
 
-    TS_ASSERT_EQUALS((ws2d->dataX(0).size()), 4);
-    TS_ASSERT_EQUALS((ws2d->dataY(0).size()), 4);
-    TS_ASSERT_EQUALS((ws2d->dataE(0).size()), 4);
+    TS_ASSERT_EQUALS((ws2d->x(0).size()), 4);
+    TS_ASSERT_EQUALS((ws2d->y(0).size()), 4);
+    TS_ASSERT_EQUALS((ws2d->e(0).size()), 4);
 
     double tolerance(1e-06);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[0], 1.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[1], 2.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[2], 3.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataX(0)[3], 4.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[0], 1.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[1], 2.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[2], 3.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->x(0)[3], 4.0, tolerance);
 
-    TS_ASSERT_DELTA(ws2d->dataY(0)[0], 4.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataY(0)[1], 9.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataY(0)[2], 16.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataY(0)[3], 25.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[0], 4.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[1], 9.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[2], 16.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->y(0)[3], 25.0, tolerance);
 
-    TS_ASSERT_DELTA(ws2d->dataE(0)[0], 2.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataE(0)[1], 3.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataE(0)[2], 4.0, tolerance);
-    TS_ASSERT_DELTA(ws2d->dataE(0)[3], 5.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[0], 2.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[1], 3.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[2], 4.0, tolerance);
+    TS_ASSERT_DELTA(ws2d->e(0)[3], 5.0, tolerance);
   }
 
 private:

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -869,11 +869,11 @@ public:
     TS_ASSERT_EQUALS((*WS->sharedX(0)).size(), 200002);
     TS_ASSERT_DELTA((*WS->sharedX(0))[1], 1.0, 1e-6);
     // Data
-    TS_ASSERT_EQUALS(WS->dataY(0).size(), 200001);
-    TS_ASSERT_DELTA(WS->dataY(0)[12], 0.0, 1e-6);
+    TS_ASSERT_EQUALS(WS->y(0).size(), 200001);
+    TS_ASSERT_DELTA(WS->y(0)[12], 0.0, 1e-6);
     // Error
-    TS_ASSERT_EQUALS(WS->dataE(0).size(), 200001);
-    TS_ASSERT_DELTA(WS->dataE(0)[12], 0.0, 1e-6);
+    TS_ASSERT_EQUALS(WS->e(0).size(), 200001);
+    TS_ASSERT_DELTA(WS->e(0)[12], 0.0, 1e-6);
     // Check geometry for a monitor
     const auto &specInfo = WS->spectrumInfo();
     TS_ASSERT(specInfo.isMonitor(2));

--- a/Framework/DataHandling/test/LoadILLIndirect2Test.h
+++ b/Framework/DataHandling/test/LoadILLIndirect2Test.h
@@ -123,9 +123,9 @@ public:
 
     // check some values near the center tubes to verify the geometry
     // used is from the older version
-    TS_ASSERT_EQUALS(output2D->dataY(1050)[1156], 16)
-    TS_ASSERT_EQUALS(output2D->dataY(871)[1157], 17)
-    TS_ASSERT_EQUALS(output2D->dataY(746)[1157], 18)
+    TS_ASSERT_EQUALS(output2D->y(1050)[1156], 16)
+    TS_ASSERT_EQUALS(output2D->y(871)[1157], 17)
+    TS_ASSERT_EQUALS(output2D->y(746)[1157], 18)
     checkTimeFormat(output2D);
   }
   void test_diffraction_doppler() {
@@ -145,9 +145,9 @@ public:
 
     // check some values near the center tubes to verify the geometry
     // used is from the newer version
-    TS_ASSERT_EQUALS(output2D->dataY(1050)[558], 2)
-    TS_ASSERT_EQUALS(output2D->dataY(873)[557], 2)
-    TS_ASSERT_EQUALS(output2D->dataY(724)[561], 3)
+    TS_ASSERT_EQUALS(output2D->y(1050)[558], 2)
+    TS_ASSERT_EQUALS(output2D->y(873)[557], 2)
+    TS_ASSERT_EQUALS(output2D->y(724)[561], 3)
     checkTimeFormat(output2D);
   }
 
@@ -193,7 +193,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 2049)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 2048)
 
-    TS_ASSERT_EQUALS(outputWS->dataY(58)[3], 1.0)
+    TS_ASSERT_EQUALS(outputWS->y(58)[3], 1.0)
   }
 
   void checkTimeFormat(MatrixWorkspace_const_sptr outputWS) {

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -491,7 +491,7 @@ private:
 
     // If applicable, ensure that both have the same Xdev data
     if (m_parameters.hasDx) {
-      auto readDataDX = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->dataDx(index); };
+      auto readDataDX = [](const MatrixWorkspace_sptr &ws, size_t index) { return ws->dx(index); };
       do_assert_data(wsIn, wsOut, readDataDX);
     }
 

--- a/Framework/DataHandling/test/LoadNexusTest.h
+++ b/Framework/DataHandling/test/LoadNexusTest.h
@@ -68,11 +68,11 @@ public:
     // "../../../../Test/Nexus/emu00006473.nxs";
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 32);
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(3)) == (output2D->dataX(31)));
+    TS_ASSERT((output2D->x(3)) == (output2D->x(31)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(5).size(), output2D->dataY(17).size());
+    TS_ASSERT_EQUALS(output2D->y(5).size(), output2D->y(17).size());
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(11)[686], 81);
+    TS_ASSERT_EQUALS(output2D->y(11)[686], 81);
   }
 
   void testExec2() {
@@ -112,15 +112,15 @@ public:
     // "../../../../Test/Nexus/emu00006475.nxs";
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 32);
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(3)) == (output2D->dataX(31)));
+    TS_ASSERT((output2D->x(3)) == (output2D->x(31)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(5).size(), output2D->dataY(17).size());
+    TS_ASSERT_EQUALS(output2D->y(5).size(), output2D->y(17).size());
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D2->dataY(8)[502], 121);
+    TS_ASSERT_EQUALS(output2D2->y(8)[502], 121);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D2->dataE(8)[502], 11);
+    TS_ASSERT_EQUALS(output2D2->e(8)[502], 11);
     // Check that the time is as expected from bin boundary update
-    TS_ASSERT_DELTA(output2D->dataX(11)[687], 10.738, 0.001);
+    TS_ASSERT_DELTA(output2D->x(11)[687], 10.738, 0.001);
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output2->getAxis(0)->unit()->unitID(), "Label");

--- a/Framework/DataHandling/test/LoadRKHTest.h
+++ b/Framework/DataHandling/test/LoadRKHTest.h
@@ -86,32 +86,32 @@ public:
 
     // Test the size of the data vectors (there should be 102 data points so x
     // have 103)
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 102);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 102);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 102);
+    TS_ASSERT_EQUALS(static_cast<int>(data->x(0).size()), 102);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(0).size()), 102);
+    TS_ASSERT_EQUALS(static_cast<int>(data->e(0).size()), 102);
 
     // Test first 3 bin edges for the correct values
     double tolerance(1e-06);
-    TS_ASSERT_DELTA(data->dataX(0)[0], 1.34368, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[1], 1.37789, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[2], 1.41251, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[0], 1.34368, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[1], 1.37789, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[2], 1.41251, tolerance);
     // Test a couple of random ones
-    TS_ASSERT_DELTA(data->dataX(0)[20], 2.20313, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[45], 4.08454, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[87], 11.52288, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[20], 2.20313, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[45], 4.08454, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[87], 11.52288, tolerance);
     // Test the last 3
-    TS_ASSERT_DELTA(data->dataX(0)[100], 15.88747, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[101], 16.28282, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[100], 15.88747, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[101], 16.28282, tolerance);
 
     // Now Y values
-    TS_ASSERT_DELTA(data->dataY(0)[0], 0.168419, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[25], 2.019846, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[99], 0.0, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[0], 0.168419, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[25], 2.019846, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[99], 0.0, tolerance);
 
     // Now E values
-    TS_ASSERT_DELTA(data->dataE(0)[0], 0.122346, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[25], 0.018345, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[99], 0.0, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[0], 0.122346, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[25], 0.018345, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[99], 0.0, tolerance);
   }
 
   void test2D() {
@@ -154,30 +154,30 @@ public:
 
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 2);
 
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 3);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 2);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(1).size()), 2);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 2);
+    TS_ASSERT_EQUALS(static_cast<int>(data->x(0).size()), 3);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(0).size()), 2);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(1).size()), 2);
+    TS_ASSERT_EQUALS(static_cast<int>(data->e(0).size()), 2);
 
     double tolerance(1e-06);
     // check a sample of values, the workspace is pretty small and so this will
     // check nearly all of them
-    TS_ASSERT_DELTA(data->dataX(0)[0], -3.000000e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[1], -2.900000e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[2], -2.800000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[0], -3.000000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[1], -2.900000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[2], -2.800000e-01, tolerance);
 
-    TS_ASSERT_DELTA(data->dataX(1)[0], -3.000000e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataX(1)[1], -2.900000e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataX(1)[2], -2.800000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(1)[0], -3.000000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(1)[1], -2.900000e-01, tolerance);
+    TS_ASSERT_DELTA(data->x(1)[2], -2.800000e-01, tolerance);
 
-    TS_ASSERT_DELTA(data->dataY(0)[0], 11, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[1], 12, tolerance);
-    TS_ASSERT_DELTA(data->dataY(1)[1], 22, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[0], 11, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[1], 12, tolerance);
+    TS_ASSERT_DELTA(data->y(1)[1], 22, tolerance);
 
     // Now E values
-    TS_ASSERT_DELTA(data->dataE(0)[1], 2, tolerance);
-    TS_ASSERT_DELTA(data->dataE(1)[0], 3, tolerance);
-    TS_ASSERT_DELTA(data->dataE(1)[1], 4, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[1], 2, tolerance);
+    TS_ASSERT_DELTA(data->e(1)[0], 3, tolerance);
+    TS_ASSERT_DELTA(data->e(1)[1], 4, tolerance);
 
     Axis *secondAxis = data->getAxis(1);
     TS_ASSERT_EQUALS(secondAxis->length(), 3)
@@ -219,25 +219,25 @@ public:
 
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
 
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 10);
+    TS_ASSERT_EQUALS(static_cast<int>(data->x(0).size()), 10);
     TS_ASSERT_EQUALS(static_cast<int>(data->dx(0).size()), 10);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 10);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 10);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 10);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(0).size()), 10);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(0).size()), 10);
+    TS_ASSERT_EQUALS(static_cast<int>(data->e(0).size()), 10);
 
     double tolerance(1e-06);
 
-    TS_ASSERT_DELTA(data->dataX(0)[0], 0.5, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[1], 1.5, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[2], 2.5, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[0], 0.5, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[1], 1.5, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[2], 2.5, tolerance);
 
-    TS_ASSERT_DELTA(data->dataY(0)[0], 1.000000e+00, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[1], 1.000000e+00, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[1], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[0], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[1], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[1], 1.000000e+00, tolerance);
 
-    TS_ASSERT_DELTA(data->dataE(0)[1], 1.000000e+00, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[0], 1.000000e+00, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[1], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[1], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[0], 1.000000e+00, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[1], 1.000000e+00, tolerance);
 
     TS_ASSERT_DELTA(data->dx(0)[0], 5.000000e-01, tolerance);
     TS_ASSERT_DELTA(data->dx(0)[1], 1.207107e+00, tolerance);
@@ -276,23 +276,23 @@ public:
 
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
 
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 4);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 4);
-    TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->x(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->y(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->e(0).size()), 4);
 
     double tolerance(1e-06);
 
-    TS_ASSERT_DELTA(data->dataX(0)[0], 0.00520, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[1], 0.00562, tolerance);
-    TS_ASSERT_DELTA(data->dataX(0)[2], 0.00607, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[0], 0.00520, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[1], 0.00562, tolerance);
+    TS_ASSERT_DELTA(data->x(0)[2], 0.00607, tolerance);
 
-    TS_ASSERT_DELTA(data->dataY(0)[0], 1.055855e+00, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[1], 9.784999e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataY(0)[2], 1.239836e+00, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[0], 1.055855e+00, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[1], 9.784999e-01, tolerance);
+    TS_ASSERT_DELTA(data->y(0)[2], 1.239836e+00, tolerance);
 
-    TS_ASSERT_DELTA(data->dataE(0)[0], 2.570181e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[1], 1.365013e-01, tolerance);
-    TS_ASSERT_DELTA(data->dataE(0)[2], 9.582824e-02, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[0], 2.570181e-01, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[1], 1.365013e-01, tolerance);
+    TS_ASSERT_DELTA(data->e(0)[2], 9.582824e-02, tolerance);
 
     remove(tempFile3.c_str());
   }

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -179,15 +179,15 @@ public:
     // Should be 2584 for file HET15869.RAW
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 2584);
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(99)) == (output2D->dataX(1734)));
+    TS_ASSERT((output2D->x(99)) == (output2D->x(1734)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(673).size(), output2D->dataY(2111).size());
+    TS_ASSERT_EQUALS(output2D->y(673).size(), output2D->y(2111).size());
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(999)[777], 9);
+    TS_ASSERT_EQUALS(output2D->y(999)[777], 9);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(999)[777], 3);
+    TS_ASSERT_EQUALS(output2D->e(999)[777], 3);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(999)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(999)[777], 554.1875);
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF")
@@ -277,17 +277,17 @@ public:
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 9);
 
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(1)) == (output2D->dataX(5)));
+    TS_ASSERT((output2D->x(1)) == (output2D->x(5)));
 
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(2).size(), output2D->dataY(7).size());
+    TS_ASSERT_EQUALS(output2D->y(2).size(), output2D->y(7).size());
 
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(8)[777], 9);
+    TS_ASSERT_EQUALS(output2D->y(8)[777], 9);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(8)[777], 3);
+    TS_ASSERT_EQUALS(output2D->e(8)[777], 3);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(8)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(8)[777], 554.1875);
   }
 
   void testMinlimit() {
@@ -471,10 +471,10 @@ public:
     MatrixWorkspace_sptr outsptr2;
     TS_ASSERT_THROWS_NOTHING(outsptr2 = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>((*++itr)));
 
-    TS_ASSERT_EQUALS(outsptr1->dataX(0), outsptr2->dataX(0))
+    TS_ASSERT_EQUALS(outsptr1->x(0), outsptr2->x(0))
 
     // But the data should be different
-    TS_ASSERT_DIFFERS(outsptr1->dataY(1)[8], outsptr2->dataY(1)[8])
+    TS_ASSERT_DIFFERS(outsptr1->y(1)[8], outsptr2->y(1)[8])
 
     TS_ASSERT_EQUALS(outsptr1->getInstrument()->baseInstrument(), outsptr2->getInstrument()->baseInstrument())
     TS_ASSERT_EQUALS(&(outsptr1->sample()), &(outsptr2->sample()))
@@ -568,15 +568,15 @@ public:
     TS_ASSERT(monitoroutput2D->getSpectrum(1).hasDetectorID(602));
 
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(95)) == (output2D->dataX(1730)));
+    TS_ASSERT((output2D->x(95)) == (output2D->x(1730)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(669).size(), output2D->dataY(2107).size());
+    TS_ASSERT_EQUALS(output2D->y(669).size(), output2D->y(2107).size());
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(995)[0], 1);
+    TS_ASSERT_EQUALS(output2D->y(995)[0], 1);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(995)[777], 3);
+    TS_ASSERT_EQUALS(output2D->e(995)[777], 3);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(995)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(995)[777], 554.1875);
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF")
@@ -693,10 +693,10 @@ public:
     MatrixWorkspace_sptr monoutsptr2;
     TS_ASSERT_THROWS_NOTHING(monoutsptr2 = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>((*++monitr)));
 
-    TS_ASSERT_EQUALS(monoutsptr1->dataX(0), monoutsptr2->dataX(0))
+    TS_ASSERT_EQUALS(monoutsptr1->x(0), monoutsptr2->x(0))
 
     // But the data should be different
-    TS_ASSERT_DIFFERS(monoutsptr1->dataY(1)[555], monoutsptr2->dataY(1)[555])
+    TS_ASSERT_DIFFERS(monoutsptr1->y(1)[555], monoutsptr2->y(1)[555])
 
     // Same number of logs
     const auto &monPeriod1Run = monoutsptr1->run();
@@ -732,8 +732,8 @@ public:
     MatrixWorkspace_sptr outsptr2;
     TS_ASSERT_THROWS_NOTHING(outsptr2 = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>((*++itr)));
 
-    TS_ASSERT_EQUALS(outsptr1->dataX(0), outsptr2->dataX(0))
-    TS_ASSERT_EQUALS(outsptr1->dataY(1)[555], outsptr2->dataY(1)[555])
+    TS_ASSERT_EQUALS(outsptr1->x(0), outsptr2->x(0))
+    TS_ASSERT_EQUALS(outsptr1->y(1)[555], outsptr2->y(1)[555])
 
     // But the data should be different
     TS_ASSERT_DIFFERS(&(outsptr1->run()), &(outsptr2->run()))
@@ -829,17 +829,17 @@ public:
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 9);
 
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(1)) == (output2D->dataX(5)));
+    TS_ASSERT((output2D->x(1)) == (output2D->x(5)));
 
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(2).size(), output2D->dataY(7).size());
+    TS_ASSERT_EQUALS(output2D->y(2).size(), output2D->y(7).size());
 
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(8)[777], 9);
+    TS_ASSERT_EQUALS(output2D->y(8)[777], 9);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(8)[777], 3);
+    TS_ASSERT_EQUALS(output2D->e(8)[777], 3);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(8)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(8)[777], 554.1875);
     AnalysisDataService::Instance().remove("outWS");
   }
 
@@ -874,10 +874,10 @@ public:
     // TS_ASSERT( (output2D->dataX(1)) == (output2D->dataX(5)) );
 
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(1).size(), output2D->dataY(2).size());
+    TS_ASSERT_EQUALS(output2D->y(1).size(), output2D->y(2).size());
 
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(1)[1], 192);
+    TS_ASSERT_EQUALS(output2D->y(1)[1], 192);
     AnalysisDataService::Instance().remove("outWS");
   }
 
@@ -911,10 +911,10 @@ public:
     TS_ASSERT_EQUALS(monitoroutput2D->getNumberHistograms(), 3);
 
     // Check two X vectors are the same
-    TS_ASSERT((monitoroutput2D->dataX(1)) == (output2D->dataX(1)));
+    TS_ASSERT((monitoroutput2D->x(1)) == (output2D->x(1)));
 
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(2).size(), output2D->dataY(3).size());
+    TS_ASSERT_EQUALS(output2D->y(2).size(), output2D->y(3).size());
     AnalysisDataService::Instance().remove("outWS_monitors");
     AnalysisDataService::Instance().remove("outWS");
 
@@ -978,11 +978,11 @@ public:
     // Should be 6 for selected input
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 2580);
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(995)[777], 9);
+    TS_ASSERT_EQUALS(output2D->y(995)[777], 9);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(995)[777], 3);
+    TS_ASSERT_EQUALS(output2D->e(995)[777], 3);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(995)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(995)[777], 554.1875);
     AnalysisDataService::Instance().remove("outWS");
   }
 

--- a/Framework/DataHandling/test/LoadRawBin0Test.h
+++ b/Framework/DataHandling/test/LoadRawBin0Test.h
@@ -63,14 +63,14 @@ public:
     // Should be 2584 for file LOQ48127.RAW
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 8);
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(2)) == (output2D->dataX(6)));
+    TS_ASSERT((output2D->x(2)) == (output2D->x(6)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(2).size(), output2D->dataY(6).size());
+    TS_ASSERT_EQUALS(output2D->y(2).size(), output2D->y(6).size());
 
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(3)[0], 0.);
+    TS_ASSERT_EQUALS(output2D->y(3)[0], 0.);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(2)[0], std::sqrt(output2D->dataY(2)[0]));
+    TS_ASSERT_EQUALS(output2D->e(2)[0], std::sqrt(output2D->y(2)[0]));
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF")
@@ -122,7 +122,7 @@ public:
     MatrixWorkspace_sptr outsptr2;
     TS_ASSERT_THROWS_NOTHING(outsptr2 = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>((*++itr)));
 
-    TS_ASSERT_EQUALS(outsptr1->dataX(0), outsptr2->dataX(0))
+    TS_ASSERT_EQUALS(outsptr1->x(0), outsptr2->x(0))
 
     TS_ASSERT_EQUALS(&(outsptr1->sample()), &(outsptr2->sample()))
     TS_ASSERT_DIFFERS(&(outsptr1->run()), &(outsptr2->run()))

--- a/Framework/DataHandling/test/LoadRawSaveNxsLoadNxsTest.h
+++ b/Framework/DataHandling/test/LoadRawSaveNxsLoadNxsTest.h
@@ -115,15 +115,15 @@ public:
     // set to 4 for CSP78173
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 4);
     // Check two X vectors are the same
-    TS_ASSERT((output2D->dataX(1)) == (output2D->dataX(3)));
+    TS_ASSERT((output2D->x(1)) == (output2D->x(3)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output2D->dataY(1).size(), output2D->dataY(2).size());
+    TS_ASSERT_EQUALS(output2D->y(1).size(), output2D->y(2).size());
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(1)[14], 9.0);
+    TS_ASSERT_EQUALS(output2D->y(1)[14], 9.0);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(1)[14], 3.0);
+    TS_ASSERT_EQUALS(output2D->e(1)[14], 3.0);
     // Check that the X data is as expected
-    TS_ASSERT_EQUALS(output2D->dataX(2)[777], 15550.0);
+    TS_ASSERT_EQUALS(output2D->x(2)[777], 15550.0);
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "TOF");
@@ -246,9 +246,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(myOutputSpace));
     TS_ASSERT_EQUALS(output->getNumberHistograms(), 1);
     // Check two X vectors are the same
-    TS_ASSERT((output->dataX(0)) == (singleValuedWs->dataX(0)));
+    TS_ASSERT((output->x(0)) == (singleValuedWs->x(0)));
     // Check two Y arrays have the same number of elements
-    TS_ASSERT_EQUALS(output->dataY(0).size(), singleValuedWs->dataY(0).size());
+    TS_ASSERT_EQUALS(output->y(0).size(), singleValuedWs->y(0).size());
   }
 
 private:

--- a/Framework/DataHandling/test/LoadRawSpectrum0Test.h
+++ b/Framework/DataHandling/test/LoadRawSpectrum0Test.h
@@ -67,11 +67,11 @@ public:
     // Check two X vectors are the same
 
     // Check one particular value
-    TS_ASSERT_EQUALS(output2D->dataY(0)[777], 355);
+    TS_ASSERT_EQUALS(output2D->y(0)[777], 355);
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataE(0)[777], std::sqrt(output2D->dataY(0)[777]));
+    TS_ASSERT_EQUALS(output2D->e(0)[777], std::sqrt(output2D->y(0)[777]));
     // Check that the error on that value is correct
-    TS_ASSERT_EQUALS(output2D->dataX(0)[777], 554.1875);
+    TS_ASSERT_EQUALS(output2D->x(0)[777], 554.1875);
 
     // Check the unit has been set correctly
     TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF")
@@ -121,7 +121,7 @@ public:
     MatrixWorkspace_sptr outsptr2;
     TS_ASSERT_THROWS_NOTHING(outsptr2 = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>((*++itr)));
 
-    TS_ASSERT_EQUALS(outsptr1->dataX(0), outsptr2->dataX(0))
+    TS_ASSERT_EQUALS(outsptr1->x(0), outsptr2->x(0))
 
     TS_ASSERT_EQUALS(&(outsptr1->sample()), &(outsptr2->sample()))
     TS_ASSERT_DIFFERS(&(outsptr1->run()), &(outsptr2->run()))

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -74,7 +74,7 @@ std::string getIDFfromWorkspace(const Mantid::API::MatrixWorkspace_sptr &workspa
 }
 
 void setXValuesOn1DWorkspace(const Mantid::API::MatrixWorkspace_sptr &workspace, double xmin, double xmax) {
-  auto &xValues = workspace->dataX(0);
+  auto &xValues = workspace->mutableX(0);
   const double step = (xmax - xmin) / static_cast<double>(xValues.size() - 1);
   double value(xmin);
   std::generate(std::begin(xValues), std::end(xValues), [&value, &step]() {

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -178,9 +178,9 @@ public:
     Mantid::DataObjects::Workspace2D_sptr wsToSave = std::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
         WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));
     for (int i = 0; i < 2; i++) {
-      std::vector<double> &X = wsToSave->dataX(i);
-      std::vector<double> &Y = wsToSave->dataY(i);
-      std::vector<double> &E = wsToSave->dataE(i);
+      auto &X = wsToSave->mutableX(i);
+      auto &Y = wsToSave->mutableY(i);
+      auto &E = wsToSave->mutableE(i);
       for (int j = 0; j < 3; j++) {
         X[j] = 1.5 * j / 0.9;
         Y[j] = (i + 1) * (2. + 4. * X[j]);

--- a/Framework/DataHandling/test/SaveRKHTest.h
+++ b/Framework/DataHandling/test/SaveRKHTest.h
@@ -286,8 +286,8 @@ private:
     for (size_t j = 0; j < nSpec; ++j) {
       ws->setBinEdges(j, x);
       ws->setPointStandardDeviations(j, dx);
-      ws->dataY(j).assign(y_length, double(1));
-      ws->dataE(j).assign(y_length, double(1));
+      ws->mutableY(j).assign(y_length, double(1));
+      ws->mutableE(j).assign(y_length, double(1));
     }
     return ws;
   }

--- a/Framework/DataObjects/src/RebinnedOutput.cpp
+++ b/Framework/DataObjects/src/RebinnedOutput.cpp
@@ -130,7 +130,7 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
   if (m_finalized) {
     PARALLEL_FOR_IF(Kernel::threadSafe(*this))
     for (int i = 0; i < nHist; ++i) {
-      MantidVec &err = this->dataE(i);
+      auto &err = this->mutableE(i);
       MantidVec &frac = this->dataF(i);
       if (hasSqrdErrs) {
         std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::divides<double>());
@@ -146,8 +146,8 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int i = 0; i < nHist; ++i) {
-    MantidVec &data = this->dataY(i);
-    MantidVec &err = this->dataE(i);
+    auto &data = this->mutableY(i);
+    auto &err = this->mutableE(i);
     MantidVec &frac = this->dataF(i);
     std::transform(data.begin(), data.end(), frac.begin(), data.begin(), std::divides<double>());
     std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::divides<double>());
@@ -173,8 +173,8 @@ void RebinnedOutput::unfinalize() {
   auto nHist = static_cast<int>(this->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int i = 0; i < nHist; ++i) {
-    MantidVec &data = this->dataY(i);
-    MantidVec &err = this->dataE(i);
+    auto &data = this->mutableY(i);
+    auto &err = this->mutableE(i);
     MantidVec &frac = this->dataF(i);
     std::transform(data.begin(), data.end(), frac.begin(), data.begin(), std::multiplies<double>());
     std::transform(err.begin(), err.end(), frac.begin(), err.begin(), std::multiplies<double>());

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -141,7 +141,7 @@ double SpecialWorkspace2D::getValue(const detid_t detectorID) const {
        << "  Size(Map) = " << this->detID_to_WI.size() << '\n';
     throw std::invalid_argument(os.str());
   } else {
-    return this->dataY(it->second)[0];
+    return this->y(it->second)[0];
   }
 }
 
@@ -160,7 +160,7 @@ double SpecialWorkspace2D::getValue(const detid_t detectorID, const double defau
   else {
     if (it->second < getNumberHistograms()) // don't let it generate an exception
     {
-      return this->dataY(it->second)[0];
+      return this->y(it->second)[0];
     } else {
       g_log.debug() << "getValue(" << detectorID << "->" << (it->second) << ", " << defaultValue
                     << ") index out of range\n";
@@ -271,8 +271,8 @@ void SpecialWorkspace2D::binaryOperation(const unsigned int operatortype) {
 void SpecialWorkspace2D::binaryAND(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
 
     if (y1 < 1.0E-10 || y2 < 1.0E-10) {
       this->mutableY(i)[0] = 0.0;
@@ -288,8 +288,8 @@ void SpecialWorkspace2D::binaryAND(const std::shared_ptr<const SpecialWorkspace2
 void SpecialWorkspace2D::binaryOR(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
 
     double max = y1;
     if (y2 > y1) {
@@ -313,8 +313,8 @@ if (y1 < 1.0E-10 && y2 < 1.0E-10){
 void SpecialWorkspace2D::binaryXOR(const std::shared_ptr<const SpecialWorkspace2D> &ws) {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
-    double y2 = ws->dataY(i)[0];
+    double y1 = this->y(i)[0];
+    double y2 = ws->y(i)[0];
     if (y1 < 1.0E-10 && y2 < 1.0E-10) {
       this->mutableY(i)[0] = 0.0;
     } else if (y1 > 1.0E-10 && y2 > 1.0E-10) {
@@ -331,7 +331,7 @@ void SpecialWorkspace2D::binaryXOR(const std::shared_ptr<const SpecialWorkspace2
 void SpecialWorkspace2D::binaryNOT() {
 
   for (size_t i = 0; i < this->getNumberHistograms(); i++) {
-    double y1 = this->dataY(i)[0];
+    double y1 = this->y(i)[0];
     if (y1 < 1.0E-10) {
       this->mutableY(i)[0] = 1.0;
     } else {

--- a/Framework/DataObjects/test/RebinnedOutputTest.h
+++ b/Framework/DataObjects/test/RebinnedOutputTest.h
@@ -52,11 +52,11 @@ public:
   void testRepresentation() {
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 4);
     TS_ASSERT_EQUALS(ws->blocksize(), nHist);
-    TS_ASSERT_EQUALS(ws->dataX(0).size(), 7);
-    TS_ASSERT_EQUALS(ws->dataX(0)[2], -1.);
-    TS_ASSERT_EQUALS(ws->dataY(1)[3], 1.);
+    TS_ASSERT_EQUALS(ws->x(0).size(), 7);
+    TS_ASSERT_EQUALS(ws->x(0)[2], -1.);
+    TS_ASSERT_EQUALS(ws->y(1)[3], 1.);
     // 1/sqrt(3)
-    TS_ASSERT_DELTA(ws->dataE(1)[3], 0.57735026918963, 1.e-5);
+    TS_ASSERT_DELTA(ws->e(1)[3], 0.57735026918963, 1.e-5);
     TS_ASSERT_EQUALS(ws->dataF(0).size(), nHist);
     TS_ASSERT_EQUALS(ws->dataF(1)[3], 3.);
   }

--- a/Framework/DataObjects/test/TimeSplitterTest.h
+++ b/Framework/DataObjects/test/TimeSplitterTest.h
@@ -410,8 +410,8 @@ public:
 
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3);
 
-    auto &X = ws->dataX(0);
-    auto &Y = ws->dataY(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
     // X[0] is 0 by default, unit is seconds.
     X[1] = 10.0;
     X[2] = 15.0;
@@ -448,8 +448,8 @@ public:
     splitter.addROI(DateAndTime(0) + offset_ns, DateAndTime(10, 0) + offset_ns, 1);
 
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1);
-    auto &X = ws->dataX(0);
-    auto &Y = ws->dataY(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
     // X[0] is 0 by default, unit is seconds.
     X[1] = 10.0;
     Y[0] = 1.0;
@@ -467,8 +467,8 @@ public:
     g_log.notice("\ntest_timeSplitterFromMatrixWorkspaceError...");
     // Testing the case where an X value in the MatrixWorkspace is negative.
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3);
-    auto &X = ws->dataX(0);
-    auto &Y = ws->dataY(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
     X[0] = -5.0;
     X[1] = 10.0;
     X[2] = 15.0;

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -71,11 +71,11 @@ public:
     ;
 
     for (int i = 0; i < nhist; ++i) {
-      TS_ASSERT_EQUALS(ws->dataX(i).size(), nbins + 1);
+      TS_ASSERT_EQUALS(ws->x(i).size(), nbins + 1);
       ;
-      TS_ASSERT_EQUALS(ws->dataY(i).size(), nbins);
+      TS_ASSERT_EQUALS(ws->y(i).size(), nbins);
       ;
-      TS_ASSERT_EQUALS(ws->dataE(i).size(), nbins);
+      TS_ASSERT_EQUALS(ws->e(i).size(), nbins);
       ;
     }
   }
@@ -137,7 +137,7 @@ public:
     double aNumber = 5.3;
     auto v = std::make_shared<HistogramData::HistogramX>(nbins + 1, LinearGenerator(aNumber, 1.0));
     TS_ASSERT_THROWS_NOTHING(ws->setSharedX(0, v));
-    TS_ASSERT_EQUALS(ws->dataX(0)[0], aNumber);
+    TS_ASSERT_EQUALS(ws->x(0)[0], aNumber);
     TS_ASSERT_THROWS(ws->setSharedX(-1, v), const std::range_error &);
     TS_ASSERT_THROWS(ws->setSharedX(nhist + 5, v), const std::range_error &);
   }
@@ -146,7 +146,7 @@ public:
     double aNumber = 5.4;
     auto v = Kernel::make_cow<HistogramData::HistogramX>(nbins + 1, LinearGenerator(aNumber, 1.0));
     TS_ASSERT_THROWS_NOTHING(ws->setSharedX(0, v));
-    TS_ASSERT_EQUALS(ws->dataX(0)[0], aNumber);
+    TS_ASSERT_EQUALS(ws->x(0)[0], aNumber);
     TS_ASSERT_THROWS(ws->setSharedX(-1, v), const std::range_error &);
     TS_ASSERT_THROWS(ws->setSharedX(nhist + 5, v), const std::range_error &);
   }
@@ -155,8 +155,8 @@ public:
     double aNumber = 5.5;
     auto v = Kernel::make_cow<HistogramData::HistogramY>(nbins, aNumber);
     TS_ASSERT_THROWS_NOTHING(ws->setCounts(0, v));
-    TS_ASSERT_EQUALS(ws->dataY(0)[0], aNumber);
-    TS_ASSERT_DIFFERS(ws->dataY(1)[0], aNumber);
+    TS_ASSERT_EQUALS(ws->y(0)[0], aNumber);
+    TS_ASSERT_DIFFERS(ws->y(1)[0], aNumber);
   }
 
   void testSetCounts_cowptr2() {
@@ -165,10 +165,10 @@ public:
     auto e = Kernel::make_cow<HistogramData::HistogramE>(nbins, aNumber * 2);
     TS_ASSERT_THROWS_NOTHING(ws->setCounts(0, v));
     TS_ASSERT_THROWS_NOTHING(ws->setCountStandardDeviations(0, e));
-    TS_ASSERT_EQUALS(ws->dataY(0)[0], aNumber);
-    TS_ASSERT_EQUALS(ws->dataE(0)[0], aNumber * 2);
-    TS_ASSERT_DIFFERS(ws->dataY(1)[0], aNumber);
-    TS_ASSERT_DIFFERS(ws->dataE(1)[0], aNumber * 2);
+    TS_ASSERT_EQUALS(ws->y(0)[0], aNumber);
+    TS_ASSERT_EQUALS(ws->e(0)[0], aNumber * 2);
+    TS_ASSERT_DIFFERS(ws->y(1)[0], aNumber);
+    TS_ASSERT_DIFFERS(ws->e(1)[0], aNumber * 2);
   }
 
   void testSetCounts() {
@@ -177,10 +177,10 @@ public:
     auto e = std::make_shared<HistogramData::HistogramE>(nbins, aNumber * 2);
     TS_ASSERT_THROWS_NOTHING(ws->setCounts(0, v));
     TS_ASSERT_THROWS_NOTHING(ws->setCountStandardDeviations(0, e));
-    TS_ASSERT_EQUALS(ws->dataY(0)[0], aNumber);
-    TS_ASSERT_EQUALS(ws->dataE(0)[0], aNumber * 2);
-    TS_ASSERT_DIFFERS(ws->dataY(1)[0], aNumber);
-    TS_ASSERT_DIFFERS(ws->dataE(1)[0], aNumber * 2);
+    TS_ASSERT_EQUALS(ws->y(0)[0], aNumber);
+    TS_ASSERT_EQUALS(ws->e(0)[0], aNumber * 2);
+    TS_ASSERT_DIFFERS(ws->y(1)[0], aNumber);
+    TS_ASSERT_DIFFERS(ws->e(1)[0], aNumber * 2);
   }
 
   void testIntegrateSpectra_entire_range() {

--- a/Framework/DataObjects/test/WorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/WorkspaceIteratorTest.h
@@ -52,9 +52,9 @@ public:
     int count = 0;
     for (MatrixWorkspace::const_iterator ti(*workspace); ti != ti.end(); ++ti) {
       TS_ASSERT_THROWS_NOTHING(LocatedDataRef tr = *ti; int datablock = count / size; int blockindex = count % size;
-                               TS_ASSERT_EQUALS(tr.X(), workspace->dataX(datablock)[blockindex]);
-                               TS_ASSERT_EQUALS(tr.Y(), workspace->dataY(datablock)[blockindex]);
-                               TS_ASSERT_EQUALS(tr.E(), workspace->dataE(datablock)[blockindex]);)
+                               TS_ASSERT_EQUALS(tr.X(), workspace->x(datablock)[blockindex]);
+                               TS_ASSERT_EQUALS(tr.Y(), workspace->y(datablock)[blockindex]);
+                               TS_ASSERT_EQUALS(tr.E(), workspace->e(datablock)[blockindex]);)
       count++;
     }
     TS_ASSERT_EQUALS(count, size * histogramCount);
@@ -78,9 +78,9 @@ public:
       for (MatrixWorkspace::const_iterator ti(*workspace, loopCount); ti != ti.end(); ++ti) {
         TS_ASSERT_THROWS_NOTHING(LocatedDataRef tr = *ti; int indexPosition = count % (size * histogramCount);
                                  int datablock = indexPosition / size; int blockindex = indexPosition % size;
-                                 TS_ASSERT_EQUALS(tr.X(), workspace->dataX(datablock)[blockindex]);
-                                 TS_ASSERT_EQUALS(tr.Y(), workspace->dataY(datablock)[blockindex]);
-                                 TS_ASSERT_EQUALS(tr.E(), workspace->dataE(datablock)[blockindex]);)
+                                 TS_ASSERT_EQUALS(tr.X(), workspace->x(datablock)[blockindex]);
+                                 TS_ASSERT_EQUALS(tr.Y(), workspace->y(datablock)[blockindex]);
+                                 TS_ASSERT_EQUALS(tr.E(), workspace->e(datablock)[blockindex]);)
         count++;
       }
       TS_ASSERT_EQUALS(count, size * histogramCount * loopCount);
@@ -123,9 +123,9 @@ public:
 
     int count = 0;
     for (MatrixWorkspace::const_iterator ti(*workspace); ti != ti.end(); ++ti) {
-      TS_ASSERT_THROWS_NOTHING(LocatedDataRef tr = *ti; TS_ASSERT_EQUALS(tr.X(), workspace->dataX(0)[count]);
-                               TS_ASSERT_EQUALS(tr.Y(), workspace->dataY(0)[count]);
-                               TS_ASSERT_EQUALS(tr.E(), workspace->dataE(0)[count]);)
+      TS_ASSERT_THROWS_NOTHING(LocatedDataRef tr = *ti; TS_ASSERT_EQUALS(tr.X(), workspace->x(0)[count]);
+                               TS_ASSERT_EQUALS(tr.Y(), workspace->y(0)[count]);
+                               TS_ASSERT_EQUALS(tr.E(), workspace->e(0)[count]);)
       count++;
     }
     TS_ASSERT_EQUALS(count, 1);
@@ -149,9 +149,9 @@ public:
       for (MatrixWorkspace::const_iterator ti(*workspace, loopCount); ti != ti.end(); ++ti) {
         TS_ASSERT_THROWS_NOTHING(LocatedDataRef tr = *ti; int indexPosition = count % (size * histogramCount);
                                  int datablock = indexPosition / size; int blockindex = indexPosition % size;
-                                 TS_ASSERT_EQUALS(tr.X(), workspace->dataX(datablock)[blockindex]);
-                                 TS_ASSERT_EQUALS(tr.Y(), workspace->dataY(datablock)[blockindex]);
-                                 TS_ASSERT_EQUALS(tr.E(), workspace->dataE(datablock)[blockindex]);)
+                                 TS_ASSERT_EQUALS(tr.X(), workspace->x(datablock)[blockindex]);
+                                 TS_ASSERT_EQUALS(tr.Y(), workspace->y(datablock)[blockindex]);
+                                 TS_ASSERT_EQUALS(tr.E(), workspace->e(datablock)[blockindex]);)
         count++;
       }
       TS_ASSERT_EQUALS(count, size * histogramCount * loopCount);

--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -105,7 +105,7 @@ public:
   void test_iterate_over_histogram_x_errors() {
     Histogram hist(Points{1.1, 1.2, 1.3}, Counts{5, 4, 6});
     hist.setPointStandardDeviations(PointStandardDeviations{0.1, 0.3, 0.5});
-    const auto dX = hist.dataDx();
+    const auto &dX = hist.dx();
     TS_ASSERT(std::equal(hist.begin(), hist.end(), dX.begin(),
                          [](const HistogramItem &item, const double &dx) { return item.centerError() == dx; }));
   }

--- a/Framework/LiveData/test/LoadLiveDataTest.h
+++ b/Framework/LiveData/test/LoadLiveDataTest.h
@@ -287,7 +287,7 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberEvents(), 200);
     // Check that rebin was called
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
-    TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
+    TS_ASSERT_DELTA(ws->x(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 2);
   }
 
@@ -299,7 +299,7 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 2);
     // Check that rebin was called
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
-    TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
+    TS_ASSERT_DELTA(ws->x(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 1);
     TS_ASSERT(ws->monitorWorkspace());
   }
@@ -321,7 +321,7 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(ws->getNumberEvents(), 200);
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
-    TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
+    TS_ASSERT_DELTA(ws->x(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 2);
   }
 
@@ -361,7 +361,7 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(ws->getNumberEvents(), 200);
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
-    TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
+    TS_ASSERT_DELTA(ws->x(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 2);
   }
 

--- a/Framework/LiveData/test/StartLiveDataTest.h
+++ b/Framework/LiveData/test/StartLiveDataTest.h
@@ -95,7 +95,7 @@ public:
     TS_ASSERT_EQUALS(ws->getNumberEvents(), 200);
     // Check that rebin was called
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
-    TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
+    TS_ASSERT_DELTA(ws->x(0)[0], 40e3, 1e-4);
   }
 
   //--------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -634,8 +634,8 @@ void ConvertCWPDMDToSpectra::scaleMatrixWorkspace(const API::MatrixWorkspace_spt
                                                   const double &infinitesimal) {
   size_t numspec = matrixws->getNumberHistograms();
   for (size_t iws = 0; iws < numspec; ++iws) {
-    MantidVec &datay = matrixws->dataY(iws);
-    MantidVec &datae = matrixws->dataE(iws);
+    auto &datay = matrixws->mutableY(iws);
+    auto &datae = matrixws->mutableE(iws);
     size_t numelements = datay.size();
     for (size_t i = 0; i < numelements; ++i) {
       // bin with zero counts is not scaled up

--- a/Framework/MDAlgorithms/test/FitMDTest.h
+++ b/Framework/MDAlgorithms/test/FitMDTest.h
@@ -130,8 +130,8 @@ public:
     ws2->initialize(10, 10, 10);
 
     for (size_t is = 0; is < ws2->getNumberHistograms(); ++is) {
-      Mantid::MantidVec &x = ws2->dataX(is);
-      Mantid::MantidVec &y = ws2->dataY(is);
+      auto &x = ws2->mutableX(is);
+      auto &y = ws2->mutableY(is);
       // Mantid::MantidVec& e = ws2->dataE(is);
       for (size_t i = 0; i < y.size(); ++i) {
         x[i] = 0.1 * static_cast<double>(i);

--- a/Framework/MDAlgorithms/test/IntegrateFluxTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateFluxTest.h
@@ -336,14 +336,14 @@ private:
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4, 101, 100);
     auto axis = ws->getAxis(0);
     axis->setUnit("Momentum");
-    auto &x = ws->dataX(0);
+    auto &x = ws->mutableX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
       *i = *(i - 1) + 0.3;
     }
     for (size_t spec = 0; spec != ws->getNumberHistograms(); ++spec) {
       ws->setBinEdges(spec, x);
-      auto &y = ws->dataY(spec);
+      auto &y = ws->mutableY(spec);
       for (auto j = y.begin(); j != y.end(); ++j) {
         auto i = std::distance(y.begin(), j);
         *j = double(2 * i) + 1.0;
@@ -356,7 +356,7 @@ private:
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4, 101, 100);
     auto axis = ws->getAxis(0);
     axis->setUnit("Momentum");
-    auto &x = ws->dataX(0);
+    auto &x = ws->mutableX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
       double tmp = *(i - 1);
@@ -364,7 +364,7 @@ private:
     }
     for (size_t spec = 0; spec != ws->getNumberHistograms(); ++spec) {
       ws->setBinEdges(spec, x);
-      auto &y = ws->dataY(spec);
+      auto &y = ws->mutableY(spec);
       for (auto j = y.begin(); j != y.end(); ++j) {
         auto i = std::distance(y.begin(), j);
         *j = double(2 * i) + 1.0;
@@ -377,14 +377,14 @@ private:
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4, 101, 100);
     auto axis = ws->getAxis(0);
     axis->setUnit("Momentum");
-    auto &x = ws->dataX(0);
+    auto &x = ws->mutableX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
       *i = *(i - 1) + 0.3;
     }
     for (size_t spec = 0; spec != ws->getNumberHistograms(); ++spec) {
       ws->setBinEdges(spec, x);
-      auto &y = ws->dataY(spec);
+      auto &y = ws->mutableY(spec);
       for (auto j = y.begin(); j != y.end(); ++j) {
         auto i = std::distance(y.begin(), j);
         *j = double(2 * i) + 1.0;
@@ -399,14 +399,14 @@ private:
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4, 100, 100);
     auto axis = ws->getAxis(0);
     axis->setUnit("Momentum");
-    auto &x = ws->dataX(0);
+    auto &x = ws->mutableX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
       *i = *(i - 1) + 0.3;
     }
     for (size_t spec = 0; spec != ws->getNumberHistograms(); ++spec) {
       ws->setPoints(spec, x);
-      auto &y = ws->dataY(spec);
+      auto &y = ws->mutableY(spec);
       for (auto j = y.begin(); j != y.end(); ++j) {
         auto i = std::distance(y.begin(), j);
         *j = 2 * x[i] + 1.0;
@@ -419,7 +419,7 @@ private:
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4, 100, 100);
     auto axis = ws->getAxis(0);
     axis->setUnit("Momentum");
-    auto &x = ws->dataX(0);
+    auto &x = ws->mutableX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
       double tmp = *(i - 1);
@@ -427,7 +427,7 @@ private:
     }
     for (size_t spec = 0; spec != ws->getNumberHistograms(); ++spec) {
       ws->setPoints(spec, x);
-      auto &y = ws->dataY(spec);
+      auto &y = ws->mutableY(spec);
       for (auto j = y.begin(); j != y.end(); ++j) {
         auto i = std::distance(y.begin(), j);
         *j = 2 * x[i] + 1.0;

--- a/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
+++ b/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
@@ -162,7 +162,7 @@ public:
     }
 
     // Let WS know that it is in TOF now (one column)
-    auto &T = ws2D->dataX(0);
+    auto &T = ws2D->mutableX(0);
 
     auto pAxis0 = std::make_unique<NumericAxis>(n_bins - 1);
     for (size_t i = 0; i < n_bins - 1; i++) {

--- a/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
@@ -269,7 +269,7 @@ class SaveNexusPD(mantid.api.PythonAlgorithm):
             for i in range(wksp.getNumberHistograms()):
                 if spectrum_info.hasDetectors(i) and spectrum_info.isMonitor(i):
                     continue  # skip monitor spectra
-                writeDx = not np.all(wksp.readDx(i) == 0)
+                writeDx = not np.all(wksp.dx(i) == 0)
 
                 dataname = "spectrum_%d" % wksp.getSpectrum(i).getSpectrumNo()
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLConvertToQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLConvertToQ.py
@@ -126,7 +126,7 @@ class ReflectometryILLConvertToQ(DataProcessorAlgorithm):
                 Formula="4*pi*{}/x".format(np.sin(theta0)),
                 AxisUnits="MomentumTransfer",
             )
-            theta_ws_in_q.setDx(0, ws.dx(0))
+            theta_ws_in_q.setSharedDx(0, ws.dx(0))
             theta_ws_in_q = self._to_point_data(theta_ws_in_q)
             theta_ws_in_q = self._group_points(theta_ws_in_q, "theta_")
             self._cleanup.cleanupLater(theta_ws_in_q)
@@ -319,7 +319,7 @@ class ReflectometryILLConvertToQ(DataProcessorAlgorithm):
         reflectivity_ws.setYUnit("Reflectivity")
         reflectivity_ws.setYUnitLabel("Reflectivity")
         # The X error data is lost in Divide.
-        reflectivity_ws.setDx(0, ws.dx(0))
+        reflectivity_ws.setSharedDx(0, ws.dx(0))
         self._cleanup.cleanup(ws)
         return reflectivity_ws
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegration.py
@@ -571,7 +571,7 @@ class SANSILLIntegration(PythonAlgorithm):
                 mid_x = (x[1:] + x[:-1]) / 2
                 res = self._deltaQ(mid_x)
             for i in range(mtd[ws].getNumberHistograms()):
-                mtd[ws].setDx(i, res)
+                mtd[ws].setSharedDx(i, res)
         return res
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSStitch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSStitch.py
@@ -515,7 +515,7 @@ class QErrorCorrectionForMergedWorkspaces(object):
         q_resolution = self._divide_q_resolution_by_counts(new_q_res, new_counts)
 
         # Set the dx error
-        output_ws.setDx(0, q_resolution)
+        output_ws.setSharedDx(0, q_resolution)
 
     def _comment(self, ws, message):
         comment = AlgorithmManager.createUnmanaged("Comment")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SavePlot1DAsJsonTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SavePlot1DAsJsonTest.py
@@ -123,7 +123,7 @@ class SavePlot1DAsJsonTest(unittest.TestCase):
         err = intensity**0.5
         # create workspace
         dataws = api.CreateWorkspace(DataX=Q, DataY=intensity, DataE=err, NSpec=1, UnitX="Momentum")
-        dataws.setDx(0, dQ)
+        dataws.setSharedDx(0, dQ)
         # Add to data service
         AnalysisDataService.addOrReplace(datawsname, dataws)
         return Q, intensity, err, dQ

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSStitchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSStitchTest.py
@@ -803,7 +803,7 @@ class TestQErrorCorrectionForMergedWorkspaces(unittest.TestCase):
         if use_xerror:
             for hists in range(0, nspec):
                 x_error_array = np.asarray(x_error)
-                ws.setDx(hists, x_error_array)
+                ws.setSharedDx(hists, x_error_array)
         return ws
 
     def test_error_is_ignored_for_more_than_one_spectrum(self):

--- a/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne2.cpp
@@ -990,7 +990,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::sumInQ(const MatrixWorkspace_sp
   const size_t numGroups = detectorGroups().size();
   for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
     auto &detectors = detectorGroups()[groupIdx];
-    auto &outputE = IvsLam->dataE(groupIdx);
+    auto &outputE = IvsLam->mutableE(groupIdx);
 
     // Loop through each spectrum in the detector group
     for (auto spIdx : detectors) {
@@ -1094,8 +1094,8 @@ void ReflectometryReductionOne2::sumInQShareCounts(const double inputCounts, con
                                                    const size_t outSpecIdx, const MatrixWorkspace_sptr &IvsLam,
                                                    std::vector<double> &outputE) {
   // Check that we have histogram data
-  const auto &outputX = IvsLam->dataX(outSpecIdx);
-  auto &outputY = IvsLam->dataY(outSpecIdx);
+  const auto &outputX = IvsLam->x(outSpecIdx);
+  auto &outputY = IvsLam->mutableY(outSpecIdx);
   if (outputX.size() != outputY.size() + 1) {
     throw std::runtime_error("Expected output array to be histogram data (got X len=" + std::to_string(outputX.size()) +
                              ", Y len=" + std::to_string(outputY.size()) + ")");

--- a/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOne3.cpp
@@ -851,7 +851,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne3::sumInQ(const MatrixWorkspace_sp
   const size_t numGroups = detectorGroups().size();
   for (size_t groupIdx = 0; groupIdx < numGroups; ++groupIdx) {
     auto &detectors = detectorGroups()[groupIdx];
-    auto &outputE = IvsLam->dataE(groupIdx);
+    auto &outputE = IvsLam->mutableE(groupIdx);
 
     // Loop through each spectrum in the detector group
     for (auto spIdx : detectors) {
@@ -955,8 +955,8 @@ void ReflectometryReductionOne3::sumInQShareCounts(const double inputCounts, con
                                                    const size_t outSpecIdx, const MatrixWorkspace_sptr &IvsLam,
                                                    std::vector<double> &outputE) {
   // Check that we have histogram data
-  const auto &outputX = IvsLam->dataX(outSpecIdx);
-  auto &outputY = IvsLam->dataY(outSpecIdx);
+  const auto &outputX = IvsLam->x(outSpecIdx);
+  auto &outputY = IvsLam->mutableY(outSpecIdx);
   if (outputX.size() != outputY.size() + 1) {
     throw std::runtime_error("Expected output array to be histogram data (got X len=" + std::to_string(outputX.size()) +
                              ", Y len=" + std::to_string(outputY.size()) + ")");

--- a/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -286,7 +286,7 @@ double PoldiPeakSearch::getFWHMEstimate(const MantidVec::const_iterator &baseLis
  * @param error :: Error that is set on the workspace.
  */
 void PoldiPeakSearch::setErrorsOnWorkspace(const Workspace2D_sptr &correlationWorkspace, double error) const {
-  MantidVec &errors = correlationWorkspace->dataE(0);
+  auto &errors = correlationWorkspace->mutableE(0);
 
   std::fill(errors.begin(), errors.end(), error);
 }

--- a/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
+++ b/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
@@ -301,8 +301,8 @@ private:
 
     // put it into a workspace
     Workspace2D_sptr ws = WorkspaceCreationHelper::create1DWorkspaceConstant(50, 0.0, 1.0, false);
-    std::vector<double> &x = ws->dataX(0);
-    std::vector<double> &y = ws->dataY(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
 
     for (size_t i = 0; i < x.size(); ++i) {
       x[i] = domain[i];

--- a/Framework/WorkflowAlgorithms/src/EQSANSDarkCurrentSubtraction2.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSDarkCurrentSubtraction2.cpp
@@ -209,8 +209,8 @@ void EQSANSDarkCurrentSubtraction2::exec() {
     Mantid::HistogramData::HistogramY const &YDarkValues = scaledDarkWS->y(i);
     Mantid::HistogramData::HistogramE const &YDarkErrors = scaledDarkWS->e(i);
     Mantid::HistogramData::HistogramX const &XValues = inputWS->x(i);
-    MantidVec &YValues = inputWS->dataY(i);
-    MantidVec &YErrors = inputWS->dataE(i);
+    auto &YValues = inputWS->mutableY(i);
+    auto &YErrors = inputWS->mutableE(i);
     for (int j = 0; j < nBins; j++) {
       double bin_scale = (XValues[j + 1] - XValues[j]) / (XValues[nBins] - XValues[0]);
       YValues[j] -= YDarkValues[0] * bin_scale;

--- a/Framework/WorkflowAlgorithms/src/EQSANSPatchSensitivity.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSPatchSensitivity.cpp
@@ -106,8 +106,8 @@ void EQSANSPatchSensitivity::exec() {
           g_log.warning() << "Spectrum " << patched_id << " has no detector, skipping (not clearing mask)\n";
           continue;
         }
-        MantidVec &YValues = inputWS->dataY(patched_id);
-        MantidVec &YErrors = inputWS->dataE(patched_id);
+        auto &YValues = inputWS->mutableY(patched_id);
+        auto &YErrors = inputWS->mutableE(patched_id);
         if (useRegression) {
           YValues[0] = alpha + beta * inSpectrumInfo.position(patched_id).Y();
           YErrors[0] = error;

--- a/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
@@ -73,10 +73,10 @@ void EQSANSQ2D::exec() {
   double wavelength_min = 0.0;
   if (inputWS->run().hasProperty("wavelength_min"))
     wavelength_min = getRunProperty(inputWS, "wavelength_min");
-  else if (inputWS->dataX(0).size() > 1)
-    wavelength_min = (inputWS->dataX(1)[0] + inputWS->dataX(1)[1]) / 2.0;
-  else if (inputWS->dataX(0).size() == 1)
-    wavelength_min = inputWS->dataX(1)[0];
+  else if (inputWS->x(0).size() > 1)
+    wavelength_min = (inputWS->x(1)[0] + inputWS->x(1)[1]) / 2.0;
+  else if (inputWS->x(0).size() == 1)
+    wavelength_min = inputWS->x(1)[0];
   else {
     g_log.error("Can't determine the minimum wavelength for the input workspace.");
     throw std::invalid_argument("Can't determine the minimum wavelength for the input workspace.");

--- a/Framework/WorkflowAlgorithms/src/HFIRDarkCurrentSubtraction.cpp
+++ b/Framework/WorkflowAlgorithms/src/HFIRDarkCurrentSubtraction.cpp
@@ -127,7 +127,7 @@ void HFIRDarkCurrentSubtraction::exec() {
   MatrixWorkspace_sptr scaledDarkWS = scaleAlg->getProperty("OutputWorkspace");
 
   // Zero out timer and monitor so that we don't subtract them out
-  for (size_t i = 0; i < scaledDarkWS->dataY(0).size(); i++) {
+  for (size_t i = 0; i < scaledDarkWS->y(0).size(); i++) {
     scaledDarkWS->mutableY(DEFAULT_TIMER_ID)[i] = 0.0;
     scaledDarkWS->mutableE(DEFAULT_TIMER_ID)[i] = 0.0;
     scaledDarkWS->mutableY(DEFAULT_MONITOR_ID)[i] = 0.0;
@@ -155,7 +155,7 @@ double HFIRDarkCurrentSubtraction::getCountingTime(const MatrixWorkspace_sptr &i
   } else {
     // If we don't have the information in the log, use the default timer
     // spectrum
-    const MantidVec &timer = inputWS->dataY(DEFAULT_TIMER_ID);
+    const auto &timer = inputWS->y(DEFAULT_TIMER_ID);
     return timer[0];
   }
 }

--- a/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
+++ b/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
@@ -614,9 +614,9 @@ private:
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(3, 3);
 
     for (size_t i = 0; i < ws->getNumberHistograms(); i++) {
-      auto &x = ws->dataX(i);
-      auto &y = ws->dataY(i);
-      auto &e = ws->dataE(i);
+      auto &x = ws->mutableX(i);
+      auto &y = ws->mutableY(i);
+      auto &e = ws->mutableE(i);
 
       const size_t numBins = y.size();
       for (size_t j = 0; j < numBins; j++) {

--- a/Framework/WorkflowAlgorithms/test/SANSSolidAngleCorrectionTest.h
+++ b/Framework/WorkflowAlgorithms/test/SANSSolidAngleCorrectionTest.h
@@ -87,7 +87,7 @@ public:
     double ix = (int)((i - nmon) / 192);
     double r = sqrt(1.0 + 5.15 * 5.15 / 6000 / 6000 * ((ix - 16.0) * (ix - 16.0) + (iy - 95.0) * (iy - 95.0)));
     double corr = r * r * r;
-    double ratio = ws2d_out->dataY(130 + nmon)[0] / ws2d_in->dataY(130 + nmon)[0];
+    double ratio = ws2d_out->y(130 + nmon)[0] / ws2d_in->y(130 + nmon)[0];
 
     double tolerance(1e-03);
     TS_ASSERT_DELTA(ratio, corr, tolerance);

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -999,7 +999,7 @@ class TestInstrumentGeometryCounts(_FunctionalTestBase):
         grouping_ws = CreateGroupingWorkspace(InputWorkspace=sim, FixedGroupCount=2, OutputWorkspace="__texplan_test_poldi_grp")[0]
         n_hist = grouping_ws.getNumberHistograms()
         for i in range(n_hist):
-            grouping_ws.dataY(i)[0] = 1.0 if i < n_hist // 2 else 2.0
+            grouping_ws.mutableY(i)[0] = 1.0 if i < n_hist // 2 else 2.0
         grouping_path = os.path.join(self._tmpdir, "poldi_grouping.xml")
         SaveDetectorsGrouping(InputWorkspace=grouping_ws, OutputFile=grouping_path)
 

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1883,7 +1883,7 @@ def correct_q_resolution_for_merged(count_ws_front, count_ws_rear, output_ws, sc
     q_resolution = divide_q_resolution_by_counts(new_q_res, new_counts)
 
     # Set the dx error
-    output_ws.setDx(0, q_resolution)
+    output_ws.setSharedDx(0, q_resolution)
 
 
 class MeasurementTimeFromNexusFileExtractor(object):

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -614,8 +614,8 @@ class CanSubtraction(ReductionStep):
         """
         if not original_ws.hasDx(0):
             return
-        for index in range(0, original_ws.getNumHistograms()):
-            subtracted_ws.setDx(index, original_ws.dataDX(index))
+        for index in range(0, original_ws.getNumberHistograms()):
+            subtracted_ws.setSharedDx(index, original_ws.dx(index))
 
 
 class Mask_ISIS(ReductionStep):

--- a/scripts/SANS/sans/algorithm_detail/single_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/single_execution.py
@@ -274,7 +274,7 @@ def correct_q_resolution_for_can(sample_workspace, can_workspace, subtracted_wor
     """
     _ = can_workspace
     if sample_workspace.getNumberHistograms() == 1 and sample_workspace.hasDx(0):
-        subtracted_workspace.setDx(0, sample_workspace.dx(0))
+        subtracted_workspace.setSharedDx(0, sample_workspace.dx(0))
 
 
 def get_merge_bundle_for_merge_request(completed_slices: CompletedSlices, parent_alg):

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -144,7 +144,7 @@ def provide_workspace_with_x_errors(
         ws = mtd[workspace_name]
         for hists in range(0, nspec):
             x_error_array = np.asarray(x_error)
-            ws.setDx(hists, x_error_array)
+            ws.setSharedDx(hists, x_error_array)
 
 
 # This test does not pass and was not used before 1/4/2015. SansUtilitytests was disabled.


### PR DESCRIPTION
### Description of work

Several other PRs worked through the Histogram 2.0 migration.

The hardest migration was `dataX()`.  There are two methods: one returns a `const&` and the other a mutable `&`.  Which one to use depends on context, if the vector was being altered or not.

Since changing `dataX()` --> `x()` would produce a loud compiler error if it was meant to be mutated, they were all put as `x` and then changed to `mutableX()` if needed.  This helped prevent silent performance regressions.

All of the changes in this PR should be obviously mechanical.

### To test:
This is a refactor.

Make sure all unit tests pass.

This does not require release notes because it is an internal refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
