### PR TITLE
Histogram 2.0 migration, use `span` to avoid `rawData`

### DIFF
--- a/Framework/API/inc/MantidAPI/BinEdgeAxis.h
+++ b/Framework/API/inc/MantidAPI/BinEdgeAxis.h
@@ -21,6 +21,9 @@ class MANTID_API_DLL BinEdgeAxis : public NumericAxis {
 public:
   BinEdgeAxis(const std::size_t &length);
   BinEdgeAxis(const std::vector<double> &edges);
+  /// Construct from a contiguous range, so that the size-checked histogram data types
+  /// can be used directly. A std::vector<double> argument still selects the overload above.
+  BinEdgeAxis(std::span<double const> edges);
 
   Axis *clone(const MatrixWorkspace *const parentWorkspace) override;
   Axis *clone(const std::size_t length, const MatrixWorkspace *const parentWorkspace) override;

--- a/Framework/API/inc/MantidAPI/FunctionDomain1D.h
+++ b/Framework/API/inc/MantidAPI/FunctionDomain1D.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/FunctionDomain.h"
 
+#include <span>
 #include <vector>
 
 namespace Mantid {
@@ -77,6 +78,9 @@ public:
   FunctionDomain1DVector(const double startX, const double endX, const size_t n);
   /// Constructor.
   FunctionDomain1DVector(const std::vector<double> &xvalues);
+  /// Constructor taking a contiguous range. Allows the size-checked histogram data
+  /// types, which do not hand out a std::vector<double>, to be used directly.
+  FunctionDomain1DVector(std::span<double const> xvalues);
   /// No-copy constructor.
   FunctionDomain1DVector(std::vector<double> &&xvalues);
   /// Constructor.

--- a/Framework/API/inc/MantidAPI/IEventList.h
+++ b/Framework/API/inc/MantidAPI/IEventList.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/DateAndTime.h"
 #include <functional>
+#include <span>
 
 namespace Mantid {
 namespace API {
@@ -45,16 +46,20 @@ public:
   virtual std::size_t getNumberEvents() const = 0;
   /// Get memory size of event list
   size_t getMemorySize() const override = 0;
-  /// Get copy of counts and errors, rebinned using on the given X values
-  virtual void generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError = false) const = 0;
+  /// Get copy of counts and errors, rebinned using on the given X values.
+  /// X is a span so that the size-checked HistogramData types can be passed without a
+  /// std::vector<double>; Y and E stay vectors because they are resized to match X.
+  virtual void generateHistogram(std::span<double const> X, MantidVec &Y, MantidVec &E,
+                                 bool skipError = false) const = 0;
   /// Get copy of counts and errors rebinned using the given X values w.r.t
   /// pulse time.
-  virtual void generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, MantidVec &E,
+  virtual void generateHistogramPulseTime(std::span<double const> X, MantidVec &Y, MantidVec &E,
                                           bool skipError = false) const = 0;
   /// Get copy of counts and errors rebinning using the given X values w.r.t
   /// absolute time at the sample.
-  virtual void generateHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, MantidVec &E, const double &tofFactor,
-                                             const double &tofOffset, bool skipError = false) const = 0;
+  virtual void generateHistogramTimeAtSample(std::span<double const> X, MantidVec &Y, MantidVec &E,
+                                             const double &tofFactor, const double &tofOffset,
+                                             bool skipError = false) const = 0;
   /// Integrate the event list
   virtual double integrate(const double minX, const double maxX, const bool entireRange) const = 0;
   /// Convert the TOF values
@@ -107,10 +112,11 @@ public:
   virtual void multiply(const double value, const double error = 0.0) = 0;
   /// Divide event list by a constant with error
   virtual void divide(const double value, const double error = 0.0) = 0;
-  /// Multiply event list by a histogram
-  virtual void multiply(const MantidVec &X, const MantidVec &Y, const MantidVec &E) = 0;
+  /// Multiply event list by a histogram. The histogram is taken as spans so that the
+  /// size-checked HistogramData types can be passed without a std::vector<double>.
+  virtual void multiply(std::span<double const> X, std::span<double const> Y, std::span<double const> E) = 0;
   /// Divide event list by a histogram
-  virtual void divide(const MantidVec &X, const MantidVec &Y, const MantidVec &E) = 0;
+  virtual void divide(std::span<double const> X, std::span<double const> Y, std::span<double const> E) = 0;
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -41,7 +41,7 @@ public:
   virtual Mantid::Types::Core::DateAndTime getTimeAtSampleMax(double tofOffset = 0) const = 0;
   virtual Mantid::Types::Core::DateAndTime getTimeAtSampleMin(double tofOffset = 0) const = 0;
   virtual EventType getEventType() const = 0;
-  void generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                          bool skipError = false) const override = 0;
 
   virtual void setAllX(const HistogramData::BinEdges &x) = 0;

--- a/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
+++ b/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/ParamFunction.h"
 #include "MantidGeometry/Crystal/UnitCell.h"
 #include <complex>
+#include <span>
 
 namespace Mantid {
 namespace API {
@@ -74,9 +75,11 @@ public:
   // void functionLocal(double* out, const double* xValues, const size_t
   // nData)const;
 
-  /// Calculate function in a range
+  /// Calculate function in a range. The ranges are taken as spans so that the size-checked
+  /// histogram data types can be evaluated over, and written into, directly. `out` must already
+  /// be sized; implementations do not resize it.
   using IFunction1D::function;
-  virtual void function(std::vector<double> &out, const std::vector<double> &xValues) const = 0;
+  virtual void function(std::span<double> out, std::span<double const> xValues) const = 0;
 
   /// Get maximum value on a given set of data points
   virtual double getMaximumValue(const std::vector<double> &xValues, size_t &indexmax) const;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <span>
 
 namespace Mantid {
 
@@ -356,7 +357,9 @@ public:
   virtual bool hasDx(const std::size_t index) const { return getSpectrum(index).hasDx(); }
 
   /// Generate the histogram or rebin the existing histogram.
-  virtual void generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  /// X is a span so that the size-checked HistogramData types can be passed without a
+  /// std::vector<double>; Y and E stay vectors because they are resized to match X.
+  virtual void generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                                  bool skipError = false) const = 0;
 
   /// Return a vector with the integrated counts for all spectra withing the

--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/Axis.h"
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,9 @@ class MANTID_API_DLL NumericAxis : public Axis {
 public:
   NumericAxis(const std::size_t &length);
   NumericAxis(std::vector<double> centres);
+  /// Construct from a contiguous range, so that the size-checked histogram data types
+  /// can be used directly. A std::vector<double> argument still selects the overload above.
+  NumericAxis(std::span<double const> centres);
 
   Axis *clone(const MatrixWorkspace *const parentWorkspace) override;
   Axis *clone(const std::size_t length, const MatrixWorkspace *const parentWorkspace) override;

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -11,6 +11,7 @@
 #include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/SplittingInterval.h"
 
+#include <span>
 #include <vector>
 
 namespace Mantid {
@@ -68,8 +69,9 @@ public:
   /// update property "duration" with the duration of the Run's TimeROI attribute
   void setDuration();
 
-  /// Store the given values as a set of histogram bin boundaries
-  void storeHistogramBinBoundaries(const std::vector<double> &histoBins);
+  /// Store the given values as a set of histogram bin boundaries. Taken as a span so that the
+  /// size-checked histogram data types can be stored directly.
+  void storeHistogramBinBoundaries(std::span<double const> histoBins);
   /// Returns the bin boundaries for a given value
   std::pair<double, double> histogramBinBoundaries(const double value) const;
   /// Returns the vector of bin boundaries

--- a/Framework/API/src/BinEdgeAxis.cpp
+++ b/Framework/API/src/BinEdgeAxis.cpp
@@ -31,6 +31,12 @@ BinEdgeAxis::BinEdgeAxis(const std::vector<double> &edges)
   m_values = edges;
 }
 
+BinEdgeAxis::BinEdgeAxis(std::span<double const> edges)
+    : NumericAxis() // default constructor
+{
+  m_values.assign(edges.begin(), edges.end());
+}
+
 /** Virtual constructor
  *  @param parentWorkspace :: The workspace is not used in this implementation
  *  @returns A pointer to a copy of the NumericAxis on which the method is

--- a/Framework/API/src/EqualBinSizesValidator.cpp
+++ b/Framework/API/src/EqualBinSizesValidator.cpp
@@ -32,7 +32,7 @@ std::string EqualBinSizesValidator::checkValidity(const MatrixWorkspace_sptr &va
   if (value->getNumberHistograms() == 0 || value->blocksize() == 0)
     return "Enter a workspace with some data in it";
 
-  Kernel::EqualBinsChecker checker(value->x(0).rawData(), m_errorLevel, -1);
+  Kernel::EqualBinsChecker checker(value->x(0), m_errorLevel, -1);
   return checker.validate();
 }
 

--- a/Framework/API/src/FunctionDomain1D.cpp
+++ b/Framework/API/src/FunctionDomain1D.cpp
@@ -47,6 +47,18 @@ FunctionDomain1DVector::FunctionDomain1DVector(const std::vector<double> &xvalue
 }
 
 /**
+ * Create a domain from a contiguous range.
+ * @param xvalues :: Range with function arguments to be copied from.
+ */
+FunctionDomain1DVector::FunctionDomain1DVector(std::span<double const> xvalues) : FunctionDomain1D(nullptr, 0) {
+  if (xvalues.empty()) {
+    throw std::invalid_argument("FunctionDomain1D cannot have zero size.");
+  }
+  m_X.assign(xvalues.begin(), xvalues.end());
+  resetData(&m_X[0], m_X.size());
+}
+
+/**
  * Create a domain from a vector using move semantics - no copy overhead.
  * @param xvalues :: Vector with function arguments to be moved from.
  */

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1757,9 +1757,9 @@ signal_t MatrixWorkspace::getSignalAtCoord(const coord_t *coords,
     try {
       coord_t xCoord = coords[0];
       if (isHistogramData())
-        i = Kernel::VectorHelper::indexOfValueFromEdges(xVals.rawData(), xCoord);
+        i = Kernel::VectorHelper::indexOfValueFromEdges(xVals, xCoord);
       else
-        i = Kernel::VectorHelper::indexOfValueFromCenters(xVals.rawData(), xCoord);
+        i = Kernel::VectorHelper::indexOfValueFromCenters(xVals, xCoord);
     } catch (std::out_of_range &) {
       return std::numeric_limits<double>::quiet_NaN();
     }

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -66,6 +66,8 @@ NumericAxis::NumericAxis(const std::size_t &length) : Axis(), m_values(length) {
  */
 NumericAxis::NumericAxis(std::vector<double> centres) : Axis(), m_values(std::move(centres)) {}
 
+NumericAxis::NumericAxis(std::span<double const> centres) : Axis(), m_values(centres.begin(), centres.end()) {}
+
 /** Virtual constructor
  *  @param parentWorkspace :: The workspace is not used in this implementation
  *  @returns A pointer to a copy of the NumericAxis on which the method is

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -446,10 +446,10 @@ void Run::setDuration() {
  * Store the given values as a set of energy bin boundaries. Throws
  *    - an invalid_argument if fewer than 2 values are given;
  *    - an out_of_range error if first value is greater of equal to the last
- * @param histoBins :: A vector of values that are interpreted as bin boundaries
- * from a histogram
+ * @param histoBins :: A contiguous range of values that are interpreted as bin
+ * boundaries from a histogram
  */
-void Run::storeHistogramBinBoundaries(const std::vector<double> &histoBins) {
+void Run::storeHistogramBinBoundaries(std::span<double const> const histoBins) {
   if (histoBins.size() < 2) {
     std::ostringstream os;
     os << "Run::storeEnergyBinBoundaries - Fewer than 2 values given, size=" << histoBins.size()
@@ -463,7 +463,7 @@ void Run::storeHistogramBinBoundaries(const std::vector<double> &histoBins) {
        << histoBins.size() << ". Cannot interpret values as bin boundaries.";
     throw std::out_of_range(os.str());
   }
-  m_histoBins = histoBins;
+  m_histoBins.assign(histoBins.begin(), histoBins.end());
 }
 
 /**

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -70,7 +70,7 @@ public:
   const std::string id(void) const override { return ""; }
   void init(const size_t &, const size_t &, const size_t &) override {}
   void init(const HistogramData::Histogram &) override {}
-  void generateHistogram(const std::size_t, const MantidVec &, MantidVec &, MantidVec &, bool) const override {}
+  void generateHistogram(const std::size_t, std::span<double const>, MantidVec &, MantidVec &, bool) const override {}
 
   void clearFileBacked(bool) override {};
   ITableWorkspace_sptr makeBoxTable(size_t /* start*/, size_t /*num*/) override { return ITableWorkspace_sptr(); }

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -801,7 +801,7 @@ public:
     a.addProperty(std::make_unique<ConcreteProperty>());
     const DblMatrix rotation_x{{1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
     a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
-    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    a.storeHistogramBinBoundaries(std::vector<double>{1, 2, 3, 4});
     Run b{a};
     TS_ASSERT_EQUALS(a, b);
     TS_ASSERT(!(a != b));
@@ -812,9 +812,9 @@ public:
     a.addProperty(std::make_unique<ConcreteProperty>());
     DblMatrix rotation_x{{1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
     a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
-    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    a.storeHistogramBinBoundaries(std::vector<double>{1, 2, 3, 4});
     Run b{a};
-    b.storeHistogramBinBoundaries({0, 2, 3, 4});
+    b.storeHistogramBinBoundaries(std::vector<double>{0, 2, 3, 4});
     TS_ASSERT_DIFFERS(a, b);
     TS_ASSERT(!(a == b));
   }
@@ -824,7 +824,7 @@ public:
     a.addProperty(std::make_unique<ConcreteProperty>());
     DblMatrix rotation_x{{1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
     a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
-    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    a.storeHistogramBinBoundaries(std::vector<double>{1, 2, 3, 4});
     Run b{a};
     b.removeProperty("Test");
     TS_ASSERT_DIFFERS(a, b);
@@ -836,7 +836,7 @@ public:
     a.addProperty(std::make_unique<ConcreteProperty>());
     DblMatrix rotation_x{{1, 0, 0, 0, 0, -1, 0, 1, 0}}; // 90 degrees around x axis
     a.setGoniometer(Goniometer{rotation_x}, false /*do not use log angles*/);
-    a.storeHistogramBinBoundaries({1, 2, 3, 4});
+    a.storeHistogramBinBoundaries(std::vector<double>{1, 2, 3, 4});
     Run b{a};
     Mantid::Kernel::DblMatrix rotation_y{{0, 0, 1, 0, 1, 0, -1, 0, 0}}; // 90 degrees around y axis
     b.setGoniometer(Goniometer{rotation_y}, false /*do not use log angles*/);

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -16,6 +16,8 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidHistogramData/Histogram.h"
 
+#include <span>
+
 namespace Mantid {
 namespace Algorithms {
 
@@ -123,9 +125,10 @@ protected:
   virtual void performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs);
 
   /// Carries out the binary operation IN-PLACE on a single EventList, with another (histogrammed) spectrum as the
-  /// right-hand operand.
-  virtual void performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                           const MantidVec &rhsE);
+  /// right-hand operand. The rhs arrays are spans so that the size-checked HistogramData types can
+  /// be passed without going through a std::vector<double>.
+  virtual void performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                           std::span<double const> rhsY, std::span<double const> rhsE);
 
   /// Carries out the binary operation IN-PLACE on a single EventList, with a single (double) value as the right-hand
   /// operand

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateSampleWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateSampleWorkspace.h
@@ -14,6 +14,8 @@
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/PseudoRandomNumberGenerator.h"
 
+#include <span>
+
 namespace Mantid {
 namespace Algorithms {
 
@@ -56,8 +58,7 @@ private:
   Geometry::IObject_sptr createCappedCylinder(double radius, double height, const Kernel::V3D &baseCentre,
                                               const Kernel::V3D &axis, const std::string &id);
   Geometry::IObject_sptr createSphere(double radius, const Kernel::V3D &centre, const std::string &id);
-  std::vector<double> evalFunction(const std::string &functionString, const std::vector<double> &xVal,
-                                   double noiseScale);
+  std::vector<double> evalFunction(const std::string &functionString, std::span<double const> xVal, double noiseScale);
   void replaceAll(std::string &str, const std::string &from, const std::string &to);
   void addChopperParameters(API::MatrixWorkspace_sptr &ws);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -20,6 +20,7 @@
 #include "MantidKernel/PseudoRandomNumberGenerator.h"
 #include <boost/container/small_vector.hpp>
 #include <shared_mutex>
+#include <span>
 
 namespace Mantid {
 namespace API {
@@ -168,7 +169,7 @@ private:
   void convertWsBothAxesToPoints(API::MatrixWorkspace_sptr &ws);
   std::tuple<double, double> getKinematicRange(double kf, double ki);
   std::vector<std::tuple<double, int, double>> generateInputKOutputWList(const double efixed,
-                                                                         const std::vector<double> &xPoints);
+                                                                         std::span<double const> xPoints);
   std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
   integrateQSQ(const std::shared_ptr<DiscusData2D> &QSQ, double kinc, const bool returnCumulative);
   double getQSQIntegral(const DiscusData1D &QSQScaleFactor, double k);

--- a/Framework/Algorithms/inc/MantidAlgorithms/Divide.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Divide.h
@@ -54,8 +54,8 @@ private:
 
   void performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) override;
 
-  void performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                   const MantidVec &rhsE) override;
+  void performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                   std::span<double const> rhsY, std::span<double const> rhsE) override;
 
   void performEventBinaryOperation(DataObjects::EventList &lhs, const double &rhsY, const double &rhsE) override;
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
@@ -15,6 +15,7 @@
 
 #include <list>
 #include <optional>
+#include <span>
 
 namespace Mantid {
 namespace API {
@@ -124,12 +125,11 @@ private:
   using Mantid::API::Algorithm::validateInputs;
   bool validateInputsForEventWorkspaces(const std::vector<std::string> &inputWorkspaces);
   std::optional<std::vector<double>> checkRebinning();
-  static std::vector<double> calculateRebinParams(const std::vector<double> &bins1, const std::vector<double> &bins2);
-  static void noOverlapParams(const HistogramData::HistogramX &X1, const HistogramData::HistogramX &X2,
-                              std::vector<double> &params);
-  static void intersectionParams(const HistogramData::HistogramX &X1, size_t &i, const HistogramData::HistogramX &X2,
+  static std::vector<double> calculateRebinParams(std::span<double const> bins1, std::span<double const> bins2);
+  static void noOverlapParams(std::span<double const> X1, std::span<double const> X2, std::vector<double> &params);
+  static void intersectionParams(std::span<double const> X1, size_t &i, std::span<double const> X2,
                                  std::vector<double> &params);
-  static void inclusionParams(const HistogramData::HistogramX &X1, size_t &i, const HistogramData::HistogramX &X2,
+  static void inclusionParams(std::span<double const> X1, size_t &i, std::span<double const> X2,
                               std::vector<double> &params);
   API::MatrixWorkspace_sptr rebinInput(const API::MatrixWorkspace_sptr &workspace, const std::vector<double> &params);
   API::MatrixWorkspace_sptr buildScanningOutputWorkspace(const API::MatrixWorkspace_sptr &outWS,

--- a/Framework/Algorithms/inc/MantidAlgorithms/Minus.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Minus.h
@@ -48,8 +48,8 @@ private:
   void performBinaryOperation(const HistogramData::Histogram &lhs, const double rhsY, const double rhsE,
                               HistogramData::HistogramY &YOut, HistogramData::HistogramE &EOut) override;
   void performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) override;
-  void performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                   const MantidVec &rhsE) override;
+  void performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                   std::span<double const> rhsY, std::span<double const> rhsE) override;
   void performEventBinaryOperation(DataObjects::EventList &lhs, const double &rhsY, const double &rhsE) override;
 
   void checkRequirements() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/Multiply.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Multiply.h
@@ -52,8 +52,8 @@ private:
 
   void performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) override;
 
-  void performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                   const MantidVec &rhsE) override;
+  void performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                   std::span<double const> rhsY, std::span<double const> rhsE) override;
 
   void performEventBinaryOperation(DataObjects::EventList &lhs, const double &rhsY, const double &rhsE) override;
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/Plus.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Plus.h
@@ -50,8 +50,8 @@ private:
   void performBinaryOperation(const HistogramData::Histogram &lhs, const double rhsY, const double rhsE,
                               HistogramData::HistogramY &YOut, HistogramData::HistogramE &EOut) override;
   void performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) override;
-  void performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                   const MantidVec &rhsE) override;
+  void performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                   std::span<double const> rhsY, std::span<double const> rhsE) override;
   void performEventBinaryOperation(DataObjects::EventList &lhs, const double &rhsY, const double &rhsE) override;
 
   void checkRequirements() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/Regroup.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Regroup.h
@@ -13,6 +13,8 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
+#include <span>
+
 namespace Mantid {
 namespace HistogramData {
 class HistogramX;
@@ -47,7 +49,7 @@ public:
   /// Algorithm's category for identification overriding a virtual method
   const std::string category() const override { return "Transforms\\Rebin"; }
 
-  int newAxis(const std::vector<double> &params, const std::vector<double> &xold, std::vector<double> &xnew,
+  int newAxis(const std::vector<double> &params, std::span<double const> xold, std::vector<double> &xnew,
               std::vector<int> &xoldIndex);
 
 private:

--- a/Framework/Algorithms/inc/MantidAlgorithms/XrayAbsorptionCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/XrayAbsorptionCorrection.h
@@ -16,6 +16,8 @@
 #include "MantidAlgorithms/SampleCorrections/MCInteractionVolume.h"
 #include "MantidAlgorithms/SampleCorrections/SparseWorkspace.h"
 
+#include <span>
+
 namespace Mantid {
 namespace API {
 class Sample;
@@ -55,7 +57,7 @@ protected:
   std::vector<Kernel::V3D> calculateMuonPos(API::MatrixWorkspace_sptr &muonProfile,
                                             const API::MatrixWorkspace_sptr &inputWS, double detectorDistance);
 
-  std::vector<double> normaliseMuonIntensity(MantidVec muonIntensity);
+  std::vector<double> normaliseMuonIntensity(std::span<double const> muonIntensity);
 
 private:
   void init() override;

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -588,7 +588,7 @@ void BinaryOperation::doSingleSpectrum() {
       for (int64_t i = 0; i < numHists; ++i) {
         PARALLEL_START_INTERRUPT_REGION
         // Perform the operation on the event list on the output (== lhs)
-        performEventBinaryOperation(m_eout->getSpectrum(i), rhsX.rawData(), rhsY.rawData(), rhsE.rawData());
+        performEventBinaryOperation(m_eout->getSpectrum(i), rhsX, rhsY, rhsE);
         m_progress->report(this->name());
         PARALLEL_END_INTERRUPT_REGION
       }
@@ -702,8 +702,7 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
         }
 
         // Reach here? Do the division
-        performEventBinaryOperation(m_eout->getSpectrum(i), m_rhs->x(rhs_wi).rawData(), m_rhs->y(rhs_wi).rawData(),
-                                    m_rhs->e(rhs_wi).rawData());
+        performEventBinaryOperation(m_eout->getSpectrum(i), m_rhs->x(rhs_wi), m_rhs->y(rhs_wi), m_rhs->e(rhs_wi));
 
         // Free up memory on the RHS if that is possible
         if (m_ClearRHSWorkspace)
@@ -808,8 +807,8 @@ void BinaryOperation::performEventBinaryOperation(DataObjects::EventList &lhs, c
  *  @param rhsY :: Rhs data values
  *  @param rhsE :: Rhs error values
  */
-void BinaryOperation::performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX,
-                                                  const MantidVec &rhsY, const MantidVec &rhsE) {
+void BinaryOperation::performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                                  std::span<double const> rhsY, std::span<double const> rhsE) {
   UNUSED_ARG(lhs);
   UNUSED_ARG(rhsX);
   UNUSED_ARG(rhsY);

--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -71,7 +71,7 @@ std::vector<std::vector<double>> allYValuesAtIndex(const std::vector<MatrixWorks
                                                    const std::size_t index) {
   std::vector<std::vector<double>> yValues(workspaces[0]->getDimension(0)->getNBins());
   for (auto &&workspace : workspaces) {
-    const auto values = workspace->y(index).rawData();
+    const auto &values = workspace->y(index);
     for (auto j = 0u; j < values.size(); ++j)
       yValues[j].emplace_back(values[j]);
   }

--- a/Framework/Algorithms/src/CalculateZscore.cpp
+++ b/Framework/Algorithms/src/CalculateZscore.cpp
@@ -91,8 +91,8 @@ void CalculateZscore::exec() {
     }
 
     // b) Calculate Zscore
-    auto &inpY = inpWS->y(wsindex).rawData();
-    auto &inpE = inpWS->e(wsindex).rawData();
+    auto &inpY = inpWS->y(wsindex);
+    auto &inpE = inpWS->e(wsindex);
 
     auto &histY = outWS->mutableY(i);
     auto &histE = outWS->mutableE(i);

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -398,7 +398,7 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
   size_t checkIndex = 0;
   spectrumInfo.getDetectorValues(*fromUnit, *outputUnit, emode, signedTheta, checkIndex, upmap);
   // copy the X values for the check
-  auto checkXValues = inputWS->x(checkIndex).rawData();
+  auto checkXValues = inputWS->x(checkIndex);
   try {
     // Convert the input unit to time-of-flight
     checkFromUnit->toTOF(checkXValues.begin(), checkXValues.end(), l1, emode, upmap);

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -333,9 +333,9 @@ MatrixWorkspace_sptr CreateSampleWorkspace::createHistogramWorkspace(int numPixe
                                                                      const Geometry::Instrument_sptr &inst,
                                                                      const std::string &functionString, bool isRandom) {
   BinEdges x(numBins + 1, LinearGenerator(x0, binDelta));
-  Points xValues(x);
+  Points const xValues(x);
 
-  Counts y(evalFunction(functionString, xValues.rawData(), isRandom ? 1 : 0));
+  Counts y(evalFunction(functionString, xValues, isRandom ? 1 : 0));
 
   std::vector<SpectrumDefinition> specDefs(numPixels + numMonitors);
   for (int wi = 0; wi < numMonitors + numPixels; wi++)
@@ -439,8 +439,8 @@ EventWorkspace_sptr CreateSampleWorkspace::createEventWorkspace(int numPixels, i
  *no noise
  * @returns the calculated values
  */
-std::vector<double> CreateSampleWorkspace::evalFunction(const std::string &functionString,
-                                                        const std::vector<double> &xVal, double noiseScale = 0) {
+std::vector<double> CreateSampleWorkspace::evalFunction(std::string const &functionString,
+                                                        std::span<double const> const xVal, double noiseScale = 0) {
   size_t xSize = xVal.size();
   // replace $PCx$ values
   std::string parsedFuncString = functionString;

--- a/Framework/Algorithms/src/CropWorkspaceRagged.cpp
+++ b/Framework/Algorithms/src/CropWorkspaceRagged.cpp
@@ -12,9 +12,11 @@
 #include "MantidKernel/MandatoryValidator.h"
 
 #include <algorithm>
+#include <span>
 
 namespace {
-std::vector<double> getSubVector(Mantid::MantidVec const &data, const int64_t &lowerIndex, const int64_t &upperIndex) {
+std::vector<double> getSubVector(std::span<double const> const data, const int64_t &lowerIndex,
+                                 const int64_t &upperIndex) {
   auto low = std::next(data.begin(), lowerIndex);
   auto up = std::next(data.begin(), upperIndex);
   // get new vectors
@@ -132,14 +134,14 @@ void CropWorkspaceRagged::exec() {
     int64_t upperIndex = std::distance(points.begin(), up);
 
     // get new vectors
-    std::vector<double> newY = getSubVector(yValues.rawData(), lowerIndex, upperIndex);
-    std::vector<double> newE = getSubVector(eValues.rawData(), lowerIndex, upperIndex);
+    std::vector<double> newY = getSubVector(yValues, lowerIndex, upperIndex);
+    std::vector<double> newE = getSubVector(eValues, lowerIndex, upperIndex);
     if (histogram && upperIndex + (size_t)1 <= xValues.size()) {
       // the offset adds one to the upper index for histograms
       // only use the offset if the end is cropped
       upperIndex += 1;
     }
-    std::vector<double> newX = getSubVector(xValues.rawData(), lowerIndex, upperIndex);
+    std::vector<double> newX = getSubVector(xValues, lowerIndex, upperIndex);
 
     // resize the histogram; this keeps X, Y and E consistent with the storage mode
     outputWS->resizeHistogram(i, newY.size());

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -246,8 +246,7 @@ void CrossCorrelate::exec() {
     std::vector<double> tempY(static_cast<size_t>(numReferenceY));
     std::vector<double> tempE(static_cast<size_t>(numReferenceY));
 
-    VectorHelper::rebin(inputXVector.rawData(), inputYVector.rawData(), inputEVector.rawData(), referenceXVector, tempY,
-                        tempE, isDistribution);
+    VectorHelper::rebin(inputXVector, inputYVector, inputEVector, referenceXVector, tempY, tempE, isDistribution);
     const auto tempVar = subtractMean(tempY, tempE);
 
     // Calculate the normalisation constant

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -322,7 +322,7 @@ void DiffractionFocussing2::exec() {
         // generateHistogram overwrites the data in Y and E so write to a temporary vector
         MantidVec Ytemp;
         MantidVec Etemp;
-        el.generateHistogram(group2xstep.at(group), Xout.rawData(), Ytemp, Etemp);
+        el.generateHistogram(group2xstep.at(group), Xout, Ytemp, Etemp);
         // accumulate the histogram into the output
         std::transform(Ytemp.cbegin(), Ytemp.cend(), Yout.begin(), Yout.begin(),
                        [](const auto &left, const auto &right) { return left + right; });
@@ -330,8 +330,8 @@ void DiffractionFocussing2::exec() {
         std::transform(Etemp.cbegin(), Etemp.cend(), Eout.begin(), Eout.begin(),
                        [](const auto &left, const auto &right) { return left * left + right; });
       } else {
-        auto &Yin = inSpec.y();
-        auto &Ein = inSpec.e();
+        auto const &Yin = inSpec.y();
+        auto const &Ein = inSpec.e();
 
         try {
           // TODO This should be implemented in Histogram as rebin

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -277,7 +277,8 @@ void DiffractionFocussing2::exec() {
     auto group = static_cast<int>(m_validGroups[outWorkspaceIndex]);
 
     // Get the group
-    auto &Xout = group2xvector.at(group);
+    // const so that binding it to a std::span does not detach the cow_ptr
+    auto const &Xout = group2xvector.at(group);
 
     // Assign the new X axis only once (i.e when this group is encountered the
     // first time)
@@ -334,8 +335,7 @@ void DiffractionFocussing2::exec() {
 
         try {
           // TODO This should be implemented in Histogram as rebin
-          Mantid::Kernel::VectorHelper::rebinHistogram(Xin.rawData(), Yin.rawData(), Ein.rawData(), Xout.rawData(),
-                                                       Yout, Eout, true);
+          Mantid::Kernel::VectorHelper::rebinHistogram(Xin, Yin, Ein, Xout, Yout, Eout, true);
         } catch (...) {
           // Should never happen because Xout is constructed to envelop all of the
           // Xin vectors
@@ -377,7 +377,7 @@ void DiffractionFocussing2::exec() {
         // here
         const MantidVec zeroes(weights.size(), 0.0);
         // Rebin the weights - note that this is a distribution
-        VectorHelper::rebin(weight_bins, weights, zeroes, Xout.rawData(), groupWgt, EOutDummy, true, true);
+        VectorHelper::rebin(weight_bins, weights, zeroes, Xout, groupWgt, EOutDummy, true, true);
       } else // If no masked bins we want to add 1 to the weight of the output
              // bins that this input covers
       {
@@ -394,7 +394,7 @@ void DiffractionFocussing2::exec() {
         }
 
         // Rebin the weights - note that this is a distribution
-        VectorHelper::rebin(limits, weights_default, emptyVec, Xout.rawData(), groupWgt, EOutDummy, true, true);
+        VectorHelper::rebin(limits, weights_default, emptyVec, Xout, groupWgt, EOutDummy, true, true);
       }
       prog.report();
     } // end of loop for input spectra

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -521,8 +521,10 @@ void DiscusMultipleScatteringCorrection::exec() {
   prepareQSQ(qmax);
 
   m_simulateEnergiesIndependently = getProperty("SimulateEnergiesIndependently");
-  // call this function with dummy efixed to determine total possible simulation points
-  const auto inputNbins = generateInputKOutputWList(-1.0, inputWS->points(0).rawData()).size();
+  // call this function with dummy efixed to determine total possible simulation points.
+  // the Points is named and const, so that viewing it as a span does not trigger a copy-on-write detach
+  auto const inputPoints = inputWS->points(0);
+  auto const inputNbins = generateInputKOutputWList(-1.0, inputPoints).size();
 
   int nSimulationPointsInt = getProperty("NumberOfSimulationPoints");
   size_t nSimulationPoints = static_cast<size_t>(nSimulationPointsInt);
@@ -599,7 +601,7 @@ void DiscusMultipleScatteringCorrection::exec() {
     if (spectrumInfo.hasDetectors(i) && !spectrumInfo.isMonitor(i) && !spectrumInfo.isMasked(i)) {
 
       const double eFixedValue = efixed.value(spectrumInfo.detector(i).getID());
-      auto xPoints = instrumentWS.points(i).rawData();
+      const auto xPoints = instrumentWS.points(i);
 
       auto kInW = generateInputKOutputWList(eFixedValue, xPoints);
 
@@ -627,7 +629,8 @@ void DiscusMultipleScatteringCorrection::exec() {
                         " bin index=" + std::to_string(std::get<1>(kInW[bin])));
           continue;
         }
-        std::vector<double> wValues = std::get<1>(kInW[bin]) == -1 ? xPoints : std::vector{std::get<2>(kInW[bin])};
+        std::vector<double> wValues = std::get<1>(kInW[bin]) == -1 ? std::vector<double>(xPoints.begin(), xPoints.end())
+                                                                   : std::vector{std::get<2>(kInW[bin])};
 
         if (m_importanceSampling)
           prepareCumulativeProbForQ(kinc, componentWorkspaces);
@@ -790,7 +793,8 @@ void DiscusMultipleScatteringCorrection::exec() {
  * @param xPoints The x points either in momentum (elastic) or energy transfer (inelastic)
  */
 std::vector<std::tuple<double, int, double>>
-DiscusMultipleScatteringCorrection::generateInputKOutputWList(const double efixed, const std::vector<double> &xPoints) {
+DiscusMultipleScatteringCorrection::generateInputKOutputWList(const double efixed,
+                                                              std::span<double const> const xPoints) {
   std::vector<std::tuple<double, int, double>> kInW;
   const double kFixed = toWaveVector(efixed);
   if (m_EMode == DeltaEMode::Elastic) {

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -291,7 +291,7 @@ std::map<std::string, std::string> DiscusMultipleScatteringCorrection::validateI
           issues["StructureFactorWorkspace"] += "S(Q,w) must have common w values at all Q";
       }
 
-      auto checkEqualQBins = [&issues](const MantidVec &qValues) {
+      auto checkEqualQBins = [&issues](std::span<double const> qValues) {
         Kernel::EqualBinsChecker checker(qValues, 1.0E-07, -1);
         if (!checker.validate().empty())
           issues["StructureFactorWorkspace"] +=
@@ -301,8 +301,7 @@ std::map<std::string, std::string> DiscusMultipleScatteringCorrection::validateI
 
       if (SQWS->getAxis(0)->unit()->unitID() == "MomentumTransfer") {
         for (size_t iHist = 0; iHist < SQWS->getNumberHistograms(); iHist++) {
-          const auto &qValues = SQWS->x(iHist).rawData();
-          checkEqualQBins(qValues);
+          checkEqualQBins(SQWS->x(iHist));
         }
       } else if (SQWS->getAxis(1)->unit()->unitID() == "MomentumTransfer") {
         auto qAxis = dynamic_cast<NumericAxis *>(SQWS->getAxis(1));

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -301,7 +301,7 @@ std::map<std::string, std::string> DiscusMultipleScatteringCorrection::validateI
 
       if (SQWS->getAxis(0)->unit()->unitID() == "MomentumTransfer") {
         for (size_t iHist = 0; iHist < SQWS->getNumberHistograms(); iHist++) {
-          auto qValues = SQWS->dataX(iHist);
+          const auto &qValues = SQWS->x(iHist).rawData();
           checkEqualQBins(qValues);
         }
       } else if (SQWS->getAxis(1)->unit()->unitID() == "MomentumTransfer") {
@@ -474,7 +474,7 @@ void DiscusMultipleScatteringCorrection::convertWsBothAxesToPoints(MatrixWorkspa
           API::WorkspaceFactory::Instance().create(ws, ws->getNumberHistograms(), ws->blocksize(), ws->blocksize());
       SQWSPoints->setSharedY(0, ws->sharedY(0));
       SQWSPoints->setSharedE(0, ws->sharedE(0));
-      std::vector<double> newX = ws->histogram(0).dataX();
+      std::vector<double> newX = ws->x(0).rawData();
       newX.pop_back();
       SQWSPoints->setSharedX(0, HistogramData::Points(newX).cowData());
       ws = SQWSPoints;

--- a/Framework/Algorithms/src/Divide.cpp
+++ b/Framework/Algorithms/src/Divide.cpp
@@ -121,8 +121,8 @@ void Divide::setOutputUnits(const API::MatrixWorkspace_const_sptr lhs, const API
 void Divide::performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) {
   // We must histogram the rhs event list to divide.
   MantidVec rhsY, rhsE;
-  rhs.generateHistogram(rhs.x().rawData(), rhsY, rhsE);
-  lhs.divide(rhs.x().rawData(), rhsY, rhsE);
+  rhs.generateHistogram(rhs.x(), rhsY, rhsE);
+  lhs.divide(rhs.x(), rhsY, rhsE);
 }
 
 /** Carries out the binary operation IN-PLACE on a single EventList,
@@ -133,8 +133,8 @@ void Divide::performEventBinaryOperation(DataObjects::EventList &lhs, const Data
  *  @param rhsY :: The vector of rhs data values
  *  @param rhsE :: The vector of rhs error values
  */
-void Divide::performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                         const MantidVec &rhsE) {
+void Divide::performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                         std::span<double const> rhsY, std::span<double const> rhsE) {
   // Divide is implemented at the EventList level.
   lhs.divide(rhsX, rhsY, rhsE);
 }

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -363,7 +363,7 @@ bool FFT::areBinWidthsUneven(const HistogramData::BinEdges &xBins) const {
   const double warnValue = acceptXRoundingErrors ? 0.1 : -1;
 
   // TODO should be added to HistogramData as a convenience function
-  Kernel::EqualBinsChecker binChecker(xBins.rawData(), tolerance, warnValue);
+  Kernel::EqualBinsChecker binChecker(xBins, tolerance, warnValue);
 
   // Compatibility with previous behaviour
   if (!acceptXRoundingErrors) {

--- a/Framework/Algorithms/src/FindEPP.cpp
+++ b/Framework/Algorithms/src/FindEPP.cpp
@@ -77,8 +77,8 @@ void FindEPP::fitGaussian(int64_t index) {
   m_outWS->cell<int>(spectrum, 0) = static_cast<int>(spectrum);
 
   const auto x = m_inWS->points(spectrum);
-  const auto &y = m_inWS->y(spectrum).rawData();
-  const auto &e = m_inWS->e(spectrum).rawData();
+  const auto &y = m_inWS->y(spectrum);
+  const auto &e = m_inWS->e(spectrum);
 
   // Find the maximum value and it's index
   const auto maxIt = std::max_element(y.begin(), y.end());

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -245,8 +245,8 @@ std::pair<size_t, bool> FindPeaksConvolve::getKernelBinCount(const HistogramData
 
   size_t kernelBinCount{0};
   if (peakExtent != EMPTY_DBL()) {
-    const double x1{xData->rawData()[static_cast<size_t>(std::floor((xData->size() - 1) / 2))]};
-    const double x2{xData->rawData()[static_cast<size_t>(std::floor((xData->size() - 1) / 2)) + 1]};
+    const double x1{(*xData)[static_cast<size_t>(std::floor((xData->size() - 1) / 2))]};
+    const double x2{(*xData)[static_cast<size_t>(std::floor((xData->size() - 1) / 2)) + 1]};
     kernelBinCount = static_cast<size_t>(std::floor(peakExtent * 2 / (x2 - x1)));
   } else {
     kernelBinCount = static_cast<size_t>(peakExtentNBins);
@@ -296,9 +296,9 @@ void FindPeaksConvolve::extractPeaks(const size_t dataIndex, const Tensor1D &iOv
 
 double FindPeaksConvolve::getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex) const {
   if (m_centreBins) {
-    return (xData->rawData()[xIndex] + xData->rawData()[xIndex + 1]) / 2;
+    return ((*xData)[xIndex] + (*xData)[xIndex + 1]) / 2;
   } else {
-    return xData->rawData()[xIndex];
+    return (*xData)[xIndex];
   }
 }
 

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1782,9 +1782,9 @@ bool FitPeaks::fitBackground(const size_t &ws_index, const std::pair<double, dou
   // find out how to fit background
   const auto histogram = m_inputMatrixWS->histogram(ws_index);
   const auto &points = histogram.points();
-  size_t start_index = findXIndex(points.rawData(), fit_window.first);
-  size_t expected_peak_index = findXIndex(points.rawData(), expected_peak_pos, start_index);
-  size_t stop_index = findXIndex(points.rawData(), fit_window.second, expected_peak_index);
+  size_t start_index = findXIndex(points, fit_window.first);
+  size_t expected_peak_index = findXIndex(points, expected_peak_pos, start_index);
+  size_t stop_index = findXIndex(points, fit_window.second, expected_peak_index);
 
   // treat 5 as a magic number - TODO explain why
   bool good_fit(false);
@@ -2312,7 +2312,7 @@ void FitPeaks::processOutputs(std::vector<std::shared_ptr<FitPeaksAlgorithm::Pea
  */
 double FitPeaks::numberCounts(size_t iws) {
   const Histogram histogram = m_inputMatrixWS->histogram(iws);
-  const auto &vec_y = histogram.y().rawData();
+  const auto &vec_y = histogram.y();
   double total = std::accumulate(vec_y.begin(), vec_y.end(), 0.);
   return total;
 }
@@ -2396,8 +2396,8 @@ void FitPeaks::getRangeData(size_t iws, const std::pair<double, double> &range, 
 
   size_t num_datapoints = m_inputMatrixWS->isHistogramData() ? num_elements_x - 1 : num_elements_x;
 
-  const auto &orig_y = histogram.y().rawData();
-  const auto &orig_e = histogram.e().rawData();
+  const auto &orig_y = histogram.y();
+  const auto &orig_e = histogram.e();
   vec_y.resize(num_datapoints);
   vec_e.resize(num_datapoints);
   std::copy(orig_y.begin() + left_index, orig_y.begin() + left_index + num_datapoints, vec_y.begin());

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -479,7 +479,7 @@ bool GetAllEi::peakGuess(const API::MatrixWorkspace_sptr &inputWS, size_t index,
   double SmoothRange = 2 * maxSigma;
 
   std::vector<double> SAvrg, binsAvrg;
-  Kernel::VectorHelper::smoothInRange(S.rawData(), SAvrg, SmoothRange, &X.rawData(), ind_min, ind_max, &binsAvrg);
+  Kernel::VectorHelper::smoothInRange(S, SAvrg, SmoothRange, X, ind_min, ind_max, &binsAvrg);
 
   double realPeakPos(xOfMax); // this position is less shifted
   // due to the skew in averaging formula
@@ -495,7 +495,7 @@ bool GetAllEi::peakGuess(const API::MatrixWorkspace_sptr &inputWS, size_t index,
   size_t ic(0), stay_still_count(0);
   bool iterations_fail(false);
   while ((nPeaks > 1 || nHills > 2) && (!iterations_fail)) {
-    Kernel::VectorHelper::smoothInRange(SAvrg, SAvrg1, SmoothRange, &binsAvrg, 0, ind_max - ind_min, &binsAvrg1);
+    Kernel::VectorHelper::smoothInRange(SAvrg, SAvrg1, SmoothRange, binsAvrg, 0, ind_max - ind_min, &binsAvrg1);
     const auto nPrevHills = nHills;
 
     nPeaks = this->calcDerivativeAndCountZeros(binsAvrg1, SAvrg1, der1Avrg, peaks);
@@ -681,7 +681,7 @@ namespace { // for lambda extracted from findBinRanges
 void getBinRange(const HistogramData::HistogramX &eBins, double eMin, double eMax, size_t &index_min,
                  size_t &index_max) {
 
-  const auto &bins = eBins.rawData();
+  const auto &bins = eBins;
   const size_t nBins = bins.size();
   if (eMin <= bins[0]) {
     index_min = 0;

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -217,10 +217,10 @@ Histogram InterpolatingRebin::cubicInterpolation(const Histogram &oldHistogram, 
 
   // get the bin centres of the input data
   auto xCensOld = oldHistogram.points();
-  VectorHelper::convertToBinCentre(oldHistogram.x().rawData(), xCensOld.mutableRawData());
+  VectorHelper::convertToBinCentre(oldHistogram.x(), xCensOld.mutableRawData());
   // the centres of the output data
   Points xCensNew(size_new);
-  VectorHelper::convertToBinCentre(xNew.rawData(), xCensNew.mutableRawData());
+  VectorHelper::convertToBinCentre(xNew, xCensNew.mutableRawData());
 
   // find the range of input values whose x-values just suround the output
   // x-values
@@ -274,7 +274,7 @@ Histogram InterpolatingRebin::cubicInterpolation(const Histogram &oldHistogram, 
 
   // No Interpolation branch
   if (!canInterpol) {
-    if (VectorHelper::isConstantValue(yOld.rawData())) {
+    if (VectorHelper::isConstantValue(yOld)) {
       // this copies the single y-value into the output array, errors are still
       // calculated from the nearest input data points
       // this is as much as we need to do in this (trival) case

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -241,7 +241,7 @@ void MaxEnt::validateBinEdges(const std::string &wsName, std::map<std::string, s
   MatrixWorkspace_const_sptr ws = getProperty(wsName);
   if (ws) {
 
-    Kernel::EqualBinsChecker binChecker(ws->x(0).rawData(), BIN_WIDTH_ERROR_LEVEL, warningLevel);
+    Kernel::EqualBinsChecker binChecker(ws->x(0), BIN_WIDTH_ERROR_LEVEL, warningLevel);
     const std::string binError = binChecker.validate();
     if (!binError.empty()) {
       messages[wsName] = binError;

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -461,7 +461,7 @@ std::optional<std::vector<double>> MergeRuns::checkRebinning() {
                                       ". Binning is different from the reference run.");
         }
       }
-      rebinParams = this->calculateRebinParams(bins, (*it)->x(0).rawData());
+      rebinParams = this->calculateRebinParams(bins, (*it)->x(0));
       VectorHelper::createAxisFromRebinParams(*rebinParams, bins);
     }
   }
@@ -476,8 +476,8 @@ std::optional<std::vector<double>> MergeRuns::checkRebinning() {
  *  @param bins2 ::    The second bin edges
  *  @return :: The rebinning parameters
  */
-std::vector<double> MergeRuns::calculateRebinParams(const std::vector<double> &bins1,
-                                                    const std::vector<double> &bins2) {
+std::vector<double> MergeRuns::calculateRebinParams(std::span<double const> const bins1,
+                                                    std::span<double const> const bins2) {
   std::vector<double> newParams;
   // Try to reserve memory for the worst-case scenario: two non-overlapping
   // ranges.
@@ -520,7 +520,8 @@ std::vector<double> MergeRuns::calculateRebinParams(const std::vector<double> &b
  *  @param X2 ::     The bin boundaries from the second workspace
  *  @param params :: A reference to the vector of rebinning parameters
  */
-void MergeRuns::noOverlapParams(const HistogramX &X1, const HistogramX &X2, std::vector<double> &params) {
+void MergeRuns::noOverlapParams(std::span<double const> const X1, std::span<double const> const X2,
+                                std::vector<double> &params) {
   // Add all the bins from the first workspace
   for (size_t i = 1; i < X1.size(); ++i) {
     params.emplace_back(X1[i - 1]);
@@ -549,16 +550,17 @@ void MergeRuns::noOverlapParams(const HistogramX &X1, const HistogramX &X2, std:
  *  @param X2 ::     The bin boundaries from the second workspace
  *  @param params :: A reference to the vector of rebinning parameters
  */
-void MergeRuns::intersectionParams(const HistogramX &X1, size_t &i, const HistogramX &X2, std::vector<double> &params) {
+void MergeRuns::intersectionParams(std::span<double const> const X1, size_t &i, std::span<double const> const X2,
+                                   std::vector<double> &params) {
   // First calculate the number of bins in each workspace that are in the
   // overlap region
   auto const overlapbins1 = X1.size() - i;
-  auto const iterX2 = std::lower_bound(X2.cbegin(), X2.cend(), X1.back());
+  auto const iterX2 = std::lower_bound(X2.begin(), X2.end(), X1.back());
   if (iterX2 == X2.end()) {
     throw std::runtime_error("MergerRuns::intersectionParams: no intersection "
                              "between the histograms.");
   }
-  auto const overlapbins2 = std::distance(X2.cbegin(), iterX2);
+  auto const overlapbins2 = std::distance(X2.begin(), iterX2);
   // We want to use whichever one has the larger bins (on average)
   if (overlapbins1 < static_cast<size_t>(overlapbins2)) {
     // In this case we want the rest of the bins from the first workspace.....
@@ -594,14 +596,15 @@ void MergeRuns::intersectionParams(const HistogramX &X1, size_t &i, const Histog
  *  @param X2 ::     The bin boundaries from the second workspace
  *  @param params :: A reference to the vector of rebinning parameters
  */
-void MergeRuns::inclusionParams(const HistogramX &X1, size_t &i, const HistogramX &X2, std::vector<double> &params) {
+void MergeRuns::inclusionParams(std::span<double const> const X1, size_t &i, std::span<double const> const X2,
+                                std::vector<double> &params) {
   // First calculate the number of bins in each workspace that are in the
   // overlap region
-  const auto iterX1 = std::lower_bound(X1.cbegin() + i, X1.cend(), X2.back());
-  if (iterX1 == X1.cend()) {
+  const auto iterX1 = std::lower_bound(X1.begin() + i, X1.end(), X2.back());
+  if (iterX1 == X1.end()) {
     throw std::runtime_error("MergeRuns::inclusionParams: no overlap between the histograms");
   }
-  auto const overlapbins1 = std::distance(X1.cbegin(), iterX1) - i;
+  auto const overlapbins1 = std::distance(X1.begin(), iterX1) - i;
   auto const overlapbins2 = X2.size() - 1;
 
   // In the overlap region, we want to use whichever one has the larger bins (on

--- a/Framework/Algorithms/src/Minus.cpp
+++ b/Framework/Algorithms/src/Minus.cpp
@@ -58,8 +58,8 @@ void Minus::performEventBinaryOperation(DataObjects::EventList &lhs, const DataO
  *  @param rhsY :: The vector of rhs data values
  *  @param rhsE :: The vector of rhs error values
  */
-void Minus::performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                        const MantidVec &rhsE) {
+void Minus::performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                        std::span<double const> rhsY, std::span<double const> rhsE) {
   (void)lhs; // Avoid compiler warnings
   (void)rhsX;
   (void)rhsY;

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -348,7 +348,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
     const double lambdaFixed = toWavelength(efixed.value(spectrumInfo.detector(i).getID()));
     MersenneTwister rng(seed + int(i));
 
-    const auto lambdas = simulationWS.points(i).rawData();
+    const auto lambdas = simulationWS.points(i);
 
     const auto nbins = lambdas.size();
     const size_t lambdaStepSize = nbins / nlambda;

--- a/Framework/Algorithms/src/Multiply.cpp
+++ b/Framework/Algorithms/src/Multiply.cpp
@@ -70,8 +70,8 @@ void Multiply::setOutputUnits(const API::MatrixWorkspace_const_sptr lhs, const A
 void Multiply::performEventBinaryOperation(DataObjects::EventList &lhs, const DataObjects::EventList &rhs) {
   // We must histogram the rhs event list to multiply.
   MantidVec rhsY, rhsE;
-  rhs.generateHistogram(rhs.x().rawData(), rhsY, rhsE);
-  lhs.multiply(rhs.x().rawData(), rhsY, rhsE);
+  rhs.generateHistogram(rhs.x(), rhsY, rhsE);
+  lhs.multiply(rhs.x(), rhsY, rhsE);
 }
 
 /** Carries out the binary operation IN-PLACE on a single EventList,
@@ -82,8 +82,8 @@ void Multiply::performEventBinaryOperation(DataObjects::EventList &lhs, const Da
  *  @param rhsY :: The vector of rhs data values
  *  @param rhsE :: The vector of rhs error values
  */
-void Multiply::performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                           const MantidVec &rhsE) {
+void Multiply::performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                           std::span<double const> rhsY, std::span<double const> rhsE) {
   // Multiply is implemented at the EventList level.
   lhs.multiply(rhsX, rhsY, rhsE);
 }

--- a/Framework/Algorithms/src/NormaliseByDetector.cpp
+++ b/Framework/Algorithms/src/NormaliseByDetector.cpp
@@ -126,8 +126,9 @@ void NormaliseByDetector::processHistogram(size_t wsIndex, const MatrixWorkspace
     function->setParameter(fitParam.getName(), paramValue);
   }
 
-  auto wavelengths = inWS->points(wsIndex);
-  FunctionDomain1DVector domain(wavelengths.rawData());
+  // const so that binding it to a std::span does not detach the cow_ptr
+  auto const wavelengths = inWS->points(wsIndex);
+  FunctionDomain1DVector domain(wavelengths);
   FunctionValues values(domain);
   function->function(domain, values);
 

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -27,6 +27,7 @@
 
 #include <cfloat>
 #include <numeric>
+#include <utility>
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -638,6 +639,7 @@ void NormaliseToMonitor::normaliseBinByBin(const MatrixWorkspace_sptr &inputWork
   for (auto &workspaceIndex : m_workspaceIndexes) {
     // Get hold of the monitor spectrum
     const auto &monX = m_monitor->binEdges(workspaceIndex);
+    // not const: normalisationFactor() below rescales these in place
     auto monY = m_monitor->counts(workspaceIndex);
     auto monE = m_monitor->countStandardDeviations(workspaceIndex);
     size_t timeIndex = 0;
@@ -677,8 +679,10 @@ void NormaliseToMonitor::normaliseBinByBin(const MatrixWorkspace_sptr &inputWork
           continue;
         // Rebin the monitor spectrum to match the binning of the current data
         // spectrum
-        VectorHelper::rebinHistogram(monX.rawData(), monY.mutableRawData(), monE.mutableRawData(), X.rawData(),
-                                     Y.mutableRawData(), E.mutableRawData(), false);
+        // as_const on the monitor data: these are read-only inputs, and binding a
+        // non-const Counts/CountStandardDeviations to a span would detach the cow_ptr
+        VectorHelper::rebinHistogram(monX, std::as_const(monY), std::as_const(monE), X, Y.mutableRawData(),
+                                     E.mutableRawData(), false);
         // Recalculate the overall normalization factor
         this->normalisationFactor(X, Y, E);
       }

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -690,7 +690,8 @@ void NormaliseToMonitor::normaliseBinByBin(const MatrixWorkspace_sptr &inputWork
       if (inputEvent) {
         // --- EventWorkspace ---
         EventList &outEL = outputEvent->getSpectrum(i);
-        outEL.divide(X.rawData(), Y.mutableRawData(), E.mutableRawData());
+        // read-only inputs: as_const avoids detaching the cow_ptr that Y/E may share with monY/monE
+        outEL.divide(X, std::as_const(Y), std::as_const(E));
       } else {
         // --- Workspace2D ---
         auto &YOut = outputWorkspace->mutableY(i);

--- a/Framework/Algorithms/src/Plus.cpp
+++ b/Framework/Algorithms/src/Plus.cpp
@@ -61,8 +61,8 @@ void Plus::performEventBinaryOperation(DataObjects::EventList &lhs, const DataOb
  *  @param rhsY :: The vector of rhs data values
  *  @param rhsE :: The vector of rhs error values
  */
-void Plus::performEventBinaryOperation(DataObjects::EventList &lhs, const MantidVec &rhsX, const MantidVec &rhsY,
-                                       const MantidVec &rhsE) {
+void Plus::performEventBinaryOperation(DataObjects::EventList &lhs, std::span<double const> rhsX,
+                                       std::span<double const> rhsY, std::span<double const> rhsE) {
   (void)lhs; // Avoid compiler warnings
   (void)rhsX;
   (void)rhsY;

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -406,8 +406,7 @@ void HeliumAnalyserEfficiency::convertToTheoreticalEfficiencies(const std::vecto
     const auto pHeError = pHeErrorVec.at(index);
     const auto eff = efficiencies.at(index);
 
-    const auto &pointData = eff->histogram(0).points();
-    const auto &binPoints = pointData.rawData();
+    const auto &binPoints = eff->histogram(0).points();
     const auto &binBoundaries = eff->x(0);
 
     auto &theoreticalEff = eff->mutableY(0);

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -310,7 +310,7 @@ bool PolarizationEfficiencyCor::needInterpolation(MatrixWorkspace const &efficie
 
   auto const &x = inWS.x(0);
   for (size_t i = 0; i < efficiencies.getNumberHistograms(); ++i) {
-    if (efficiencies.x(i).rawData() != x.rawData())
+    if (efficiencies.x(i) != x)
       return true;
   }
   return false;

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -23,6 +23,8 @@
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
+#include <utility>
+
 namespace Mantid {
 
 namespace PropertyNames {
@@ -338,10 +340,12 @@ void Rebin::exec() {
         const EventList &el = eventInputWS->getSpectrum(i);
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
+        // as_const: XValues_new is shared with every output spectrum, so binding it
+        // non-const to a span would deep-copy the X data on each iteration
         if (useUnsortingHistogram)
-          el.generateHistogram(rbParams[1], XValues_new.rawData(), y_data, e_data);
+          el.generateHistogram(rbParams[1], std::as_const(XValues_new), y_data, e_data);
         else
-          el.generateHistogram(XValues_new.rawData(), y_data, e_data);
+          el.generateHistogram(std::as_const(XValues_new), y_data, e_data);
 
         // Copy the data over.
         outputWS->mutableY(i) = y_data;

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -19,6 +19,8 @@
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
+#include <utility>
+
 namespace Mantid::Algorithms {
 
 // Register the algorithm into the AlgorithmFactory
@@ -129,9 +131,10 @@ void Rebin2D::exec() {
       const double x_jp1 = oldXEdges[j + 1];
       Quadrilateral inputQ(x_j, x_jp1, vlo, vhi);
       if (!useFractionalArea) {
-        FractionalRebinning::rebinToOutput(inputQ, inputWS, i, j, *outputWS, newYBins.rawData());
+        FractionalRebinning::rebinToOutput(inputQ, inputWS, i, j, *outputWS, std::as_const(newYBins));
       } else {
-        FractionalRebinning::rebinToFractionalOutput(inputQ, inputWS, i, j, *outputRB, newYBins.rawData(), inputHasFA);
+        FractionalRebinning::rebinToFractionalOutput(inputQ, inputWS, i, j, *outputRB, std::as_const(newYBins),
+                                                     inputHasFA);
       }
     }
 
@@ -185,7 +188,7 @@ MatrixWorkspace_sptr Rebin2D::createOutputWorkspace(const MatrixWorkspace_const_
   } else {
     outputWS = create<RebinnedOutput>(*parent, newYSize - 1, binEdges);
   }
-  auto verticalAxis = std::make_unique<BinEdgeAxis>(newYBins.rawData());
+  auto verticalAxis = std::make_unique<BinEdgeAxis>(std::as_const(newYBins));
   // Meta data
   verticalAxis->unit() = parent->getAxis(1)->unit();
   verticalAxis->title() = parent->getAxis(1)->title();

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -17,6 +17,8 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/VectorHelper.h"
 
+#include <utility>
+
 namespace Mantid::Algorithms {
 
 // Register the algorithm into the AlgorithmFactory
@@ -196,7 +198,7 @@ void RebinRagged::exec() {
 
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
-        el.generateHistogram(delta, XValues_new.rawData(), y_data, e_data);
+        el.generateHistogram(delta, std::as_const(XValues_new), y_data, e_data);
 
         // Create and set the output histogram
         HistogramBuilder builder;

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -274,8 +274,8 @@ void RebinRagged::exec() {
       for (int hist = 0; hist < histnumber; ++hist) {
         HistogramBuilder builder;
         builder.setX(outputWS->histogram(hist).points().rawData());
-        builder.setY(outputWS->y(hist).rawData());
-        builder.setE(outputWS->e(hist).rawData());
+        builder.setY(outputWS->y(hist));
+        builder.setE(outputWS->e(hist));
         if (outputWS->hasDx(hist))
           builder.setDx(outputWS->dx(hist));
         builder.setDistribution(dist);

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -159,7 +159,7 @@ void RebinToWorkspace::histogram(API::MatrixWorkspace_sptr &toRebin, API::Matrix
     // TODO this should be in HistogramData/Rebin
     const auto &eventlist = inputWS->getSpectrum(i);
     MantidVec y_data(edges.size() - 1), e_data(edges.size() - 1);
-    eventlist.generateHistogram(edges.rawData(), y_data, e_data);
+    eventlist.generateHistogram(edges, y_data, e_data);
 
     outputWS->setHistogram(i, edges, Counts(std::move(y_data)), CountStandardDeviations(std::move(e_data)));
     prog.report();

--- a/Framework/Algorithms/src/Regroup.cpp
+++ b/Framework/Algorithms/src/Regroup.cpp
@@ -66,7 +66,7 @@ void Regroup::exec() {
   std::vector<int> xoldIndex; // indeces of new x in XValues_old
   // create new output X axis
   std::vector<double> xAxisTmp;
-  int ntcnew = newAxis(rb_params, XValues_old.rawData(), xAxisTmp, xoldIndex);
+  int ntcnew = newAxis(rb_params, XValues_old, xAxisTmp, xoldIndex);
   HistogramData::BinEdges XValues_new(std::move(xAxisTmp));
 
   // make output Workspace the same type is the input, but with new length of
@@ -174,7 +174,7 @@ void Regroup::rebin(const HistogramX &xold, const HistogramY &yold, const Histog
  *  @param xoldIndex :: indeces of new x in XValues_old
  *  @return The number of bin boundaries in the new X array
  **/
-int Regroup::newAxis(const std::vector<double> &params, const std::vector<double> &xold, std::vector<double> &xnew,
+int Regroup::newAxis(const std::vector<double> &params, std::span<double const> const xold, std::vector<double> &xnew,
                      std::vector<int> &xoldIndex) {
   double xcurr, xs;
   int ibound(2), istep(1), inew(0);
@@ -183,7 +183,7 @@ int Regroup::newAxis(const std::vector<double> &params, const std::vector<double
 
   xcurr = params[0];
   using std::placeholders::_1;
-  auto iup = std::find_if(xold.cbegin(), xold.cend(), std::bind(std::greater_equal<double>(), _1, xcurr));
+  auto iup = std::find_if(xold.begin(), xold.end(), std::bind(std::greater_equal<double>(), _1, xcurr));
   if (iup != xold.end()) {
     xcurr = *iup;
     xnew.emplace_back(xcurr);

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -442,8 +442,7 @@ void ResampleX::exec() {
 
       // output data arrays are implicitly filled by function
       try {
-        VectorHelper::rebin(XValues.rawData(), YValues.rawData(), YErrors.rawData(), XValues_new, YValues_new,
-                            YErrors_new, m_isDistribution);
+        VectorHelper::rebin(XValues, YValues, YErrors, XValues_new, YValues_new, YErrors_new, m_isDistribution);
       } catch (std::exception &ex) {
         g_log.error() << "Error in rebin function: " << ex.what() << '\n';
         throw;

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -136,12 +136,10 @@ Histogram smooth(const Histogram &histogram, unsigned int const npts) {
 
   Histogram smoothed(histogram);
 
-  auto const &Y = histogram.y().rawData();
-  auto const &E = histogram.e().rawData();
   auto &newY = smoothed.mutableY();
   auto &newE = smoothed.mutableE();
-  newY = Mantid::Kernel::Smoothing::boxcarSmooth(Y, npts);
-  newE = Mantid::Kernel::Smoothing::boxcarErrorSmooth(E, npts);
+  newY = Mantid::Kernel::Smoothing::boxcarSmooth(histogram.y(), npts);
+  newE = Mantid::Kernel::Smoothing::boxcarErrorSmooth(histogram.e(), npts);
   return smoothed;
 }
 

--- a/Framework/Algorithms/src/Stitch.cpp
+++ b/Framework/Algorithms/src/Stitch.cpp
@@ -125,7 +125,7 @@ MatrixWorkspace_sptr medianWorkspaceGlobal(const MatrixWorkspace_sptr &ws) {
   std::vector<double> allY;
   allY.reserve(ws->getNumberHistograms() * ws->blocksize());
   for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
-    const auto spectrum = ws->mutableY(i).rawData();
+    const auto &spectrum = ws->y(i);
     std::copy(spectrum.cbegin(), spectrum.cend(), std::back_inserter(allY));
   }
   auto &y = out->mutableY(0);

--- a/Framework/Algorithms/src/Stitch.cpp
+++ b/Framework/Algorithms/src/Stitch.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
+#include <span>
 #include <utility>
 
 #include "MantidAPI/ADSValidator.h"
@@ -81,15 +82,15 @@ std::pair<double, double> getOverlap(const MatrixWorkspace_sptr &ws1, const Matr
 }
 
 /**
- * @brief Calculates the median of a vector
- * @param vec : input vector
+ * @brief Calculates the median of a contiguous range
+ * @param vec : input range
  * @return the median if not empty, 1 otherwise
  */
-double median(const std::vector<double> &vec) {
+double median(std::span<double const> const vec) {
   if (vec.empty())
     return 1;
   const size_t s = vec.size();
-  std::vector<double> sorted = vec;
+  std::vector<double> sorted(vec.begin(), vec.end());
   std::sort(sorted.begin(), sorted.end());
   if (s % 2 == 0) {
     return 0.5 * (sorted[s / 2] + sorted[s / 2 - 1]);
@@ -110,7 +111,7 @@ MatrixWorkspace_sptr medianWorkspaceLocal(const MatrixWorkspace_sptr &ws) {
   for (int i = 0; i < static_cast<int>(nSpectra); ++i) {
     const size_t wsIndex = static_cast<size_t>(i);
     auto &y = out->mutableY(wsIndex);
-    y = std::vector<double>(1, median(ws->y(wsIndex).rawData()));
+    y = std::vector<double>(1, median(ws->y(wsIndex)));
   }
   return out;
 }

--- a/Framework/Algorithms/src/StripVanadiumPeaks.cpp
+++ b/Framework/Algorithms/src/StripVanadiumPeaks.cpp
@@ -130,8 +130,8 @@ void StripVanadiumPeaks::exec() {
         // Find the bin indices on both sides.
         //  We use averaging regions of 1/2 width, centered at +- width/2 from
         //  the center
-        int L1 = getBinIndex(X.rawData(), center - width * 0.75);
-        int L2 = getBinIndex(X.rawData(), center - width * 0.25);
+        int L1 = getBinIndex(X, center - width * 0.75);
+        int L2 = getBinIndex(X, center - width * 0.25);
         double leftX = (midX[L1] + midX[L2]) / 2;
         double totY = 0;
 
@@ -141,8 +141,8 @@ void StripVanadiumPeaks::exec() {
 
         double leftY = totY / (L2 - L1 + 1);
 
-        int R1 = getBinIndex(X.rawData(), center + width * 0.25);
-        int R2 = getBinIndex(X.rawData(), center + width * 0.75);
+        int R1 = getBinIndex(X, center + width * 0.25);
+        int R2 = getBinIndex(X, center + width * 0.75);
         double rightX = (midX[R1] + midX[R2]) / 2;
         totY = 0;
 

--- a/Framework/Algorithms/src/Transpose.cpp
+++ b/Framework/Algorithms/src/Transpose.cpp
@@ -114,9 +114,9 @@ API::MatrixWorkspace_sptr Transpose::createOutputWorkspace(const API::MatrixWork
   // Values come from input X
   std::unique_ptr<API::NumericAxis> newYAxis(nullptr);
   if (inputWorkspace->isHistogramData()) {
-    newYAxis = std::make_unique<API::BinEdgeAxis>(inX.rawData());
+    newYAxis = std::make_unique<API::BinEdgeAxis>(inX);
   } else {
-    newYAxis = std::make_unique<API::NumericAxis>(inX.rawData());
+    newYAxis = std::make_unique<API::NumericAxis>(inX);
   }
 
   newYAxis->unit() = inputWorkspace->getAxis(0)->unit();

--- a/Framework/Algorithms/src/XrayAbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/XrayAbsorptionCorrection.cpp
@@ -113,17 +113,18 @@ Kernel::V3D XrayAbsorptionCorrection::calculateDetectorPos(double const detector
 
 /**
  * normalise moun intensity to 1.
- * @param muonIntensity A MantidVec which contains the intensity of muons as a
- * function  of depth
+ * @param muonIntensity A contiguous range which contains the intensity of muons
+ * as a function  of depth
  * @return A vector of doubles which contains the normalised muon intensity
  */
-std::vector<double> XrayAbsorptionCorrection::normaliseMuonIntensity(MantidVec muonIntensity) {
+std::vector<double> XrayAbsorptionCorrection::normaliseMuonIntensity(std::span<double const> const muonIntensity) {
 
   double sum_of_elems = std::accumulate(muonIntensity.begin(), muonIntensity.end(), 0.0);
 
-  std::transform(muonIntensity.begin(), muonIntensity.end(), muonIntensity.begin(),
+  std::vector<double> normalised(muonIntensity.size());
+  std::transform(muonIntensity.begin(), muonIntensity.end(), normalised.begin(),
                  [sum_of_elems](double d) { return d / sum_of_elems; });
-  return muonIntensity;
+  return normalised;
 }
 
 /**
@@ -172,7 +173,7 @@ void XrayAbsorptionCorrection::exec() {
 
   MatrixWorkspace_sptr muonProfile = getProperty("MuonImplantationProfile");
   Mantid::HistogramData::HistogramY const &muonIntensity = muonProfile->y(0);
-  std::vector<double> normalisedMuonIntensity = normaliseMuonIntensity(muonIntensity.rawData());
+  std::vector<double> normalisedMuonIntensity = normaliseMuonIntensity(muonIntensity);
   double detectorAngle = getProperty("DetectorAngle");
   double detectorDistance = getProperty("DetectorDistance");
   Kernel::V3D detectorPos = calculateDetectorPos(detectorAngle, detectorDistance);

--- a/Framework/Algorithms/test/BinaryOperationTest.h
+++ b/Framework/Algorithms/test/BinaryOperationTest.h
@@ -63,8 +63,8 @@ private:
   void performBinaryOperation(const HistogramData::Histogram &, const double, const double, HistogramData::HistogramY &,
                               HistogramData::HistogramE &) override {}
   void performEventBinaryOperation(DataObjects::EventList &, const DataObjects::EventList &) override {}
-  void performEventBinaryOperation(DataObjects::EventList &, const MantidVec &, const MantidVec &,
-                                   const MantidVec &) override {}
+  void performEventBinaryOperation(DataObjects::EventList &, std::span<double const>, std::span<double const>,
+                                   std::span<double const>) override {}
   void performEventBinaryOperation(DataObjects::EventList &, const double &, const double &) override {}
 };
 

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
@@ -195,8 +195,8 @@ private:
     TS_ASSERT_EQUALS(groupOut->getNumberOfEntries(), HeFitSize);
     for (size_t index = 0; index < HeFitSize; index++) {
       const auto ws = std::dynamic_pointer_cast<MatrixWorkspace>(groupOut->getItem(index));
-      const auto &y = ws->dataY(0);
-      TS_ASSERT_DELTA(y, m_polParameters.outEfficiencies.at(index)->dataY(0), DELTA);
+      const auto &y = ws->y(0).rawData();
+      TS_ASSERT_DELTA(y, m_polParameters.outEfficiencies.at(index)->y(0).rawData(), DELTA);
     }
 
     // Assert Polarization parameters

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTimeTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTimeTest.h
@@ -107,7 +107,7 @@ public:
 
     TS_ASSERT(alg->isExecuted());
     const MatrixWorkspace_sptr out = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(OUTPUT_NAME);
-    TS_ASSERT_DELTA(out->dataY(0), effTest->dataY(0), DELTA);
+    TS_ASSERT_DELTA(out->y(0).rawData(), effTest->y(0).rawData(), DELTA);
   }
 
   void test_algorithm_unpolarized_transmission_output_with_string_time_stamp_input() {
@@ -124,7 +124,7 @@ public:
     TS_ASSERT(alg->isExecuted());
     const MatrixWorkspace_sptr out = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outUnpolarized);
 
-    TS_ASSERT_DELTA(out->dataY(0), unpolTest->dataY(0), DELTA);
+    TS_ASSERT_DELTA(out->y(0).rawData(), unpolTest->y(0).rawData(), DELTA);
   }
 
   void test_algorithm_output_with_reference_workspace_input() {
@@ -139,7 +139,7 @@ public:
 
     TS_ASSERT(alg->isExecuted());
     const MatrixWorkspace_sptr out = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(OUTPUT_NAME);
-    TS_ASSERT_DELTA(out->dataY(0), effTest->dataY(0), DELTA);
+    TS_ASSERT_DELTA(out->y(0).rawData(), effTest->y(0).rawData(), DELTA);
   }
 
   void test_reference_workspace_takes_precedence_over_timestamp_if_both_are_provided() {
@@ -154,7 +154,7 @@ public:
 
     TS_ASSERT(alg->isExecuted());
     const MatrixWorkspace_sptr out = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(OUTPUT_NAME);
-    TS_ASSERT_DELTA(out->dataY(0), effTest->dataY(0), DELTA)
+    TS_ASSERT_DELTA(out->y(0).rawData(), effTest->y(0).rawData(), DELTA)
   }
 
 private:

--- a/Framework/Algorithms/test/PowerTest.h
+++ b/Framework/Algorithms/test/PowerTest.h
@@ -106,7 +106,7 @@ public:
     WorkspaceSingleValue_sptr output = AnalysisDataService::Instance().retrieveWS<WorkspaceSingleValue>("WSCor");
 
     Mantid::MantidVec expectedValue(1, 4);
-    TSM_ASSERT_EQUALS("Power has not been determined correctly", expectedValue, output->dataY(0));
+    TSM_ASSERT_EQUALS("Power has not been determined correctly", expectedValue, output->y(0).rawData());
 
     AnalysisDataService::Instance().remove("InputWS");
     AnalysisDataService::Instance().remove("WSCor");
@@ -129,10 +129,10 @@ public:
     WorkspaceSingleValue_sptr output = AnalysisDataService::Instance().retrieveWS<WorkspaceSingleValue>("WSCor");
 
     Mantid::MantidVec expectedValue(1, 0.25);
-    TSM_ASSERT_EQUALS("Power has not been determined correctly", expectedValue, output->dataY(0));
+    TSM_ASSERT_EQUALS("Power has not been determined correctly", expectedValue, output->y(0).rawData());
 
     Mantid::MantidVec expectedError(1, 0.35355);
-    TS_ASSERT_DELTA(0.353553391, output->dataE(0)[0], 0.001);
+    TS_ASSERT_DELTA(0.353553391, output->e(0)[0], 0.001);
 
     AnalysisDataService::Instance().remove("InputWS");
     AnalysisDataService::Instance().remove("WSCor");
@@ -159,7 +159,7 @@ public:
     WorkspaceSingleValue_sptr output = AnalysisDataService::Instance().retrieveWS<WorkspaceSingleValue>("WSCor");
 
     Mantid::MantidVec expectedError(1, 16);
-    TSM_ASSERT_EQUALS("Error has not been determined correctly", expectedError, output->dataE(0));
+    TSM_ASSERT_EQUALS("Error has not been determined correctly", expectedError, output->e(0).rawData());
 
     AnalysisDataService::Instance().remove("InputWS");
     AnalysisDataService::Instance().remove("WSCor");

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -89,8 +89,8 @@ public:
   MOCK_CONST_METHOD1(getTimeAtSampleMax, DateAndTime(double));
   MOCK_CONST_METHOD1(getTimeAtSampleMin, DateAndTime(double));
   MOCK_CONST_METHOD0(getEventType, EventType());
-  MOCK_CONST_METHOD5(generateHistogram, void(const std::size_t, const Mantid::MantidVec &, Mantid::MantidVec &,
-                                             Mantid::MantidVec &, bool));
+  MOCK_CONST_METHOD5(generateHistogram,
+                     void(const std::size_t, std::span<double const>, Mantid::MantidVec &, Mantid::MantidVec &, bool));
   MOCK_METHOD1(setAllX, void(const Mantid::HistogramData::BinEdges &));
   MOCK_METHOD0(resetAllXToSingleBin, void());
   MOCK_METHOD0(clearMRU, void());

--- a/Framework/Algorithms/test/StripVanadiumPeaks2Test.h
+++ b/Framework/Algorithms/test/StripVanadiumPeaks2Test.h
@@ -62,8 +62,8 @@ public:
     output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputWSName);
 
     // Get a spectrum
-    MantidVec X = output->dataX(2);
-    MantidVec Y = output->dataX(2);
+    MantidVec X = output->x(2).rawData();
+    MantidVec Y = output->x(2).rawData();
 
     // Check the height at a couple of peak position
     int bin;

--- a/Framework/Algorithms/test/XrayAbsorptionCorrectionTest.h
+++ b/Framework/Algorithms/test/XrayAbsorptionCorrectionTest.h
@@ -52,7 +52,7 @@ public:
   void test_NormaliseMounIntensity() {
     TestableXrayAbsorptionCorrection alg;
     API::MatrixWorkspace_sptr muonProfile = createWorkspace(1);
-    std::vector<double> normalisedIntensity = alg.normaliseMuonIntensity(muonProfile->y(0).rawData());
+    std::vector<double> normalisedIntensity = alg.normaliseMuonIntensity(muonProfile->y(0));
     for (auto intensity : normalisedIntensity) {
       TS_ASSERT_DELTA(intensity, 0.1, 1.0e-6);
     }

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -105,7 +105,7 @@ void CentroidPeaks::integrate() {
     size_t workspaceIndex = detidIterator->second;
     double TOFPeakd = peak.getTOF();
     const auto &X = m_inWS->x(workspaceIndex);
-    int chan = Kernel::VectorHelper::getBinIndex(X.rawData(), TOFPeakd);
+    int chan = Kernel::VectorHelper::getBinIndex(X, TOFPeakd);
     std::string bankName = peak.getBankName();
     int nCols = 0, nRows = 0;
     sizeBanks(bankName, nCols, nRows);

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -163,7 +163,7 @@ void PeakIntegration::exec() {
     if (TOFmax > numbins)
       TOFmax = numbins;
 
-    TOFPeak = VectorHelper::getBinIndex(X.rawData(), TOFPeakd);
+    TOFPeak = VectorHelper::getBinIndex(X, TOFPeakd);
     const double peakLoc = X[TOFPeak];
     int iTOF;
     for (iTOF = TOFmin; iTOF < TOFmax; iTOF++) {

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
@@ -18,6 +18,8 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Crystal/UnitCell.h"
 
+#include <span>
+
 namespace Mantid {
 namespace CurveFitting {
 namespace Algorithms {
@@ -367,7 +369,7 @@ bool observePeakParameters(const DataObjects::Workspace2D_sptr &dataws, size_t w
                            double &fwhm, std::string &errmsg);
 
 /// Find maximum value
-size_t findMaxValue(const std::vector<double> &Y);
+size_t findMaxValue(std::span<double const> Y);
 
 /// Find maximum value
 size_t findMaxValue(const API::MatrixWorkspace_sptr &dataws, size_t wsindex, double leftbound, double rightbound);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFit.h
@@ -20,6 +20,8 @@
 
 #include <gsl/gsl_sf_erf.h>
 
+#include <span>
+
 namespace Mantid {
 namespace HistogramData {
 class HistogramX;
@@ -135,8 +137,9 @@ private:
 
   /// Work on Markov chain to 'solve' LeBail function
   void doMarkovChain(const std::map<std::string, Parameter> &parammap, const Mantid::HistogramData::HistogramX &vecX,
-                     const Mantid::HistogramData::HistogramY &vecPurePeak, const std::vector<double> &vecBkgd,
-                     size_t maxcycles, const Kernel::Rfactor &startR, int randomseed);
+                     const Mantid::HistogramData::HistogramY &vecPurePeak,
+                     const Mantid::HistogramData::HistogramY &vecBkgd, size_t maxcycles, const Kernel::Rfactor &startR,
+                     int randomseed);
 
   /// Set up Monte Carlo random walk strategy
   void setupBuiltInRandomWalkStrategy();
@@ -164,7 +167,7 @@ private:
   double limitProposedValueInBound(const Parameter &param, double newvalue, double direction, int choice);
 
   /// Book keep the (sopposed) best MC result
-  void bookKeepBestMCResult(const std::map<std::string, Parameter> &parammap, const std::vector<double> &bkgddata,
+  void bookKeepBestMCResult(const std::map<std::string, Parameter> &parammap, std::span<double const> bkgddata,
                             Kernel::Rfactor rfactor, size_t istep);
 
   /// Apply the value of parameters in the source to target

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFunction.h
@@ -12,6 +12,8 @@
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/Functions/BackgroundFunction.h"
 
+#include <span>
+
 namespace Mantid {
 namespace HistogramData {
 class HistogramX;
@@ -73,7 +75,7 @@ public:
                                              bool calbkgd) const;
 
   ///  Calculate a single peak's value
-  Mantid::HistogramData::HistogramY calPeak(size_t ipk, const std::vector<double> &xvalues, size_t ySize) const;
+  Mantid::HistogramData::HistogramY calPeak(size_t ipk, std::span<double const> xvalues, size_t ySize) const;
 
   /// Return the composite function
   API::IFunction_sptr getFunction();
@@ -100,7 +102,7 @@ public:
   void setFixPeakHeights();
 
   /// Calculate peak intensities by Le Bail algorithm
-  bool calculatePeaksIntensities(const std::vector<double> &vecX, const std::vector<double> &vecY,
+  bool calculatePeaksIntensities(std::span<double const> vecX, std::span<double const> vecY,
                                  std::vector<double> &vec_summedpeaks);
 
   /// Get the maximum value of a peak in a given set of data points
@@ -122,7 +124,7 @@ private:
 
   /// Calculate the peaks intensities in same group
   bool calculateGroupPeakIntensities(std::vector<std::pair<double, API::IPowderDiffPeakFunction_sptr>> peakgroup,
-                                     const std::vector<double> &vecX, const std::vector<double> &vecY,
+                                     std::span<double const> vecX, std::span<double const> vecY,
                                      std::vector<double> &vec_summedpeaks);
 
   /// Group close peaks together

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters3.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters3.h
@@ -16,6 +16,8 @@
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h"
 
+#include <span>
+
 namespace Mantid {
 namespace CurveFitting {
 namespace Algorithms {
@@ -181,8 +183,8 @@ void duplicateParameters(const std::map<std::string, Parameter> &source, std::ma
 void copyParametersValues(const std::map<std::string, Parameter> &source, std::map<std::string, Parameter> &target);
 
 /// Calculate Chi^2
-double calculateFunctionChiSquare(const std::vector<double> &modelY, const std::vector<double> &dataY,
-                                  const std::vector<double> &dataE);
+double calculateFunctionChiSquare(std::span<double const> modelY, std::span<double const> dataY,
+                                  std::span<double const> dataE);
 
 } // namespace Algorithms
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -13,6 +13,8 @@
 
 #include <map>
 
+#include <span>
+
 namespace Mantid {
 
 namespace Kernel {
@@ -71,7 +73,7 @@ private:
                                      const Kernel::V3D &detPos, const DetectorParams &detPar,
                                      const CurveFitting::Functions::ResolutionParams &detRes);
   /// Compute a TOF spectrum for the given inputs & spectrum
-  std::vector<double> calculateTofSpectrum(const std::vector<double> &inSpectrum, std::vector<double> &tmpWork,
+  std::vector<double> calculateTofSpectrum(std::span<double const> inSpectrum, std::vector<double> &tmpWork,
                                            const size_t wsIndex, const DetectorParams &detpar,
                                            const CurveFitting::Functions::ResolutionParams &respar);
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
@@ -49,7 +49,7 @@ public:
   // virtual double height()const;
 
   using IFunction1D::function;
-  void function(std::vector<double> &out, const std::vector<double> &xValues) const override;
+  void function(std::span<double> out, std::span<double const> xValues) const override;
 
   /// Function you want to fit to.
   void function1D(double *out, const double *xValues, const size_t nData) const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
@@ -16,6 +16,8 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ArrayProperty.h"
 
+#include <span>
+
 namespace Mantid {
 namespace CurveFitting {
 namespace Functions {
@@ -32,7 +34,7 @@ private:
                                std::vector<double> &vec_peakfwhm);
 
   /// Exclude peak regions
-  size_t excludePeaks(std::vector<double> v_inX, std::vector<bool> &v_useX, const std::vector<double> &v_centre,
+  size_t excludePeaks(std::span<double const> v_inX, std::vector<bool> &v_useX, const std::vector<double> &v_centre,
                       const std::vector<double> &v_fwhm, double num_fwhm);
 
   std::vector<double> m_vecPeakCentre;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
@@ -77,7 +77,7 @@ public:
   // virtual double height()const;
 
   using IFunction1D::function;
-  void function(std::vector<double> &out, const std::vector<double> &xValues) const override;
+  void function(std::span<double> out, std::span<double const> xValues) const override;
 
   /// Function you want to fit to.
   void function1D(double *out, const double *xValues, const size_t nData) const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h
@@ -16,6 +16,8 @@
 #include <cmath>
 #include <gsl/gsl_sf_erf.h>
 
+#include <span>
+
 namespace Mantid {
 namespace CurveFitting {
 namespace Functions {
@@ -35,7 +37,7 @@ public:
   const std::string category() const override { return "General"; }
 
   /// Calculate function values
-  void function1D(std::vector<double> &out, const std::vector<double> &xValues) const;
+  void function1D(std::span<double> out, std::span<double const> xValues) const;
 
 protected:
   /// overwrite IFunction base class method, which declare function parameters

--- a/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
+++ b/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
@@ -1148,7 +1148,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(const BackToBackExponential_sptr
   g_log.notice(dbss2.str());
 
   // 3. Estimate peak heights
-  size_t imaxheight = findMaxValue(peakdataws->y(1).rawData());
+  size_t imaxheight = findMaxValue(peakdataws->y(1));
   double maxheight = peakdataws->y(1)[imaxheight];
   if (maxheight <= m_minPeakHeight) {
     // Max height / peak height is smaller than user defined minimum height.  No
@@ -2968,7 +2968,7 @@ bool observePeakParameters(const Workspace2D_sptr &dataws, size_t wsindex, doubl
   const auto &Y = dataws->y(wsindex);
 
   // 2. The highest peak should be the centre
-  size_t icentre = findMaxValue(Y.rawData());
+  size_t icentre = findMaxValue(Y);
   centre = X[icentre];
   height = Y[icentre];
 
@@ -3056,7 +3056,7 @@ bool observePeakParameters(const Workspace2D_sptr &dataws, size_t wsindex, doubl
  * @param Y :: vector to get maximum value from
  * @return index of the maximum value
  */
-size_t findMaxValue(const std::vector<double> &Y) {
+size_t findMaxValue(std::span<double const> const Y) {
 
   auto maxIt = std::max_element(Y.begin(), Y.end());
   return std::distance(Y.begin(), maxIt);

--- a/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
+++ b/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
@@ -744,7 +744,7 @@ bool FitPowderDiffPeaks::fitSinglePeakRobust(const BackToBackExponential_sptr &p
   }
 
   // 9. Plot function
-  FunctionDomain1DVector domain(peakws->x(0).rawData());
+  FunctionDomain1DVector domain(peakws->x(0));
   plotFunction(peak, backgroundfunction, domain);
 
   return fitgood;
@@ -1319,7 +1319,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(const BackToBackExponential_sptr
 
   // 6. Plot the peak in the output workspace data
   if (goodfit) {
-    FunctionDomain1DVector domain(peakdataws->x(1).rawData());
+    FunctionDomain1DVector domain(peakdataws->x(1));
     plotFunction(peak, backgroundfunction, domain);
   } else {
     // Throw exception if fit peak bad.  This is NOT a PERMANANT solution.
@@ -1792,7 +1792,7 @@ bool FitPowderDiffPeaks::fitOverlappedPeaks(vector<BackToBackExponential_sptr> p
 
   // 9. Plot peaks
   if (fitsuccess) {
-    FunctionDomain1DVector domain(peaksws->x(1).rawData());
+    FunctionDomain1DVector domain(peaksws->x(1));
     plotFunction(peaksfunction, backgroundfunction, domain);
   }
 
@@ -1893,7 +1893,7 @@ bool FitPowderDiffPeaks::doFitMultiplePeaks(const Workspace2D_sptr &dataws, size
     restoreFunctionParameters(peaksfunc, peaksfuncparams);
 
   // -1. Final debug output
-  FunctionDomain1DVector domain(dataws->x(wsindex).rawData());
+  FunctionDomain1DVector domain(dataws->x(wsindex));
   FunctionValues values(domain);
   peaksfunc->function(domain, values);
   stringstream rss;
@@ -1913,7 +1913,7 @@ bool FitPowderDiffPeaks::doFitMultiplePeaks(const Workspace2D_sptr &dataws, size
 void FitPowderDiffPeaks::estimatePeakHeightsLeBail(const Workspace2D_sptr &dataws, size_t wsindex,
                                                    vector<BackToBackExponential_sptr> peaks) {
   // 1. Build data structures
-  FunctionDomain1DVector domain(dataws->x(wsindex).rawData());
+  FunctionDomain1DVector domain(dataws->x(wsindex));
   FunctionValues values(domain);
   vector<vector<double>> peakvalues;
   for (size_t i = 0; i < (peaks.size() + 1); ++i) {
@@ -2938,7 +2938,7 @@ void estimateBackgroundCoarse(const DataObjects::Workspace2D_sptr &dataws, const
   background->setParameter("A1", b1);
 
   // 4. Calcualte background
-  FunctionDomain1DVector domain(X.rawData());
+  FunctionDomain1DVector domain(X);
   FunctionValues values(domain);
   background->function(domain, values);
 

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -426,8 +426,7 @@ void LeBailFit::execPatternCalculation() {
   g_log.information() << "Output individual peaks  = " << ploteachpeak << ".\n";
   if (ploteachpeak) {
     for (size_t ipk = 0; ipk < m_lebailFunction->getNumberOfPeaks(); ++ipk) {
-      // calPeak still requires a std::vector<double>
-      m_outputWS->mutableY(9 + ipk) = m_lebailFunction->calPeak(ipk, vecX.rawData(), m_outputWS->y(9 + ipk).size());
+      m_outputWS->mutableY(9 + ipk) = m_lebailFunction->calPeak(ipk, vecX, m_outputWS->y(9 + ipk).size());
     }
   }
 
@@ -1372,7 +1371,7 @@ void LeBailFit::execRandomWalkMinimizer(size_t maxcycles, map<string, Parameter>
                         " unphyiscal parameters values.");
   }
 
-  doMarkovChain(parammap, vecX, vecPurePeak, vecBkgd.rawData(), maxcycles, startR, randomseed);
+  doMarkovChain(parammap, vecX, vecPurePeak, vecBkgd, maxcycles, startR, randomseed);
 
   // 5. Sum up: retrieve the best result from class variable: m_bestParameters
   Rfactor finalR(-DBL_MAX, -DBL_MAX);
@@ -1406,8 +1405,9 @@ void LeBailFit::execRandomWalkMinimizer(size_t maxcycles, map<string, Parameter>
 /** Work on Markov chain to 'solve' LeBail function
  */
 void LeBailFit::doMarkovChain(const map<string, Parameter> &parammap, const Mantid::HistogramData::HistogramX &vecX,
-                              const Mantid::HistogramData::HistogramY &vecPurePeak, const vector<double> &vecBkgd,
-                              size_t maxcycles, const Rfactor &startR, int randomseed) {
+                              const Mantid::HistogramData::HistogramY &vecPurePeak,
+                              const Mantid::HistogramData::HistogramY &vecBkgd, size_t maxcycles, const Rfactor &startR,
+                              int randomseed) {
 
   // Rfactors in loop
   Rfactor currR(-DBL_MAX, -DBL_MAX), newR(-DBL_MAX, -DBL_MAX);
@@ -1862,14 +1862,14 @@ bool LeBailFit::calculateDiffractionPattern(const HistogramX &vecX, const Histog
     }
 
     // Calculate peak intensity
-    peaksvalid = m_lebailFunction->calculatePeaksIntensities(vecX.rawData(), vecPureY, values);
+    peaksvalid = m_lebailFunction->calculatePeaksIntensities(vecX, vecPureY, values);
   } // [input is raw]
   else {
     // Calculate peaks intensities
     g_log.debug() << "Calculate diffraction pattern from input data with "
                      "background removed. "
                   << ".\n";
-    peaksvalid = m_lebailFunction->calculatePeaksIntensities(vecX.rawData(), vecY.rawData(), values);
+    peaksvalid = m_lebailFunction->calculatePeaksIntensities(vecX, vecY, values);
   }
 
   // Calculate Le Bail function
@@ -2148,7 +2148,7 @@ bool LeBailFit::acceptOrDeny(Rfactor currR, Rfactor newR) {
  * @param rfactor :: R-factor (Rwp and Rp)
  * @param istep:     current MC step to be recorded
  */
-void LeBailFit::bookKeepBestMCResult(const map<string, Parameter> &parammap, const vector<double> &bkgddata,
+void LeBailFit::bookKeepBestMCResult(const map<string, Parameter> &parammap, std::span<double const> const bkgddata,
                                      Rfactor rfactor, size_t istep) {
   // TODO : [RPRWP] Here is a metric of goodness of it.
   double goodness = rfactor.Rwp;
@@ -2172,7 +2172,7 @@ void LeBailFit::bookKeepBestMCResult(const map<string, Parameter> &parammap, con
     }
 
     // c) Background
-    m_bestBackgroundData = bkgddata;
+    m_bestBackgroundData.assign(bkgddata.begin(), bkgddata.end());
   } else {
     // In code calling this function, it should be better always.
     g_log.warning("[Book keep best MC result] Shouldn't be here as it is found "

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -313,7 +313,7 @@ void LeBailFit::exec() {
   setProperty("OutputWorkspace", m_outputWS);
 
   // 8. Final statistic
-  Rfactor finalR = getRFactor(m_outputWS->y(0).rawData(), m_outputWS->y(1).rawData(), m_outputWS->e(0).rawData());
+  Rfactor finalR = getRFactor(m_outputWS->y(0), m_outputWS->y(1), m_outputWS->e(0));
   g_log.notice() << "\nFinal R factor: Rwp = " << finalR.Rwp << ", Rp = " << finalR.Rp
                  << ", Data points = " << m_outputWS->y(1).size() << ", Range = " << m_outputWS->x(0)[0] << ", "
                  << m_outputWS->x(0).back() << "\n";
@@ -392,7 +392,7 @@ void LeBailFit::processInputBackground() {
  */
 void LeBailFit::execPatternCalculation() {
   // Generate domain and values vectors
-  const auto &vecX = m_dataWS->x(m_wsIndex).rawData();
+  const auto &vecX = m_dataWS->x(m_wsIndex);
   std::vector<double> vecY(m_outputWS->y(CALDATAINDEX).size(), 0);
 
   // Calculate diffraction pattern
@@ -426,7 +426,8 @@ void LeBailFit::execPatternCalculation() {
   g_log.information() << "Output individual peaks  = " << ploteachpeak << ".\n";
   if (ploteachpeak) {
     for (size_t ipk = 0; ipk < m_lebailFunction->getNumberOfPeaks(); ++ipk) {
-      m_outputWS->mutableY(9 + ipk) = m_lebailFunction->calPeak(ipk, vecX, m_outputWS->y(9 + ipk).size());
+      // calPeak still requires a std::vector<double>
+      m_outputWS->mutableY(9 + ipk) = m_lebailFunction->calPeak(ipk, vecX.rawData(), m_outputWS->y(9 + ipk).size());
     }
   }
 
@@ -467,7 +468,7 @@ void LeBailFit::execRefineBackground() {
   }
 
   // 1. Generate domain and value
-  const auto &vecX = m_dataWS->x(m_wsIndex).rawData();
+  const auto &vecX = m_dataWS->x(m_wsIndex);
   const auto &vecY = m_dataWS->y(m_wsIndex);
   vector<double> valueVec(vecX.size(), 0);
   size_t numpts = vecX.size();
@@ -1326,7 +1327,7 @@ void LeBailFit::execRandomWalkMinimizer(size_t maxcycles, map<string, Parameter>
   const auto &vecX = m_dataWS->x(m_wsIndex);
   const auto &vecInY = m_dataWS->y(m_wsIndex);
 
-  const auto &domain = m_dataWS->x(m_wsIndex).rawData();
+  const auto &domain = m_dataWS->x(m_wsIndex);
   std::vector<double> vecCalPurePeaks(domain.size(), 0.0);
 
   //    Strategy and map
@@ -1354,7 +1355,7 @@ void LeBailFit::execRandomWalkMinimizer(size_t maxcycles, map<string, Parameter>
   Rfactor startR(-DBL_MAX, -DBL_MAX);
 
   // Process background to make a pure peak spectrum in output workspace
-  HistogramY vecBkgd = m_lebailFunction->function(vecX.rawData(), false, true);
+  HistogramY vecBkgd = m_lebailFunction->function(vecX, false, true);
   m_outputWS->mutableY(INPUTBKGDINDEX) = vecBkgd;
   m_outputWS->mutableY(INPUTPUREPEAKINDEX) = vecInY - vecBkgd;
 
@@ -1855,7 +1856,7 @@ bool LeBailFit::calculateDiffractionPattern(const HistogramX &vecX, const Histog
       g_log.information() << "Calculate diffraction pattern from input data "
                              "and newly calculated background. "
                           << ".\n";
-      veccalbkgd = m_lebailFunction->function(vecX.rawData(), false, true);
+      veccalbkgd = m_lebailFunction->function(vecX, false, true);
       ::transform(vecY.begin(), vecY.end(), veccalbkgd.begin(), vecPureY.begin(), ::minus<double>());
       veccalbkgdIsEmpty = false;
     }
@@ -1887,7 +1888,7 @@ bool LeBailFit::calculateDiffractionPattern(const HistogramX &vecX, const Histog
         throw runtime_error("Programming logic error.");
       ::transform(values.begin(), values.end(), veccalbkgd.begin(), values.begin(), ::plus<double>());
     }
-    rfactor = getRFactor(m_dataWS->y(m_wsIndex).rawData(), values, m_dataWS->e(m_wsIndex).rawData());
+    rfactor = getRFactor(m_dataWS->y(m_wsIndex), values, m_dataWS->e(m_wsIndex));
   } else {
     vector<double> caldata(values.size(), 0.0);
     if (vecBkgd.size() == vecY.size()) {
@@ -1899,7 +1900,7 @@ bool LeBailFit::calculateDiffractionPattern(const HistogramX &vecX, const Histog
         throw runtime_error("Programming logic error (2). ");
       std::transform(values.begin(), values.end(), veccalbkgd.begin(), caldata.begin(), std::plus<double>());
     }
-    rfactor = getRFactor(m_dataWS->y(m_wsIndex).rawData(), caldata, m_dataWS->e(m_wsIndex).rawData());
+    rfactor = getRFactor(m_dataWS->y(m_wsIndex), caldata, m_dataWS->e(m_wsIndex));
   }
 
   if (!peaksvalid) {

--- a/Framework/CurveFitting/src/Algorithms/LeBailFunction.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFunction.cpp
@@ -106,7 +106,6 @@ HistogramY LeBailFunction::function(const Mantid::HistogramData::HistogramX &xva
 
   // Reset output elements to zero
   std::vector<double> out(xvalues.size(), 0);
-  const auto &xvals = xvalues.rawData();
 
   // Peaks
   if (calpeaks) {
@@ -114,7 +113,7 @@ HistogramY LeBailFunction::function(const Mantid::HistogramData::HistogramX &xva
       // Reset temporary vector for output
       vector<double> temp(xvalues.size(), 0);
       IPowderDiffPeakFunction_sptr peak = m_vecPeaks[ipk];
-      peak->function(temp, xvals);
+      peak->function(temp, xvalues);
       transform(out.begin(), out.end(), temp.begin(), out.begin(), ::plus<double>());
     }
   }
@@ -125,7 +124,7 @@ HistogramY LeBailFunction::function(const Mantid::HistogramData::HistogramX &xva
       throw runtime_error("Must define background first!");
     }
 
-    FunctionDomain1DVector domain(xvals);
+    FunctionDomain1DVector domain(xvalues);
     FunctionValues values(domain);
     g_log.information() << "Background function (in LeBailFunction): " << m_background->asString() << ".\n";
     m_background->function(domain, values);
@@ -139,7 +138,7 @@ HistogramY LeBailFunction::function(const Mantid::HistogramData::HistogramX &xva
 
 /**  Calculate a single peak's value
  */
-HistogramY LeBailFunction::calPeak(size_t ipk, const std::vector<double> &xvalues, size_t ySize) const {
+HistogramY LeBailFunction::calPeak(size_t ipk, std::span<double const> const xvalues, size_t ySize) const {
 
   if (ipk >= m_numPeaks) {
     stringstream errss;
@@ -321,7 +320,7 @@ IPowderDiffPeakFunction_sptr LeBailFunction::generatePeak(int h, int k, int l) {
  *
  * Return: True if all peaks' height are physical.  False otherwise
  */
-bool LeBailFunction::calculatePeaksIntensities(const vector<double> &vecX, const vector<double> &vecY,
+bool LeBailFunction::calculatePeaksIntensities(std::span<double const> const vecX, std::span<double const> const vecY,
                                                vector<double> &vec_summedpeaks) {
   // Clear inputs
   std::fill(vec_summedpeaks.begin(), vec_summedpeaks.end(), 0.0);
@@ -365,7 +364,8 @@ bool LeBailFunction::calculatePeaksIntensities(const vector<double> &vecX, const
  * @return :: boolean whether the peaks' heights are physical
  */
 bool LeBailFunction::calculateGroupPeakIntensities(vector<pair<double, IPowderDiffPeakFunction_sptr>> peakgroup,
-                                                   const vector<double> &vecX, const vector<double> &vecY,
+                                                   std::span<double const> const vecX,
+                                                   std::span<double const> const vecY,
                                                    vector<double> &vec_summedpeaks) {
   // Check input peaks group and sort peak by d-spacing
   if (peakgroup.empty()) {
@@ -416,9 +416,7 @@ bool LeBailFunction::calculateGroupPeakIntensities(vector<pair<double, IPowderDi
   }
 
   // Determine calculation range to input workspace: [ileft, iright)
-  vector<double>::const_iterator cviter;
-
-  cviter = lower_bound(vecX.begin(), vecX.end(), leftbound);
+  auto cviter = lower_bound(vecX.begin(), vecX.end(), leftbound);
   size_t ileft = static_cast<size_t>(cviter - vecX.begin());
   if (ileft > 0)
     --ileft;

--- a/Framework/CurveFitting/src/Algorithms/NormaliseByPeakArea.cpp
+++ b/Framework/CurveFitting/src/Algorithms/NormaliseByPeakArea.cpp
@@ -274,14 +274,14 @@ void NormaliseByPeakArea::normaliseTOFData(const double area, const size_t index
 void NormaliseByPeakArea::saveToOutput(const API::MatrixWorkspace_sptr &accumWS,
                                        const Kernel::cow_ptr<HistogramData::HistogramY> &yValues,
                                        const Kernel::cow_ptr<HistogramData::HistogramE> &eValues, const size_t index) {
-  assert(yValues->rawData().size() == eValues->rawData().size());
+  assert(yValues->size() == eValues->size());
 
   if (m_sumResults) {
     const size_t npts(accumWS->blocksize());
     auto &accumY = accumWS->mutableY(0);
     auto &accumE = accumWS->mutableE(0);
-    const auto &yValuesRaw = yValues->rawData();
-    const auto &eValuesRaw = eValues->rawData();
+    const auto &yValuesRaw = *yValues;
+    const auto &eValuesRaw = *eValues;
 
     for (size_t j = 0; j < npts; ++j) {
       double accumYj = accumWS->y(0)[j];

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -207,7 +207,7 @@ void RefinePowderInstrumentParameters::fitInstrumentParameters() {
   m_Function = std::make_shared<ThermalNeutronDtoTOFFunction>();
   m_Function->initialize();
 
-  API::FunctionDomain1DVector domain(m_dataWS->x(1).rawData());
+  API::FunctionDomain1DVector domain(m_dataWS->x(1));
   API::FunctionValues values(domain);
   const auto &rawY = m_dataWS->y(0);
   const auto &rawE = m_dataWS->e(0);
@@ -325,9 +325,9 @@ void RefinePowderInstrumentParameters::fitInstrumentParameters() {
   // 7. Play with Zscore:     template<typename TYPE>
   //    std::vector<double> getZscore(const std::vector<TYPE>& data, const bool
   //    sorted=false);
-  vector<double> z0 = Kernel::getZscore(m_dataWS->y(0).rawData());
-  vector<double> z1 = Kernel::getZscore(m_dataWS->y(1).rawData());
-  vector<double> z2 = Kernel::getZscore(m_dataWS->y(2).rawData());
+  vector<double> z0 = Kernel::getZscore(m_dataWS->y(0));
+  vector<double> z1 = Kernel::getZscore(m_dataWS->y(1));
+  vector<double> z2 = Kernel::getZscore(m_dataWS->y(2));
   stringstream zss;
   zss << setw(20) << "d_h" << setw(20) << "Z DataY" << setw(20) << "Z ModelY" << setw(20) << "Z DiffY" << setw(20)
       << "DiffY\n";
@@ -453,7 +453,7 @@ void RefinePowderInstrumentParameters::refineInstrumentParametersMC(const TableW
   const auto &X = m_dataWS->x(0);
   const auto &Y = m_dataWS->y(0);
   const auto &E = m_dataWS->e(0);
-  FunctionDomain1DVector domain(X.rawData());
+  FunctionDomain1DVector domain(X);
   FunctionValues values(domain);
   for (size_t i = 0; i < m_BestFitParameters.size(); ++i) {
     // a. Set the function with the
@@ -506,7 +506,7 @@ void RefinePowderInstrumentParameters::doParameterSpaceRandomWalk(const vector<s
   const auto &X = m_dataWS->x(0);
   const auto &rawY = m_dataWS->y(0);
   const auto &rawE = m_dataWS->e(0);
-  FunctionDomain1DVector domain(X.rawData());
+  FunctionDomain1DVector domain(X);
   FunctionValues values(domain);
 
   // 2. Determine the parameters to fit

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
@@ -113,7 +113,7 @@ void RefinePowderInstrumentParameters3::exec() {
   setFunctionParameterValues(m_positionFunc, m_profileParameters);
 
   // b) Generate some global useful value and Calculate starting chi^2
-  API::FunctionDomain1DVector domain(m_dataWS->x(m_wsIndex).rawData());
+  API::FunctionDomain1DVector domain(m_dataWS->x(m_wsIndex));
   API::FunctionValues rawvalues(domain);
   m_positionFunc->function(domain, rawvalues);
 
@@ -1068,7 +1068,7 @@ Workspace2D_sptr RefinePowderInstrumentParameters3::genOutputWorkspace(const Fun
   outws->mutableY(4) = dataY - rawvalues.toVector();
 
   // 5. Zscore
-  vector<double> zscore = Kernel::getZscore(outws->y(2).rawData());
+  vector<double> zscore = Kernel::getZscore(outws->y(2));
   outws->mutableY(5) = zscore;
 
   return outws;

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
@@ -744,7 +744,7 @@ double RefinePowderInstrumentParameters3::calculateFunction(const map<string, Pa
     setFunctionParameterValues(m_positionFunc, parammap);
 
   // 2. Calculate
-  const auto &vecX = m_dataWS->x(m_wsIndex).rawData();
+  const auto &vecX = m_dataWS->x(m_wsIndex);
   //    Check
   if (vecY.size() != vecX.size())
     throw runtime_error("vecY must be initialized with proper size!");
@@ -752,7 +752,7 @@ double RefinePowderInstrumentParameters3::calculateFunction(const map<string, Pa
   m_positionFunc->function1D(vecY, vecX);
 
   // 3. Calcualte error
-  double chisq = calculateFunctionChiSquare(vecY, m_dataWS->y(m_wsIndex).rawData(), m_dataWS->e(m_wsIndex).rawData());
+  double chisq = calculateFunctionChiSquare(vecY, m_dataWS->y(m_wsIndex), m_dataWS->e(m_wsIndex));
 
   return chisq;
 }
@@ -760,8 +760,8 @@ double RefinePowderInstrumentParameters3::calculateFunction(const map<string, Pa
 //----------------------------------------------------------------------------------------------
 /** Calculate Chi^2
  */
-double calculateFunctionChiSquare(const vector<double> &modelY, const vector<double> &dataY,
-                                  const vector<double> &dataE) {
+double calculateFunctionChiSquare(std::span<double const> const modelY, std::span<double const> const dataY,
+                                  std::span<double const> const dataE) {
   // 1. Check
   if (modelY.size() != dataY.size() || dataY.size() != dataE.size())
     throw runtime_error("Input model, data and error have different size.");

--- a/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
@@ -172,20 +172,18 @@ void SplineInterpolation::exec() {
     // perform cubic spline interpolation
     // for each histogram in workspace, calculate interpolation and derivatives
     spline_creator = [iwspt](size_t i) {
-      return std::make_unique<Mantid::Kernel::CubicSpline<double, double>>(iwspt->x(i).rawData(),
-                                                                           iwspt->y(i).rawData());
+      return std::make_unique<Mantid::Kernel::CubicSpline<double, double>>(iwspt->x(i), iwspt->y(i));
     };
   } else {
     // perform linear interpolation
 
     // first check that the x-axis (first spectrum) is sorted ascending
-    if (!std::is_sorted(mwspt->x(0).rawData().begin(), mwspt->x(0).rawData().end())) {
+    if (!std::is_sorted(mwspt->x(0).begin(), mwspt->x(0).end())) {
       throw std::runtime_error("X-axis of the workspace to match is not sorted. "
                                "Consider calling SortXAxis before.");
     }
     spline_creator = [iwspt](size_t i) {
-      return std::make_unique<Mantid::Kernel::LinearSpline<double, double>>(iwspt->x(i).rawData(),
-                                                                            iwspt->y(i).rawData());
+      return std::make_unique<Mantid::Kernel::LinearSpline<double, double>>(iwspt->x(i), iwspt->y(i));
     };
   }
 
@@ -290,7 +288,7 @@ std::pair<size_t, size_t> SplineInterpolation::findInterpolationRange(const Matr
 
   auto xAxisIn = iwspt->x(row).rawData();
   std::sort(xAxisIn.begin(), xAxisIn.end());
-  const auto &xAxisOut = mwspt->x(0).rawData();
+  const auto &xAxisOut = mwspt->x(0);
 
   size_t firstIndex = 0;
   size_t lastIndex = xAxisOut.size();

--- a/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
@@ -286,7 +286,8 @@ std::pair<size_t, size_t> SplineInterpolation::findInterpolationRange(const Matr
                                                                       const MatrixWorkspace_sptr &mwspt,
                                                                       const size_t row) {
 
-  auto xAxisIn = iwspt->x(row).rawData();
+  // a sorted copy is needed, so this must not alias the input; the length is unchanged
+  auto xAxisIn = iwspt->x(row);
   std::sort(xAxisIn.begin(), xAxisIn.end());
   const auto &xAxisOut = mwspt->x(0);
 

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -227,7 +227,7 @@ void VesuvioCalculateGammaBackground::calculateSpectrumFromDetector(const size_t
   // at the detector point & sum to a single spectrum
   auto &ctdet = m_correctedWS->mutableY(outputIndex);
   std::vector<double> tmpWork(ctdet.size());
-  ctdet = calculateTofSpectrum(ctdet.rawData(), tmpWork, outputIndex, detPar, detRes);
+  ctdet = calculateTofSpectrum(ctdet, tmpWork, outputIndex, detPar, detRes);
   // Correct for distance to the detector: 0.5/l2^2
   const double detDistCorr = 0.5 / detPar.l2 / detPar.l2;
   std::transform(ctdet.begin(), ctdet.end(), ctdet.begin(), std::bind(std::multiplies<double>(), _1, detDistCorr));
@@ -345,7 +345,7 @@ void VesuvioCalculateGammaBackground::calculateBackgroundSingleFoil(std::vector<
  * @param detpar Struct containing parameters about the detector
  * @param respar Struct containing parameters about the resolution
  */
-std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(const std::vector<double> &inSpectrum,
+std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(std::span<double const> const inSpectrum,
                                                                           std::vector<double> &tmpWork,
                                                                           const size_t wsIndex,
                                                                           const DetectorParams &detpar,
@@ -362,7 +362,7 @@ std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(const 
   auto profileFunction =
       std::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createInitialized(m_profileFunction));
 
-  std::vector<double> correctedVals(inSpectrum);
+  std::vector<double> correctedVals(inSpectrum.begin(), inSpectrum.end());
 
   for (size_t i = 0; i < m_npeaks; ++i) {
     auto profile = std::dynamic_pointer_cast<CurveFitting::Functions::ComptonProfile>(profileFunction->getFunction(i));

--- a/Framework/CurveFitting/src/Functions/NeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/NeutronBk2BkExpConvPVoigt.cpp
@@ -302,7 +302,7 @@ void NeutronBk2BkExpConvPVoigt::setParameter(const std::string &name, const doub
  * with a value of zero everywhere.
  * @param xValues: The x-values to evaluate the peak at.
  */
-void NeutronBk2BkExpConvPVoigt::function(vector<double> &out, const vector<double> &xValues) const {
+void NeutronBk2BkExpConvPVoigt::function(std::span<double> const out, std::span<double const> const xValues) const {
   // Calculate peak parameters
   if (m_hasNewParameterValue)
     calculateParameters(false);
@@ -317,10 +317,10 @@ void NeutronBk2BkExpConvPVoigt::function(vector<double> &out, const vector<doubl
   const double RANGE = m_fwhm * PEAKRANGE;
 
   const double LEFT_VALUE = m_centre - RANGE;
-  auto iter = std::lower_bound(xValues.cbegin(), xValues.cend(), LEFT_VALUE);
+  auto iter = std::lower_bound(xValues.begin(), xValues.end(), LEFT_VALUE);
 
   const double RIGHT_VALUE = m_centre + RANGE;
-  auto iter_end = std::lower_bound(iter, xValues.cend(), RIGHT_VALUE);
+  auto iter_end = std::lower_bound(iter, xValues.end(), RIGHT_VALUE);
 
   // Calcualte
   std::size_t pos(std::distance(xValues.begin(), iter)); // second loop variable

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -611,7 +611,7 @@ Workspace2D_sptr ProcessBackground::filterForBackground(const BackgroundFunction
 
   // Calcualte theoretical values
   const auto &x = m_dataWS->x(m_wsIndex);
-  API::FunctionDomain1DVector domain(x.rawData());
+  API::FunctionDomain1DVector domain(x);
   API::FunctionValues values(domain);
   bkgdfunction->function(domain, values);
 
@@ -752,7 +752,7 @@ void ProcessBackground::fitBackgroundFunction(const std::string &bkgdfunctiontyp
   // Set output workspace
   const auto &vecX = m_outputWS->x(0);
   const auto &vecY = m_outputWS->y(0);
-  FunctionDomain1DVector domain(vecX.rawData());
+  FunctionDomain1DVector domain(vecX);
   FunctionValues values(domain);
 
   funcout->function(domain, values);

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -822,7 +822,7 @@ Workspace2D_sptr RemovePeaks::removePeaks(const API::MatrixWorkspace_const_sptr 
   vector<bool> vec_useX(sizex, true);
 
   // Exclude regions
-  size_t numbkgdpoints = excludePeaks(vecX.rawData(), vec_useX, m_vecPeakCentre, m_vecPeakFWHM, numfwhm);
+  size_t numbkgdpoints = excludePeaks(vecX, vec_useX, m_vecPeakCentre, m_vecPeakFWHM, numfwhm);
   size_t numbkgdpointsy = numbkgdpoints;
   size_t sizey = vecY.size();
   if (sizex > sizey)
@@ -895,8 +895,8 @@ void RemovePeaks::parsePeakTableWorkspace(const TableWorkspace_sptr &peaktablews
 //----------------------------------------------------------------------------------------------
 /** Exclude peaks from
  */
-size_t RemovePeaks::excludePeaks(vector<double> v_inX, vector<bool> &v_useX, const vector<double> &v_centre,
-                                 const vector<double> &v_fwhm, double num_fwhm) {
+size_t RemovePeaks::excludePeaks(std::span<double const> const v_inX, vector<bool> &v_useX,
+                                 const vector<double> &v_centre, const vector<double> &v_fwhm, double num_fwhm) {
   // Validate
   if (v_centre.size() != v_fwhm.size())
     throw runtime_error("Input different number of peak centres and fwhm.");
@@ -912,7 +912,7 @@ size_t RemovePeaks::excludePeaks(vector<double> v_inX, vector<bool> &v_useX, con
     double xmin = centre - num_fwhm * fwhm;
     double xmax = centre + num_fwhm * fwhm;
 
-    vector<double>::iterator viter;
+    std::span<double const>::iterator viter;
     int i_min, i_max;
 
     // Locate index in v_inX

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
@@ -381,7 +381,8 @@ void ThermalNeutronBk2BkExpConvPVoigt::functionLocal(double *out, const double *
  * with a value of zero everywhere.
  * @param xValues: The x-values to evaluate the peak at.
  */
-void ThermalNeutronBk2BkExpConvPVoigt::function(vector<double> &out, const vector<double> &xValues) const {
+void ThermalNeutronBk2BkExpConvPVoigt::function(std::span<double> const out,
+                                                std::span<double const> const xValues) const {
   // calculate peak parameters
   const double HEIGHT = getParameter(0);
   const double INVERT_SQRT2SIGMA = 1.0 / sqrt(2.0 * m_Sigma2);

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronDtoTOFFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronDtoTOFFunction.cpp
@@ -60,7 +60,8 @@ void ThermalNeutronDtoTOFFunction::function1D(double *out, const double *xValues
 /** Main function
  * xValues containing the d-space value of peaks centres
  */
-void ThermalNeutronDtoTOFFunction::function1D(vector<double> &out, const vector<double> &xValues) const {
+void ThermalNeutronDtoTOFFunction::function1D(std::span<double> const out,
+                                              std::span<double const> const xValues) const {
   double dtt1 = getParameter(0);
   double dtt1t = getParameter(1);
   double dtt2t = getParameter(2);

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -57,7 +57,7 @@ public:
     if (iter >= m_data.size() - 1) {
       API::MatrixWorkspace_sptr ws =
           API::WorkspaceFactory::Instance().create("Workspace2D", 1, m_data.size(), m_data.size());
-      auto &Y = ws->dataY(0);
+      auto &Y = ws->mutableY(0);
       for (size_t i = 0; i < Y.size(); ++i) {
         Y[i] = static_cast<double>(m_data[i]);
       }
@@ -174,9 +174,9 @@ public:
     // create mock data to test against
     int ndata = 21;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 0.01;
@@ -209,9 +209,9 @@ public:
     // Mock data
     int ndata = 19;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 1.0;
@@ -259,9 +259,9 @@ public:
     const double sqrh = 0.70710678; // cos( 45 degrees )
 
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 1.;
@@ -308,9 +308,9 @@ public:
     // Mock data
     int ndata = 18;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i - 8);
       e[i] = 1.0;
@@ -338,9 +338,9 @@ public:
     // Mock data
     int ndata = 18;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i - 8);
       e[i] = 1.0;
@@ -374,9 +374,9 @@ public:
     // Mock data
     int ndata = 41;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = 0.146785 * static_cast<double>(i);
     }
@@ -414,9 +414,9 @@ public:
     // Mock data
     int ndata = 18;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 0.01;
@@ -447,9 +447,9 @@ public:
     // Mock data
     int ndata = 15;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 1.0;
@@ -480,9 +480,9 @@ public:
     // Mock data
     int ndata = 15;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 1.0;
@@ -513,9 +513,9 @@ public:
     // Mock data
     int ndata = 18;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     for (int i = 0; i < ndata; i++) {
       x[i] = static_cast<double>(i);
       e[i] = 1.0;
@@ -549,9 +549,9 @@ public:
     // Mock data
     int ndata = 20;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     // values extracted from y(x)=2*exp(-(x/4)^0.5)
     y = {2,          1.2130613,  0.98613738, 0.84124005, 0.73575888, 0.65384379, 0.58766531,
          0.53273643, 0.48623347, 0.44626032, 0.41148132, 0.38092026, 0.35384241, 0.32968143,
@@ -585,9 +585,9 @@ public:
     // Mock data
     int ndata = 13;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     // values extracted from y(x)=2*exp(-(x/4)^0.5)
     y = {1, 3, 4, 28, 221, 872, 1495, 1832, 1830, 1917, 2045, 1996, 0};
     for (int i = 0; i < ndata; i++) {
@@ -622,9 +622,9 @@ public:
     // Mock data
     int ndata = 30;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     x = {0,   0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1,   1.1, 1.2, 1.3, 1.4,
          1.5, 1.6, 1.7, 1.8, 1.9, 2,   2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9};
     y = {0.001362, 0.00434468, 0.0127937, 0.0347769, 0.0872653, 0.202138, 0.432228,  0.853165,  1.55457,   2.61483,
@@ -700,21 +700,26 @@ public:
     MatrixWorkspace_sptr ws =
         std::dynamic_pointer_cast<MatrixWorkspace>(WorkspaceFactory::Instance().create("Workspace2D", 1, nX, nY));
 
-    const double dx = 10 / 99;
+    const double dx = 10.0 / nY;
 
-    Mantid::MantidVec &X = ws->dataX(0);
-    Mantid::MantidVec &Y = ws->dataY(0);
-    Mantid::MantidVec &E = ws->dataE(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
+    auto &E = ws->mutableE(0);
 
-    X = {0.000000, 0.101010, 0.202020, 0.303030, 0.404040, 0.505051, 0.606061, 0.707071, 0.808081, 0.909091, 1.010101,
-         1.111111, 1.212121, 1.313131, 1.414141, 1.515152, 1.616162, 1.717172, 1.818182, 1.919192, 2.020202, 2.121212,
-         2.222222, 2.323232, 2.424242, 2.525253, 2.626263, 2.727273, 2.828283, 2.929293, 3.030303, 3.131313, 3.232323,
-         3.333333, 3.434343, 3.535354, 3.636364, 3.737374, 3.838384, 3.939394, 4.040404, 4.141414, 4.242424, 4.343434,
-         4.444444, 4.545455, 4.646465, 4.747475, 4.848485, 4.949495, 5.050505, 5.151515, 5.252525, 5.353535, 5.454545,
-         5.555556, 5.656566, 5.757576, 5.858586, 5.959596, 6.060606, 6.161616, 6.262626, 6.363636, 6.464646, 6.565657,
-         6.666667, 6.767677, 6.868687, 6.969697, 7.070707, 7.171717, 7.272727, 7.373737, 7.474747, 7.575758, 7.676768,
-         7.777778, 7.878788, 7.979798, 8.080808, 8.181818, 8.282828, 8.383838, 8.484848, 8.585859, 8.686869, 8.787879,
-         8.888889, 8.989899, 9.090909, 9.191919, 9.292929, 9.393939, 9.494949, 9.595960, 9.696970, 9.797980, 9.898990};
+    // Only the first nY of the nX bin edges are listed; the last one is computed below. These are
+    // copied into X rather than assigned to it, since assigning a shorter list would change the
+    // length of the histogram.
+    const std::vector<double> binEdges = {
+        0.000000, 0.101010, 0.202020, 0.303030, 0.404040, 0.505051, 0.606061, 0.707071, 0.808081, 0.909091, 1.010101,
+        1.111111, 1.212121, 1.313131, 1.414141, 1.515152, 1.616162, 1.717172, 1.818182, 1.919192, 2.020202, 2.121212,
+        2.222222, 2.323232, 2.424242, 2.525253, 2.626263, 2.727273, 2.828283, 2.929293, 3.030303, 3.131313, 3.232323,
+        3.333333, 3.434343, 3.535354, 3.636364, 3.737374, 3.838384, 3.939394, 4.040404, 4.141414, 4.242424, 4.343434,
+        4.444444, 4.545455, 4.646465, 4.747475, 4.848485, 4.949495, 5.050505, 5.151515, 5.252525, 5.353535, 5.454545,
+        5.555556, 5.656566, 5.757576, 5.858586, 5.959596, 6.060606, 6.161616, 6.262626, 6.363636, 6.464646, 6.565657,
+        6.666667, 6.767677, 6.868687, 6.969697, 7.070707, 7.171717, 7.272727, 7.373737, 7.474747, 7.575758, 7.676768,
+        7.777778, 7.878788, 7.979798, 8.080808, 8.181818, 8.282828, 8.383838, 8.484848, 8.585859, 8.686869, 8.787879,
+        8.888889, 8.989899, 9.090909, 9.191919, 9.292929, 9.393939, 9.494949, 9.595960, 9.696970, 9.797980, 9.898990};
+    std::copy(binEdges.cbegin(), binEdges.cend(), X.begin());
     Y = {0.000000, 0.000000, 0.000000, 0.000000, 0.000001, 0.000001, 0.000002, 0.000004, 0.000006, 0.000012, 0.000021,
          0.000036, 0.000063, 0.000108, 0.000183, 0.000305, 0.000503, 0.000818, 0.001314, 0.002084, 0.003262, 0.005041,
          0.007692, 0.011586, 0.017229, 0.025295, 0.036664, 0.052465, 0.074121, 0.103380, 0.142353, 0.193520, 0.259728,
@@ -726,7 +731,7 @@ public:
          0.004829, 0.003121, 0.001991, 0.001254, 0.000780, 0.000479, 0.000290, 0.000174, 0.000103, 0.000060, 0.000034};
     E.assign(nY, 1.0);
 
-    X.back() = X[98] + dx;
+    X.back() = X[nY - 1] + dx;
     AnalysisDataService::Instance().add("ResolutionTest_WS", ws);
 
     Algorithms::Fit fit;
@@ -739,9 +744,12 @@ public:
     fit.setPropertyValue("InputWorkspace", "ResolutionTest_WS");
     fit.setPropertyValue("WorkspaceIndex", "0");
     fit.execute();
+    TS_ASSERT(fit.isExecuted());
+
+    AnalysisDataService::Instance().remove("ResolutionTest_WS");
   }
 
-  void getStretchExpMockData(Mantid::MantidVec &y, Mantid::MantidVec &e) {
+  void getStretchExpMockData(Mantid::HistogramData::HistogramY &y, Mantid::HistogramData::HistogramE &e) {
     // values extracted from y(x)=2*exp(-(x/4)^0.5)
     y = {2,          1.2130613,  0.98613738, 0.84124005, 0.73575888, 0.65384379, 0.58766531,
          0.53273643, 0.48623347, 0.44626032, 0.41148132, 0.38092026, 0.35384241, 0.32968143,
@@ -762,12 +770,12 @@ public:
     Workspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D", histogramNumber, timechannels, timechannels);
     Workspace2D_sptr ws2D = std::dynamic_pointer_cast<Workspace2D>(ws);
     // in this case, x-values are just the running index
-    auto &x = ws2D->dataX(0);
+    auto &x = ws2D->mutableX(0);
     for (int i = 0; i < timechannels; i++)
       x[i] = 1.0 * i + 0.00001;
 
-    Mantid::MantidVec &y = ws2D->dataY(0); // y-values (counts)
-    Mantid::MantidVec &e = ws2D->dataE(0); // error values of counts
+    auto &y = ws2D->mutableY(0); // y-values (counts)
+    auto &e = ws2D->mutableE(0); // error values of counts
     getStretchExpMockData(y, e);
 
     // put this workspace in the data service
@@ -811,9 +819,9 @@ public:
     std::shared_ptr<WorkspaceTester> data = std::make_shared<WorkspaceTester>();
     data->initialize(1, 100, 100);
 
-    auto &x = data->dataX(0);
-    auto &y = data->dataY(0);
-    auto &e = data->dataE(0);
+    auto &x = data->mutableX(0);
+    auto &y = data->mutableY(0);
+    auto &e = data->mutableE(0);
 
     y = {0.00679397551246448, 0.00684266083126313, 0.00698285916556982, 0.00719965548825388, 0.00747519954546736,
          0.00779445649068509, 0.00814796531751759, 0.0085316132498512,  0.00894499942724,    0.00938983058044737,
@@ -961,11 +969,11 @@ public:
     const int timechannels = 20;
     Workspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D", histogramNumber, timechannels, timechannels);
     Workspace2D_sptr ws2D = std::dynamic_pointer_cast<Workspace2D>(ws);
-    Mantid::MantidVec &x = ws2D->dataX(0); // x-values
+    auto &x = ws2D->mutableX(0); // x-values
     for (int i = 0; i < timechannels; i++)
       x[i] = i;
-    Mantid::MantidVec &y = ws2D->dataY(0); // y-values (counts)
-    Mantid::MantidVec &e = ws2D->dataE(0); // error values of counts
+    auto &y = ws2D->mutableY(0); // y-values (counts)
+    auto &e = ws2D->mutableE(0); // error values of counts
 
     y = {5,
          3.582656552869,
@@ -1114,8 +1122,8 @@ public:
     ws->initialize(1, 30, 30);
     {
       const double dx = 1.0;
-      Mantid::MantidVec &x = ws->dataX(0);
-      Mantid::MantidVec &y = ws->dataY(0);
+      auto &x = ws->mutableX(0);
+      auto &y = ws->mutableY(0);
       for (size_t i = 0; i < 10; ++i) {
         x[i] = dx * double(i);
         y[i] = A0 + B0 * x[i];
@@ -1252,9 +1260,9 @@ public:
     // Mock data
     int ndata = 35;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     // values extracted from y(x)=2*exp(-(x/4)^0.5)
     x = {54999.094000, 55010.957000, 55022.820000, 55034.684000, 55046.547000, 55058.410000, 55070.273000,
          55082.137000, 55094.000000, 55105.863000, 55117.727000, 55129.590000, 55141.453000, 55153.320000,
@@ -1300,9 +1308,9 @@ public:
     // Mock data
     int ndata = 20;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {3.56811123, 3.25921675,  2.69444562,  3.05054488,   2.86077216,  2.29916480,  2.57468876,
          3.65843827, 15.31622763, 56.57989073, 101.20662386, 76.30364797, 31.54892552, 8.09166673,
          3.20615343, 2.95246554,  2.75421444,  3.70180447,   2.77832668,  2.29507565};
@@ -1338,9 +1346,9 @@ public:
     // Mock data
     int ndata = 20;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {3.56811123, 3.25921675,  2.69444562,  3.05054488,   2.86077216,  2.29916480,  2.57468876,
          3.65843827, 15.31622763, 56.57989073, 101.20662386, 76.30364797, 31.54892552, 8.09166673,
          3.20615343, 2.95246554,  2.75421444,  3.70180447,   2.77832668,  2.29507565};
@@ -1383,9 +1391,9 @@ public:
 
     int ndata = 41;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     // x-values in time-of-flight
     for (int i = 0; i < 8; i++)
       x[i] = 79292.4375 + 7.875 * double(i);
@@ -1438,9 +1446,9 @@ public:
 
     int ndata = 41;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     // x-values in time-of-flight
     for (int i = 0; i < 8; i++)
       x[i] = 79292.4375 + 7.875 * double(i);
@@ -1487,9 +1495,9 @@ public:
 
     int ndata = 31;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {0.0000,  0.0003,  0.0028,  0.0223,  0.1405,  0.6996,  2.7608,  8.6586, 21.6529, 43.3558, 69.8781,
          91.2856, 97.5646, 86.4481, 64.7703, 42.3348, 25.3762, 15.0102, 9.4932, 6.7037,  5.2081,  4.2780,
          3.6037,  3.0653,  2.6163,  2.2355,  1.9109,  1.6335,  1.3965,  1.1938, 1.0206};
@@ -1540,9 +1548,9 @@ public:
     for (int i = 0; i < ndata; i++) {
       ws->mutableX(0)[i] = i * 5;
     }
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {0.0000,  0.0003,  0.0028,  0.0223,  0.1405,  0.6996,  2.7608,  8.6586, 21.6529, 43.3558, 69.8781,
          91.2856, 97.5646, 86.4481, 64.7703, 42.3348, 25.3762, 15.0102, 9.4932, 6.7037,  5.2081,  4.2780,
          3.6037,  3.0653,  2.6163,  2.2355,  1.9109,  1.6335,  1.3965,  1.1938, 1.0206};
@@ -1603,9 +1611,9 @@ public:
     // Mock data
     int ndata = 20;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {0.0,       1.52798e-15, 6.4577135e-07, 0.0020337351, 0.12517292, 1.2282908, 4.3935083,
          8.5229866, 11.127883,   11.110426,     9.1925694,    6.6457304,  4.353104,  2.6504159,
          1.5279732, 0.84552286,  0.45371715,    0.23794487,   0.12268847, 0.0624878};
@@ -1638,9 +1646,9 @@ public:
     // Mock data
     int ndata = 100;
     API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D", 1, ndata, ndata);
-    Mantid::MantidVec &x = ws->dataX(0);
-    Mantid::MantidVec &y = ws->dataY(0);
-    Mantid::MantidVec &e = ws->dataE(0);
+    auto &x = ws->mutableX(0);
+    auto &y = ws->mutableY(0);
+    auto &e = ws->mutableE(0);
     y = {0.680508, 0.459591, 0.332266, 1.2717,  0.925787, 1.36216,  0.890605, 0.983653, 0.965918, 0.916039,
          0.979414, 0.861061, 0.973214, 1.53418, 1.52668,  1.10537,  1.36965,  1.64708,  1.52887,  2.0042,
          2.11257,  2.44183,  2.29917,  2.61657, 2.25268,  2.82788,  3.089,    3.45517,  3.41001,  4.39168,
@@ -1690,9 +1698,9 @@ public:
   void test_function_Chebyshev() {
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D", 1, 11, 11);
 
-    Mantid::MantidVec &X = ws->dataX(0);
-    Mantid::MantidVec &Y = ws->dataY(0);
-    Mantid::MantidVec &E = ws->dataE(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
+    auto &E = ws->mutableE(0);
     for (size_t i = 0; i < Y.size(); i++) {
       double x = -1. + 0.1 * static_cast<double>(i);
       X[i] = x;
@@ -1721,9 +1729,9 @@ public:
   void test_function_Chebyshev_Background() {
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D", 1, 21, 21);
 
-    Mantid::MantidVec &X = ws->dataX(0);
-    Mantid::MantidVec &Y = ws->dataY(0);
-    Mantid::MantidVec &E = ws->dataE(0);
+    auto &X = ws->mutableX(0);
+    auto &Y = ws->mutableY(0);
+    auto &E = ws->mutableE(0);
     for (size_t i = 0; i < Y.size(); i++) {
       double x = -10. + 1 * static_cast<double>(i);
       X[i] = x;
@@ -1772,9 +1780,9 @@ public:
     double tof0 = 8000.;
     double dtof = 5.;
 
-    Mantid::MantidVec &X = ws2D->dataX(0);
-    Mantid::MantidVec &Y = ws2D->dataY(0);
-    Mantid::MantidVec &E = ws2D->dataE(0);
+    auto &X = ws2D->mutableX(0);
+    auto &Y = ws2D->mutableY(0);
+    auto &E = ws2D->mutableE(0);
     for (int i = 0; i < timechannels; i++) {
       X[i] = static_cast<double>(i) * dtof + tof0;
       Y[i] = X[i] * 0.013;
@@ -2109,9 +2117,9 @@ private:
 
     siFn->function(xValues, yValues);
 
-    std::vector<double> &xData = ws->dataX(0);
-    std::vector<double> &yData = ws->dataY(0);
-    std::vector<double> &eData = ws->dataE(0);
+    auto &xData = ws->mutableX(0);
+    auto &yData = ws->mutableY(0);
+    auto &eData = ws->mutableE(0);
 
     for (size_t i = 0; i < n; ++i) {
       xData[i] = xValues[i];

--- a/Framework/CurveFitting/test/Algorithms/LeBailFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/LeBailFunctionTest.h
@@ -293,7 +293,7 @@ public:
     vector<double> vecoutput(vecY.size(), 0.);
 
     // Calculate peaks' intensities
-    lebailfunction.calculatePeaksIntensities(vecX.rawData(), vecY.rawData(), vecoutput);
+    lebailfunction.calculatePeaksIntensities(vecX, vecY, vecoutput);
 
     // Check
     size_t ipeak1 = 6;

--- a/Framework/CurveFitting/test/Functions/ChebyshevTest.h
+++ b/Framework/CurveFitting/test/Functions/ChebyshevTest.h
@@ -95,9 +95,9 @@ public:
     cheb.setAttributeValue("EndX", 10.0);
 
     Mantid::API::MatrixWorkspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D", 1, 21, 21);
-    Mantid::MantidVec &X = ws->dataX(0);
+    auto &X = ws->mutableX(0);
 
-    Mantid::API::FunctionDomain1DVector domain(X);
+    Mantid::API::FunctionDomain1DVector domain(X.rawData());
     Mantid::API::FunctionValues values(domain);
 
     cheb.function(domain, values);

--- a/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
@@ -59,12 +59,12 @@ public:
         dx(0.5); // chosen to give put us near the peak for this mass & spectrum
     auto testWS =
         ComptonProfileTestHelpers::createTestWorkspace(1, x0, x1, dx, ComptonProfileTestHelpers::NoiseType::None);
-    auto &dataX = testWS->dataX(0);
+    auto &dataX = testWS->mutableX(0);
     using std::placeholders::_1;
     std::transform(dataX.begin(), dataX.end(), dataX.begin(),
                    std::bind(std::multiplies<double>(), _1, 1e-06)); // to seconds
     func->setMatrixWorkspace(testWS, 0, dataX.front(), dataX.back());
-    FunctionDomain1DView domain(dataX.data(), dataX.size());
+    FunctionDomain1DView domain(dataX.rawData().data(), dataX.size());
     FunctionValues values(domain);
 
     TS_ASSERT_THROWS_NOTHING(func->function(domain, values));

--- a/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
@@ -81,12 +81,12 @@ public:
         dx(0.5); // chosen to give put us near the peak for this mass & spectrum
     auto testWS =
         ComptonProfileTestHelpers::createTestWorkspace(1, x0, x1, dx, ComptonProfileTestHelpers::NoiseType::None);
-    auto &dataX = testWS->dataX(0);
+    auto &dataX = testWS->mutableX(0);
     using std::placeholders::_1;
     std::transform(dataX.begin(), dataX.end(), dataX.begin(),
                    std::bind(std::multiplies<double>(), _1, 1e-06)); // to seconds
     func->setMatrixWorkspace(testWS, 0, dataX.front(), dataX.back());
-    FunctionDomain1DView domain(dataX.data(), dataX.size());
+    FunctionDomain1DView domain(dataX.rawData().data(), dataX.size());
     FunctionValues values(domain);
 
     TS_ASSERT_THROWS_NOTHING(func->function(domain, values));

--- a/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
@@ -67,12 +67,12 @@ public:
     double x0(200.0), x1(220.0), dx(10.0);
     auto testWS =
         ComptonProfileTestHelpers::createTestWorkspace(1, x0, x1, dx, ComptonProfileTestHelpers::NoiseType::None);
-    auto &dataX = testWS->dataX(0);
+    auto &dataX = testWS->mutableX(0);
     using std::placeholders::_1;
     std::transform(dataX.begin(), dataX.end(), dataX.begin(),
                    std::bind(std::multiplies<double>(), _1, 1e-06)); // to seconds
     func->setMatrixWorkspace(testWS, 0, dataX.front(), dataX.back());
-    FunctionDomain1DView domain(dataX.data(), dataX.size());
+    FunctionDomain1DView domain(dataX.rawData().data(), dataX.size());
     FunctionValues values(domain);
 
     TS_ASSERT_THROWS_NOTHING(func->function(domain, values));

--- a/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
+++ b/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
@@ -24,7 +24,7 @@ using namespace Mantid::DataObjects;
 
 class MuonFInteractionTest : public CxxTest::TestSuite {
 public:
-  void getMockData(Mantid::MantidVec &y, Mantid::MantidVec &e) {
+  void getMockData(Mantid::HistogramData::HistogramY &y, Mantid::HistogramData::HistogramE &e) {
     // Mock data got from an Excel spreadsheet with
     // Lambda = 0.16, Omega = 0.4, Beta = 1.2 &  A = 1.5
 
@@ -67,8 +67,8 @@ public:
     Workspace2D_sptr ws2D = std::dynamic_pointer_cast<Workspace2D>(ws);
     for (int i = 0; i < 21; i++)
       ws2D->mutableX(0)[i] = i;
-    Mantid::MantidVec &y = ws2D->dataY(0); // y-values (counts)
-    Mantid::MantidVec &e = ws2D->dataE(0); // error values of counts
+    auto &y = ws2D->mutableY(0); // y-values (counts)
+    auto &e = ws2D->mutableE(0); // error values of counts
     getMockData(y, e);
 
     // put this workspace in the data service

--- a/Framework/CurveFitting/test/Functions/VesuvioResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/VesuvioResolutionTest.h
@@ -39,12 +39,12 @@ public:
         dx(0.5); // chosen to give put us near the peak for this mass & spectrum
     auto testWS =
         ComptonProfileTestHelpers::createTestWorkspace(1, x0, x1, dx, ComptonProfileTestHelpers::NoiseType::None);
-    auto &dataX = testWS->dataX(0);
+    auto &dataX = testWS->mutableX(0);
     using std::placeholders::_1;
     std::transform(dataX.begin(), dataX.end(), dataX.begin(),
                    std::bind(std::multiplies<double>(), _1, 1e-06)); // to seconds
     func->setMatrixWorkspace(testWS, 0, dataX.front(), dataX.back());
-    FunctionDomain1DView domain(dataX.data(), dataX.size());
+    FunctionDomain1DView domain(dataX.rawData().data(), dataX.size());
     FunctionValues values(domain);
 
     TS_ASSERT_THROWS_NOTHING(func->function(domain, values));

--- a/Framework/DataHandling/inc/MantidDataHandling/CompressEventAccumulator.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CompressEventAccumulator.h
@@ -9,6 +9,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventList.h"
 
+#include <span>
 #include <vector>
 
 namespace Mantid {
@@ -45,7 +46,7 @@ private:
   double m_divisor;
   double m_offset;
   /// function pointer on how to find the bin boundaries
-  std::optional<size_t> (*m_findBin)(const MantidVec &, const double, const double, const double, const bool);
+  std::optional<size_t> (*m_findBin)(std::span<double const>, const double, const double, const double, const bool);
 
 protected:
   /// track whether this has allocated the "big" memory objects

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveVTK.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveVTK.h
@@ -12,6 +12,8 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataHandling/DllConfig.h"
 
+#include <span>
+
 namespace Mantid {
 namespace DataHandling {
 /**
@@ -70,8 +72,8 @@ private:
   void checkOptionalProperties();
 
   /// Write a histogram to the file
-  void writeVTKPiece(std::ostream &outVTP, const std::vector<double> &xValue, const std::vector<double> &yValue,
-                     const std::vector<double> &errors, int index) const;
+  void writeVTKPiece(std::ostream &outVTP, std::span<double const> xValue, std::span<double const> yValue,
+                     std::span<double const> errors, int index) const;
 
   /// The x-axis minimum
   double m_Xmin;

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -1025,16 +1025,18 @@ void LoadILLSANS::adjustTOF() {
 
   // Try to set sensible (but not strictly physical) wavelength axes for monitors
   // Normalisation is done by acquisition time, so these axes should not be used
-  auto firstPixel = m_localWorkspace->x(0).rawData();
+  // scaled in place on a copy of the first pixel's axis, so the pixel itself is untouched
+  auto firstPixel = m_localWorkspace->x(0);
   const double l2 = specInfo.l2(0);
   const double monitor2 = -specInfo.position(nHist - 1).Z();
   const double l1Monitor2 = m_sourcePos - monitor2;
   const double monScale = (l1 + l2) / l1Monitor2;
   std::transform(firstPixel.begin(), firstPixel.end(), firstPixel.begin(),
                  [monScale](double lambda) { return monScale * lambda; });
+  // all the monitors share these bin edges, so build them once
+  const HistogramData::BinEdges binEdges(std::move(firstPixel));
   for (size_t mIndex = nHist - m_numberOfMonitors; mIndex < nHist; ++mIndex) {
     const HistogramData::Counts counts = m_localWorkspace->histogram(mIndex).counts();
-    const HistogramData::BinEdges binEdges(firstPixel);
     m_localWorkspace->setHistogram(mIndex, binEdges, counts);
   }
 }

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -1025,7 +1025,7 @@ void LoadILLSANS::adjustTOF() {
 
   // Try to set sensible (but not strictly physical) wavelength axes for monitors
   // Normalisation is done by acquisition time, so these axes should not be used
-  auto firstPixel = m_localWorkspace->histogram(0).dataX();
+  auto firstPixel = m_localWorkspace->x(0).rawData();
   const double l2 = specInfo.l2(0);
   const double monitor2 = -specInfo.position(nHist - 1).Z();
   const double l1Monitor2 = m_sourcePos - monitor2;

--- a/Framework/DataHandling/src/SaveCSV.cpp
+++ b/Framework/DataHandling/src/SaveCSV.cpp
@@ -120,8 +120,8 @@ void SaveCSV::exec() {
       // check if x-axis has changed. If yes print out new x-axis line
 
       if (i > 0) {
-        auto &xValue = localworkspace->x(i);
-        auto &xValuePrevious = localworkspace->x(i - 1);
+        auto const &xValue = localworkspace->x(i);
+        auto const &xValuePrevious = localworkspace->x(i - 1);
 
         if (xValue != xValuePrevious) {
           outCSV_File << "A";

--- a/Framework/DataHandling/src/SaveCSV.cpp
+++ b/Framework/DataHandling/src/SaveCSV.cpp
@@ -123,7 +123,7 @@ void SaveCSV::exec() {
         auto &xValue = localworkspace->x(i);
         auto &xValuePrevious = localworkspace->x(i - 1);
 
-        if (xValue.rawData() != xValuePrevious.rawData()) {
+        if (xValue != xValuePrevious) {
           outCSV_File << "A";
 
           for (double j : xValue) {

--- a/Framework/DataHandling/src/SaveGDA.cpp
+++ b/Framework/DataHandling/src/SaveGDA.cpp
@@ -143,7 +143,8 @@ void SaveGDA::exec() {
     const auto ws = inputWS->getItem(i);
     const auto matrixWS = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
 
-    auto x = matrixWS->x(0).rawData();
+    // converted to TOF in place below, but never resized
+    auto x = matrixWS->x(0);
     const size_t bankIndex(groupingScheme[i] - 1);
     if (bankIndex >= calibParams.size()) {
       throw Kernel::Exception::IndexError(bankIndex, calibParams.size(), "Bank number out of range");
@@ -155,11 +156,10 @@ void SaveGDA::exec() {
     std::vector<double> tofScaled;
     tofScaled.reserve(x.size());
     Kernel::Units::dSpacing dSpacingUnit;
-    std::vector<double> yunused;
-    dSpacingUnit.toTOF(x, yunused, 0., Kernel::DeltaEMode::Elastic,
-                       {{Kernel::UnitParams::difa, bankCalibParams.difa},
-                        {Kernel::UnitParams::difc, bankCalibParams.difc},
-                        {Kernel::UnitParams::tzero, bankCalibParams.tzero}});
+    dSpacingUnit.toTOF(x.begin(), x.end(), 0., Kernel::DeltaEMode::Elastic,
+                       Kernel::UnitParametersMap{{Kernel::UnitParams::difa, bankCalibParams.difa},
+                                                 {Kernel::UnitParams::difc, bankCalibParams.difc},
+                                                 {Kernel::UnitParams::tzero, bankCalibParams.tzero}});
     std::transform(x.begin(), x.end(), std::back_inserter(tofScaled),
                    [](const double tofVal) { return tofVal * tofScale; });
     const auto averageDeltaTByT = computeAverageDeltaTByT(tofScaled);

--- a/Framework/DataHandling/src/SaveGDA.cpp
+++ b/Framework/DataHandling/src/SaveGDA.cpp
@@ -143,7 +143,7 @@ void SaveGDA::exec() {
     const auto ws = inputWS->getItem(i);
     const auto matrixWS = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
 
-    auto x = matrixWS->dataX(0);
+    auto x = matrixWS->x(0).rawData();
     const size_t bankIndex(groupingScheme[i] - 1);
     if (bankIndex >= calibParams.size()) {
       throw Kernel::Exception::IndexError(bankIndex, calibParams.size(), "Bank number out of range");

--- a/Framework/DataHandling/src/SaveNXcanSASHelper.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASHelper.cpp
@@ -88,7 +88,7 @@ public:
   T const *operator()(const MatrixWorkspace_sptr &ws, size_t index) {
     if (ws->isHistogramData()) {
       qxPointData.clear();
-      VectorHelper::convertToBinCentre(ws->x(index).rawData(), qxPointData);
+      VectorHelper::convertToBinCentre(ws->x(index), qxPointData);
       return qxPointData.data();
     }
     return ws->x(index).rawData().data();

--- a/Framework/DataHandling/src/SaveVTK.cpp
+++ b/Framework/DataHandling/src/SaveVTK.cpp
@@ -88,8 +88,7 @@ void SaveVTK::exec() {
     Progress prog(this, 0.0, 1.0, 97);
     if (!xMin && !xMax) {
       for (int hNum = 2; hNum < 100; ++hNum) {
-        writeVTKPiece(outVTP, localWorkspace->x(hNum).rawData(), localWorkspace->y(hNum).rawData(),
-                      localWorkspace->e(hNum).rawData(), hNum);
+        writeVTKPiece(outVTP, localWorkspace->x(hNum), localWorkspace->y(hNum), localWorkspace->e(hNum), hNum);
         prog.report();
       }
     } else {
@@ -160,8 +159,9 @@ void SaveVTK::checkOptionalProperties() {
  * @param errors :: The error data
  * @param index :: The histogram number
  */
-void SaveVTK::writeVTKPiece(std::ostream &outVTP, const std::vector<double> &xValue, const std::vector<double> &yValue,
-                            const std::vector<double> &errors, int index) const {
+void SaveVTK::writeVTKPiece(std::ostream &outVTP, std::span<double const> const xValue,
+                            std::span<double const> const yValue, std::span<double const> const errors,
+                            int index) const {
   (void)errors; // Avoid compiler warning
 
   auto nY = static_cast<int>(yValue.size());

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -1575,6 +1575,8 @@ private:
       inputWs->setPointStandardDeviations(0, dx1);
       inputWs->setPointStandardDeviations(1, dx2);
       if (legacyXErrors) {
+        // Deliberately grow Dx to the legacy length (one longer than Y). Only the legacy
+        // accessor can do this; the size-checked histogram types forbid it by design.
         inputWs->dataDx(0).emplace_back(1);
         inputWs->dataDx(1).emplace_back(1);
       }

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -14,6 +14,7 @@
 
 #include <iosfwd>
 #include <optional>
+#include <span>
 #include <vector>
 
 namespace Mantid {
@@ -210,13 +211,13 @@ public:
   void compressFatEvents(const double tolerance, const Types::Core::DateAndTime &timeStart, const double seconds,
                          EventList *destination);
   // get EventType declaration
-  void generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError = false) const override;
-  void generateHistogram(const double step, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogram(std::span<double const> X, MantidVec &Y, MantidVec &E, bool skipError = false) const override;
+  void generateHistogram(const double step, std::span<double const> X, MantidVec &Y, MantidVec &E,
                          bool skipError = false) const;
-  void generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogramPulseTime(std::span<double const> X, MantidVec &Y, MantidVec &E,
                                   bool skipError = false) const override;
 
-  void generateHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, MantidVec &E, const double &tofFactor,
+  void generateHistogramTimeAtSample(std::span<double const> X, MantidVec &Y, MantidVec &E, const double &tofFactor,
                                      const double &tofOffset, bool skipError = false) const override;
 
   void integrate(const double minX, const double maxX, const bool entireRange, double &sum, double &error) const;
@@ -283,12 +284,12 @@ public:
   void multiply(const double value, const double error = 0.0) override;
   EventList &operator*=(const double value);
 
-  void multiply(const MantidVec &X, const MantidVec &Y, const MantidVec &E) override;
+  void multiply(std::span<double const> X, std::span<double const> Y, std::span<double const> E) override;
 
   void divide(const double value, const double error = 0.0) override;
   EventList &operator/=(const double value);
 
-  void divide(const MantidVec &X, const MantidVec &Y, const MantidVec &E) override;
+  void divide(std::span<double const> X, std::span<double const> Y, std::span<double const> E) override;
 
   void convertUnitsViaTof(Mantid::Kernel::Unit const *fromUnit, Mantid::Kernel::Unit const *toUnit);
   void convertUnitsQuickly(const double &factor, const double &power);
@@ -359,24 +360,24 @@ private:
                                                                      const double seek_time, const double &tofFactor,
                                                                      const double &tofOffset) const;
 
-  void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
-  void generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const;
+  void generateCountsHistogram(std::span<double const> X, MantidVec &Y) const;
+  void generateCountsHistogram(const double step, std::span<double const> X, MantidVec &Y) const;
 
 public:
-  static std::optional<size_t> findLinearBin(const MantidVec &X, const double tof, const double divisor,
+  static std::optional<size_t> findLinearBin(std::span<double const> X, const double tof, const double divisor,
                                              const double offset, const bool findExact = true);
-  static std::optional<size_t> findLogBin(const MantidVec &X, const double tof, const double divisor,
+  static std::optional<size_t> findLogBin(std::span<double const> X, const double tof, const double divisor,
                                           const double offset, const bool findExact = true);
 
 private:
-  static size_t findExactBin(const MantidVec &X, const double tof, const size_t n_bin);
+  static size_t findExactBin(std::span<double const> X, const double tof, const size_t n_bin);
 
-  void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
+  void generateCountsHistogramPulseTime(std::span<double const> X, MantidVec &Y) const;
 
-  void generateCountsHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, const double &tofFactor,
+  void generateCountsHistogramTimeAtSample(std::span<double const> X, MantidVec &Y, const double &tofFactor,
                                            const double &tofOffset) const;
 
-  void generateErrorsHistogram(const MantidVec &Y, MantidVec &E) const;
+  void generateErrorsHistogram(std::span<double const> Y, MantidVec &E) const;
 
   void switchToWeightedEvents();
   void switchToWeightedEventsNoTime();
@@ -404,9 +405,10 @@ private:
                                       const double seconds);
 
   template <class T>
-  static void histogramForWeightsHelper(const std::vector<T> &events, const MantidVec &X, MantidVec &Y, MantidVec &E);
+  static void histogramForWeightsHelper(const std::vector<T> &events, std::span<double const> X, MantidVec &Y,
+                                        MantidVec &E);
   template <class T>
-  static void histogramForWeightsHelper(const std::vector<T> &events, const double step, const MantidVec &X,
+  static void histogramForWeightsHelper(const std::vector<T> &events, const double step, std::span<double const> X,
                                         MantidVec &Y, MantidVec &E);
   template <class T>
   static void integrateHelper(std::vector<T> &events, const double minX, const double maxX, const bool entireRange,
@@ -440,10 +442,11 @@ private:
 
   template <class T> static void multiplyHelper(std::vector<T> &events, const double value, const double error = 0.0);
   template <class T>
-  static void multiplyHistogramHelper(std::vector<T> &events, const MantidVec &X, const MantidVec &Y,
-                                      const MantidVec &E);
+  static void multiplyHistogramHelper(std::vector<T> &events, std::span<double const> X, std::span<double const> Y,
+                                      std::span<double const> E);
   template <class T>
-  static void divideHistogramHelper(std::vector<T> &events, const MantidVec &X, const MantidVec &Y, const MantidVec &E);
+  static void divideHistogramHelper(std::vector<T> &events, std::span<double const> X, std::span<double const> Y,
+                                    std::span<double const> E);
   template <class T>
   void convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid::Kernel::Unit const *fromUnit,
                                 Mantid::Kernel::Unit const *toUnit);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -108,11 +108,11 @@ public:
   Kernel::cow_ptr<HistogramData::HistogramX> refX(const std::size_t) const override;
 
   /// Generate a new histogram from specified event list at the given index.
-  void generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                          bool skipError = false) const override;
 
   /// Generate a new histogram from specified event list at the given index.
-  void generateHistogramPulseTime(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogramPulseTime(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                                   bool skipError = false) const;
 
   // Set the x-axis data (histogram bins) for all pixels

--- a/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
@@ -13,6 +13,8 @@
 #include "MantidDataObjects/RebinnedOutput.h"
 #include "MantidGeometry/Math/Quadrilateral.h"
 
+#include <span>
+
 namespace Mantid {
 //------------------------------------------------------------------------------
 // Forward declarations
@@ -33,9 +35,10 @@ namespace DataObjects {
 
 namespace FractionalRebinning {
 
-/// Find the intersect region on the output grid
-MANTID_DATAOBJECTS_DLL bool getIntersectionRegion(const std::vector<double> &xAxis,
-                                                  const std::vector<double> &verticalAxis,
+/// Find the intersect region on the output grid.
+/// The axes are taken as spans so that the size-checked histogram data types can be
+/// passed directly, without going through a std::vector<double>.
+MANTID_DATAOBJECTS_DLL bool getIntersectionRegion(std::span<double const> xAxis, std::span<double const> verticalAxis,
                                                   const Geometry::Quadrilateral &inputQ, size_t &qstart, size_t &qend,
                                                   size_t &x_start, size_t &x_end);
 
@@ -48,13 +51,13 @@ MANTID_DATAOBJECTS_DLL void normaliseOutput(const API::MatrixWorkspace_sptr &out
 MANTID_DATAOBJECTS_DLL void rebinToOutput(const Geometry::Quadrilateral &inputQ,
                                           const API::MatrixWorkspace_const_sptr &inputWS, const size_t i,
                                           const size_t j, API::MatrixWorkspace &outputWS,
-                                          const std::vector<double> &verticalAxis);
+                                          std::span<double const> verticalAxis);
 
 /// Rebin the input quadrilateral to to output grid
 MANTID_DATAOBJECTS_DLL void rebinToFractionalOutput(const Geometry::Quadrilateral &inputQ,
                                                     const API::MatrixWorkspace_const_sptr &inputWS, const size_t i,
                                                     const size_t j, DataObjects::RebinnedOutput &outputWS,
-                                                    const std::vector<double> &verticalAxis,
+                                                    std::span<double const> verticalAxis,
                                                     const DataObjects::RebinnedOutput_const_sptr &inputRB = nullptr);
 
 /// Set finalize flag after fractional rebinning loop

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -67,7 +67,7 @@ public:
   const Histogram1D &getSpectrum(const size_t index) const override;
 
   /// Generate a new histogram by rebinning the existing histogram.
-  void generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                          bool skipError = false) const override;
 
   /** sets the monitorWorkspace indexlist

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -60,7 +60,7 @@ public:
   }
   const Histogram1D &getSpectrum(const size_t /*index*/) const override { return data; }
 
-  void generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+  void generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                          bool skipError = false) const override;
 
   /// Returns the number of dimensions, 0 in this case.

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -142,7 +142,7 @@ struct comparePulseTimeTOFDelta {
 struct FindBin {
   double divisor;
   double offset;
-  std::optional<size_t> (*findBin)(const Mantid::MantidVec &, const double, const double, const double, const bool);
+  std::optional<size_t> (*findBin)(std::span<double const>, const double, const double, const double, const bool);
   FindBin(double step, double xmin) {
     if (step < 0) {
       findBin = Mantid::DataObjects::EventList::findLogBin;
@@ -155,7 +155,7 @@ struct FindBin {
     }
   }
 
-  std::optional<size_t> operator()(const Mantid::MantidVec &X, const double tof, const bool findExact) {
+  std::optional<size_t> operator()(std::span<double const> X, const double tof, const bool findExact) {
     return findBin(X, tof, divisor, offset, findExact);
   }
 };
@@ -2117,7 +2117,7 @@ template <class T> typename std::vector<T>::iterator static findFirstEvent(std::
  * @throw runtime_error if the EventList does not have weighted events
  */
 template <class T>
-void EventList::histogramForWeightsHelper(const std::vector<T> &events, const MantidVec &X, MantidVec &Y,
+void EventList::histogramForWeightsHelper(const std::vector<T> &events, std::span<double const> X, MantidVec &Y,
                                           MantidVec &E) {
   // For slight speed=up.
   size_t x_size = X.size();
@@ -2213,7 +2213,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
  * @throw runtime_error if the EventList does not have weighted events
  */
 template <class T>
-void EventList::histogramForWeightsHelper(const std::vector<T> &events, const double step, const MantidVec &X,
+void EventList::histogramForWeightsHelper(const std::vector<T> &events, const double step, std::span<double const> X,
                                           MantidVec &Y, MantidVec &E) {
   size_t x_size = X.size();
 
@@ -2268,7 +2268,8 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
  * @param skipError: skip calculating the error. This has no effect for weighted
  *        events; you can just ignore the returned E vector.
  */
-void EventList::generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError) const {
+void EventList::generateHistogramPulseTime(std::span<double const> X, MantidVec &Y, MantidVec &E,
+                                           bool skipError) const {
   // All types of weights need to be sorted by Pulse Time
   this->sortPulseTime();
 
@@ -2300,8 +2301,8 @@ void EventList::generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, Man
  * weighted
  *          events; you can just ignore the returned E vector.
  */
-void EventList::generateHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, MantidVec &E, const double &tofFactor,
-                                              const double &tofOffset, bool skipError) const {
+void EventList::generateHistogramTimeAtSample(std::span<double const> X, MantidVec &Y, MantidVec &E,
+                                              const double &tofFactor, const double &tofOffset, bool skipError) const {
   // All types of weights need to be sorted by time at sample
   this->sortTimeAtSample(tofFactor, tofOffset);
 
@@ -2332,7 +2333,7 @@ void EventList::generateHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, 
  * @param skipError: skip calculating the error. This has no effect for weighted
  *        events; you can just ignore the returned E vector.
  */
-void EventList::generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError) const {
+void EventList::generateHistogram(std::span<double const> X, MantidVec &Y, MantidVec &E, bool skipError) const {
   // All types of weights need to be sorted by TOF
 
   this->sortTof();
@@ -2370,7 +2371,7 @@ void EventList::generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E
  * @param skipError: skip calculating the error. This has no effect for weighted
  *        events; you can just ignore the returned E vector.
  */
-void EventList::generateHistogram(const double step, const MantidVec &X, MantidVec &Y, MantidVec &E,
+void EventList::generateHistogram(const double step, std::span<double const> X, MantidVec &Y, MantidVec &E,
                                   bool skipError) const {
   // if events are already sorted, use faster sorted histogram method
   if (isSortedByTof() || empty())
@@ -2400,7 +2401,7 @@ void EventList::generateHistogram(const double step, const MantidVec &X, MantidV
  * @param X :: The x bins
  * @param Y :: The generated counts histogram
  */
-void EventList::generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const {
+void EventList::generateCountsHistogramPulseTime(std::span<double const> X, MantidVec &Y) const {
   // For slight speed=up.
   size_t x_size = X.size();
 
@@ -2508,7 +2509,7 @@ void EventList::generateCountsHistogramPulseTime(const double &xMin, const doubl
  * @param tofFactor :: time of flight factor
  * @param tofOffset :: time of flight offset
  */
-void EventList::generateCountsHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, const double &tofFactor,
+void EventList::generateCountsHistogramTimeAtSample(std::span<double const> X, MantidVec &Y, const double &tofFactor,
                                                     const double &tofOffset) const {
   // For slight speed=up.
   const size_t x_size = X.size();
@@ -2573,7 +2574,7 @@ void EventList::generateCountsHistogramTimeAtSample(const MantidVec &X, MantidVe
  * @param X :: The x bins
  * @param Y :: The generated counts histogram
  */
-void EventList::generateCountsHistogram(const MantidVec &X, MantidVec &Y) const {
+void EventList::generateCountsHistogram(std::span<double const> X, MantidVec &Y) const {
   // For slight speed=up.
   size_t x_size = X.size();
 
@@ -2598,13 +2599,13 @@ void EventList::generateCountsHistogram(const MantidVec &X, MantidVec &Y) const 
     auto itev = findFirstEvent(*this->events, TofEvent(X[0]));
     const auto itend = this->events->end();
     // Go through all the events,
-    for (auto itx = X.cbegin(); itev != itend; ++itev) {
+    for (auto itx = X.begin(); itev != itend; ++itev) {
       const double tof = itev->tof();
-      itx = std::find_if(itx, X.cend(), [tof](const double x) { return tof < x; });
-      if (itx == X.cend()) {
+      itx = std::find_if(itx, X.end(), [tof](const double x) { return tof < x; });
+      if (itx == X.end()) {
         break;
       }
-      const auto bin = static_cast<size_t>(std::max(std::distance(X.cbegin(), itx) - 1, std::ptrdiff_t{0}));
+      const auto bin = static_cast<size_t>(std::max(std::distance(X.begin(), itx) - 1, std::ptrdiff_t{0}));
       ++Y[bin];
     }
   } // end if (there are any events to histogram)
@@ -2620,7 +2621,7 @@ void EventList::generateCountsHistogram(const MantidVec &X, MantidVec &Y) const 
  * @param offset :: pre-calculated offset
  * @param findExact :: do extra check of supplied time-of-flight compared to bin boundaries and move the bin if needed
  */
-std::optional<size_t> EventList::findLinearBin(const MantidVec &X, const double tof, const double divisor,
+std::optional<size_t> EventList::findLinearBin(std::span<double const> X, const double tof, const double divisor,
                                                const double offset, const bool findExact) {
   const auto bin = static_cast<size_t>(tof * divisor - offset);
   if (bin >= X.size())
@@ -2649,7 +2650,7 @@ std::optional<size_t> EventList::findLinearBin(const MantidVec &X, const double 
  * @param offset :: pre-calculated offset
  * @param findExact :: do extra check of supplied time-of-flight compared to bin boundaries and move the bin if needed
  */
-std::optional<size_t> EventList::findLogBin(const MantidVec &X, const double tof, const double divisor,
+std::optional<size_t> EventList::findLogBin(std::span<double const> X, const double tof, const double divisor,
                                             const double offset, const bool findExact) {
   const auto bin = static_cast<size_t>(log(tof) * divisor - offset);
   if (bin >= X.size())
@@ -2667,9 +2668,9 @@ std::optional<size_t> EventList::findLogBin(const MantidVec &X, const double tof
  * @param tof :: TOF of the event we are trying to bin
  * @param n_bin :: starting estiamted bin number
  */
-size_t EventList::findExactBin(const MantidVec &X, const double tof, const size_t n_bin) {
+size_t EventList::findExactBin(std::span<double const> X, const double tof, const size_t n_bin) {
   // is tof slower than suggested bin
-  auto tof_of_bin = X.cbegin() + n_bin; // boundary suggested
+  auto tof_of_bin = X.begin() + n_bin; // boundary suggested
   if (tof < *tof_of_bin)
     return std::move(n_bin - 1);
 
@@ -2693,7 +2694,7 @@ size_t EventList::findExactBin(const MantidVec &X, const double tof, const size_
  * @param X :: The x bins
  * @param Y :: The generated counts histogram
  */
-void EventList::generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const {
+void EventList::generateCountsHistogram(const double step, std::span<double const> X, MantidVec &Y) const {
   // For slight speed=up.
   size_t x_size = X.size();
 
@@ -2739,12 +2740,12 @@ void EventList::generateCountsHistogram(const double step, const MantidVec &X, M
  * @param Y :: The counts histogram
  * @param E :: The generated error histogram
  */
-void EventList::generateErrorsHistogram(const MantidVec &Y, MantidVec &E) const {
+void EventList::generateErrorsHistogram(std::span<double const> Y, MantidVec &E) const {
   // Fill the vector for the errors, containing sqrt(count)
   E.resize(Y.size(), 0);
 
   // windows can get confused about std::sqrt
-  std::transform(Y.cbegin(), Y.cend(), E.begin(), static_cast<double (*)(double)>(sqrt));
+  std::transform(Y.begin(), Y.end(), E.begin(), static_cast<double (*)(double)>(sqrt));
 
 } //----------------------------------------------------------------------------------
 
@@ -3834,8 +3835,8 @@ void EventList::multiply(const double value, const double error) {
  * @throw invalid_argument if the sizes of X, Y, E are not consistent.
  * */
 template <class T>
-void EventList::multiplyHistogramHelper(std::vector<T> &events, const MantidVec &X, const MantidVec &Y,
-                                        const MantidVec &E) {
+void EventList::multiplyHistogramHelper(std::vector<T> &events, std::span<double const> X, std::span<double const> Y,
+                                        std::span<double const> E) {
   // Validate inputs
   if ((X.size() < 2) || (Y.size() != E.size()) || (X.size() != 1 + Y.size())) {
     std::stringstream msg;
@@ -3928,7 +3929,7 @@ void EventList::multiplyHistogramHelper(std::vector<T> &events, const MantidVec 
  * @param E: error on the value to multiply.
  * @throw invalid_argument if the sizes of X, Y, E are not consistent.
  */
-void EventList::multiply(const MantidVec &X, const MantidVec &Y, const MantidVec &E) {
+void EventList::multiply(std::span<double const> X, std::span<double const> Y, std::span<double const> E) {
   switch (eventType) {
   case TOF:
     // Switch to weights if needed.
@@ -3959,8 +3960,8 @@ void EventList::multiply(const MantidVec &X, const MantidVec &Y, const MantidVec
  * @throw invalid_argument if the sizes of X, Y, E are not consistent.
  * */
 template <class T>
-void EventList::divideHistogramHelper(std::vector<T> &events, const MantidVec &X, const MantidVec &Y,
-                                      const MantidVec &E) {
+void EventList::divideHistogramHelper(std::vector<T> &events, std::span<double const> X, std::span<double const> Y,
+                                      std::span<double const> E) {
   // Validate inputs
   if ((X.size() < 2) || (Y.size() != E.size()) || (X.size() != 1 + Y.size())) {
     std::stringstream msg;
@@ -4065,7 +4066,7 @@ void EventList::divideHistogramHelper(std::vector<T> &events, const MantidVec &X
  * @param E: error on the value to multiply.
  * @throw invalid_argument if the sizes of X, Y, E are not consistent.
  */
-void EventList::divide(const MantidVec &X, const MantidVec &Y, const MantidVec &E) {
+void EventList::divide(std::span<double const> X, std::span<double const> Y, std::span<double const> E) {
   switch (eventType) {
   case TOF:
     // Switch to weights if needed.

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -563,7 +563,7 @@ Kernel::cow_ptr<HistogramData::HistogramX> EventWorkspace::refX(const std::size_
  * @param skipError :: if true, the error vector is NOT calculated.
  *        This may save some processing time.
  */
-void EventWorkspace::generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+void EventWorkspace::generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                                        bool skipError) const {
   if (index >= data.size())
     throw std::range_error("EventWorkspace::generateHistogram, histogram number out of range");
@@ -580,8 +580,8 @@ void EventWorkspace::generateHistogram(const std::size_t index, const MantidVec 
  * @param skipError :: if true, the error vector is NOT calculated.
  *        This may save some processing time.
  */
-void EventWorkspace::generateHistogramPulseTime(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
-                                                bool skipError) const {
+void EventWorkspace::generateHistogramPulseTime(const std::size_t index, std::span<double const> X, MantidVec &Y,
+                                                MantidVec &E, bool skipError) const {
   if (index >= data.size())
     throw std::range_error("EventWorkspace::generateHistogramPulseTime, "
                            "histogram number out of range");

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -70,8 +70,8 @@ QuadrilateralType getQuadrilateralType(const Quadrilateral &inputQ) {
  * Find the possible region of intersection on the output workspace for the
  * given polygon. The given polygon must have a CLOCKWISE winding and the
  * first vertex must be the "lowest left" point.
- * @param xAxis A vector containing the output horizontal axis edges
- * @param verticalAxis A vector containing the output vertical axis edges
+ * @param xAxis The output horizontal axis edges
+ * @param verticalAxis The output vertical axis edges
  * @param inputQ The input polygon (Polygon winding must be clockwise)
  * @param qstart An output giving the starting index in the Q direction
  * @param qend An output giving the end index in the Q direction
@@ -79,7 +79,7 @@ QuadrilateralType getQuadrilateralType(const Quadrilateral &inputQ) {
  * @param x_end An output giving the end index in the dX direction
  * @return True if an intersection is possible
  */
-bool getIntersectionRegion(const std::vector<double> &xAxis, const std::vector<double> &verticalAxis,
+bool getIntersectionRegion(std::span<double const> xAxis, std::span<double const> verticalAxis,
                            const Quadrilateral &inputQ, size_t &qstart, size_t &qend, size_t &x_start, size_t &x_end) {
   const double xn_lo(inputQ.minX()), xn_hi(inputQ.maxX());
   const double yn_lo(inputQ.minY()), yn_hi(inputQ.maxY());
@@ -87,20 +87,20 @@ bool getIntersectionRegion(const std::vector<double> &xAxis, const std::vector<d
   if (xn_hi < xAxis.front() || xn_lo > xAxis.back() || yn_hi < verticalAxis.front() || yn_lo > verticalAxis.back())
     return false;
 
-  auto start_it = std::upper_bound(xAxis.cbegin(), xAxis.cend(), xn_lo);
-  auto end_it = std::upper_bound(start_it, xAxis.cend(), xn_hi);
+  auto start_it = std::upper_bound(xAxis.begin(), xAxis.end(), xn_lo);
+  auto end_it = std::upper_bound(start_it, xAxis.end(), xn_hi);
   x_start = 0;
-  if (start_it != xAxis.cbegin()) {
-    x_start = (start_it - xAxis.cbegin() - 1);
+  if (start_it != xAxis.begin()) {
+    x_start = (start_it - xAxis.begin() - 1);
   }
   x_end = xAxis.size() - 1;
-  if (end_it != xAxis.cend()) {
-    x_end = end_it - xAxis.cbegin();
+  if (end_it != xAxis.end()) {
+    x_end = end_it - xAxis.begin();
   }
 
   // Q region
-  start_it = std::upper_bound(verticalAxis.cbegin(), verticalAxis.cend(), yn_lo);
-  end_it = std::upper_bound(start_it, verticalAxis.cend(), yn_hi);
+  start_it = std::upper_bound(verticalAxis.begin(), verticalAxis.end(), yn_lo);
+  end_it = std::upper_bound(start_it, verticalAxis.end(), yn_hi);
   qstart = 0;
   if (start_it != verticalAxis.begin()) {
     qstart = (start_it - verticalAxis.begin() - 1);
@@ -116,7 +116,7 @@ bool getIntersectionRegion(const std::vector<double> &xAxis, const std::vector<d
 /**
  * Computes the output grid bins which intersect the input quad and their
  * overlapping areas assuming both input and output grids are rectangular
- * @param xAxis A vector containing the output horizontal axis edges
+ * @param xAxis The output horizontal axis edges
  * @param yAxis The output data vertical axis
  * @param inputQ The input quadrilateral
  * @param y_start The starting y-axis index
@@ -125,7 +125,7 @@ bool getIntersectionRegion(const std::vector<double> &xAxis, const std::vector<d
  * @param x_end The starting x-axis index
  * @param areaInfos Output vector of indices and areas of overlapping bins
  */
-void calcRectangleIntersections(const std::vector<double> &xAxis, const std::vector<double> &yAxis,
+void calcRectangleIntersections(std::span<double const> xAxis, std::span<double const> yAxis,
                                 const Quadrilateral &inputQ, const size_t y_start, const size_t y_end,
                                 const size_t x_start, const size_t x_end, std::vector<AreaInfo> &areaInfos) {
   std::vector<double> width;
@@ -150,7 +150,7 @@ void calcRectangleIntersections(const std::vector<double> &xAxis, const std::vec
 /**
  * Computes the output grid bins which intersect the input quad and their
  * overlapping areas assuming input quad is a y-axis aligned trapezoid.
- * @param xAxis A vector containing the output horizontal axis edges
+ * @param xAxis The output horizontal axis edges
  * @param yAxis The output data vertical axis
  * @param inputQ The input quadrilateral
  * @param y_start The starting y-axis index
@@ -159,7 +159,7 @@ void calcRectangleIntersections(const std::vector<double> &xAxis, const std::vec
  * @param x_end The ending x-axis index
  * @param areaInfos Output vector of indices and areas of overlapping bins
  */
-void calcTrapezoidYIntersections(const std::vector<double> &xAxis, const std::vector<double> &yAxis,
+void calcTrapezoidYIntersections(std::span<double const> xAxis, std::span<double const> yAxis,
                                  const Quadrilateral &inputQ, const size_t y_start, const size_t y_end,
                                  const size_t x_start, const size_t x_end, std::vector<AreaInfo> &areaInfos) {
   // The algorithm proceeds as follows:
@@ -430,7 +430,7 @@ void calcTrapezoidYIntersections(const std::vector<double> &xAxis, const std::ve
 /**
  * Computes the output grid bins which intersect the input quad and their
  * overlapping areas for arbitrary shaped input grids
- * @param xAxis A vector containing the output horizontal axis edges
+ * @param xAxis The output horizontal axis edges
  * @param yAxis The output data vertical axis
  * @param inputQ The input quadrilateral
  * @param qstart The starting y-axis index
@@ -439,9 +439,9 @@ void calcTrapezoidYIntersections(const std::vector<double> &xAxis, const std::ve
  * @param x_end The starting x-axis index
  * @param areaInfos Output vector of indices and areas of overlapping bins
  */
-void calcGeneralIntersections(const std::vector<double> &xAxis, const std::vector<double> &yAxis,
-                              const Quadrilateral &inputQ, const size_t qstart, const size_t qend, const size_t x_start,
-                              const size_t x_end, std::vector<AreaInfo> &areaInfos) {
+void calcGeneralIntersections(std::span<double const> xAxis, std::span<double const> yAxis, const Quadrilateral &inputQ,
+                              const size_t qstart, const size_t qend, const size_t x_start, const size_t x_end,
+                              std::vector<AreaInfo> &areaInfos) {
   ConvexPolygon intersectOverlap;
   areaInfos.reserve((qend - qstart) * (x_end - x_start));
   for (size_t yi = qstart; yi < qend; ++yi) {
@@ -498,18 +498,18 @@ void normaliseOutput(const MatrixWorkspace_sptr &outputWS, const MatrixWorkspace
  * @param i The index in the vertical axis direction that inputQ references
  * @param j The index in the horizontal axis direction that inputQ references
  * @param outputWS A pointer to the output workspace that accumulates the data
- * @param verticalAxis A vector containing the output vertical axis bin
+ * @param verticalAxis The output vertical axis bin
  * boundaries
  */
 void rebinToOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr &inputWS, const size_t i,
-                   const size_t j, MatrixWorkspace &outputWS, const std::vector<double> &verticalAxis) {
+                   const size_t j, MatrixWorkspace &outputWS, std::span<double const> verticalAxis) {
   const auto &inY = inputWS->y(i);
   // Check once whether the signal
   if (std::isnan(inY[j])) {
     return;
   }
 
-  const auto &X = outputWS.x(0).rawData();
+  const auto &X = outputWS.x(0);
   size_t qstart(0), qend(verticalAxis.size() - 1), x_start(0), x_end(X.size() - 1);
   if (!getIntersectionRegion(X, verticalAxis, inputQ, qstart, qend, x_start, x_end))
     return;
@@ -561,7 +561,7 @@ void rebinToOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr
  * @param outputWS A pointer to the output workspace that accumulates the data
  *        Note that the error array of the output workspace contains the
  *        **variance** and not the errors (standard deviations).
- * @param verticalAxis A vector containing the output vertical axis bin
+ * @param verticalAxis The output vertical axis bin
  * boundaries
  * @param inputRB A pointer, of RebinnedOutput type, to the input workspace.
  * It is used to take into account the input area fractions when calcuting
@@ -569,7 +569,7 @@ void rebinToOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr
  * This can be null to indicate that the input was a standard 2D workspace.
  */
 void rebinToFractionalOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr &inputWS, const size_t i,
-                             const size_t j, RebinnedOutput &outputWS, const std::vector<double> &verticalAxis,
+                             const size_t j, RebinnedOutput &outputWS, std::span<double const> verticalAxis,
                              const RebinnedOutput_const_sptr &inputRB) {
   const auto &inX = inputWS->binEdges(i);
   const auto &inY = inputWS->y(i);
@@ -578,7 +578,7 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ, const MatrixWorkspace_
   if (std::isnan(signal))
     return;
 
-  const auto &X = outputWS.x(0).rawData();
+  const auto &X = outputWS.x(0);
   size_t qstart(0), qend(verticalAxis.size() - 1), x_start(0), x_end(X.size() - 1);
   if (!getIntersectionRegion(X, verticalAxis, inputQ, qstart, qend, x_start, x_end))
     return;

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -322,7 +322,7 @@ size_t Workspace2D::getHistogramNumberHelper() const { return data.size(); }
  * @param skipError :: if true, the error vector is NOT calculated.
  *        CURRENTLY IGNORED, the Error is always calculated.
  */
-void Workspace2D::generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
+void Workspace2D::generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y, MantidVec &E,
                                     bool skipError) const {
   UNUSED_ARG(skipError);
   if (index >= data.size())

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -342,12 +342,11 @@ void Workspace2D::generateHistogram(const std::size_t index, const MantidVec &X,
   {                                       // VectorHelper::rebin, assumes bin boundaries, even if
     std::vector<double> histX;            // it is a distribution!
     histX.resize(currentX.size() + 1);
-    Mantid::Kernel::VectorHelper::convertToBinBoundary(currentX.rawData(), histX);
-    Mantid::Kernel::VectorHelper::rebin(histX, currentY.rawData(), currentE.rawData(), X, Y, E, true);
+    Mantid::Kernel::VectorHelper::convertToBinBoundary(currentX, histX);
+    Mantid::Kernel::VectorHelper::rebin(histX, currentY, currentE, X, Y, E, true);
   } else // assume x_size = y_size + 1
   {
-    Mantid::Kernel::VectorHelper::rebin(currentX.rawData(), currentY.rawData(), currentE.rawData(), X, Y, E,
-                                        this->isDistribution());
+    Mantid::Kernel::VectorHelper::rebin(currentX, currentY, currentE, X, Y, E, this->isDistribution());
   }
 }
 

--- a/Framework/DataObjects/src/WorkspaceSingleValue.cpp
+++ b/Framework/DataObjects/src/WorkspaceSingleValue.cpp
@@ -57,8 +57,8 @@ Histogram1D &WorkspaceSingleValue::getSpectrumWithoutInvalidation(const size_t /
 }
 
 /// Rebin the workspace. Not implemented for this workspace.
-void WorkspaceSingleValue::generateHistogram(const std::size_t index, const MantidVec &X, MantidVec &Y, MantidVec &E,
-                                             bool skipError) const {
+void WorkspaceSingleValue::generateHistogram(const std::size_t index, std::span<double const> X, MantidVec &Y,
+                                             MantidVec &E, bool skipError) const {
   UNUSED_ARG(index);
   UNUSED_ARG(X);
   UNUSED_ARG(Y);

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -653,9 +653,9 @@ public:
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int i = 0; i < numpix; i++) {
       for (int j = 0; j < 10; j++) {
-        MantidVec Y = ew1->dataY(i);
-        const MantidVec &E = ew1->dataE(i);
-        MantidVec E2 = E;
+        MantidVec Y = ew1->y(i).rawData();
+        Mantid::HistogramData::HistogramE const &E = ew1->e(i);
+        MantidVec E2 = E.rawData();
       }
     }
   }

--- a/Framework/HistogramData/src/HistogramMath.cpp
+++ b/Framework/HistogramData/src/HistogramMath.cpp
@@ -62,7 +62,7 @@ void checkSameYMode(const Histogram &hist1, const Histogram &hist2) {
 }
 
 void checkSameX(const Histogram &hist1, const Histogram &hist2) {
-  if (!(hist1.sharedX() == hist2.sharedX()) && (hist1.x().rawData() != hist2.x().rawData()))
+  if (!(hist1.sharedX() == hist2.sharedX()) && (hist1.x() != hist2.x()))
     throw std::runtime_error("Invalid operation: Histogram X data must match");
 }
 } // namespace

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -109,7 +109,7 @@ void sanityCheck(const Histogram &input, const Histogram &output, const size_t m
 void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
                                 const Mantid::HistogramData::Points &points, Mantid::HistogramData::Histogram &output,
                                 const bool calculateErrors = false, const bool independentErrors = true) {
-  const auto xs = input.x().rawData();
+  const auto &xs = input.x();
   // Interpolation and Error propagation follows method described in Gardner paper
   // "Uncertainties in Interpolated Spectral Data", Journal of Research of the
   // National Institute of Standards and Technology, 2003
@@ -133,7 +133,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
   double hMaxEpsilon = xsMaxEpsilon * 2 / 3;
 
   std::vector<double> d(xs.size() - 2);
-  const auto ys = input.y().rawData();
+  const auto &ys = input.y();
   for (size_t i = 0; i < xs.size() - 2; i++) {
     d[i] = (ys[i + 2] - ys[i + 1]) / (xs[i + 2] - xs[i + 1]) - (ys[i + 1] - ys[i]) / (xs[i + 1] - xs[i]);
   }

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -26,7 +26,7 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
   const auto &yold = input.y();
   const auto &eold = input.e();
 
-  const auto &xnew = binEdges.rawData();
+  const auto &xnew = binEdges;
   Counts newCounts(xnew.size() - 1);
   CountVariances newCountVariances(xnew.size() - 1);
   auto &ynew = newCounts.mutableData();
@@ -84,7 +84,7 @@ Histogram rebinFrequencies(const Histogram &input, const BinEdges &binEdges) {
   const auto &yold = input.y();
   const auto &eold = input.e();
 
-  const auto &xnew = binEdges.rawData();
+  const auto &xnew = binEdges;
   Frequencies newFrequencies(xnew.size() - 1);
   FrequencyStandardDeviations newFrequencyStdDev(xnew.size() - 1);
   auto &ynew = newFrequencies.mutableData();

--- a/Framework/Kernel/inc/MantidKernel/EqualBinsChecker.h
+++ b/Framework/Kernel/inc/MantidKernel/EqualBinsChecker.h
@@ -26,9 +26,8 @@ public:
   enum class ReferenceBin { Average, First };
   /// Type of errors to check
   enum class ErrorType { Cumulative, Individual };
-  /// @param xData :: a non-owning view of the x data; it must outlive this object.
-  ///                 Taken as a span so that the size-checked histogram data types can be
-  ///                 checked directly, without going through a std::vector<double>.
+  // Note: xData is a non-owning view and must outlive this object. It is a span so that the
+  // size-checked histogram data types can be checked directly, without a std::vector<double>.
   EqualBinsChecker(std::span<double const> xData, const double errorLevel, const double warningLevel = -1);
   virtual ~EqualBinsChecker() = default;
   virtual std::string validate() const;

--- a/Framework/Kernel/inc/MantidKernel/EqualBinsChecker.h
+++ b/Framework/Kernel/inc/MantidKernel/EqualBinsChecker.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/cow_ptr.h"
+#include <span>
 #include <string>
 
 namespace Mantid {
@@ -25,7 +26,10 @@ public:
   enum class ReferenceBin { Average, First };
   /// Type of errors to check
   enum class ErrorType { Cumulative, Individual };
-  EqualBinsChecker(const MantidVec &xData, const double errorLevel, const double warningLevel = -1);
+  /// @param xData :: a non-owning view of the x data; it must outlive this object.
+  ///                 Taken as a span so that the size-checked histogram data types can be
+  ///                 checked directly, without going through a std::vector<double>.
+  EqualBinsChecker(std::span<double const> xData, const double errorLevel, const double warningLevel = -1);
   virtual ~EqualBinsChecker() = default;
   virtual std::string validate() const;
   virtual void setReferenceBin(const ReferenceBin &refBinType);
@@ -36,7 +40,7 @@ protected:
   virtual double getDifference(const size_t bin, const double dx) const;
 
 private:
-  const MantidVec &m_xData;
+  std::span<double const> const m_xData;
   const double m_errorLevel;
   const bool m_warn;
   const double m_warningLevel;

--- a/Framework/Kernel/inc/MantidKernel/Smoothing.h
+++ b/Framework/Kernel/inc/MantidKernel/Smoothing.h
@@ -6,6 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidKernel/DllConfig.h"
+
+#include <span>
 #include <vector>
 
 namespace Mantid::Kernel {
@@ -33,6 +36,19 @@ template <typename T> std::vector<T> boxcarSmooth(std::vector<T> const &input, u
  * @tparam T Numeric type (e.g., int, float, double)
  */
 template <typename T> std::vector<T> boxcarErrorSmooth(std::vector<T> const &input, unsigned int const numPoints);
+
+/** Overloads taking a contiguous range of doubles, so that the size-checked histogram data
+ * types, which do not hand out a std::vector<double>, can be smoothed directly. A
+ * std::vector<double> argument still selects the templates above; deduction cannot produce a
+ * std::span, hence these are not templates.
+ *
+ * @param input The contiguous range to be smoothed
+ * @param numPoints The width of the boxcar window (must be >= 3)
+ * @return A new vector containing the smoothed data
+ * @throw std::invalid_argument if numPoints is too small
+ */
+MANTID_KERNEL_DLL std::vector<double> boxcarSmooth(std::span<double const> input, unsigned int const numPoints);
+MANTID_KERNEL_DLL std::vector<double> boxcarErrorSmooth(std::span<double const> input, unsigned int const numPoints);
 
 /** Performs boxcar (moving average) smoothing on the input data,
  * using a RMSE average, as is appropriate for error averaging.

--- a/Framework/Kernel/inc/MantidKernel/Statistics.h
+++ b/Framework/Kernel/inc/MantidKernel/Statistics.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidKernel/DllConfig.h"
+#include <span>
 #include <vector>
 
 namespace Mantid {
@@ -80,13 +81,21 @@ template <typename TYPE>
 Statistics getStatistics(const std::vector<TYPE> &data, const unsigned int flags = StatOptions::AllStats);
 /// Return the Z score values for a dataset
 template <typename TYPE> std::vector<double> getZscore(const std::vector<TYPE> &data);
+
+/// Overloads taking a contiguous range of doubles, so that the size-checked histogram
+/// data types can be used directly. A std::vector<double> argument still selects the
+/// template above; deduction cannot produce a std::span, hence these are not templates.
+MANTID_KERNEL_DLL Statistics getStatistics(std::span<double const> data,
+                                           const unsigned int flags = StatOptions::AllStats);
+MANTID_KERNEL_DLL std::vector<double> getZscore(std::span<double const> data);
+
 template <typename TYPE>
 std::vector<double> getWeightedZscore(const std::vector<TYPE> &data, const std::vector<TYPE> &weights);
 /// Return the modified Z score values for a dataset
 template <typename TYPE> std::vector<double> getModifiedZscore(const std::vector<TYPE> &data);
 /// Return the R-factors (Rwp) of a diffraction pattern data
-Rfactor MANTID_KERNEL_DLL getRFactor(const std::vector<double> &obsI, const std::vector<double> &calI,
-                                     const std::vector<double> &obsE);
+Rfactor MANTID_KERNEL_DLL getRFactor(std::span<double const> obsI, std::span<double const> calI,
+                                     std::span<double const> obsE);
 
 /// Return the first n-moments of the supplied data.
 template <typename TYPE>

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -36,34 +36,34 @@ std::size_t MANTID_KERNEL_DLL createAxisFromRebinParams(
     const bool full_bins_only = false, const double xMinHint = std::nan(""), const double xMaxHint = std::nan(""),
     const bool useReverseLogarithmic = false, const double power = -1);
 
-/// The output ranges are taken as spans so that the size-checked histogram data types, which do not
-/// hand out a modifiable std::vector<double>, can be rebinned into directly. The outputs must already
-/// be sized; neither function resizes them.
-void MANTID_KERNEL_DLL rebin(const std::vector<double> &xold, const std::vector<double> &yold,
-                             const std::vector<double> &eold, const std::vector<double> &xnew, std::span<double> ynew,
-                             std::span<double> enew, bool distribution, bool addition = false);
+/// The input and output ranges are taken as spans so that the size-checked histogram data types,
+/// which do not hand out a modifiable std::vector<double>, can be rebinned from and into directly.
+/// The outputs must already be sized; neither function resizes them.
+void MANTID_KERNEL_DLL rebin(std::span<double const> xold, std::span<double const> yold, std::span<double const> eold,
+                             std::span<double const> xnew, std::span<double> ynew, std::span<double> enew,
+                             bool distribution, bool addition = false);
 
 // New method to rebin Histogram data, should be faster than previous one
-void MANTID_KERNEL_DLL rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold,
-                                      const std::vector<double> &eold, const std::vector<double> &xnew,
+void MANTID_KERNEL_DLL rebinHistogram(std::span<double const> xold, std::span<double const> yold,
+                                      std::span<double const> eold, std::span<double const> xnew,
                                       std::span<double> ynew, std::span<double> enew, bool addition);
 
 /// Convert an array of bin boundaries to bin center values.
-void MANTID_KERNEL_DLL convertToBinCentre(const std::vector<double> &bin_edges, std::vector<double> &bin_centres);
+void MANTID_KERNEL_DLL convertToBinCentre(std::span<double const> bin_edges, std::vector<double> &bin_centres);
 
 /// Convert an array of bin centers to bin boundary values.
-void MANTID_KERNEL_DLL convertToBinBoundary(const std::vector<double> &bin_centers, std::vector<double> &bin_edges);
+void MANTID_KERNEL_DLL convertToBinBoundary(std::span<double const> bin_centers, std::vector<double> &bin_edges);
 
 /// Gets the bin of a value from a vector of bin centers and throws exception if out of range
-size_t MANTID_KERNEL_DLL indexOfValueFromCenters(const std::vector<double> &bin_centers, const double value);
+size_t MANTID_KERNEL_DLL indexOfValueFromCenters(std::span<double const> bin_centers, const double value);
 
 /// Gets the bin of a value from a vector of bin centers and returns -1 if out of range
-int MANTID_KERNEL_DLL indexOfValueFromCentersNoThrow(const std::vector<double> &bin_centers, const double value);
+int MANTID_KERNEL_DLL indexOfValueFromCentersNoThrow(std::span<double const> bin_centers, const double value);
 
 /// Gets the bin of a value from a vector of bin edges
-size_t MANTID_KERNEL_DLL indexOfValueFromEdges(const std::vector<double> &bin_edges, const double value);
+size_t MANTID_KERNEL_DLL indexOfValueFromEdges(std::span<double const> bin_edges, const double value);
 
-bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
+bool MANTID_KERNEL_DLL isConstantValue(std::span<double const> arra);
 
 /**
  * A convenience function to "flatten" the given vector of vectors
@@ -87,14 +87,14 @@ template <typename T> std::vector<T> flattenVector(const std::vector<std::vector
 template <typename NumT>
 MANTID_KERNEL_DLL std::vector<NumT> splitStringIntoVector(std::string listString, const std::string &separators = ", ");
 
-MANTID_KERNEL_DLL int getBinIndex(const std::vector<double> &bins, const double value);
+MANTID_KERNEL_DLL int getBinIndex(std::span<double const> bins, const double value);
 
 // Do running average of input vector within specified range, considering
 // heterogeneous bin-boundaries
-// if such boundaries are provided
-MANTID_KERNEL_DLL void smoothInRange(const std::vector<double> &input, std::vector<double> &output, double avrgInterval,
-                                     std::vector<double> const *const binBndrs = nullptr, size_t startIndex = 0,
-                                     size_t endIndex = 0, std::vector<double> *const outBins = nullptr);
+// if such boundaries are provided. An empty binBndrs means no boundaries were provided.
+MANTID_KERNEL_DLL void smoothInRange(std::span<double const> input, std::vector<double> &output, double avrgInterval,
+                                     std::span<double const> binBndrs = {}, size_t startIndex = 0, size_t endIndex = 0,
+                                     std::vector<double> *const outBins = nullptr);
 
 // Forward declare SumSquares to use it in lengthVector
 template <class T> struct SumSquares;

--- a/Framework/Kernel/src/EqualBinsChecker.cpp
+++ b/Framework/Kernel/src/EqualBinsChecker.cpp
@@ -22,14 +22,15 @@ namespace Mantid::Kernel {
 /**
  * Constructor, setting data and thresholds for errors and warnings.
  * By default, checks against average bin width and uses cumulative errors.
- * @param xData :: [input] Reference to bins to check
+ * @param xData :: [input] Non-owning view of the bins to check; it must outlive this
+ * object, exactly as the previous reference parameter had to.
  * @param errorLevel :: [input] Threshold for error. If bin differences are
  * larger than this, check fails.
  * @param warningLevel :: [input] Threshold for warning. If bin difference are
  * larger than this, the user is warned but the check doesn't necessarily fail.
  * If set negative, warnings are off and only error level is used (default).
  */
-EqualBinsChecker::EqualBinsChecker(const MantidVec &xData, const double errorLevel, const double warningLevel)
+EqualBinsChecker::EqualBinsChecker(std::span<double const> xData, const double errorLevel, const double warningLevel)
     : m_xData(xData), m_errorLevel(errorLevel), m_warn(warningLevel > 0), m_warningLevel(warningLevel),
       m_refBinType(ReferenceBin::Average), m_errorType(ErrorType::Cumulative) {}
 

--- a/Framework/Kernel/src/Smoothing.cpp
+++ b/Framework/Kernel/src/Smoothing.cpp
@@ -90,7 +90,7 @@ template <typename T> struct GeometricAverager : public Averager<T> {
 };
 
 template <typename T>
-std::vector<T> boxcarSmoothWithFunction(std::vector<T> const &input, unsigned int const numPoints,
+std::vector<T> boxcarSmoothWithFunction(std::span<T const> const input, unsigned int const numPoints,
                                         Averager<T> &averager) {
   if (numPoints < 3) {
     throw std::invalid_argument("Boxcar Smoothing requires at least 3 points in the moving average");
@@ -140,22 +140,33 @@ std::vector<T> boxcarSmoothWithFunction(std::vector<T> const &input, unsigned in
 
 template <typename T> std::vector<T> boxcarSmooth(std::vector<T> const &input, unsigned int const numPoints) {
   detail::ArithmeticAverager<T> averager;
-  return detail::boxcarSmoothWithFunction(input, numPoints, averager);
+  // the template argument is explicit because a std::vector cannot deduce a std::span
+  return detail::boxcarSmoothWithFunction<T>(input, numPoints, averager);
 }
 
 template <typename T> std::vector<T> boxcarErrorSmooth(std::vector<T> const &input, unsigned int const numPoints) {
   detail::ErrorPropagationAverager<T> averager;
-  return detail::boxcarSmoothWithFunction(input, numPoints, averager);
+  return detail::boxcarSmoothWithFunction<T>(input, numPoints, averager);
 }
 
 template <typename T> std::vector<T> boxcarRMSESmooth(std::vector<T> const &input, unsigned int const numPoints) {
   detail::SumSquareAverager<T> averager;
-  return detail::boxcarSmoothWithFunction(input, numPoints, averager);
+  return detail::boxcarSmoothWithFunction<T>(input, numPoints, averager);
 }
 
 template MANTID_KERNEL_DLL std::vector<double> boxcarSmooth(std::vector<double> const &, unsigned int const);
 template MANTID_KERNEL_DLL std::vector<double> boxcarRMSESmooth(std::vector<double> const &, unsigned int const);
 template MANTID_KERNEL_DLL std::vector<double> boxcarErrorSmooth(std::vector<double> const &, unsigned int const);
+
+std::vector<double> boxcarSmooth(std::span<double const> const input, unsigned int const numPoints) {
+  detail::ArithmeticAverager<double> averager;
+  return detail::boxcarSmoothWithFunction(input, numPoints, averager);
+}
+
+std::vector<double> boxcarErrorSmooth(std::span<double const> const input, unsigned int const numPoints) {
+  detail::ErrorPropagationAverager<double> averager;
+  return detail::boxcarSmoothWithFunction(input, numPoints, averager);
+}
 
 // FFT SMOOTHING METHODS
 

--- a/Framework/Kernel/src/Statistics.cpp
+++ b/Framework/Kernel/src/Statistics.cpp
@@ -36,6 +36,11 @@ void assertMomentIsValid(const int maxMoment) {
 using std::string;
 using std::vector;
 
+/// Shared implementations, generic over any sized contiguous range, so that the
+/// std::vector and std::span entry points below do not duplicate the algorithms.
+template <typename Range> Statistics getStatisticsImpl(Range const &data, const unsigned int flags);
+template <typename Range> std::vector<double> getZscoreImpl(Range const &data);
+
 Statistics::Statistics() {
   constexpr double nan = std::numeric_limits<double>::quiet_NaN();
   minimum = nan;
@@ -49,12 +54,13 @@ Statistics::Statistics() {
  * There are enough special cases in determining the median where it useful to
  * put it in a single function.
  */
-template <typename TYPE> double getMedian(const vector<TYPE> &data) {
+template <typename Range> double getMedian(Range const &data) {
+  using value_type = std::decay_t<decltype(data[0])>;
   const size_t size = data.size();
   if (size == 1)
     return static_cast<double>(data[0]);
 
-  const bool isSorted = std::is_sorted(data.cbegin(), data.cend());
+  const bool isSorted = std::is_sorted(data.begin(), data.end());
   const bool is_even = (size % 2 == 0);
   if (isSorted) {
     if (is_even)
@@ -62,7 +68,7 @@ template <typename TYPE> double getMedian(const vector<TYPE> &data) {
     else
       return static_cast<double>(data[size / 2]);
   } else {
-    std::vector<TYPE> tmpSortedData(data);
+    std::vector<value_type> tmpSortedData(data.begin(), data.end());
     std::sort(tmpSortedData.begin(), tmpSortedData.end());
     if (is_even)
       return (static_cast<double>(tmpSortedData[size / 2 - 1]) + static_cast<double>(tmpSortedData[size / 2])) / 2;
@@ -75,24 +81,28 @@ template <typename TYPE> double getMedian(const vector<TYPE> &data) {
  * There are enough special cases in determining the Z score where it useful to
  * put it in a single function.
  */
-template <typename TYPE> std::vector<double> getZscore(const vector<TYPE> &data) {
+template <typename Range> std::vector<double> getZscoreImpl(Range const &data) {
   std::vector<double> Zscore;
   if (data.size() < 3) {
     Zscore.resize(data.size(), 0.);
     return Zscore;
   }
-  Statistics stats = getStatistics(data);
+  Statistics stats = getStatisticsImpl(data, StatOptions::AllStats);
   if (stats.standard_deviation == 0.) {
     Zscore.resize(data.size(), 0.);
     return Zscore;
   }
-  for (auto it = data.cbegin(); it != data.cend(); ++it) {
+  for (auto it = data.begin(); it != data.end(); ++it) {
     auto tmp = static_cast<double>(*it);
     // unclear why Zscore is non-negative, was first implemented in #5316
     Zscore.emplace_back(fabs((stats.mean - tmp) / stats.standard_deviation));
   }
   return Zscore;
 }
+
+template <typename TYPE> std::vector<double> getZscore(const vector<TYPE> &data) { return getZscoreImpl(data); }
+
+std::vector<double> getZscore(std::span<double const> data) { return getZscoreImpl(data); }
 /**
  * There are enough special cases in determining the Z score where it useful to
  * put it in a single function.
@@ -162,7 +172,7 @@ template <typename TYPE> std::vector<double> getModifiedZscore(const vector<TYPE
  * @param data Data points whose statistics are to be evaluated
  * @param flags A set of flags to control the computation of the stats
  */
-template <typename TYPE> Statistics getStatistics(const vector<TYPE> &data, const unsigned int flags) {
+template <typename Range> Statistics getStatisticsImpl(Range const &data, const unsigned int flags) {
   Statistics statistics;
   if (data.empty()) { // don't do anything
     return statistics;
@@ -203,6 +213,14 @@ template <typename TYPE> Statistics getStatistics(const vector<TYPE> &data, cons
   return statistics;
 }
 
+template <typename TYPE> Statistics getStatistics(const vector<TYPE> &data, const unsigned int flags) {
+  return getStatisticsImpl(data, flags);
+}
+
+Statistics getStatistics(std::span<double const> data, const unsigned int flags) {
+  return getStatisticsImpl(data, flags);
+}
+
 /// Getting statistics of a string array should just give a bunch of NaNs
 template <> DLLExport Statistics getStatistics<string>(const vector<string> &data, const unsigned int flags) {
   UNUSED_ARG(flags);
@@ -224,7 +242,7 @@ template <> DLLExport Statistics getStatistics<bool>(const vector<bool> &data, c
  * @return :: RFactor including Rp and Rwp
  *
  */
-Rfactor getRFactor(const std::vector<double> &obsI, const std::vector<double> &calI, const std::vector<double> &obsE) {
+Rfactor getRFactor(std::span<double const> obsI, std::span<double const> calI, std::span<double const> obsE) {
   // 1. Check
   if (obsI.size() != calI.size() || obsI.size() != obsE.size()) {
     std::stringstream errss;

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -302,8 +302,8 @@ std::size_t createAxisFromRebinParams(const std::vector<double> &params, std::ve
  *  @throw runtime_error Thrown if algorithm cannot execute.
  *  @throw invalid_argument Thrown if input to function is incorrect.
  **/
-void rebin(const std::vector<double> &xold, const std::vector<double> &yold, const std::vector<double> &eold,
-           const std::vector<double> &xnew, std::span<double> ynew, std::span<double> enew, bool distribution,
+void rebin(std::span<double const> xold, std::span<double const> yold, std::span<double const> eold,
+           std::span<double const> xnew, std::span<double> ynew, std::span<double> enew, bool distribution,
            bool addition) {
   // Make sure y and e vectors are of correct sizes
   const size_t size_xold = xold.size();
@@ -419,8 +419,8 @@ void rebin(const std::vector<double> &xold, const std::vector<double> &yold, con
  *SQUARED ERRORS!
  *  @throw runtime_error Thrown if vector sizes are inconsistent
  **/
-void rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold, const std::vector<double> &eold,
-                    const std::vector<double> &xnew, std::span<double> ynew, std::span<double> enew, bool addition) {
+void rebinHistogram(std::span<double const> xold, std::span<double const> yold, std::span<double const> eold,
+                    std::span<double const> xnew, std::span<double> ynew, std::span<double> enew, bool addition) {
   // Make sure y and e vectors are of correct sizes
   const size_t size_yold = yold.size();
   if (xold.size() != (size_yold + 1) || size_yold != eold.size())
@@ -439,17 +439,17 @@ void rebinHistogram(const std::vector<double> &xold, const std::vector<double> &
   size_t iold = 0, inew = 0; // iold/inew is the bin number under consideration
                              // (counting from 1, so index+1)
   if (xnew.front() > xold.front()) {
-    auto it = std::upper_bound(xold.cbegin(), xold.cend(), xnew.front());
+    auto it = std::upper_bound(xold.begin(), xold.end(), xnew.front());
     if (it == xold.end())
       return;
     //      throw std::runtime_error("No overlap: max of X-old < min of X-new");
     iold = std::distance(xold.begin(), it) - 1; // Old bin to start at (counting from 0)
   } else {
-    auto it = std::upper_bound(xnew.cbegin(), xnew.cend(), xold.front());
-    if (it == xnew.cend())
+    auto it = std::upper_bound(xnew.begin(), xnew.end(), xold.front());
+    if (it == xnew.end())
       return;
     //      throw std::runtime_error("No overlap: max of X-new < min of X-old");
-    inew = std::distance(xnew.cbegin(), it) - 1; // New bin to start at (counting from 0)
+    inew = std::distance(xnew.begin(), it) - 1; // New bin to start at (counting from 0)
   }
 
   double frac, fracE;
@@ -510,7 +510,7 @@ void rebinHistogram(const std::vector<double> &xold, const std::vector<double> &
  * @param bin_edges :: A vector of values specifying bin boundaries
  * @param bin_centres :: An output vector of bin centre values.
  */
-void convertToBinCentre(const std::vector<double> &bin_edges, std::vector<double> &bin_centres) {
+void convertToBinCentre(std::span<double const> bin_edges, std::vector<double> &bin_centres) {
   const std::vector<double>::size_type npoints = bin_edges.size();
   if (bin_centres.size() != npoints) {
     bin_centres.resize(npoints);
@@ -542,7 +542,7 @@ void convertToBinCentre(const std::vector<double> &bin_edges, std::vector<double
  *                       boundaries
  *
  */
-void convertToBinBoundary(const std::vector<double> &bin_centers, std::vector<double> &bin_edges) {
+void convertToBinBoundary(std::span<double const> bin_centers, std::vector<double> &bin_edges) {
   const auto n = bin_centers.size();
 
   // Special case empty input: output is also empty
@@ -580,7 +580,7 @@ void convertToBinBoundary(const std::vector<double> &bin_centers, std::vector<do
  * (in bin edge representation)
  */
 
-size_t indexOfValueFromCenters(const std::vector<double> &bin_centers, const double value) {
+size_t indexOfValueFromCenters(std::span<double const> bin_centers, const double value) {
   int index = indexOfValueFromCentersNoThrow(bin_centers, value);
   if (index >= 0)
     return static_cast<size_t>(index);
@@ -588,7 +588,7 @@ size_t indexOfValueFromCenters(const std::vector<double> &bin_centers, const dou
     throw std::out_of_range("indexOfValue - value out of range");
 }
 
-int indexOfValueFromCentersNoThrow(const std::vector<double> &bin_centers, const double value) {
+int indexOfValueFromCentersNoThrow(std::span<double const> bin_centers, const double value) {
   if (bin_centers.empty()) {
     throw std::out_of_range("indexOfValue - vector is empty");
   }
@@ -628,7 +628,7 @@ int indexOfValueFromCentersNoThrow(const std::vector<double> &bin_centers, const
  * @throw std::out_of_range : if vector is empty, contains one element,
  *  or value is out of it's range
  */
-size_t indexOfValueFromEdges(const std::vector<double> &bin_edges, const double value) {
+size_t indexOfValueFromEdges(std::span<double const> bin_edges, const double value) {
   if (bin_edges.empty()) {
     throw std::out_of_range("indexOfValue - vector is empty");
   }
@@ -656,11 +656,11 @@ size_t indexOfValueFromEdges(const std::vector<double> &bin_edges, const double 
  * different values
  *  @param[in] arra the vector to examine
  */
-bool isConstantValue(const std::vector<double> &arra) {
+bool isConstantValue(std::span<double const> arra) {
   // make comparisons with the first value
-  auto i = arra.cbegin();
+  auto i = arra.begin();
 
-  if (i == arra.cend()) { // empty array
+  if (i == arra.end()) { // empty array
     return true;
   }
 
@@ -669,14 +669,14 @@ bool isConstantValue(const std::vector<double> &arra) {
   // != nan, deal with these first
   for (; val != val;) {
     ++i;
-    if (i == arra.cend()) {
+    if (i == arra.end()) {
       // all values are contant (NAN)
       return true;
     }
     val = *i;
   }
 
-  for (; i != arra.cend(); ++i) {
+  for (; i != arra.end(); ++i) {
     if (*i != val) {
       return false;
     }
@@ -722,7 +722,7 @@ std::vector<NumT> splitStringIntoVector(std::string listString, const std::strin
  *               monotonically increasing values and this is NOT checked
  *  @param value The value whose boundaries should be found
  */
-int getBinIndex(const std::vector<double> &bins, const double value) {
+int getBinIndex(std::span<double const> bins, const double value) {
   assert(bins.size() >= 2);
   // Since we cast to an int below:
   assert(bins.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
@@ -755,22 +755,22 @@ namespace {
  *                     should be: index<=endIndex<=input.size()
  *@param halfWidth  -- half width of the interval to integrate.
  *@param input      -- vector of input signal
- *@param binBndrs   -- pointer to vector of bin boundaries or NULL pointer.
+ *@param binBndrs   -- vector of bin boundaries, or an empty span if none were provided.
  */
 double runAverage(size_t index, size_t startIndex, size_t endIndex, const double halfWidth,
-                  const std::vector<double> &input, std::vector<double> const *const binBndrs) {
+                  std::span<double const> input, std::span<double const> binBndrs) {
 
   size_t iStart, iEnd;
   double weight0(0), weight1(0), start(0.0), end(0.0);
   //
-  if (binBndrs) {
+  if (!binBndrs.empty()) {
     // identify initial and final bins to
     // integrate over. Notice the difference
     // between start and end bin and shift of
     // the interpolating function into the center
     // of each bin
-    auto &rBndrs = *binBndrs;
-    // bin0 = binBndrs->operator[](index + 1) - binBndrs->operator[](index);
+    auto const &rBndrs = binBndrs;
+    // bin0 = binBndrs[index + 1] - binBndrs[index];
 
     double binC = 0.5 * (rBndrs[index + 1] + rBndrs[index]);
     start = binC - halfWidth;
@@ -779,7 +779,7 @@ double runAverage(size_t index, size_t startIndex, size_t endIndex, const double
       iStart = startIndex;
       start = rBndrs[iStart];
     } else {
-      iStart = getBinIndex(*binBndrs, start);
+      iStart = getBinIndex(binBndrs, start);
       weight0 = (rBndrs[iStart + 1] - start) / (rBndrs[iStart + 1] - rBndrs[iStart]);
       iStart++;
     }
@@ -787,7 +787,7 @@ double runAverage(size_t index, size_t startIndex, size_t endIndex, const double
       iEnd = endIndex; // the signal defined up to i<iEnd
       end = rBndrs[endIndex];
     } else {
-      iEnd = getBinIndex(*binBndrs, end);
+      iEnd = getBinIndex(binBndrs, end);
       weight1 = (end - rBndrs[iEnd]) / (rBndrs[iEnd + 1] - rBndrs[iEnd]);
     }
     if (iStart > iEnd) { // start and end get into the same bin
@@ -810,7 +810,7 @@ double runAverage(size_t index, size_t startIndex, size_t endIndex, const double
     avrg += input[j];
     ic++;
   }
-  if (binBndrs) { // add values at edges
+  if (!binBndrs.empty()) { // add values at edges
     if (iStart != startIndex)
       avrg += input[iStart - 1] * weight0;
     if (iEnd != endIndex)
@@ -840,7 +840,7 @@ double runAverage(size_t index, size_t startIndex, size_t endIndex, const double
  * @param output::  resulting vector (can not coincide with input)
  * @param avrgInterval:: the interval to average function in.
  *                      the function is averaged within +-0.5*avrgInterval
- * @param binBndrs :: pointer to the vector, containing bin boundaries.
+ * @param binBndrs :: span over the bin boundaries, empty if there are none.
  *                    If provided, its length has to be input.size()+1,
  *                    if not, equal size bins of size 1 are assumed,
  *                    so avrgInterval becomes the number of points
@@ -855,9 +855,10 @@ double runAverage(size_t index, size_t startIndex, size_t endIndex, const double
  * @param outBins ::   if present, pointer to a vector to return
  *                     bin boundaries for output array.
  */
-void smoothInRange(const std::vector<double> &input, std::vector<double> &output, const double avrgInterval,
-                   std::vector<double> const *const binBndrs, size_t startIndex, size_t endIndex,
+void smoothInRange(std::span<double const> input, std::vector<double> &output, const double avrgInterval,
+                   std::span<double const> binBndrs, size_t startIndex, size_t endIndex,
                    std::vector<double> *const outBins) {
+  bool const haveBndrs = !binBndrs.empty();
 
   if (endIndex == 0)
     endIndex = input.size();
@@ -870,8 +871,8 @@ void smoothInRange(const std::vector<double> &input, std::vector<double> &output
   }
 
   size_t max_size = input.size();
-  if (binBndrs) {
-    if (binBndrs->size() != max_size + 1) {
+  if (haveBndrs) {
+    if (binBndrs.size() != max_size + 1) {
       throw std::invalid_argument("Array of bin boundaries, "
                                   "if present, have to be one bigger then the input array");
     }
@@ -881,7 +882,7 @@ void smoothInRange(const std::vector<double> &input, std::vector<double> &output
   output.resize(length);
 
   double halfWidth = avrgInterval / 2;
-  if (!binBndrs) {
+  if (!haveBndrs) {
     if (std::floor(halfWidth) * 2 - avrgInterval > 1.e-6) {
       halfWidth = std::floor(halfWidth) + 1;
     }
@@ -893,16 +894,16 @@ void smoothInRange(const std::vector<double> &input, std::vector<double> &output
   //  Run averaging
   double binSize = 1;
   for (size_t i = startIndex; i < endIndex; i++) {
-    if (binBndrs) {
-      binSize = binBndrs->operator[](i + 1) - binBndrs->operator[](i);
+    if (haveBndrs) {
+      binSize = binBndrs[i + 1] - binBndrs[i];
     }
     output[i - startIndex] = runAverage(i, startIndex, endIndex, halfWidth, input, binBndrs) * binSize;
-    if (outBins && binBndrs) {
-      outBins->operator[](i - startIndex) = binBndrs->operator[](i);
+    if (outBins && haveBndrs) {
+      outBins->operator[](i - startIndex) = binBndrs[i];
     }
   }
-  if (outBins && binBndrs) {
-    outBins->operator[](endIndex - startIndex) = binBndrs->operator[](endIndex);
+  if (outBins && haveBndrs) {
+    outBins->operator[](endIndex - startIndex) = binBndrs[endIndex];
   }
 }
 

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -544,10 +544,9 @@ public:
     std::vector<double> inputBoundaries(ib, ib + sizeof(ib) / sizeof(double));
 
     std::vector<double> output;
-    TS_ASSERT_THROWS(VectorHelper::smoothInRange(inputData, output, 6, &inputBoundaries),
-                     const std::invalid_argument &);
+    TS_ASSERT_THROWS(VectorHelper::smoothInRange(inputData, output, 6, inputBoundaries), const std::invalid_argument &);
     inputBoundaries.emplace_back(6);
-    VectorHelper::smoothInRange(inputData, output, 6, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 6, inputBoundaries);
 
     TS_ASSERT_DELTA(output[1] - output[0], 0.492, 1.e-3);
     TS_ASSERT_DELTA(output[3] - output[2], 0.4545, 1.e-3);
@@ -558,13 +557,13 @@ public:
     inputBoundaries[4] = 10;
     inputBoundaries[5] = 15;
     inputBoundaries[6] = 21;
-    VectorHelper::smoothInRange(inputData, output, 6, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 6, inputBoundaries);
     TS_ASSERT_DELTA(output[2], 3, 1.e-8);
     TS_ASSERT_DELTA(output[0], 1, 1.e-8);
     TS_ASSERT_DELTA(output[5], 6, 1.e-8);
 
     std::vector<double> out_bins;
-    VectorHelper::smoothInRange(inputData, output, 3, &inputBoundaries, 1, 5, &out_bins);
+    VectorHelper::smoothInRange(inputData, output, 3, inputBoundaries, 1, 5, &out_bins);
     TS_ASSERT_EQUALS(output.size(), 4);
     TS_ASSERT_DELTA(output[1], 3, 1.e-8);
   }
@@ -596,7 +595,7 @@ public:
 
     TS_ASSERT(iLeft < fMax);
     TS_ASSERT(iRight < fMax);
-    VectorHelper::smoothInRange(inputData, output, 10, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 10, inputBoundaries);
     fMax = output[indOfMax] / (inputBoundaries[indOfMax + 1] - inputBoundaries[indOfMax]);
     iLeft = inputData[indOfMax - 1] / (inputBoundaries[indOfMax] - inputBoundaries[indOfMax - 1]);
     iRight = inputData[indOfMax + 1] / (inputBoundaries[indOfMax + 2] - inputBoundaries[indOfMax + 1]);
@@ -605,7 +604,7 @@ public:
     TS_ASSERT(iRight < fMax);
 
     output.swap(inputData);
-    VectorHelper::smoothInRange(inputData, output, 10, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 10, inputBoundaries);
 
     fMax = output[indOfMax] / (inputBoundaries[indOfMax + 1] - inputBoundaries[indOfMax]);
     iLeft = inputData[indOfMax - 1] / (inputBoundaries[indOfMax] - inputBoundaries[indOfMax - 1]);
@@ -615,7 +614,7 @@ public:
     TS_ASSERT(iRight < fMax);
 
     output.swap(inputData);
-    VectorHelper::smoothInRange(inputData, output, 10, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 10, inputBoundaries);
 
     fMax = output[indOfMax] / (inputBoundaries[indOfMax + 1] - inputBoundaries[indOfMax]);
     iLeft = inputData[indOfMax - 1] / (inputBoundaries[indOfMax] - inputBoundaries[indOfMax - 1]);
@@ -625,7 +624,7 @@ public:
     TS_ASSERT(iRight < fMax);
 
     output.swap(inputData);
-    VectorHelper::smoothInRange(inputData, output, 10, &inputBoundaries);
+    VectorHelper::smoothInRange(inputData, output, 10, inputBoundaries);
 
     fMax = output[indOfMax] / (inputBoundaries[indOfMax + 1] - inputBoundaries[indOfMax]);
     iLeft = inputData[indOfMax - 1] / (inputBoundaries[indOfMax] - inputBoundaries[indOfMax - 1]);

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -414,7 +414,7 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
   uint16_t nexpts = mdEventWS->getNumExperimentInfo();
   if (nexpts > 0) {
     ExperimentInfo_sptr expt = mdEventWS->getExperimentInfo(static_cast<uint16_t>(nexpts - 1));
-    expt->mutableRun().storeHistogramBinBoundaries(binBoundaries.rawData());
+    expt->mutableRun().storeHistogramBinBoundaries(binBoundaries);
   }
 }
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -499,7 +499,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD::integrate(typename MDE
         wsFit2D->setSharedX(i, wsProfile2D->sharedX(i));
         wsDiff2D->setSharedX(i, wsProfile2D->sharedX(i));
 
-        FunctionDomain1DVector domain(x.rawData());
+        FunctionDomain1DVector domain(x);
         FunctionValues yy(domain);
         fun->function(domain, yy);
         auto funcValues = yy.toVector();

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -834,7 +834,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
         wsFit2D->setSharedX(i, wsProfile2D->sharedX(i));
         wsDiff2D->setSharedX(i, wsProfile2D->sharedX(i));
 
-        FunctionDomain1DVector domain(x.rawData());
+        FunctionDomain1DVector domain(x);
         FunctionValues yy(domain);
         fun->function(domain, yy);
         auto funcValues = yy.toVector();

--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -93,8 +93,8 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram, con
   size_t i0 = startIndexFromTime(xData, startX);
   size_t iN = endIndexFromTime(xData, endX);
   // remove an extra index as XData is bin boundaries and not point data
-  auto iy0 = std::next(yData.rawData().begin(), i0);
-  auto iyN = std::next(yData.rawData().begin(), iN);
+  auto iy0 = std::next(yData.begin(), i0);
+  auto iyN = std::next(yData.begin(), iN);
   double summation = std::accumulate(iy0, iyN, 0.0);
   double denominator = 0.0;
   /* this replaces (from doc):
@@ -117,12 +117,12 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram, con
  * @returns :: The index to start calculations from
  */
 size_t startIndexFromTime(const HistogramData::BinEdges &xData, const double startX) {
-  auto upper = std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
+  auto upper = std::lower_bound(xData.begin(), xData.end(), startX);
 
-  if (upper == xData.rawData().end()) {
+  if (upper == xData.end()) {
     throw std::invalid_argument("Start of range is after data end.");
   }
-  return std::distance(xData.rawData().begin(), upper);
+  return std::distance(xData.begin(), upper);
 }
 /**
  * find the last index in bin edges that is before
@@ -133,11 +133,11 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData, const double sta
  */
 size_t endIndexFromTime(const HistogramData::BinEdges &xData, const double endX) {
 
-  auto lower = std::upper_bound(xData.rawData().begin(), xData.rawData().end(), endX);
-  if (lower == xData.rawData().begin()) {
+  auto lower = std::upper_bound(xData.begin(), xData.end(), endX);
+  if (lower == xData.begin()) {
     throw std::invalid_argument("End of range is before data start.");
   }
-  return std::distance(xData.rawData().begin(), lower - 1);
+  return std::distance(xData.begin(), lower - 1);
 }
 
 /*****

--- a/Framework/Reflectometry/src/FindReflectometryLines2.cpp
+++ b/Framework/Reflectometry/src/FindReflectometryLines2.cpp
@@ -53,7 +53,7 @@ void convertXToWorkspaceIndex(Mantid::API::MatrixWorkspace &ws) {
  */
 double median(const Mantid::API::MatrixWorkspace &ws) {
   using namespace Mantid::Kernel;
-  const auto statistics = getStatistics(ws.y(0).rawData(), StatOptions::Median);
+  const auto statistics = getStatistics(ws.y(0), StatOptions::Median);
   return statistics.median;
 }
 

--- a/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
@@ -18,6 +18,8 @@
 #include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 
+#include <span>
+
 namespace Mantid {
 namespace HistogramData {
 class HistogramY;
@@ -76,11 +78,11 @@ protected:
   double getTransformedCenter(double value, const Kernel::Unit_sptr &unit) const;
   std::vector<PoldiPeak_sptr> getPeaks(const MantidVec::const_iterator &baseListStart,
                                        const MantidVec::const_iterator &baseListEnd,
-                                       std::list<MantidVec::const_iterator> peakPositions, const MantidVec &xData,
-                                       const Kernel::Unit_sptr &unit) const;
+                                       std::list<MantidVec::const_iterator> peakPositions,
+                                       std::span<double const> xData, const Kernel::Unit_sptr &unit) const;
 
   double getFWHMEstimate(const MantidVec::const_iterator &baseListStart, const MantidVec::const_iterator &baseListEnd,
-                         MantidVec::const_iterator peakPosition, const MantidVec &xData) const;
+                         MantidVec::const_iterator peakPosition, std::span<double const> xData) const;
 
   void setErrorsOnWorkspace(const DataObjects::Workspace2D_sptr &correlationWorkspace, double error) const;
 

--- a/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -221,7 +221,8 @@ double PoldiPeakSearch::getTransformedCenter(double value, const Unit_sptr &unit
 std::vector<PoldiPeak_sptr> PoldiPeakSearch::getPeaks(const MantidVec::const_iterator &baseListStart,
                                                       const MantidVec::const_iterator &baseListEnd,
                                                       std::list<MantidVec::const_iterator> peakPositions,
-                                                      const MantidVec &xData, const Unit_sptr &unit) const {
+                                                      std::span<double const> const xData,
+                                                      const Unit_sptr &unit) const {
   std::vector<PoldiPeak_sptr> peakData;
   peakData.reserve(peakPositions.size());
 
@@ -253,7 +254,8 @@ std::vector<PoldiPeak_sptr> PoldiPeakSearch::getPeaks(const MantidVec::const_ite
  */
 double PoldiPeakSearch::getFWHMEstimate(const MantidVec::const_iterator &baseListStart,
                                         const MantidVec::const_iterator &baseListEnd,
-                                        MantidVec::const_iterator peakPosition, const MantidVec &xData) const {
+                                        MantidVec::const_iterator peakPosition,
+                                        std::span<double const> const xData) const {
   size_t peakPositionIndex = std::distance(baseListStart, peakPosition);
   double halfPeakIntensity = *peakPosition / 2.0;
 
@@ -552,8 +554,8 @@ void PoldiPeakSearch::exec() {
    * original count data,
    * along with the Q-values.
    */
-  std::vector<PoldiPeak_sptr> peakCoordinates = getPeaks(correlatedCounts.cbegin(), correlatedCounts.cend(),
-                                                         peakPositionsCorrelation, correlationQValues.rawData(), xUnit);
+  std::vector<PoldiPeak_sptr> peakCoordinates =
+      getPeaks(correlatedCounts.cbegin(), correlatedCounts.cend(), peakPositionsCorrelation, correlationQValues, xUnit);
   g_log.information() << "   Extracted peak positions in Q and intensity guesses.\n";
 
   UncertainValue backgroundWithSigma = getBackgroundWithSigma(peakPositionsCorrelation, correlatedCounts.rawData());

--- a/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -531,7 +531,7 @@ void PoldiPeakSearch::exec() {
 
   g_log.information() << "   Parameters set.\n";
 
-  MantidVec summedNeighborCounts = getNeighborSums(correlatedCounts.rawData());
+  MantidVec summedNeighborCounts = getNeighborSums(correlatedCounts);
   g_log.information() << "   Neighboring counts summed, contains " << summedNeighborCounts.size() << " data points.\n";
 
   std::list<MantidVec::const_iterator> peakPositionsSummed =

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
@@ -84,14 +84,14 @@ public:
   const MantidVec &dataY() const override { return m_histogram.y().rawData(); }
   const MantidVec &dataE() const override { return m_histogram.e().rawData(); }
 
-  size_t getMemorySize() const override { return readY().size() * sizeof(double) * 2; }
+  size_t getMemorySize() const override { return y().size() * sizeof(double) * 2; }
 
   /// Mask the spectrum to this value
   void clearData() override {
     // Assign the value to the data and error arrays
-    MantidVec &yValues = this->dataY();
+    auto &yValues = this->mutableY();
     std::fill(yValues.begin(), yValues.end(), 0.0);
-    MantidVec &eValues = this->dataE();
+    auto &eValues = this->mutableE();
     std::fill(eValues.begin(), eValues.end(), 0.0);
   }
 
@@ -126,9 +126,9 @@ public:
     if (m_vec.empty()) {
       throw std::runtime_error("Vector data is empty, cannot check for ragged workspace.");
     } else {
-      const auto numberOfBins = m_vec[0].dataY().size();
+      const auto numberOfBins = m_vec[0].y().size();
       return std::any_of(m_vec.cbegin(), m_vec.cend(),
-                         [&numberOfBins](const auto &spectrum) { return numberOfBins != spectrum.dataY().size(); });
+                         [&numberOfBins](const auto &spectrum) { return numberOfBins != spectrum.y().size(); });
     }
   }
 
@@ -137,13 +137,13 @@ public:
   const std::string id() const override { return "AxeslessWorkspaceTester"; }
   size_t size() const override {
     return std::accumulate(m_vec.cbegin(), m_vec.cend(), static_cast<size_t>(0),
-                           [](size_t total, const SpectrumTester &i) { return total + i.dataY().size(); });
+                           [](size_t total, const SpectrumTester &i) { return total + i.y().size(); });
   }
   size_t blocksize() const override {
     if (m_vec.empty()) {
       return 0;
     }
-    size_t numY = m_vec[0].dataY().size();
+    size_t numY = m_vec[0].y().size();
     if (std::any_of(m_vec.cbegin(), m_vec.cend(), [numY](auto it) { return it.y().size() != numY; })) {
       throw std::logic_error("non-constant number of bins");
     }
@@ -153,7 +153,7 @@ public:
   std::size_t getNumberBins(const std::size_t &index) const override {
     if (index >= m_vec.size())
       return 0;
-    return m_vec[index].dataY().size();
+    return m_vec[index].y().size();
   }
 
   std::size_t getMaxNumberBins() const override {
@@ -162,9 +162,9 @@ public:
     } else {
       const auto iter =
           std::max_element(m_vec.cbegin(), m_vec.cend(), [](const SpectrumTester &s1, const SpectrumTester &s2) {
-            return s1.dataY().size() < s2.dataY().size();
+            return s1.y().size() < s2.y().size();
           });
-      return iter->dataY().size();
+      return iter->y().size();
     }
   }
 
@@ -184,9 +184,15 @@ protected:
                                         Mantid::HistogramData::Histogram::YMode::Counts));
     for (size_t i = 0; i < m_spec; i++) {
       m_vec[i].setMatrixWorkspace(this, i);
-      m_vec[i].dataX().resize(j, 1.0);
-      m_vec[i].dataY().resize(k, 1.0);
-      m_vec[i].dataE().resize(k, 1.0);
+      // The data arrays cannot be resized individually, so set them all at the required lengths.
+      // getHistogramXMode() above guarantees that j is either k (points) or k + 1 (bin edges).
+      if (m_vec[i].histogram().xMode() == Mantid::HistogramData::Histogram::XMode::BinEdges) {
+        m_vec[i].setHistogram(Mantid::HistogramData::BinEdges(j, 1.0), Mantid::HistogramData::Counts(k, 1.0),
+                              Mantid::HistogramData::CountStandardDeviations(k, 1.0));
+      } else {
+        m_vec[i].setHistogram(Mantid::HistogramData::Points(j, 1.0), Mantid::HistogramData::Counts(k, 1.0),
+                              Mantid::HistogramData::CountStandardDeviations(k, 1.0));
+      }
       m_vec[i].addDetectorID(detid_t(i));
       m_vec[i].setSpectrumNo(specnum_t(i + 1));
     }
@@ -611,8 +617,8 @@ private:
 
 class VariableBinThrowingTester : public AxeslessWorkspaceTester {
   size_t blocksize() const override {
-    if (getSpectrum(0).dataY().size() == getSpectrum(1).dataY().size())
-      return getSpectrum(0).dataY().size();
+    if (getSpectrum(0).y().size() == getSpectrum(1).y().size())
+      return getSpectrum(0).y().size();
     else
       throw std::length_error("Mismatched bins sizes");
 

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <fstream>
 #include <map>
+#include <span>
 #include <string>
 
 #include "MantidAPI/IMDHistoWorkspace.h"
@@ -174,7 +175,7 @@ public:
     return m_vec[index];
   }
   const ISpectrum &getSpectrum(const size_t index) const override { return m_vec[index]; }
-  void generateHistogram(const std::size_t, const MantidVec &, MantidVec &, MantidVec &, bool) const override {}
+  void generateHistogram(const std::size_t, std::span<double const>, MantidVec &, MantidVec &, bool) const override {}
   Mantid::Kernel::SpecialCoordinateSystem getSpecialCoordinateSystem() const override { return Mantid::Kernel::None; }
 
 protected:

--- a/Framework/WorkflowAlgorithms/test/ExtractQENSMembersTest.h
+++ b/Framework/WorkflowAlgorithms/test/ExtractQENSMembersTest.h
@@ -52,7 +52,7 @@ public:
 
     auto inputWS = loadWorkspace(fileName + "_red.nxs");
     const auto numSpectra = inputWS->getNumberHistograms();
-    const auto &dataX = inputWS->dataX(0);
+    const auto &dataX = inputWS->x(0).rawData();
     auto resultGroup = createResultGroup(members, dataX, numSpectra);
 
     WorkspaceGroup_sptr membersWorkspace = extractMembers(inputWS, resultGroup, outputName);
@@ -75,7 +75,7 @@ public:
 
     auto inputWS = loadWorkspace(fileName + "_red.nxs");
     const auto numSpectra = inputWS->getNumberHistograms();
-    const auto &dataX = inputWS->dataX(0);
+    const auto &dataX = inputWS->x(0).rawData();
     auto resultGroup = createResultGroup(members, dataX, numSpectra);
 
     WorkspaceGroup_sptr membersWorkspace = extractMembers(inputWS, resultGroup, convolved, outputName);
@@ -94,7 +94,7 @@ private:
       const auto &memberName = memberWorkspace->getName();
       const auto expectedName = outputName + "_" + members[i];
       const auto numMemberSpectra = memberWorkspace->getNumberHistograms();
-      const auto &memberDataX = memberWorkspace->dataX(0);
+      const auto &memberDataX = memberWorkspace->x(0).rawData();
 
       TS_ASSERT_EQUALS(dataX, memberDataX);
       TS_ASSERT_EQUALS(numSpectra, numMemberSpectra);

--- a/docs/source/concepts/HistogramData.rst
+++ b/docs/source/concepts/HistogramData.rst
@@ -532,6 +532,56 @@ For compatibility reasons an interface to the internal data, equivalent to the o
   };
 
 
+Migrating off the legacy accessors
+##################################
+
+The legacy accessors are deprecated. In C++ their declarations carry a
+``Deprecated, use ... instead`` comment; in Python they emit a ``DeprecationWarning``
+naming the replacement. Use this table when migrating a call site:
+
++---------------------------------+-----------------------------------------+--------------------------------+
+| Deprecated                      | Replacement                             | Notes                          |
++=================================+=========================================+================================+
+| ``readX/readY/readE/readDx``    | ``x()``/``y()``/``e()``/``dx()``        | read-only                      |
++---------------------------------+-----------------------------------------+--------------------------------+
+| ``dataX/dataY/dataE/dataDx``    | ``x()``/``y()``/``e()``/``dx()``        | const overload; read-only      |
++---------------------------------+-----------------------------------------+--------------------------------+
+| ``dataX/dataY/dataE/dataDx``    | ``mutableX()``/``mutableY()``/          | non-const overload; in-place   |
+|                                 | ``mutableE()``/``mutableDx()``          | write                          |
++---------------------------------+-----------------------------------------+--------------------------------+
+| ``refX(i)`` / ``ptrX()``        | ``sharedX(i)``                          | ``cow_ptr``                    |
++---------------------------------+-----------------------------------------+--------------------------------+
+| ``setX(i, cow)``                | ``setSharedX(i, cow)``                  | ``cow_ptr`` setter             |
++---------------------------------+-----------------------------------------+--------------------------------+
+| ``setX/setY/setE/setDx``        | ``setSharedX()``/``setSharedY()``/      | Python only                    |
+| (Python)                        | ``setSharedE()``/``setSharedDx()``      |                                |
++---------------------------------+-----------------------------------------+--------------------------------+
+
+Things to watch for while migrating:
+
+- **Classify each ``data*`` site as a read or a write.**
+  In a non-``const`` context ``dataY(i)`` binds to the *mutable* overload even when the
+  code only reads, which detaches the copy-on-write pointer. Mapping such a site to
+  ``mutableY(i)`` preserves that needless copy; mapping it to ``y(i)`` removes it.
+  When in doubt map to the read-only accessor -- if a write was in fact needed the
+  compiler will reject it, whereas an over-eager ``mutable*`` is a silent performance
+  regression.
+- **``mutable*()`` is lvalue-ref-qualified** (``&``), so it must be called on a named
+  lvalue rather than a temporary.
+- **Individual arrays cannot be resized.** ``dataX().resize(n)`` has no direct
+  equivalent, by design. Use ``MatrixWorkspace::resizeHistogram(i, n)`` (which keeps X,
+  Y and E consistent with the storage mode), or one of the ``setHistogram()`` /
+  ``setBinEdges()`` / ``setPoints()`` / ``setCounts()`` setters.
+- **``EventList``** computes ``y()``/``e()`` from the events via the MRU cache, exactly as
+  the legacy ``dataY()``/``dataE()`` const overloads did. The non-``const`` ``dataY()``
+  throws, so there are no in-place ``EventList`` writes to migrate.
+- **Code that genuinely needs a raw vector** can use ``x(i).rawData()``, which returns
+  ``const std::vector<double> &``. There is deliberately no public route to a
+  *modifiable* ``std::vector<double> &``; callees that require one should be given an
+  iterator-range or ``HistogramX``/``HistogramY``/``HistogramE`` overload instead.
+  ``Kernel::Unit::toTOF()``/``fromTOF()`` provide such an iterator-range overload.
+
+
 Rollout status
 --------------
 

--- a/docs/source/concepts/HistogramData.rst
+++ b/docs/source/concepts/HistogramData.rst
@@ -577,9 +577,36 @@ Things to watch for while migrating:
   throws, so there are no in-place ``EventList`` writes to migrate.
 - **Code that genuinely needs a raw vector** can use ``x(i).rawData()``, which returns
   ``const std::vector<double> &``. There is deliberately no public route to a
-  *modifiable* ``std::vector<double> &``; callees that require one should be given an
-  iterator-range or ``HistogramX``/``HistogramY``/``HistogramE`` overload instead.
-  ``Kernel::Unit::toTOF()``/``fromTOF()`` provide such an iterator-range overload.
+  *modifiable* ``std::vector<double> &``; callees that require one should be given a
+  ``std::span``, iterator-range, or ``HistogramX``/``HistogramY``/``HistogramE`` overload
+  instead. ``Kernel::Unit::toTOF()``/``fromTOF()`` provide such an iterator-range overload.
+- **Prefer ``std::span`` for the parameters of Mantid-defined callees.** All of the
+  histogram data types satisfy ``std::ranges::contiguous_range`` and
+  ``std::ranges::sized_range``, so they convert implicitly to ``std::span<double const>``
+  (read-only) and ``std::span<double>`` (fixed-size in-place write). A plain
+  ``std::vector<double>`` still converts too, so changing a parameter from
+  ``const std::vector<double> &`` to ``std::span<double const>`` breaks no existing caller
+  while letting every histogram type be passed without ``rawData()``.
+  ``Kernel::VectorHelper::rebin()``, ``Kernel::EqualBinsChecker`` and
+  ``DataObjects::FractionalRebinning`` are examples. Two caveats:
+
+  - A ``std::span`` parameter must *not* replace a ``std::vector<double> &`` out-parameter
+    that resizes its argument, and in C++20 ``std::span`` cannot be constructed from a
+    braced initializer list, so callees invoked as ``f({a, b, c})`` must keep their vector
+    parameter.
+  - Do not write ``template <typename T> f(std::span<T const>)`` in place of
+    ``f(const std::vector<T> &)``: ``T`` is not deducible from a ``std::vector`` argument,
+    so every existing caller would stop compiling. Add a non-template overload for the
+    concrete element type instead, as ``Kernel::getZscore()`` does.
+- **Beware copy-on-write detachment when taking a span of the ``cow_ptr``-backed types.**
+  ``BinEdges``, ``Points``, ``Counts``, ``Frequencies`` and friends reach ``begin()``
+  through ``Iterable``, whose non-``const`` overload calls ``mutableData()`` and therefore
+  detaches the ``cow_ptr``. ``rawData()`` is ``const``-qualified and never did this, so
+  binding a **non-const** lvalue of one of those types to ``std::span<double const>`` can
+  introduce a silent copy where the old code had none. Bind such arguments through a
+  ``const`` reference -- or wrap them in ``std::as_const()`` -- when they are read-only.
+  ``x(i)``, ``y(i)`` and ``e(i)`` already return ``const`` references, so the common case
+  is safe; named ``BinEdges``/``Points``/``Counts`` locals are the ones to check.
 
 
 Rollout status

--- a/docs/source/release/v7.0.0/SANS/Bugfixes/41960.rst
+++ b/docs/source/release/v7.0.0/SANS/Bugfixes/41960.rst
@@ -1,0 +1,1 @@
+- Fixed an error in the old ISIS SANS reduction when the sample workspace carries X error (``Dx``) values. Passing those values on to the can-subtracted workspace called two methods that do not exist on :class:`~mantid.api.MatrixWorkspace` (``getNumHistograms`` and ``dataDX``), which raised an ``AttributeError`` instead of copying the values.

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -41,7 +41,7 @@ IFunction_sptr createGaussian(double const height = 0.0, double const peakCentre
   return gaussian;
 }
 
-IFunction_sptr createGaussian(Mantid::MantidVec const &xData, Mantid::MantidVec const &yData,
+IFunction_sptr createGaussian(std::span<double const> const xData, std::span<double const> const yData,
                               double const backgroundHeight) {
   const auto maxValue = *std::max_element(yData.begin(), yData.end());
 
@@ -113,7 +113,7 @@ IFunction_sptr ALFAnalysisModel::calculateEstimateImpl(MatrixWorkspace_sptr cons
   auto const backgroundHeight = std::accumulate(yData.begin(), yData.end(), 0.0) / static_cast<double>(yData.size());
 
   return createCompositeFunction(createFlatBackground(backgroundHeight),
-                                 createGaussian(xData.rawData(), yData.rawData(), backgroundHeight));
+                                 createGaussian(xData, yData, backgroundHeight));
 }
 
 void ALFAnalysisModel::exportWorkspaceCopyToADS() const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -199,7 +199,7 @@ FitDataPresenter::getDataForParameterEstimation(const EstimationDataSelector &se
       auto const &x = ws->x(spectrum.value);
       auto const &y = ws->y(spectrum.value);
       auto range = m_model->getFittingRange(i, spectrum);
-      dataCollection.emplace_back(selector(x.rawData(), y.rawData(), range));
+      dataCollection.emplace_back(selector(x, y, range));
     }
   }
   return dataCollection;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -245,18 +245,18 @@ void ConvFunctionTemplateModel::removeBackground() {
 bool ConvFunctionTemplateModel::hasBackground() const { return m_backgroundType != BackgroundType::None; }
 
 EstimationDataSelector ConvFunctionTemplateModel::getEstimationDataSelector() const {
-  return [](const Mantid::MantidVec &x, const Mantid::MantidVec &y,
+  return [](std::span<double const> const x, std::span<double const> const y,
             const std::pair<double, double> &range) -> DataForParameterEstimation {
     (void)range;
 
-    auto const maxElement = std::max_element(y.cbegin(), y.cend());
+    auto const maxElement = std::max_element(y.begin(), y.end());
     auto const halfMaxElement =
-        std::find_if(y.cbegin(), y.cend(), [&maxElement](double const val) { return val > *maxElement / 2.0; });
-    if (maxElement == y.cend() || halfMaxElement == y.cend())
+        std::find_if(y.begin(), y.end(), [&maxElement](double const val) { return val > *maxElement / 2.0; });
+    if (maxElement == y.end() || halfMaxElement == y.end())
       return DataForParameterEstimation{{}, {}};
 
-    auto const maxElementIndex = std::distance(y.cbegin(), maxElement);
-    auto const halfMaxElementIndex = std::distance(y.cbegin(), halfMaxElement);
+    auto const maxElementIndex = std::distance(y.begin(), maxElement);
+    auto const halfMaxElementIndex = std::distance(y.begin(), halfMaxElement);
 
     return DataForParameterEstimation{{x[halfMaxElementIndex], x[maxElementIndex]}, {*halfMaxElement, *maxElement}};
   };

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
@@ -266,7 +266,7 @@ void IqtFunctionTemplateModel::tieIntensities(bool on) {
 }
 
 EstimationDataSelector IqtFunctionTemplateModel::getEstimationDataSelector() const {
-  return [](const Mantid::MantidVec &x, const Mantid::MantidVec &y,
+  return [](std::span<double const> const x, std::span<double const> const y,
             const std::pair<double, double> range) -> DataForParameterEstimation {
     (void)range;
     size_t const n = 4;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
@@ -103,7 +103,7 @@ void SingleFunctionTemplateModel::setFitType(const std::string &type) {
 const std::string &SingleFunctionTemplateModel::getFitType() { return m_fitType; }
 
 EstimationDataSelector SingleFunctionTemplateModel::getEstimationDataSelector() const {
-  return [](const std::vector<double> &x, const std::vector<double> &y,
+  return [](std::span<double const> const x, std::span<double const> const y,
             const std::pair<double, double> range) -> DataForParameterEstimation {
     // Find data thats within range
     double xmin = range.first;
@@ -113,14 +113,14 @@ EstimationDataSelector SingleFunctionTemplateModel::getEstimationDataSelector() 
     }
 
     const auto startItr =
-        std::find_if(x.cbegin(), x.cend(), [xmin](const double &val) -> bool { return val >= (xmin - 1e-5); });
-    const auto endItr = std::find_if(x.cbegin(), x.cend(), [xmax](const double &val) -> bool { return val > xmax; });
+        std::find_if(x.begin(), x.end(), [xmin](const double &val) -> bool { return val >= (xmin - 1e-5); });
+    const auto endItr = std::find_if(x.begin(), x.end(), [xmax](const double &val) -> bool { return val > xmax; });
 
     if (std::distance(startItr, endItr - 1) < 2)
       return DataForParameterEstimation{};
 
-    size_t first = std::distance(x.cbegin(), startItr);
-    size_t end = std::distance(x.cbegin(), endItr);
+    size_t first = std::distance(x.begin(), startItr);
+    size_t end = std::distance(x.begin(), endItr);
     size_t m = first + (end - first) / 2;
 
     return DataForParameterEstimation{{x[first], x[m]}, {y[first], y[m]}};

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.h
@@ -13,6 +13,7 @@
 #include "ParameterEstimation.h"
 
 #include <optional>
+#include <span>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -24,8 +25,10 @@ struct DataForParameterEstimation {
 };
 
 using DataForParameterEstimationCollection = std::vector<DataForParameterEstimation>;
+/// The x and y ranges are taken as spans so that the size-checked histogram data types can be
+/// selected from directly, without first copying them out into a std::vector.
 using EstimationDataSelector = std::function<DataForParameterEstimation(
-    const Mantid::MantidVec &x, const Mantid::MantidVec &y, const std::pair<double, double> range)>;
+    std::span<double const> x, std::span<double const> y, const std::pair<double, double> range)>;
 
 class MANTIDQT_INELASTIC_DLL FunctionParameterEstimation {
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
@@ -25,6 +25,7 @@
 #include "MantidAPI/NumericAxis.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include <span>
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
@@ -87,7 +88,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 MATCHER_P(NoCheck, selector, "") { return arg != selector; }
 
 EstimationDataSelector getEstimationDataSelector() {
-  return [](const std::vector<double> &x, const std::vector<double> &y,
+  return [](std::span<double const> const x, std::span<double const> const y,
             const std::pair<double, double> range) -> DataForParameterEstimation {
     // Find data thats within range
     double xmin = range.first;
@@ -99,14 +100,14 @@ EstimationDataSelector getEstimationDataSelector() {
     }
 
     const auto startItr =
-        std::find_if(x.cbegin(), x.cend(), [xmin](const double &val) -> bool { return val >= (xmin - 1e-7); });
-    auto endItr = std::find_if(x.cbegin(), x.cend(), [xmax](const double &val) -> bool { return val > xmax; });
+        std::find_if(x.begin(), x.end(), [xmin](const double &val) -> bool { return val >= (xmin - 1e-7); });
+    auto endItr = std::find_if(x.begin(), x.end(), [xmax](const double &val) -> bool { return val > xmax; });
 
     if (std::distance(startItr, endItr - 1) < 2)
       return DataForParameterEstimation{};
 
-    size_t first = std::distance(x.cbegin(), startItr);
-    size_t end = std::distance(x.cbegin(), endItr);
+    size_t first = std::distance(x.begin(), startItr);
+    size_t end = std::distance(x.begin(), endItr);
     size_t m = first + (end - first) / 2;
 
     return DataForParameterEstimation{{x[first], x[m]}, {y[first], y[m]}};


### PR DESCRIPTION
### Description of work

A final QA step in the Histogram 2.0 migration.

Many Mantid internal functions require `vector` arguments.  The old methods like `dataX()` returned vectors, allowing direct use with these functions.

However, the new methods return `HistogramData` objects, which are not immediately convertible.  One simple solution is to redefine these methods to work with `span`s instead, which will enable automatic compatibility with *either* `vector` or `HistogramData` objects.

This allows removing a lot of unnecessary `rawData()` calls.

### To test:

This is a refactor.  Make sure all tests compile

This does not require release notes as it is a pure refactor and does not impact user experience.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
