### PR TITLE
Live-update the line plot as the shape moves

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/InstrumentViewer/New_features/41980.rst
+++ b/docs/source/release/v7.0.0/Workbench/InstrumentViewer/New_features/41980.rst
@@ -1,0 +1,1 @@
+- In the new Instrument View, the line plot now updates to show the spectra covered by an overlaid ROI or mask shape, and follows the shape as it is dragged, resized, rotated or as the projection is zoomed.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -52,6 +52,7 @@ class FullInstrumentViewModel:
     _source_position = np.array([0, 0, 0])
     _beam_axis = np.array([0, 0, 1])
     line_plot_workspace = None
+    line_plot_det_ids = np.array([], dtype=int)
     _lineplot_ws_in_base_units_not_summed = None
     _lineplot_ws_in_selected_units_not_summed = None
     _line_plot_workspace = None
@@ -599,7 +600,10 @@ class FullInstrumentViewModel:
         wrapped_workspaces = [
             WorkspaceDetectorPeaks(ws_name, self.get_integration_units(), self._integration_limits) for ws_name in selected_peaks_workspaces
         ]
-        peaks_by_pws = [wws.get_x_values_and_labels(self.picked_detector_ids) for wws in wrapped_workspaces]
+        # Key off the detectors actually plotted rather than the picked selection: they differ
+        # when the plot is previewing an overlaid shape or a hovered detector, and the x-position
+        # lookup below can only resolve detectors present in the extracted line plot workspace.
+        peaks_by_pws = [wws.get_x_values_and_labels(self.line_plot_det_ids) for wws in wrapped_workspaces]
         labels_by_pws = [[p.label for p in peaks] for peaks in peaks_by_pws]
         # Convert peak units to currently plotted units
         # NOTE: Need to get x coords in workspace unit for better acuracy

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -82,6 +82,9 @@ class FullInstrumentViewPresenter:
         self._interactor_styles = InteractorStyles(self._view.main_plotter, picking_callback=lambda: None, hover_callback=lambda: None)
         self._last_hovered_point_index: Optional[int] = None
         self._select_bank_tube = False
+        self._shape_preview_active = False
+        # Incremented per requested shape update so the worker can drop superseded ones
+        self._shape_update_generation = 0
         self._callback_queue = Queue()
         self._callback_stop_sentinel = object()
         self._callback_thread = Thread(None, self._callback_worker, daemon=True)
@@ -454,6 +457,57 @@ class FullInstrumentViewPresenter:
     def on_overlaid_shape_removed(self) -> None:
         self._update_interactor_style()
         self._view.set_add_selection_and_mask_buttons_enabled(False)
+        if not self._shape_preview_active:
+            return
+        # The preview replaced the plot of the committed selection, so put that back
+        self._shape_preview_active = False
+        self._update_line_plot_ws_and_draw(self._view.current_selected_lineplot_unit())
+
+    def on_shape_changed(self) -> None:
+        """Live-update the line plot with the spectra covered by the overlaid shape.
+
+        Called on the Qt thread when a shape is first drawn, and again by the shape overlay
+        manager each time it is dragged, resized or rotated, so the plot always shows what
+        would be committed by Add ROI / Add Mask.
+        """
+        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        # Projection uses VTK, so must be done on the Qt thread before queueing the rest
+        self._view.project_and_cache_detector_points(centres)
+        self._shape_update_generation += 1
+        self._callback_queue.put((self._on_shape_changed, (centres, self._shape_update_generation)))
+
+    def on_camera_changed(self) -> None:
+        """Keep the line plot in step with the overlaid shape when the view is zoomed.
+
+        The shape is drawn in fixed screen coordinates, so zooming moves the instrument
+        underneath it and changes which detectors it covers.
+        """
+        if not self._view.is_active_current_overlaid_shape():
+            return
+        self.on_shape_changed()
+
+    def _on_shape_changed(self, centres: np.ndarray, generation: int) -> None:
+        if generation != self._shape_update_generation:
+            # A newer update has been requested since this one was queued (e.g. a burst of
+            # mouse-wheel zooms), so this result would be thrown away anyway
+            return
+        if not self._view.is_active_current_overlaid_shape():
+            # Shape was removed before this queued update ran, so there is nothing to preview
+            return
+        mask = self._view.get_shape_mask(centres)
+        if self._select_bank_tube:
+            mask = self._model.expand_pickable_mask_to_parent_subtrees(mask)
+
+        self._shape_preview_active = True
+        self._model.extract_spectra_for_line_plot(
+            self._view.current_selected_lineplot_unit(), self._view.sum_spectra_selected(), np.flatnonzero(mask)
+        )
+        self._view.show_plot_for_detectors(self._model.line_plot_workspace, self._model.lineplot_limits)
+        # A shape typically covers far too many detectors for the per-detector info to be useful
+        self._view.set_selected_detector_info([])
+        self._view.set_relative_detector_angle(None)
+        # Peak overlays annotate the plotted spectra, so they have to follow the shape as well
+        self.refresh_lineplot_peaks()
 
     def _on_add_item_clicked(self) -> None:
         centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
