### PR TITLE
Fix nexus rank 1 load bug

### DIFF
--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -218,13 +218,13 @@ void LoadHelper::recurseAndAddNexusFieldsToWsRun(Nexus::File &filehandle, API::R
         case (NXnumtype::FLOAT32):
         case (NXnumtype::FLOAT64):
           // some 1d float arrays may be loaded
-          read_property = (nxinfo.dims[0] <= 9);
+          read_property = read_property && (nxinfo.dims[0] <= 9);
           break;
         case (NXnumtype::INT16):
         case (NXnumtype::INT32):
         case (NXnumtype::UINT16):
           // only read scalar values for everything else - e.g. integers
-          read_property = (nxinfo.dims.front() == 1);
+          read_property = read_property && (nxinfo.dims.front() == 1);
           break;
         default:
           read_property = false;

--- a/Framework/DataHandling/test/LoadILLReflectometryTest.h
+++ b/Framework/DataHandling/test/LoadILLReflectometryTest.h
@@ -328,6 +328,7 @@ public:
     MatrixWorkspace_sptr output;
     getWorkspaceFor(output, m_figaroDirectBeamFile, m_outWSName, emptyProperties());
     commonProperties(output, "FIGARO");
+    TS_ASSERT(!output->run().hasProperty("data.PSD_data_0"))
   }
 
   // Following tests are introduced after Nexus file changes.

--- a/docs/source/release/v7.0.0/Reflectometry/Bugfixes/41996.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/Bugfixes/41996.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the DataHandling library that caused files to become very large and extremely slow to load. This particulary effected the loading of processed FIGARO data.

--- a/docs/source/release/v7.0.0/Reflectometry/Bugfixes/figaro-multidimensional-data.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/Bugfixes/figaro-multidimensional-data.rst
@@ -1,1 +1,0 @@
-- Fixed loading processed FIGARO data creating hundreds of thousands of sample logs from multidimensional detector data, which caused files to become very large and extremely slow to reload.

--- a/docs/source/release/v7.0.0/Reflectometry/Bugfixes/figaro-multidimensional-data.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/Bugfixes/figaro-multidimensional-data.rst
@@ -1,0 +1,1 @@
+- Fixed loading processed FIGARO data creating hundreds of thousands of sample logs from multidimensional detector data, which caused files to become very large and extremely slow to reload.


### PR DESCRIPTION
### Description of work

Found this bug when making code changes that required updating of some ILL reference files.

The older ILL reference files take seconds to load, newly generated ones take so long mantid appears to hang.

This is because a regression has been introduced where we no longer check the rank of data arrays before building properties.

The rank criteria is here: https://github.com/mantidproject/mantid/blob/main/Framework/DataHandling/src/LoadHelper.cpp#L214

For `FLOAT64` and `UINT16`, the variable is overwritten here.
https://github.com/mantidproject/mantid/blob/main/Framework/DataHandling/src/LoadHelper.cpp#L221

Historically this was not the case:
https://github.com/mantidproject/mantid/blame/a82d7c0e77a16898300fdc1f62d0c23c9894ec98/Framework/DataHandling/src/LoadHelper.cpp#L183

For at least the Figaro instrument, this causes the data array to be read in as a property, leading to the creation of 250,000 + logs.

Upon reversion, the loading of newly generated processed ILL Figaro data sets is much, much faster. The loading of Figaro raw datasets also appears to be faster.

I'm not sure if this affects any other instrument, but this may speed up some system tests outside of `ILLReflAutoProcessTest`

Demonstrating the load of raw datasets, Before:
```
################################################################################
Total runtime: 00:01:26

100% tests passed, 0 tests failed out of 5 (0 skipped)
All tests passed? True
################################################################################
```

After:
```
################################################################################
Total runtime: 00:00:31

100% tests passed, 0 tests failed out of 5 (0 skipped)
All tests passed? True
################################################################################
```

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #xxxx. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run `ILLReflAutoProcessTest.py` before and after this change. Observe the speed increase.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
