### PR TITLE
Error reporter settings in separate file

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/40759.rst
@@ -1,2 +1,3 @@
-- The Error Reporter Dialog no longer updates saved contact information after clicking ``Don't share any information`` or when ``Remember me`` is disabled. Submitting unchanged contact
-  information also leaves the Workbench settings file untouched.
+- The Error Reporter Dialog now stores remembered contact information in its own settings file instead of the Workbench settings file. Previously saved Workbench contact information remains
+  available as a read-only fallback for values not yet set in the new file. The dialog also avoids updating its settings after clicking ``Don't share any information``, when ``Remember me`` is
+  disabled, or when the submitted contact information is unchanged.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PYTHON_TEST_FILES
     mantidqt/test/test_algorithm_observer.py
     mantidqt/test/test_import.py
     mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+    mantidqt/dialogs/errorreports/test/test_errorreport_settings.py
     mantidqt/dialogs/errorreports/test/test_run_pystack.py
     mantidqt/dialogs/test/test_algorithm_dialog.py
     mantidqt/dialogs/test/test_spectraselectiondialog.py

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -9,12 +9,12 @@ import json
 import os
 import zlib
 from typing import Optional
-from qtpy.QtCore import QSettings
 
 from mantid.kernel import ConfigService, ErrorReporter, Logger, UsageService
 from mantid.kernel.environment import is_linux
 from mantidqt.dialogs.errorreports.report import MAX_STACK_TRACE_LENGTH
 from mantidqt.dialogs.errorreports.run_pystack import retrieve_thread_traces_from_coredump_file
+from mantidqt.dialogs.errorreports.settings import create_error_reporter_settings
 
 
 class ErrorReporterPresenter(object):
@@ -68,7 +68,7 @@ class ErrorReporterPresenter(object):
         if not name_changed and not email_changed:
             return
 
-        settings = QSettings()
+        settings = create_error_reporter_settings()
         settings.beginGroup(self._view.CONTACT_INFO)
         if name_changed:
             settings.setValue(self._view.NAME, name)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -7,13 +7,14 @@
 import re
 
 from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtCore import Signal, QSettings
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import load_ui
 
 from .details import MoreDetailsDialog