@@ -766,7 +820,10 @@ class FullInstrumentViewPresenter:
         )
 
         self._interactor_styles = InteractorStyles(
-            self._view.main_plotter, picking_callback=wrapped_picking_callback, hover_callback=wrapped_hover_callback
+            self._view.main_plotter,
+            picking_callback=wrapped_picking_callback,
+            hover_callback=wrapped_hover_callback,
+            camera_changed_callback=self.on_camera_changed,
         )
         self._update_interactor_style()
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -85,6 +85,7 @@ class FullInstrumentViewPresenter:
         self._shape_preview_active = False
         # Incremented per requested shape update so the worker can drop superseded ones
         self._shape_update_generation = 0
+        self._sum_spectra_before_shape: Optional[bool] = None
         self._callback_queue = Queue()
         self._callback_stop_sentinel = object()
         self._callback_thread = Thread(None, self._callback_worker, daemon=True)
@@ -453,10 +454,18 @@ class FullInstrumentViewPresenter:
     def on_overlaid_shape_added(self) -> None:
         self._update_interactor_style()
         self._view.set_add_selection_and_mask_buttons_enabled(True)
+        if self._sum_spectra_before_shape is None:
+            self._sum_spectra_before_shape = self._view.sum_spectra_selected()
+        self._view.set_sum_spectra_selected(True)
+        self._view.set_sum_spectra_checkbox_disabled(True)
 
     def on_overlaid_shape_removed(self) -> None:
         self._update_interactor_style()
         self._view.set_add_selection_and_mask_buttons_enabled(False)
+        if self._sum_spectra_before_shape is not None:
+            self._view.set_sum_spectra_selected(self._sum_spectra_before_shape)
+            self._sum_spectra_before_shape = None
+            self._view.set_sum_spectra_checkbox_disabled(False)
         # Retire the generation so any queued or part-way-through preview update is discarded
         # instead of drawing a preview for a shape that no longer exists
         self._shape_update_generation += 1

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -457,9 +457,14 @@ class FullInstrumentViewPresenter:
     def on_overlaid_shape_removed(self) -> None:
         self._update_interactor_style()
         self._view.set_add_selection_and_mask_buttons_enabled(False)
+        # Retire the generation so any queued or part-way-through preview update is discarded
+        # instead of drawing a preview for a shape that no longer exists
+        self._shape_update_generation += 1
         if not self._shape_preview_active:
             return
-        # The preview replaced the plot of the committed selection, so put that back
+        self._callback_queue.put((self._restore_committed_line_plot, ()))
+
+    def _restore_committed_line_plot(self) -> None:
         self._shape_preview_active = False
         self._update_line_plot_ws_and_draw(self._view.current_selected_lineplot_unit())
 
@@ -486,22 +491,30 @@ class FullInstrumentViewPresenter:
             return
         self.on_shape_changed()
 
+    def _is_current_shape_update(self, generation: int) -> bool:
+        """Whether a queued shape preview update is still the one that should be shown.
+
+        It is superseded either by a newer update (e.g. a burst of mouse-wheel zooms) or by the
+        shape being removed, both of which retire the generation it was queued with.
+        """
+        return generation == self._shape_update_generation and self._view.is_active_current_overlaid_shape()
+
     def _on_shape_changed(self, centres: np.ndarray, generation: int) -> None:
