### PR TITLE
Script generation from plot considers dpi scaling and figure layout

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/40725.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/40725.rst
@@ -1,0 +1,1 @@
+- Script generation of a mantid plot now considers the device pixel ratio and figure layout to generate the script.

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/40725.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/40725.rst
@@ -1,1 +1,1 @@
-- Script generation of a mantid plot now considers the device pixel ratio and figure layout to generate the script.
+- :ref:`Script generation<generate_plot_script>` of a mantid plot now considers the device pixel ratio and figure layout to generate the script.

--- a/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/02_scripting_plots.rst
@@ -185,6 +185,7 @@ Output:
 
     DeleteWorkspace(ws)
 
+.. _generate_plot_script:
 
 Generate a Script
 =================

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/figure.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/figure.py
@@ -10,7 +10,7 @@ from matplotlib import rcParams
 from numpy import isclose
 
 from mantid.plots.utility import convert_color_to_hex
-from workbench.plotting.plotscriptgenerator.utils import convert_args_to_string
+from workbench.plotting.plotscriptgenerator.utils import convert_args_to_string, get_default_layout, get_figure_layout
 
 BASE_SUBPLOTS_COMMAND = "plt.subplots({})"
 
@@ -20,6 +20,7 @@ default_kwargs = {
     "facecolor": convert_color_to_hex(rcParams["figure.facecolor"]),
     "figsize": rcParams["figure.figsize"],
     "frameon": rcParams["figure.frameon"],
+    "layout": get_default_layout(),
     "ncols": 1,
     "nrows": 1,
     "num": "",
@@ -29,10 +30,11 @@ default_kwargs = {
 def get_subplots_command_kwargs(fig):
     ax = fig.get_axes()[0]
     kwargs = {
-        "dpi": fig.dpi,
+        "dpi": fig.dpi / fig.canvas.device_pixel_ratio if hasattr(fig.canvas, "device_pixel_ratio") else fig.dpi,
         "edgecolor": convert_color_to_hex(fig.get_edgecolor()),
         "facecolor": convert_color_to_hex(fig.get_facecolor()),
         "figsize": [fig.get_figwidth(), fig.get_figheight()],
+        "layout": get_figure_layout(fig),
         "frameon": fig.frameon,
         "num": fig.get_label(),
         "subplot_kw": {"projection": "mantid"},

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfigure.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfigure.py
@@ -24,6 +24,7 @@ class PlotScriptGeneratorFigureTest(unittest.TestCase):
             "nrows": 2,
             "ncols": 2,
             "frameon": True,
+            "layout": None,
             "subplot_kw": {"projection": "mantid"},
             "dpi": 110,
             "num": "fig label",
@@ -36,7 +37,7 @@ class PlotScriptGeneratorFigureTest(unittest.TestCase):
         del cls.fig
 
     def test_get_figure_command_kwargs_returns_dict_with_expected_keys(self):
-        expected_keys = ["dpi", "edgecolor", "facecolor", "figsize", "frameon", "ncols", "nrows", "num", "subplot_kw"]
+        expected_keys = ["dpi", "edgecolor", "facecolor", "figsize", "frameon", "layout", "ncols", "nrows", "num", "subplot_kw"]
         keys = sorted(get_subplots_command_kwargs(self.fig))
         self.assertEqual(expected_keys, keys)
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorutils.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorutils.py
@@ -19,6 +19,7 @@ from workbench.plotting.plotscriptgenerator.utils import (
     clean_variable_name,
     generate_workspace_retrieval_commands,
     get_figure_layout,
+    get_default_layout,
 )
 
 
@@ -59,13 +60,24 @@ class PlotScriptGeneratorUtilsTest(unittest.TestCase):
                 msg = "Invalid variable name: {}".format(clean_name)
                 self.fail(msg)
 
-    def test_get_default_engine_returns_layout_descriptor_for_tight_engine(self):
-        from matplotlib.layout_engine import TightLayoutEngine
+    def test_get_figure_layout(self):
+        from matplotlib.layout_engine import TightLayoutEngine, ConstrainedLayoutEngine
 
+        test_cases = [(None, None), (TightLayoutEngine(), "tight"), (ConstrainedLayoutEngine(), "constrained")]
         mock_fig = Mock()
-        mock_fig.get_layout_engine.side_effect = [None, TightLayoutEngine()]
-        self.assertEqual(None, get_figure_layout(mock_fig))
-        self.assertEqual("tight", get_figure_layout(mock_fig))
+        for fig_engine, output in test_cases:
+            with self.subTest(fig_engine=fig_engine):
+                mock_fig.get_layout_engine.return_value = fig_engine
+                self.assertEqual(get_figure_layout(mock_fig), output)
+
+    def test_get_default_layout(self):
+        from matplotlib import rcParams
+
+        test_cases = [((False, False), None), ((True, False), "tight"), ((False, True), "constrained")]
+        for rc_params, output in test_cases:
+            with self.subTest(rc_params=rc_params):
+                with patch.dict(rcParams, {"figure.autolayout": rc_params[0], "figure.constrained_layout.use": rc_params[1]}):
+                    self.assertEqual(get_default_layout(), output)
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorutils.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorutils.py
@@ -18,6 +18,7 @@ from workbench.plotting.plotscriptgenerator.utils import (
     get_plotted_workspaces_names,
     clean_variable_name,
     generate_workspace_retrieval_commands,
+    get_figure_layout,
 )
 
 
@@ -57,6 +58,14 @@ class PlotScriptGeneratorUtilsTest(unittest.TestCase):
             except (SyntaxError, TypeError, ValueError):
                 msg = "Invalid variable name: {}".format(clean_name)
                 self.fail(msg)
+
+    def test_get_default_engine_returns_layout_descriptor_for_tight_engine(self):
+        from matplotlib.layout_engine import TightLayoutEngine
+
+        mock_fig = Mock()
+        mock_fig.get_layout_engine.side_effect = [None, TightLayoutEngine()]
+        self.assertEqual(None, get_figure_layout(mock_fig))
+        self.assertEqual("tight", get_figure_layout(mock_fig))
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/utils.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/utils.py
@@ -9,7 +9,9 @@
 import re
 
 import numpy as np
+from matplotlib import rcParams
 from matplotlib.container import ErrorbarContainer
+from matplotlib.layout_engine import TightLayoutEngine, ConstrainedLayoutEngine
 
 
 def round_to_sig_figs(number, sig_figs):
@@ -81,3 +83,24 @@ def sorted_lines_in(ax, artists):
         if line in artists:
             sorted_lines.append(line)
     return sorted_lines
+
+
+def get_figure_layout(fig):
+    layout_engine = fig.get_layout_engine()
+    layout = None
+    match layout_engine:
+        case TightLayoutEngine():
+            layout = "tight"
+        case ConstrainedLayoutEngine():
+            layout = "constrained"
+        case _:
+            pass
+    return layout
+
+
+def get_default_layout():
+    if rcParams["figure.autolayout"]:
+        return "tight"
+    elif rcParams["figure.constrained_layout.use"]:
+        return "constrained"
+    return None


### PR DESCRIPTION
### Description of work

Fixes #40725

Title of pr describes the changes. More than the layout, the dpi was being incorrectly considered for some devices (lke macos retina displays) as the dpi scaling can multiply the actual dpi by a given factor to compensate for the screen pixel ratio. The result was that on macos the recreated figures from script were having double the size as intended when saving. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #40725. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Make a tiled plot (with a reasonable number of plots 5-8), save the script to file or clipboard, and try to recreate the plot from the script, the plot should be similar in size and layout as the original one. 


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
