### PR TITLE
pin fontconfig in host and run

### DIFF
--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -34,6 +34,7 @@ outputs:
         - llvm-openmp ${{ llvm_openmp }}
       host:
       - eigen ${{ eigen }}
+      - fontconfig ${{ fontconfig }}
       - gsl ${{ gsl }}
       - gtest ${{ gtest }}
       - gmock ${{ gmock }}
@@ -69,7 +70,6 @@ outputs:
       - if: win
         then:
         - lib3mf
-        - fontconfig ${{ fontconfig }}
       - if: osx
         then:
         - libopenblas ${{ libopenblas }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -69,6 +69,7 @@ outputs:
       - if: win
         then:
         - lib3mf
+        - fontconfig ${{ fontconfig }}
       - if: osx
         then:
         - libopenblas ${{ libopenblas }}

--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -89,6 +89,7 @@ outputs:
 
     requirements:
       run:
+        - fontconfig ${{ fontconfig }}
         - gsl ${{ gsl }}
         - hdf4 ${{ hdf4 }}
         - h5py


### PR DESCRIPTION
### Description of work

PR builds are recently failing due to the following error:
```
Error:   × Package mantiddocs contains symlinks which are not supported on most
  │ Windows systems:
  │   - var/cache/fontconfig/123d59b33ddb0e7c76bb24004bd5cfac-le64.cache-10
  │   - var/cache/fontconfig/123d59b33ddb0e7c76bb24004bd5cfac-le64.cache-11
  │   - var/cache/fontconfig/123d59b33ddb0e7c76bb24004bd5cfac-le64.cache-9
  │   - var/cache/fontconfig/210c0516121708a580e22e6b1f9a103a-le64.cache-10
  │   - var/cache/fontconfig/210c0516121708a580e22e6b1f9a103a-le64.cache-11
  │   - var/cache/fontconfig/210c0516121708a580e22e6b1f9a103a-le64.cache-9
  │   - var/cache/fontconfig/221930ae9526a9cb8049af2916f03412-le64.cache-10
  │   - var/cache/fontconfig/221930ae9526a9cb8049af2916f03412-le64.cache-11
  │   - var/cache/fontconfig/221930ae9526a9cb8049af2916f03412-le64.cache-9
  │   - var/cache/fontconfig/3830d5c3ddfd5cd38a049b759396e72e-le64.cache-10
  │   - var/cache/fontconfig/3830d5c3ddfd5cd38a049b759396e72e-le64.cache-11
  │   - var/cache/fontconfig/3830d5c3ddfd5cd38a049b759396e72e-le64.cache-9
  │   - var/cache/fontconfig/6a6d0c18f1fc563111398184a1868c17-le64.cache-10
  │   - var/cache/fontconfig/6a6d0c18f1fc563111398184a1868c17-le64.cache-11
  │   - var/cache/fontconfig/6a6d0c18f1fc563111398184a1868c17-le64.cache-9
  │   - var/cache/fontconfig/6ba42ae0000f58711b5caaf10d690066-le64.cache-10
  │   - var/cache/fontconfig/6ba42ae0000f58711b5caaf10d690066-le64.cache-11
  │   - var/cache/fontconfig/6ba42ae0000f58711b5caaf10d690066-le64.cache-9
  │   - var/cache/fontconfig/6ee3103884cce7b2fe6f32eba9089175-le64.cache-10
  │   - var/cache/fontconfig/6ee3103884cce7b2fe6f32eba9089175-le64.cache-11
  │   - var/cache/fontconfig/6ee3103884cce7b2fe6f32eba9089175-le64.cache-9
  │ To allow symlinks, use the --allow-symlinks-on-windows flag.
```

It looks like the symlinks originate from the latest version of `fontconfig`. More specifically, this update:
https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/NEWS#L28

It's not clear that just using `--allow-symlinks-on-windows` would produce a package that is installable by users without admin rights:
https://github.com/conda/conda/issues/12465

Pinning the package in `run` env of mantid seems to be the path of least resistance. I've also pinned in host, so we build with the same package.

Alternatively, we could pin the package in `mantiddocs` run time, but maybe it's better at the `mantid` level to ensure we're consistently using the same version. It's a bit weird the framework pulling in `fontconfig`, but it's doing this anyway as a secondary dependency.

### To test:

CI passing.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