-        if generation != self._shape_update_generation:
-            # A newer update has been requested since this one was queued (e.g. a burst of
-            # mouse-wheel zooms), so this result would be thrown away anyway
-            return
-        if not self._view.is_active_current_overlaid_shape():
-            # Shape was removed before this queued update ran, so there is nothing to preview
+        if not self._is_current_shape_update(generation):
             return
         mask = self._view.get_shape_mask(centres)
         if self._select_bank_tube:
             mask = self._model.expand_pickable_mask_to_parent_subtrees(mask)
 
-        self._shape_preview_active = True
         self._model.extract_spectra_for_line_plot(
             self._view.current_selected_lineplot_unit(), self._view.sum_spectra_selected(), np.flatnonzero(mask)
         )
+        if not self._is_current_shape_update(generation):
+            # Extracting takes long enough for the shape to be removed or moved again meanwhile,
+            # and drawing now would put back a preview that has already been superseded
+            return
+
+        self._shape_preview_active = True
         self._view.show_plot_for_detectors(self._model.line_plot_workspace, self._model.lineplot_limits)
         # A shape typically covers far too many detectors for the per-detector info to be useful
         self._view.set_selected_detector_info([])

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -841,6 +841,9 @@ class FullInstrumentViewView(QWidget):
     def set_sum_spectra_checkbox_disabled(self, disabled):
         self._sum_spectra_checkbox.setDisabled(disabled)
 
+    def set_sum_spectra_selected(self, selected: bool) -> None:
+        self._sum_spectra_checkbox.setChecked(selected)
+
     def set_select_bank_tube_disabled(self, disabled):
         self._select_bank_tube.setDisabled(disabled)
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -28,7 +28,7 @@ from qtpy.QtWidgets import (
     QFrame,
 )
 from qtpy.QtGui import QDoubleValidator, QDragEnterEvent, QDropEvent, QDragMoveEvent, QColor, QPalette, QPixmap, QIcon, QPainter
-from qtpy.QtCore import Qt, QEvent, QSize
+from qtpy.QtCore import Qt, QEvent, QSize, QMetaObject
 from qtpy.QtWidgets import QFileDialog
 from superqt import QDoubleRangeSlider
 from pyvistaqt import BackgroundPlotter
@@ -229,6 +229,7 @@ class FullInstrumentViewView(QWidget):
         self._last_camera_position = None
         self._last_parallel_scale = None
         self._detector_spectrum_fig = None
+        self._line_edit_connections: dict[QLineEdit, QMetaObject.Connection] = {}
 
         self._create_main_widgets()
         self._set_layouts()
@@ -524,10 +525,8 @@ class FullInstrumentViewView(QWidget):
         """Closes view, not window"""
         self._closing = True
         with suppress(TypeError):
-            self._contour_range_max_edit.disconnect()
-            self._contour_range_min_edit.disconnect()
-            self._integration_limit_max_edit.disconnect()
-            self._integration_limit_min_edit.disconnect()
+            for line_edit in self._line_edit_connections:
+                line_edit.disconnect(self._line_edit_connections[line_edit])
         # Shut down any callbacks before closing the plotter and the figure
         if hasattr(self, "_presenter") and self._presenter is not None:
             self._presenter.handle_close()
@@ -685,8 +684,8 @@ class FullInstrumentViewView(QWidget):
 
         # Connections to sync sliders and edits
         slider.valueChanged.connect(lambda lims: self._set_min_max_edit_boxes(min_edit, max_edit, lims))
-        min_edit.editingFinished.connect(set_slider(callled_from_min=True))
-        max_edit.editingFinished.connect(set_slider(callled_from_min=False))
+        self._line_edit_connections[min_edit] = min_edit.editingFinished.connect(set_slider(callled_from_min=True))
+        self._line_edit_connections[max_edit] = max_edit.editingFinished.connect(set_slider(callled_from_min=False))
 
     def _add_detector_info_boxes(self, parent_box: QVBoxLayout, label: str) -> QTextEdit:
         """Adds a text box to the given parent that is designed to show read-only information about the selected detector"""

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -86,6 +86,7 @@ def _ensure_overlay_manager(method):
         shape = method(self, *args, **kwargs)
         self._shape_overlay_manager.set_shape(shape)
         self._presenter.on_overlaid_shape_added()
+        self._register_shape_changed_callback()
 
     return wrapper
 