+from . import settings as errorreport_settings
 
 DEFAULT_PLAIN_TEXT = """Please enter any additional information about your problems. (Max 3200 characters)
 
@@ -36,9 +37,9 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
     quit_signal = Signal()
     free_text_edited = False
     interface_manager = InterfaceManager()
-    CONTACT_INFO = "ContactInfo"
-    NAME = "Name"
-    EMAIL = "Email"
+    CONTACT_INFO = errorreport_settings.CONTACT_INFO
+    NAME = errorreport_settings.NAME
+    EMAIL = errorreport_settings.EMAIL
 
     def __init__(self, parent=None, show_continue_terminate=False):
         super(self.__class__, self).__init__(parent)
@@ -109,12 +110,8 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         # Set default focus to the editing box, rather then letting qt try and guess
         self.input_free_text.setFocus()
 
-        # Prefill name and email saved in QSettings
-        qSettings = QSettings()
-        qSettings.beginGroup(self.CONTACT_INFO)
-        self.saved_name = qSettings.value(self.NAME, "", type=str)
-        self.saved_email = qSettings.value(self.EMAIL, "", type=str)
-        qSettings.endGroup()
+        # Prefer the dedicated reporter store and read missing values from the Workbench store without migrating them.
+        self.saved_name, self.saved_email = errorreport_settings.read_contact_information()
         if self.saved_name or self.saved_email:
             self.input_name_line_edit.setText(self.saved_name)
             self.input_email_line_edit.setText(self.saved_email)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/settings.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/settings.py
@@ -1,0 +1,60 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from qtpy.QtCore import QSettings
+
+ERROR_REPORTER_APPLICATION = "mantid-error-reporter"
+
+CONTACT_INFO = "ContactInfo"
+NAME = "Name"
+EMAIL = "Email"
+
+
+def _workbench_organization() -> str:
+    # Importing workbench.config constructs CONF, so defer this until settings are actually needed.
+    from workbench.config import ORGANIZATION
+
+    return ORGANIZATION
+
+
+def _workbench_application() -> str:
+    # Importing workbench.config constructs CONF, so defer this until settings are actually needed.
+    from workbench.config import APPNAME
+
+    return APPNAME
+
+
+def create_error_reporter_settings() -> QSettings:
+    """Return the dedicated user settings store for the error reporter."""
+    return QSettings(QSettings.IniFormat, QSettings.UserScope, _workbench_organization(), ERROR_REPORTER_APPLICATION)
+
+
+def create_legacy_workbench_settings() -> QSettings:
+    """Return the Workbench store used only to read legacy contact information."""
+    return QSettings(QSettings.IniFormat, QSettings.UserScope, _workbench_organization(), _workbench_application())
+
+
+def read_contact_information() -> tuple[str, str]:
+    """Read dedicated contact values, falling back individually to the legacy Workbench store."""
+    reporter_settings = create_error_reporter_settings()
+    reporter_settings.beginGroup(CONTACT_INFO)
+    name_is_set = reporter_settings.contains(NAME)
+    email_is_set = reporter_settings.contains(EMAIL)
+    name = reporter_settings.value(NAME, "", type=str) if name_is_set else ""
+    email = reporter_settings.value(EMAIL, "", type=str) if email_is_set else ""
+    reporter_settings.endGroup()
+
+    if name_is_set and email_is_set:
+        return name, email
+
+    legacy_settings = create_legacy_workbench_settings()
+    legacy_settings.beginGroup(CONTACT_INFO)
+    if not name_is_set:
+        name = legacy_settings.value(NAME, "", type=str)
+    if not email_is_set:
+        email = legacy_settings.value(EMAIL, "", type=str)
+    legacy_settings.endGroup()
+    return name, email

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -28,7 +28,7 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.errorreport_mock.return_value = self.errorreport_mock_instance
 
         self.q_settings_mock_instance = mock.MagicMock()
-        q_settings_patcher = mock.patch(f"{self.PRESENTER_CLS_PATH}.QSettings")
+        q_settings_patcher = mock.patch(f"{self.PRESENTER_CLS_PATH}.create_error_reporter_settings")
         self.addCleanup(q_settings_patcher.stop)
         self.q_settings_mock = q_settings_patcher.start()
         self.q_settings_mock.return_value = self.q_settings_mock_instance

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_settings.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_settings.py
@@ -1,0 +1,86 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from qtpy.QtCore import QSettings
+
+from mantidqt.dialogs.errorreports import settings
+
+
+class ErrorReportSettingsTest(unittest.TestCase):
+    def test_organization_comes_from_workbench_config(self):
+        from workbench.config import ORGANIZATION
+
+        self.assertEqual(settings._workbench_organization(), ORGANIZATION)
+
+    def test_legacy_application_comes_from_workbench_config(self):
+        from workbench.config import APPNAME
+
+        self.assertEqual(settings._workbench_application(), APPNAME)
+
+    @mock.patch("mantidqt.dialogs.errorreports.settings.QSettings")
+    def test_create_error_reporter_settings_uses_dedicated_file_identity(self, qsettings):
+        qsettings.IniFormat = QSettings.IniFormat
+        qsettings.UserScope = QSettings.UserScope
+
+        with mock.patch.object(settings, "_workbench_organization", return_value="workbench-organization"):
+            result = settings.create_error_reporter_settings()
+
+        qsettings.assert_called_once_with(QSettings.IniFormat, QSettings.UserScope, "workbench-organization", "mantid-error-reporter")
+        self.assertIs(result, qsettings.return_value)
+
+    @mock.patch("mantidqt.dialogs.errorreports.settings.QSettings")
+    def test_create_legacy_workbench_settings_uses_workbench_identity(self, qsettings):
+        qsettings.IniFormat = QSettings.IniFormat
+        qsettings.UserScope = QSettings.UserScope
+
+        with (
+            mock.patch.object(settings, "_workbench_organization", return_value="workbench-organization"),
+            mock.patch.object(settings, "_workbench_application", return_value="workbench-application"),
+        ):
+            result = settings.create_legacy_workbench_settings()
+
+        qsettings.assert_called_once_with(QSettings.IniFormat, QSettings.UserScope, "workbench-organization", "workbench-application")
+        self.assertIs(result, qsettings.return_value)
+
+    @mock.patch("mantidqt.dialogs.errorreports.settings.create_legacy_workbench_settings")
+    @mock.patch("mantidqt.dialogs.errorreports.settings.create_error_reporter_settings")
+    def test_read_contact_information_does_not_inspect_legacy_store_when_both_dedicated_values_are_set(
+        self, create_reporter_settings, create_legacy_settings
+    ):
+        reporter_settings = create_reporter_settings.return_value
+        reporter_settings.contains.return_value = True
+        reporter_settings.value.side_effect = lambda key, default, type: {"Name": "", "Email": "reporter@example.com"}[key]
+
+        result = settings.read_contact_information()
+
+        self.assertEqual(result, ("", "reporter@example.com"))
+        create_legacy_settings.assert_not_called()
+
+    @mock.patch("mantidqt.dialogs.errorreports.settings.create_legacy_workbench_settings")
+    @mock.patch("mantidqt.dialogs.errorreports.settings.create_error_reporter_settings")
+    def test_read_contact_information_falls_back_only_for_missing_dedicated_values(self, create_reporter_settings, create_legacy_settings):
+        reporter_settings = create_reporter_settings.return_value
+        reporter_settings.contains.side_effect = lambda key: key == "Name"
+        reporter_settings.value.return_value = "Reporter Name"
+        legacy_settings = create_legacy_settings.return_value
+        legacy_settings.value.return_value = "legacy@example.com"
+
+        result = settings.read_contact_information()
+
+        self.assertEqual(result, ("Reporter Name", "legacy@example.com"))
+        reporter_settings.value.assert_called_once_with("Name", "", type=str)
+        legacy_settings.value.assert_called_once_with("Email", "", type=str)
+        for store in (reporter_settings, legacy_settings):
+            store.setValue.assert_not_called()
+            store.remove.assert_not_called()
+            store.sync.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Since they are rarely written, but them in a separate file that cannot be blocked by mantidworkbench shutting down poorly. This also allows for caching whether or not values are changed so it only writes when necessary.

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

Refs #41904 and related to #41949 and [EWM17167](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=17167)

### To test:

1. Start mantidworkbench
2. Use the locking script from #41949 to block `mantidworkbench.ini` from being written
3. In workbench, run `Segfault` algorithm with `DryRun=False` to crash workbench and trigger the error reporter
4. See that error reporter is totally fine. In principle, you can send the error report, but maybe give a description that it is a test so people don't try to track it down.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