@@ -983,6 +984,18 @@ class FullInstrumentViewView(QWidget):
     def enable_parallel_projection(self) -> None:
         self.main_plotter.view_xy()
         self.main_plotter.enable_parallel_projection()
+
+    def _register_shape_changed_callback(self) -> None:
+        """Make the line plot follow the overlaid shape.
+
+        The overlay manager fires the callback whenever the shape is dragged, resized or
+        rotated. It is also called once here so the plot reflects the shape where it is
+        first drawn.
+        """
+        if self._shape_overlay_manager is None:
+            return
+        self._shape_overlay_manager.set_on_shape_changed(self._presenter.on_shape_changed)
+        self._presenter.on_shape_changed()
 
     @_ensure_overlay_manager
     def add_circle_widget(self) -> None:

--- a/qt/python/instrumentview/instrumentview/InteractorStyles.py
+++ b/qt/python/instrumentview/instrumentview/InteractorStyles.py
@@ -3,6 +3,8 @@ from vtkmodules.vtkInteractionStyle import vtkInteractorStyleUser, vtkInteractor
 from vtkmodules.vtkCommonCore import vtkCommand
 import numpy as np
 
+from mantid.kernel import logger
+
 
 class _PlotterWrapper:
     """Wrapper to provide PyVista-compatible interface for picking."""
@@ -13,7 +15,7 @@ class _PlotterWrapper:
 
 
 class InteractorStyles:
-    def __init__(self, plotter, picking_callback, hover_callback):
+    def __init__(self, plotter, picking_callback, hover_callback, camera_changed_callback: Callable | None = None):
         self.SCROLL_ZOOM_WITH_PICKING = CursorZoomInteractorStyle(plotter)
         self.SCROLL_ZOOM_WITH_HOVER = CursorZoomInteractorStyle(plotter)
         self.SCROLL_ZOOM_NO_PICKING = CursorZoomInteractorStyle(plotter)
@@ -23,6 +25,9 @@ class InteractorStyles:
         self.TRACKBALL.set_picking_callback(picking_callback)
         self.SCROLL_ZOOM_WITH_PICKING.set_picking_callback(picking_callback)
         self.SCROLL_ZOOM_WITH_HOVER.set_hover_callback(hover_callback)
+
+        for style in (self.SCROLL_ZOOM_WITH_PICKING, self.SCROLL_ZOOM_WITH_HOVER, self.SCROLL_ZOOM_NO_PICKING):
+            style.set_camera_changed_callback(camera_changed_callback)
 
 
 class RubberBandZoomInteractorStyle(vtkInteractorStyleRubberBandZoom):
@@ -68,6 +73,7 @@ class CursorZoomInteractorStyle(vtkInteractorStyleUser):
         # Cache the current world coordinates under the cursor
         self._cursor_world_pos = None
         self._zoom_in_progress = False
+        self._camera_changed_callback = None
 
         # Setup plotter
         self.plotter.track_mouse_position()
@@ -76,7 +82,23 @@ class CursorZoomInteractorStyle(vtkInteractorStyleUser):
         self.AddObserver(vtkCommand.MouseMoveEvent, self._on_mouse_move)
         self.AddObserver(vtkCommand.MouseWheelForwardEvent, self._on_wheel_forward)
         self.AddObserver(vtkCommand.MouseWheelBackwardEvent, self._on_wheel_backward)
-        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self._reset_camera())
+        self.AddObserver(vtkCommand.RightButtonPressEvent, lambda *_: self._reset_camera_and_notify())
+
+    def set_camera_changed_callback(self, camera_changed_callback: Callable | None):
+        """Register a zero-argument callable fired after this style has moved the camera.
+
+        Anything drawn in fixed screen coordinates (e.g. an overlaid selection shape) covers a
+        different part of the instrument once the view is zoomed, so it needs to be told.
+        """
+        self._camera_changed_callback = camera_changed_callback
+
+    def _notify_camera_changed(self):
+        if self._camera_changed_callback is None:
+            return
+        try:
+            self._camera_changed_callback()
+        except Exception as ex:
+            logger.debug(f"Exception in camera_changed callback: {ex}")
 
     def set_picking_callback(self, picking_callback: Callable):
         self.RemoveObservers(vtkCommand.LeftButtonPressEvent)
@@ -160,6 +182,8 @@ class CursorZoomInteractorStyle(vtkInteractorStyleUser):
 
         renderer.reset_camera_clipping_range()
         self.plotter.render_window.Render()
+        # Covers both branches above, so a zoom-out past the default notifies only once
+        self._notify_camera_changed()
 
     def _reset_camera(self):
         renderer = self.plotter.renderer
@@ -169,6 +193,10 @@ class CursorZoomInteractorStyle(vtkInteractorStyleUser):
         camera.parallel_scale = self._default_parallel_scale
         renderer.reset_camera_clipping_range()
         self.plotter.render_window.Render()
+
+    def _reset_camera_and_notify(self):
+        self._reset_camera()
+        self._notify_camera_changed()
 
     def update_default_camera_state(self):
         """Re-cache the current camera state as the default (right-click reset) state.

--- a/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewView.py
+++ b/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewView.py
@@ -73,6 +73,11 @@ class ALFInstrumentViewView(FullInstrumentViewView):
             self.delete_current_overlaid_shape()
             return
         self.add_rectangular_widget()
+
+    # ALF drives its tube selection from the rectangle rather than showing the base class's
+    # line-plot-only preview, so it registers its own callback here instead.
+    @override
+    def _register_shape_changed_callback(self) -> None:
         if self._shape_overlay_manager is None:
             return
         self._shape_overlay_manager.set_on_shape_changed(self._presenter.on_roi_shape_changed)

--- a/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
+++ b/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
@@ -130,6 +130,45 @@ class TestCursorZoomInteractorStyle(unittest.TestCase):
         self.assertEqual(plotter.renderer.camera.position, [7, 8, 9])
         self.assertAlmostEqual(plotter.renderer.camera.parallel_scale, 5.0)
 
+    def test_zoom_notifies_camera_changed(self):
+        style, plotter = self._create_style(parallel_scale=1.0)
+        callback = mock.MagicMock()
+        style.set_camera_changed_callback(callback)
+        style._cursor_world_pos = np.array([0.0, 0.0, 0.0])
+        with mock.patch("instrumentview.InteractorStyles._display_to_world", return_value=np.array([0.0, 0.0, 0.0])):
+            style._zoom(style.zoom_factor)
+        callback.assert_called_once()
+
+    def test_zoom_out_past_default_notifies_camera_changed_only_once(self):
+        style, plotter = self._create_style(position=(0, 0, 1), focal_point=(0, 0, 0), parallel_scale=1.0)
+        plotter.renderer.camera.parallel_scale = 0.9
+        callback = mock.MagicMock()
+        style.set_camera_changed_callback(callback)
+        style._cursor_world_pos = np.array([0.0, 0.0, 0.0])
+        with mock.patch("instrumentview.InteractorStyles._display_to_world", return_value=np.array([0.0, 0.0, 0.0])):
+            style._zoom(1.0 / style.zoom_factor)
+        callback.assert_called_once()
+
+    def test_zoom_does_not_notify_camera_changed_when_no_cursor_pos(self):
+        style, plotter = self._create_style()
+        callback = mock.MagicMock()
+        style.set_camera_changed_callback(callback)
+        style._cursor_world_pos = None
+        style._zoom(1.1)
+        callback.assert_not_called()
+
+    def test_reset_camera_and_notify_notifies_camera_changed(self):
+        style, plotter = self._create_style()
+        callback = mock.MagicMock()
+        style.set_camera_changed_callback(callback)
+        style._reset_camera_and_notify()
+        callback.assert_called_once()
+
+    def test_camera_changed_callback_exceptions_do_not_escape_into_vtk(self):
+        style, plotter = self._create_style()
+        style.set_camera_changed_callback(mock.MagicMock(side_effect=RuntimeError("boom")))
+        style._notify_camera_changed()
+
     def test_wheel_forward_calls_zoom_in(self):
         style, plotter = self._create_style()
         with mock.patch.object(style, "_zoom") as zoom_mock:

--- a/qt/python/instrumentview/instrumentview/test/test_model.py
+++ b/qt/python/instrumentview/instrumentview/test/test_model.py
@@ -1353,7 +1353,28 @@ class TestFullInstrumentViewModel(unittest.TestCase):
 
         model.get_peak_lineplot_overlay_arguments(["ws1"])
 
-        mock_wdp.get_x_values_and_labels.assert_called_once_with(model.picked_detector_ids)
+        mock_wdp.get_x_values_and_labels.assert_called_once_with(model.line_plot_det_ids)
+
+    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel._match_workspace_unit")
+    @mock.patch("instrumentview.FullInstrumentViewModel.AnalysisDataService")
+    @mock.patch("instrumentview.FullInstrumentViewModel.WorkspaceDetectorPeaks")
+    def test_get_peak_lineplot_overlay_arguments_follows_plotted_not_picked_detectors(self, mock_wdp_cls, mock_ads, mock_match_unit):
+        """The plot can preview an overlaid shape or hovered detector, in which case the peaks
+        must annotate what is plotted rather than the picked selection."""
+        model, _ = self._setup_model([1, 2, 3])
+        model._detector_is_picked = np.array([True, False, False])
+        model.line_plot_det_ids = np.array([2, 3])
+        model._lineplot_ws_in_base_units_not_summed = MagicMock()
+        model._lineplot_ws_in_selected_units_not_summed = MagicMock()
+        mock_ads.doesExist.return_value = True
+        mock_match_unit.side_effect = lambda ws_from, idx, x_from, ws_to: x_from
+        mock_wdp = MagicMock()
+        mock_wdp.get_x_values_and_labels.return_value = []
+        mock_wdp_cls.return_value = mock_wdp
+
+        model.get_peak_lineplot_overlay_arguments(["ws1"])
+
+        np.testing.assert_array_equal(np.array([2, 3]), mock_wdp.get_x_values_and_labels.call_args.args[0])
 
 
 if __name__ == "__main__":

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -425,6 +425,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter._update_line_plot_ws_and_draw = MagicMock()
 
         self._presenter.on_overlaid_shape_removed()
+        self._presenter._callback_queue.join()
 
         self._presenter._update_line_plot_ws_and_draw.assert_called_once()
         self.assertFalse(self._presenter._shape_preview_active)
@@ -433,8 +434,24 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter._update_line_plot_ws_and_draw = MagicMock()
 
         self._presenter.on_overlaid_shape_removed()
+        self._presenter._callback_queue.join()
 
         self._presenter._update_line_plot_ws_and_draw.assert_not_called()
+
+    def test_removing_shape_while_extracting_keeps_the_committed_line_plot(self):
+        """An extraction already in flight must not draw its preview over the restored plot."""
+        self._presenter._shape_preview_active = True
+        self._presenter._update_line_plot_ws_and_draw = MagicMock()
+        # Stand in for the shape being deleted part-way through the extraction on the worker
+        self._model.extract_spectra_for_line_plot = MagicMock(side_effect=lambda *_: self._presenter.on_overlaid_shape_removed())
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), self._presenter._shape_update_generation)
+        self._presenter._callback_queue.join()
+
+        self._model.extract_spectra_for_line_plot.assert_called_once()
+        self._mock_view.show_plot_for_detectors.assert_not_called()
+        self._presenter._update_line_plot_ws_and_draw.assert_called_once()
+        self.assertFalse(self._presenter._shape_preview_active)
 
     def test_on_add_item_projects_points_before_queueing(self):
         """on_add_item_clicked projects detector points on the main thread

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -328,6 +328,47 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.on_select_bank_tube_toggled(False)
         self.assertFalse(self._presenter._select_bank_tube)
 
+    def test_adding_a_shape_forces_summed_spectra(self):
+        """A shape covers too many detectors to plot individually, so the choice is taken away."""
+        self._mock_view.sum_spectra_selected.return_value = False
+
+        self._presenter.on_overlaid_shape_added()
+
+        self._mock_view.set_sum_spectra_selected.assert_called_once_with(True)
+        self._mock_view.set_sum_spectra_checkbox_disabled.assert_called_once_with(True)
+
+    def test_removing_a_shape_restores_the_users_sum_spectra_choice(self):
+        self._mock_view.sum_spectra_selected.return_value = False
+        self._presenter.on_overlaid_shape_added()
+        self._mock_view.reset_mock()
+
+        self._presenter.on_overlaid_shape_removed()
+        self._presenter._callback_queue.join()
+
+        self._mock_view.set_sum_spectra_selected.assert_called_once_with(False)
+        self._mock_view.set_sum_spectra_checkbox_disabled.assert_called_once_with(False)
+
+    def test_replacing_a_shape_remembers_the_original_sum_spectra_choice(self):
+        """Swapping shape type re-runs the added handler; it must not remember the forced value."""
+        self._mock_view.sum_spectra_selected.return_value = False
+        self._presenter.on_overlaid_shape_added()
+        self._mock_view.sum_spectra_selected.return_value = True
+        self._presenter.on_overlaid_shape_added()
+        self._mock_view.reset_mock()
+
+        self._presenter.on_overlaid_shape_removed()
+        self._presenter._callback_queue.join()
+
+        self._mock_view.set_sum_spectra_selected.assert_called_once_with(False)
+
+    def test_removing_a_shape_that_was_never_added_leaves_the_checkbox_alone(self):
+        """Deleting the shape is unconditional, so it must not re-enable a box hover pick disabled."""
+        self._presenter.on_overlaid_shape_removed()
+        self._presenter._callback_queue.join()
+
+        self._mock_view.set_sum_spectra_selected.assert_not_called()
+        self._mock_view.set_sum_spectra_checkbox_disabled.assert_not_called()
+
     def test_on_shape_changed_projects_points_before_queueing(self):
         """on_shape_changed projects detector points on the main thread before
         dispatching work to the background queue, because projection uses VTK."""

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -328,6 +328,114 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._presenter.on_select_bank_tube_toggled(False)
         self.assertFalse(self._presenter._select_bank_tube)
 
+    def test_on_shape_changed_projects_points_before_queueing(self):
+        """on_shape_changed projects detector points on the main thread before
+        dispatching work to the background queue, because projection uses VTK."""
+        self._presenter._callback_queue = MagicMock()
+        self._presenter.on_shape_changed()
+        self._mock_view.project_and_cache_detector_points.assert_called_once()
+        self._presenter._callback_queue.put.assert_called_once()
+
+    def test_on_shape_changed_plots_spectra_covered_by_the_shape(self):
+        n_hist = self._ws.getNumberHistograms()
+        mask = np.array([i < 3 for i in range(n_hist)])
+        self._mock_view.get_shape_mask.return_value = mask
+        self._mock_view.current_selected_lineplot_unit.return_value = "TOF"
+        self._mock_view.sum_spectra_selected.return_value = True
+        self._model.extract_spectra_for_line_plot = MagicMock()
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), self._presenter._shape_update_generation)
+
+        unit, sum_spectra = self._model.extract_spectra_for_line_plot.call_args.args[:2]
+        self.assertEqual("TOF", unit)
+        self.assertTrue(sum_spectra)
+        np.testing.assert_array_equal(np.flatnonzero(mask), self._model.extract_spectra_for_line_plot.call_args.args[2])
+        self._mock_view.show_plot_for_detectors.assert_called_once_with(self._model.line_plot_workspace, self._model.lineplot_limits)
+        self.assertTrue(self._presenter._shape_preview_active)
+
+    def test_on_shape_changed_refreshes_the_lineplot_peak_overlays(self):
+        """Peak lines from a previously picked detector must not linger over the shape's plot."""
+        n_hist = self._ws.getNumberHistograms()
+        self._mock_view.get_shape_mask.return_value = np.array([i < 3 for i in range(n_hist)])
+        self._model.extract_spectra_for_line_plot = MagicMock()
+        self._presenter.refresh_lineplot_peaks = MagicMock()
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), self._presenter._shape_update_generation)
+
+        self._presenter.refresh_lineplot_peaks.assert_called_once()
+
+    def test_on_shape_changed_select_bank_tube_expands_mask(self):
+        n_hist = self._ws.getNumberHistograms()
+        mask = np.array([i < 3 for i in range(n_hist)])
+        expanded = np.array([i < 5 for i in range(n_hist)])
+        self._mock_view.get_shape_mask.return_value = mask
+        self._presenter._select_bank_tube = True
+        self._model.expand_pickable_mask_to_parent_subtrees = MagicMock(return_value=expanded)
+        self._model.extract_spectra_for_line_plot = MagicMock()
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), self._presenter._shape_update_generation)
+
+        self._model.expand_pickable_mask_to_parent_subtrees.assert_called_once()
+        np.testing.assert_array_equal(np.flatnonzero(expanded), self._model.extract_spectra_for_line_plot.call_args.args[2])
+
+    def test_on_shape_changed_does_nothing_if_the_shape_has_already_been_removed(self):
+        self._mock_view.is_active_current_overlaid_shape.return_value = False
+        self._model.extract_spectra_for_line_plot = MagicMock()
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), self._presenter._shape_update_generation)
+
+        self._model.extract_spectra_for_line_plot.assert_not_called()
+        self.assertFalse(self._presenter._shape_preview_active)
+
+    def test_on_shape_changed_drops_updates_superseded_by_a_newer_one(self):
+        """A burst of zooms queues several updates; only the newest is worth running."""
+        self._model.extract_spectra_for_line_plot = MagicMock()
+        stale_generation = self._presenter._shape_update_generation
+        self._presenter._shape_update_generation += 1
+
+        self._presenter._on_shape_changed(np.array(self._model.detector_positions), stale_generation)
+
+        self._model.extract_spectra_for_line_plot.assert_not_called()
+
+    def test_zooming_updates_the_line_plot_while_a_shape_is_overlaid(self):
+        self._mock_view.is_active_current_overlaid_shape.return_value = True
+        self._presenter._callback_queue = MagicMock()
+
+        self._presenter.on_camera_changed()
+
+        self._mock_view.project_and_cache_detector_points.assert_called_once()
+        self._presenter._callback_queue.put.assert_called_once()
+
+    def test_zooming_does_nothing_when_no_shape_is_overlaid(self):
+        self._mock_view.is_active_current_overlaid_shape.return_value = False
+        self._presenter._callback_queue = MagicMock()
+
+        self._presenter.on_camera_changed()
+
+        self._mock_view.project_and_cache_detector_points.assert_not_called()
+        self._presenter._callback_queue.put.assert_not_called()
+
+    def test_reload_interactor_styles_wires_the_camera_changed_callback(self):
+        with mock.patch("instrumentview.FullInstrumentViewPresenter.InteractorStyles") as mock_styles:
+            self._presenter.reload_interactor_styles()
+        self.assertEqual(self._presenter.on_camera_changed, mock_styles.call_args.kwargs["camera_changed_callback"])
+
+    def test_removing_shape_restores_the_line_plot_for_the_committed_selection(self):
+        self._presenter._shape_preview_active = True
+        self._presenter._update_line_plot_ws_and_draw = MagicMock()
+
+        self._presenter.on_overlaid_shape_removed()
+
+        self._presenter._update_line_plot_ws_and_draw.assert_called_once()
+        self.assertFalse(self._presenter._shape_preview_active)
+
+    def test_removing_shape_leaves_the_line_plot_alone_when_no_preview_was_shown(self):
+        self._presenter._update_line_plot_ws_and_draw = MagicMock()
+
+        self._presenter.on_overlaid_shape_removed()
+
+        self._presenter._update_line_plot_ws_and_draw.assert_not_called()
+
     def test_on_add_item_projects_points_before_queueing(self):
         """on_add_item_clicked projects detector points on the main thread
         before dispatching work to the background queue."""

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -173,6 +173,14 @@ class TestFullInstrumentViewView(unittest.TestCase):
         self.assertIsNotNone(self._view._shape_overlay_manager)
         self.assertIsInstance(self._view._shape_overlay_manager.current_shape, HollowRectangleSelectionShape)
 
+    def test_adding_a_shape_registers_the_live_line_plot_callback(self) -> None:
+        self._view.add_circle_widget()
+        self.assertEqual(self._view._shape_overlay_manager._on_shape_changed, self._view._presenter.on_shape_changed)
+
+    def test_adding_a_shape_plots_the_spectra_it_covers_straight_away(self) -> None:
+        self._view.add_circle_widget()
+        self._view._presenter.on_shape_changed.assert_called_once()
+
     def test_add_selected_shape_uses_dropdown_choice(self) -> None:
         self._view._shape_selector_combo_box.setCurrentText("Ellipse")
         self._view.add_selected_shape(True)


### PR DESCRIPTION
In the new Instrument View, when a selection shape, e.g. a circle, is drawn on the projection, live-update the line plot with the sum of the spectra of the detectors contained within the shape. This will show the same line plot as if the user creates a ROI of interest, but they will be able to move the shape around, hence will preview the ROI.

Closes #41980. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Add a shape, move it around, zoom, add a peak overlay, try whatever you can find.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
