### PR TITLE
Create Infrastructure for UI QTest Suites

### DIFF
--- a/.github/workflows/weekly_ui_tests.yml
+++ b/.github/workflows/weekly_ui_tests.yml
@@ -1,0 +1,142 @@
+name: Weekly Automated UI Tests
+
+# The automated UI tests drive real Qt interfaces (see dev-docs/source/Testing/AutomatedUITests.rst).
+# They are slow and GUI-driven, so they are kept out of the pull request and nightly pipelines
+# entirely and run here instead, once a week, purely to report what they found.
+#
+# Three separate things keep this off the critical path, and all three have to stay true:
+#   * there is no `pull_request` trigger, so this never runs against a PR;
+#   * the tests carry the AutomatedUITest CTest label, which neither `ctest -L UnitTest` in the
+#     pull request build nor runSystemTests.py in the nightly selects;
+#   * the test step is continue-on-error, and the job publishes results rather than gating on them.
+# This workflow must not be added to the repository's required status checks.
+
+on:
+  schedule:
+    # 02:00 UTC on Sundays
+    - cron: '0 2 * * 0'
+
+  workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  automated-ui-tests:
+    # scheduled runs on a fork would only queue against runners that do not exist there
+    if: ${{ github.repository_owner == 'mantidproject' }}
+    permissions:
+      contents: read
+      checks: write
+
+    strategy:
+      # a failure on one platform must not cancel the others - the point of the run is the
+      # comparison between them
+      fail-fast: false
+      matrix:
+        include:
+          - os: Linux
+            cmake_preset: linux-64-ci
+          - os: Windows
+            cmake_preset: win-64-ci
+          # macOS is missing because there is no self-hosted macOS GitHub Actions runner; osx-arm64
+          # exists only as a Jenkins agent. Add an {os: macOS, cmake_preset: osx-arm64-ci} entry here
+          # once one is available.
+
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - ${{ matrix.os }}
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CMAKE_PRESET: ${{ matrix.cmake_preset }}
+      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Needed to fetch the tags for versioningit
+          fetch-depth: 100
+          fetch-tags: true
+
+      - name: Install pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Clean build tree
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+
+      # JOB_NAME is deliberately left unset: it is what tells the Jenkins scripts to configure with
+      # -DPR_JOB=True and to exclude the slower tests, and neither applies to a weekly run.
+      - name: Build code
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          echo "::add-matcher::.github/matchers/gcc.json"
+          # DOCS DEV_DOCS BUILD_CODE UNIT_TESTS SYSTEM_TESTS DOC_TESTS
+          # UNIT_TESTS and SYSTEM_TESTS are true only to build the AllTests, StandardTestData and
+          # SystemTestData targets, which is what the UI tests need. Neither suite is run below.
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET false false true true true false $EXTRA_CMAKE_FLAGS
+          echo "::remove-matcher owner=gcc-problem-matcher::"
+
+      - name: Run automated UI tests
+        id: testui
+        # reporting only - a failing UI test must never fail this job
+        continue-on-error: true
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          if [[ "${{ matrix.os }}" == "Linux" ]]; then
+            BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          else
+            BUILD_THREADS=4
+          fi
+          # bool flags for this are
+          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS <threads> UI_TESTS
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false false false false ${BUILD_THREADS} true
+
+      - name: Archive automated UI test output
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: junit-automated-ui-${{ matrix.os }}
+          if-no-files-found: warn
+          path: ${{ github.workspace }}/build/Testing/junit-uitest.xml
+
+      - name: Upload build and test log artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test_logs_${{ matrix.os }}
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/test_logs/**
+
+      - name: Publish results
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        # the action only ships a Linux implementation
+        if: ${{ always() && matrix.os == 'Linux' && hashFiles('build/Testing/junit-uitest.xml') != '' }}
+        with:
+          check_name: "Automated UI test results (${{ matrix.os }})"
+          check_run_annotations: skipped tests
+          comment_mode: off
+          files: ${{ github.workspace }}/build/Testing/junit-uitest.xml
+          # a failing UI test is something to look at on Monday, not a broken workflow
+          action_fail: false
+          action_fail_on_inconclusive: false
+
+      - name: Summarise
+        if: always()
+        run: |
+          if [[ "${{ steps.testui.outcome }}" == "success" ]]; then
+            echo ":white_check_mark: Automated UI tests passed on ${{ matrix.os }}." >> $GITHUB_STEP_SUMMARY
+          else
+            echo ":warning: Automated UI tests reported failures on ${{ matrix.os }}. See the \`junit-automated-ui-${{ matrix.os }}\` artifact." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/weekly_ui_tests.yml
+++ b/.github/workflows/weekly_ui_tests.yml
@@ -8,7 +8,8 @@ name: Weekly Automated UI Tests
 #   * there is no `pull_request` trigger, so this never runs against a PR;
 #   * the tests carry the AutomatedUITest CTest label, which neither `ctest -L UnitTest` in the
 #     pull request build nor runSystemTests.py in the nightly selects;
-#   * the test step is continue-on-error, and the job publishes results rather than gating on them.
+#   * the test step is continue-on-error, and a separate job publishes results rather than gating
+#     on them.
 # This workflow must not be added to the repository's required status checks.
 
 on:
@@ -33,7 +34,6 @@ jobs:
     if: ${{ github.repository_owner == 'mantidproject' }}
     permissions:
       contents: read
-      checks: write
 
     strategy:
       # a failure on one platform must not cancel the others - the point of the run is the
@@ -122,19 +122,6 @@ jobs:
           if-no-files-found: ignore
           path: ${{ github.workspace }}/build/test_logs/**
 
-      - name: Publish results
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        # the action only ships a Linux implementation
-        if: ${{ always() && matrix.os == 'Linux' && hashFiles('build/Testing/junit-uitest.xml') != '' }}
-        with:
-          check_name: "Automated UI test results (${{ matrix.os }})"
-          check_run_annotations: skipped tests
-          comment_mode: off
-          files: ${{ github.workspace }}/build/Testing/junit-uitest.xml
-          # a failing UI test is something to look at on Monday, not a broken workflow
-          action_fail: false
-          action_fail_on_inconclusive: false
-
       - name: Summarise
         if: always()
         run: |
@@ -143,3 +130,47 @@ jobs:
           else
             echo ":warning: Automated UI tests reported failures on ${{ matrix.os }}. See the \`junit-automated-ui-${{ matrix.os }}\` artifact." >> $GITHUB_STEP_SUMMARY
           fi
+
+  publish-results:
+    # Separate from the test job, and GitHub-hosted, because the publish action is a Docker
+    # container action: the self-hosted builders above are not guaranteed to have a usable Docker
+    # daemon, and a report-only workflow must not go red over that. This is the same split
+    # publish_test_results.yml already uses - the results come from the uploaded JUnit artifacts
+    # rather than from a build tree, so one Linux runner can report both platforms.
+    needs: automated-ui-tests
+    if: ${{ always() && github.repository_owner == 'mantidproject' }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+
+    steps:
+      - name: Download JUnit results
+        uses: actions/download-artifact@v8
+        # nothing to publish is a normal outcome here, e.g. if every build failed
+        continue-on-error: true
+        with:
+          pattern: junit-automated-ui-*
+          path: artifacts
+
+      - name: Publish results (Linux)
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        if: ${{ hashFiles('artifacts/junit-automated-ui-Linux/junit-uitest.xml') != '' }}
+        with:
+          check_name: "Automated UI test results (Linux)"
+          check_run_annotations: skipped tests
+          comment_mode: "off"
+          files: artifacts/junit-automated-ui-Linux/junit-uitest.xml
+          # a failing UI test is something to look at on Monday, not a broken workflow
+          action_fail: false
+          action_fail_on_inconclusive: false
+
+      - name: Publish results (Windows)
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
+        if: ${{ hashFiles('artifacts/junit-automated-ui-Windows/junit-uitest.xml') != '' }}
+        with:
+          check_name: "Automated UI test results (Windows)"
+          check_run_annotations: skipped tests
+          comment_mode: "off"
+          files: artifacts/junit-automated-ui-Windows/junit-uitest.xml
+          action_fail: false
+          action_fail_on_inconclusive: false

--- a/.github/workflows/weekly_ui_tests.yml
+++ b/.github/workflows/weekly_ui_tests.yml
@@ -1,6 +1,6 @@
 name: Weekly Automated UI Tests
 
-# The automated UI tests drive real Qt interfaces (see dev-docs/source/Testing/AutomatedUITests.rst).
+# The automated UI tests drive real Qt interfaces (see dev-docs/source/AutomatedUITests.rst).
 # They are slow and GUI-driven, so they are kept out of the pull request and nightly pipelines
 # entirely and run here instead, once a week, purely to report what they found.
 #
@@ -69,6 +69,9 @@ jobs:
           # Needed to fetch the tags for versioningit
           fetch-depth: 100
           fetch-tags: true
+          # nothing here pushes, and the checkout is reused by long build and test steps on a
+          # self-hosted runner - do not leave the job token in the checkout's git config
+          persist-credentials: false
 
       - name: Install pixi
         uses: ./.github/actions/setup-pixi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ if(BUILD_MANTIDFRAMEWORK
   add_subdirectory(tools)
 endif()
 
+# Automated UI tests. Registered under their own CTest label, so adding them here does not put them in any pipeline -
+# they have to be asked for with `ctest -L AutomatedUITest`.
+if(ENABLE_WORKBENCH)
+  add_subdirectory(Testing/AutomatedUITests)
+endif()
+
 if(COVERAGE)
   get_property(ALL_SRCS GLOBAL PROPERTY COVERAGE_SRCS)
   set(SRCS_FILE "")

--- a/Testing/AutomatedUITests/CMakeLists.txt
+++ b/Testing/AutomatedUITests/CMakeLists.txt
@@ -4,13 +4,13 @@
 # They live outside Testing/SystemTests on purpose. runSystemTests.py collects by walking the "framework" and "qt"
 # directories, so a suite under either of those is picked up by the nightly system test run whatever CTest label it
 # carries. From here, the AutomatedUITest label given by pyunittest_add_test_ui is the only way in, and neither the pull
-# request build (ctest -L UnitTest) nor the nightly selects it. See dev-docs/source/Testing/AutomatedUITests.rst.
+# request build (ctest -L UnitTest) nor the nightly selects it. See dev-docs/source/AutomatedUITests.rst.
 #
 # No tests are registered at this level - each interface gets its own subdirectory. The shared harness modules here
 # (automated_ui_test_base.py, qt_interaction_helpers.py) are deliberately not listed as tests; putting this directory on
 # the test PYTHONPATH is what makes them importable from the interface subdirectories, and CMake variables propagate
 # into add_subdirectory.
-set(PYUNITTEST_PYTHONPATH_EXTRA ${CMAKE_CURRENT_SOURCE_DIR})
+list(APPEND PYUNITTEST_PYTHONPATH_EXTRA ${CMAKE_CURRENT_SOURCE_DIR})
 set(PYUNITTEST_QT_API pyqt${MANTID_QT_VERSION}) # force to use the configured Qt version
 # these drive a real interface and run real algorithms, so they are both slow and greedy: give them a longer limit than
 # the global one and keep them off each other's toes

--- a/Testing/AutomatedUITests/CMakeLists.txt
+++ b/Testing/AutomatedUITests/CMakeLists.txt
@@ -19,11 +19,25 @@ set(PYUNITTEST_RUN_SERIAL ON)
 
 # A UI test replaces a manual test guide, so it uses whatever data that guide told a tester to load - which for most
 # interfaces means the SystemTest set. The built properties file only puts UnitTest and DocTest on the search path, so
-# name the rest here and let the harness add them per test. Their contents are downloaded by the SystemTestData and
-# StandardTestData targets; a test whose files are absent reports a skip through require_files.
+# name the rest here and let the harness add them per test. Their contents are downloaded by the AutomatedUITestData
+# target below; a test whose files are absent reports a skip through require_files.
 set(PYUNITTEST_DATA_DIRS
     ${ExternalData_BINARY_ROOT}/Testing/Data/SystemTest ${ExternalData_BINARY_ROOT}/Testing/Data/DocTest
     ${ExternalData_BINARY_ROOT}/Testing/Data/UnitTest
 )
+
+# The data cannot be a dependency of the tests themselves - pyunittest_add_test_ui only calls add_test, so there is no
+# build target to hang add_dependencies on, and `ctest -L AutomatedUITest` builds nothing. This target is the developer
+# equivalent of what CI already does before it runs them (buildconfig/Jenkins/Conda/build builds StandardTestData and
+# SystemTestData): `cmake --build . --target AutomatedUITestData` downloads everything the suites can ask for, so a
+# local run reports results rather than a page of skips from require_files. Both targets exist by now - SetupDataTargets
+# is included from CommonSetup, long before this directory is added.
+#
+# Guarded because the data targets are themselves conditional: CommonSetup only includes SetupDataTargets when docs or a
+# test framework were found, while this directory is added on ENABLE_WORKBENCH alone.
+if(TARGET StandardTestData AND TARGET SystemTestData)
+  add_custom_target(AutomatedUITestData)
+  add_dependencies(AutomatedUITestData StandardTestData SystemTestData)
+endif()
 
 add_subdirectory(Example)

--- a/Testing/AutomatedUITests/CMakeLists.txt
+++ b/Testing/AutomatedUITests/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Automated UI tests: tests that drive a real Qt interface with QTest, replacing the manual test guides in
+# dev-docs/source/Testing.
+#
+# They live outside Testing/SystemTests on purpose. runSystemTests.py collects by walking the "framework" and "qt"
+# directories, so a suite under either of those is picked up by the nightly system test run whatever CTest label it
+# carries. From here, the AutomatedUITest label given by pyunittest_add_test_ui is the only way in, and neither the pull
+# request build (ctest -L UnitTest) nor the nightly selects it. See dev-docs/source/Testing/AutomatedUITests.rst.
+#
+# No tests are registered at this level - each interface gets its own subdirectory. The shared harness modules here
+# (automated_ui_test_base.py, qt_interaction_helpers.py) are deliberately not listed as tests; putting this directory on
+# the test PYTHONPATH is what makes them importable from the interface subdirectories, and CMake variables propagate
+# into add_subdirectory.
+set(PYUNITTEST_PYTHONPATH_EXTRA ${CMAKE_CURRENT_SOURCE_DIR})
+set(PYUNITTEST_QT_API pyqt${MANTID_QT_VERSION}) # force to use the configured Qt version
+# these drive a real interface and run real algorithms, so they are both slow and greedy: give them a longer limit than
+# the global one and keep them off each other's toes
+set(PYUNITTEST_TIMEOUT 3600)
+set(PYUNITTEST_RUN_SERIAL ON)
+
+# A UI test replaces a manual test guide, so it uses whatever data that guide told a tester to load - which for most
+# interfaces means the SystemTest set. The built properties file only puts UnitTest and DocTest on the search path, so
+# name the rest here and let the harness add them per test. Their contents are downloaded by the SystemTestData and
+# StandardTestData targets; a test whose files are absent reports a skip through require_files.
+set(PYUNITTEST_DATA_DIRS
+    ${ExternalData_BINARY_ROOT}/Testing/Data/SystemTest ${ExternalData_BINARY_ROOT}/Testing/Data/DocTest
+    ${ExternalData_BINARY_ROOT}/Testing/Data/UnitTest
+)
+
+add_subdirectory(Example)

--- a/Testing/AutomatedUITests/Example/CMakeLists.txt
+++ b/Testing/AutomatedUITests/Example/CMakeLists.txt
@@ -1,0 +1,8 @@
+# The worked example, which is also the smoke test for the harness itself. It drives a widget defined in its own module,
+# so it depends on no Mantid interface and no test data.
+set(TEST_NAMES ExampleUITest.py)
+
+# The parent's PYUNITTEST_PYTHONPATH_EXTRA (the shared harness directory) is inherited here, and PY_ADD_TEST puts this
+# directory on PYTHONPATH itself, so the cross-interface helpers are importable from the test modules without adding
+# anything further.
+pyunittest_add_test_ui(${CMAKE_CURRENT_SOURCE_DIR} AutomatedUITest.Example ${TEST_NAMES})

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -46,7 +46,6 @@ from qt_interaction_helpers import (
     set_item_checked,
     set_line_edit,
     set_spin_box,
-    tab_titles,
     table_checkbox,
     table_column,
     tree_rows,
@@ -362,6 +361,13 @@ class ExampleUITest(AutomatedUITestBase):
         with self.check("Example / clicking the indicator toggles the checkbox"):
             self.assertTrue(self.widget.check_shout.isChecked())
 
+        with self.check("Example / a plain click() lands on the indicator too"):
+            # click() dispatches on the widget kind, so reaching for the obvious call is not a trap
+            click(self.widget.check_shout)
+            self.assertFalse(self.widget.check_shout.isChecked())
+            click(self.widget.check_shout)
+            self.assertTrue(self.widget.check_shout.isChecked())
+
         with self.check("Example / setting a checkbox to the state it is already in is a no-op"):
             self.assertTrue(set_checkbox(self.widget.check_shout, True))
 
@@ -438,9 +444,8 @@ class ExampleUITest(AutomatedUITestBase):
             self.assertFalse(self.widget.check_nested.isEnabled())
 
     def test_tabs_and_lists(self):
-        with self.check("Example / every tab is listed by title"):
-            self.assertEqual(tab_titles(self.widget.tabs), list(_TAB_TITLES))
-
+        # deliberately no assertion on the whole list of tab titles: that only restates the tab bar
+        # and needs updating whenever a tab is added. Selecting a tab is what proves it exists.
         page = select_tab(self.widget.tabs, "Diagnostics")
         with self.check("Example / a tab is selected by title, not by index"):
             self.assertEqual(self.widget.tabs.tabText(self.widget.tabs.currentIndex()), "Diagnostics")

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -1,0 +1,212 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""A worked example of an automated UI test, and the smoke test for the harness itself.
+
+The widget under test is defined here rather than imported from Mantid on purpose. Every other
+suite in this tree drives a real interface, so when one of them fails the first question is always
+"is it the interface or is it the harness?". This module answers that: it depends on nothing but
+``AutomatedUITestBase`` and ``qt_interaction_helpers``, so if it fails the harness is broken.
+
+Read it as a template. A real suite differs only in that ``setUp`` builds a Mantid interface instead
+of ``_ExampleWidget``, and that the assertions look at workspaces and files as well as widgets.
+"""
+
+import unittest
+
+from automated_ui_test_base import AutomatedUITestBase
+from qt_interaction_helpers import (
+    cell_button,
+    click,
+    click_checkbox,
+    combo_items,
+    process_events,
+    select_combo,
+    set_checkbox,
+    table_checkbox,
+    table_column,
+    wait_until,
+)
+
+# how long the fake background task takes. Long enough that a test which forgot to wait would see
+# the un-updated value, short enough not to pad the suite.
+_TASK_DURATION_MS = 250
+
+_GREETINGS = ("Hello", "Goodbye", "Good morning")
+
+
+def _build_widget():
+    """The interface under test: one of every widget kind the helpers know how to drive.
+
+    Built inside a function rather than at module scope because a ``QWidget`` cannot be constructed
+    before the ``QApplication`` exists, and the harness creates that lazily in ``setUp``.
+    """
+    from qtpy.QtCore import QTimer
+    from qtpy.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
+
+    class _ExampleWidget(QWidget):
+        def __init__(self):
+            super(_ExampleWidget, self).__init__()
+            self.setObjectName("ExampleWidget")
+
+            self.combo_greeting = QComboBox()
+            self.combo_greeting.addItems(_GREETINGS)
+            self.check_shout = QCheckBox("Shout")
+            self.button_greet = QPushButton("Greet")
+            self.label_greeting = QLabel("")
+            self.button_start_task = QPushButton("Start task")
+            self.label_task = QLabel("idle")
+
+            # one row per greeting, each with a select box in a centred cell widget and a per-row
+            # button - the awkward table layout the helpers exist to reach into
+            self.table = QTableWidget(len(_GREETINGS), 3)
+            self.table.setHorizontalHeaderLabels(["Select", "Greeting", "Action"])
+            for row, greeting in enumerate(_GREETINGS):
+                cell = QWidget()
+                layout = QHBoxLayout(cell)
+                layout.setContentsMargins(0, 0, 0, 0)
+                layout.addWidget(QCheckBox())
+                self.table.setCellWidget(row, 0, cell)
+                self.table.setItem(row, 1, QTableWidgetItem(greeting))
+                button = QPushButton("Use")
+                button.clicked.connect(lambda _checked=False, text=greeting: self._set_greeting(text))
+                self.table.setCellWidget(row, 2, button)
+
+            layout = QVBoxLayout(self)
+            for widget in (
+                self.combo_greeting,
+                self.check_shout,
+                self.button_greet,
+                self.label_greeting,
+                self.button_start_task,
+                self.label_task,
+                self.table,
+            ):
+                layout.addWidget(widget)
+
+            self.button_greet.clicked.connect(self._greet)
+            self.button_start_task.clicked.connect(self._start_task)
+
+        def _greet(self):
+            text = f"{self.combo_greeting.currentText()}, world"
+            self._set_greeting(text.upper() if self.check_shout.isChecked() else text)
+
+        def _set_greeting(self, text):
+            self.label_greeting.setText(text)
+
+        def _start_task(self):
+            """Stand in for the real thing: work that finishes on the event loop rather than on the
+            next line, so a test has to wait for it with ``wait_until``."""
+            self.label_task.setText("running")
+            QTimer.singleShot(_TASK_DURATION_MS, lambda: self.label_task.setText("done"))
+
+    return _ExampleWidget()
+
+
+class ExampleUITest(AutomatedUITestBase):
+    def setUp(self):
+        super(ExampleUITest, self).setUp()
+        self.widget = _build_widget()
+        self.widget.show()
+        process_events(2)
+
+    def tearDown(self):
+        widget = getattr(self, "widget", None)
+        if widget is not None:
+            widget.close()
+            process_events(2)
+            self.widget = None
+        super(ExampleUITest, self).tearDown()
+
+    def test_buttons_and_combo_boxes(self):
+        with self.check("Example / the combo offers every greeting"):
+            self.assertEqual(combo_items(self.widget.combo_greeting), list(_GREETINGS))
+
+        select_combo(self.widget.combo_greeting, "Goodbye")
+        click(self.widget.button_greet)
+        with self.check("Example / clicking Greet uses the selected greeting"):
+            self.assertEqual(self.widget.label_greeting.text(), "Goodbye, world")
+
+        with self.check("Example / an absent combo entry is reported rather than ignored"):
+            # setCurrentText() would silently do nothing here, which is the trap select_combo exists
+            # to close, so the failure has to be an assertion
+            self.assertRaises(AssertionError, select_combo, self.widget.combo_greeting, "Bonjour")
+
+    def test_check_boxes(self):
+        click_checkbox(self.widget.check_shout)
+        with self.check("Example / clicking the indicator toggles the checkbox"):
+            self.assertTrue(self.widget.check_shout.isChecked())
+
+        with self.check("Example / setting a checkbox to the state it is already in is a no-op"):
+            self.assertTrue(set_checkbox(self.widget.check_shout, True))
+
+        set_checkbox(self.widget.check_shout, False)
+        click(self.widget.button_greet)
+        with self.check("Example / an unticked box leaves the greeting unshouted"):
+            self.assertEqual(self.widget.label_greeting.text(), "Hello, world")
+
+        set_checkbox(self.widget.check_shout, True)
+        click(self.widget.button_greet)
+        with self.check("Example / a ticked box reaches the handler"):
+            self.assertEqual(self.widget.label_greeting.text(), "HELLO, WORLD")
+
+    def test_tables(self):
+        table = self.widget.table
+        with self.check("Example / the table has one row per greeting"):
+            self.assertEqual(table_column(table, 1), list(_GREETINGS))
+
+        with self.check("Example / rows start unselected"):
+            self.assertEqual([table_checkbox(table, row, 0).isChecked() for row in range(table.rowCount())], [False] * 3)
+
+        set_checkbox(table_checkbox(table, 1, 0), True)
+        with self.check("Example / a single row can be ticked on its own"):
+            self.assertEqual([table_checkbox(table, row, 0).isChecked() for row in range(table.rowCount())], [False, True, False])
+
+        click(cell_button(table, 2, 2))
+        with self.check("Example / a per-row button acts on its own row"):
+            self.assertEqual(self.widget.label_greeting.text(), _GREETINGS[2])
+
+    def test_waiting_for_work_that_finishes_on_the_event_loop(self):
+        click(self.widget.button_start_task)
+        with self.check("Example / the task has not finished by the time the click returns"):
+            self.assertEqual(self.widget.label_task.text(), "running")
+
+        wait_until(lambda: self.widget.label_task.text() == "done", timeout=30.0, msg="the example task")
+        with self.check("Example / waiting pumps the event loop until the task completes"):
+            self.assertEqual(self.widget.label_task.text(), "done")
+
+    def test_a_failed_check_does_not_hide_the_ones_after_it(self):
+        """The property the whole suite relies on, asserted rather than assumed.
+
+        ``check`` has to keep going after a failure, otherwise a run reports one regression at a
+        time. Verified against a throwaway ``TestCase`` so this test can pass while containing a
+        deliberate failure.
+        """
+        observed = []
+
+        class _Inner(AutomatedUITestBase):
+            def test_inner(inner_self):
+                with inner_self.check("first"):
+                    observed.append("first")
+                    inner_self.fail("deliberate")
+                with inner_self.check("second"):
+                    observed.append("second")
+                    raise RuntimeError("deliberate")
+                observed.append("after")
+
+        result = unittest.TestResult()
+        _Inner("test_inner").run(result)
+
+        with self.check("Example / every check runs even after one fails"):
+            self.assertEqual(observed, ["first", "second", "after"])
+        with self.check("Example / each failed check is reported separately"):
+            self.assertEqual(len(result.failures) + len(result.errors), 2)
+        with self.check("Example / a failed check names the step it belongs to"):
+            self.assertIn("[first]", str(result.failures[0][0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -23,9 +23,11 @@ from qt_interaction_helpers import (
     cell_combo,
     click,
     click_checkbox,
+    click_column_header,
     click_index,
     click_row_header,
     combo_items,
+    double_click_index,
     edit_index,
     index_check_state,
     item_check_state,
@@ -35,6 +37,7 @@ from qt_interaction_helpers import (
     model_row_count,
     process_events,
     select_combo,
+    select_index,
     select_list_item,
     select_radio,
     select_tab,
@@ -500,9 +503,17 @@ class ExampleUITest(AutomatedUITestBase):
             # a click on the view rather than its viewport would leave the selection untouched
             self.assertEqual(view.currentIndex().row(), 2)
 
+        select_index(view, 0, 2)
+        with self.check("Example / an index can be made current without a click"):
+            self.assertEqual((view.currentIndex().row(), view.currentIndex().column()), (0, 2))
+
         click_row_header(view, 1)
         with self.check("Example / clicking a row header selects the whole row"):
             self.assertEqual(sorted(i.column() for i in view.selectionModel().selectedIndexes()), [0, 1, 2])
+
+        click_column_header(view, 2)
+        with self.check("Example / clicking a column header selects the whole column"):
+            self.assertEqual(sorted(i.row() for i in view.selectionModel().selectedIndexes()), [0, 1, 2])
 
         edit_index(view, 0, 2, "edited")
         with self.check("Example / typing into a cell reaches the model through its delegate"):
@@ -514,6 +525,14 @@ class ExampleUITest(AutomatedUITestBase):
         rows = tree_rows(self.widget.tree_view)
         with self.check("Example / a tree walks depth-first with its nesting"):
             self.assertEqual([(depth, text) for depth, text, _ in rows], [(0, "North"), (1, "N1"), (1, "N2"), (0, "South"), (1, "S1")])
+
+        # last, because it leaves an editor open - nothing after it would see a settled view
+        with self.check("Example / double-clicking an editable cell opens its delegate's editor"):
+            # what edit_index is built on: a single click only selects, so there would be nothing to type into
+            double_click_index(view, 1, 2)
+            editor = view.focusWidget()
+            self.assertIsNotNone(editor)
+            self.assertIsNot(editor, view)
 
     def test_waiting_for_work_that_finishes_on_the_event_loop(self):
         click(self.widget.button_start_task)

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -343,196 +343,203 @@ class ExampleUITest(AutomatedUITestBase):
         super(ExampleUITest, self).tearDown()
 
     def test_buttons_and_combo_boxes(self):
-        with self.check("Example / the combo offers every greeting"):
+        with self.subTest("Example / the combo offers every greeting"):
             self.assertEqual(combo_items(self.widget.combo_greeting), list(_GREETINGS))
 
         select_combo(self.widget.combo_greeting, "Goodbye")
         click(self.widget.button_greet)
-        with self.check("Example / clicking Greet uses the selected greeting"):
+        with self.subTest("Example / clicking Greet uses the selected greeting"):
             self.assertEqual(self.widget.label_greeting.text(), "Goodbye, world")
 
-        with self.check("Example / an absent combo entry is reported rather than ignored"):
+        with self.subTest("Example / an absent combo entry is reported rather than ignored"):
             # setCurrentText() would silently do nothing here, which is the trap select_combo exists
             # to close, so the failure has to be an assertion
             self.assertRaises(AssertionError, select_combo, self.widget.combo_greeting, "Bonjour")
 
     def test_check_boxes(self):
         click_checkbox(self.widget.check_shout)
-        with self.check("Example / clicking the indicator toggles the checkbox"):
+        with self.subTest("Example / clicking the indicator toggles the checkbox"):
             self.assertTrue(self.widget.check_shout.isChecked())
 
-        with self.check("Example / a plain click() lands on the indicator too"):
+        with self.subTest("Example / a plain click() lands on the indicator too"):
             # click() dispatches on the widget kind, so reaching for the obvious call is not a trap
             click(self.widget.check_shout)
             self.assertFalse(self.widget.check_shout.isChecked())
             click(self.widget.check_shout)
             self.assertTrue(self.widget.check_shout.isChecked())
 
-        with self.check("Example / setting a checkbox to the state it is already in is a no-op"):
+        with self.subTest("Example / setting a checkbox to the state it is already in is a no-op"):
             self.assertTrue(set_checkbox(self.widget.check_shout, True))
 
         set_checkbox(self.widget.check_shout, False)
         click(self.widget.button_greet)
-        with self.check("Example / an unticked box leaves the greeting unshouted"):
+        with self.subTest("Example / an unticked box leaves the greeting unshouted"):
             self.assertEqual(self.widget.label_greeting.text(), "Hello, world")
 
         set_checkbox(self.widget.check_shout, True)
         click(self.widget.button_greet)
-        with self.check("Example / a ticked box reaches the handler"):
+        with self.subTest("Example / a ticked box reaches the handler"):
             self.assertEqual(self.widget.label_greeting.text(), "HELLO, WORLD")
 
     def test_tables(self):
         table = self.widget.table
-        with self.check("Example / the table has one row per greeting"):
+        with self.subTest("Example / the table has one row per greeting"):
             self.assertEqual(table_column(table, 1), list(_GREETINGS))
 
-        with self.check("Example / rows start unselected"):
+        with self.subTest("Example / rows start unselected"):
             self.assertEqual([table_checkbox(table, row, 0).isChecked() for row in range(table.rowCount())], [False] * 3)
 
         set_checkbox(table_checkbox(table, 1, 0), True)
-        with self.check("Example / a single row can be ticked on its own"):
+        with self.subTest("Example / a single row can be ticked on its own"):
             self.assertEqual([table_checkbox(table, row, 0).isChecked() for row in range(table.rowCount())], [False, True, False])
 
         click(cell_button(table, 2, 2))
-        with self.check("Example / a per-row button acts on its own row"):
+        with self.subTest("Example / a per-row button acts on its own row"):
             self.assertEqual(self.widget.label_greeting.text(), _GREETINGS[2])
 
     def test_line_edits_and_spin_boxes(self):
         set_line_edit(self.widget.edit_threshold, "12.5")
-        with self.check("Example / typing puts the text in the line edit"):
+        with self.subTest("Example / typing puts the text in the line edit"):
             self.assertEqual(self.widget.edit_threshold.text(), "12.5")
-        with self.check("Example / and fires editingFinished, which setText would not"):
+        with self.subTest("Example / and fires editingFinished, which setText would not"):
             # the whole reason set_line_edit replays keystrokes instead of assigning
             self.assertEqual(self.widget.label_threshold.text(), "12.5")
 
-        with self.check("Example / a second entry replaces the first rather than appending"):
+        with self.subTest("Example / a second entry replaces the first rather than appending"):
             set_line_edit(self.widget.edit_threshold, "7")
             self.assertEqual(self.widget.edit_threshold.text(), "7")
 
-        with self.check("Example / a value the validator refuses is reported"):
+        with self.subTest("Example / a value the validator refuses is reported"):
             # the validator caps at 100, so the widget would hold something unexpected and the
             # interface would quietly do nothing - that has to surface here instead
             self.assertRaises(AssertionError, set_line_edit, self.widget.edit_threshold, "999")
 
-        with self.check("Example / a spin box takes a value inside its range"):
+        with self.subTest("Example / a spin box takes a value inside its range"):
             self.assertEqual(set_spin_box(self.widget.spin_count, 4), 4)
 
-        with self.check("Example / a value outside the range is reported, not silently clamped"):
+        with self.subTest("Example / a value outside the range is reported, not silently clamped"):
             self.assertRaises(AssertionError, set_spin_box, self.widget.spin_count, 99)
 
     def test_radio_buttons_and_group_boxes(self):
-        with self.check("Example / a radio button can be selected by its label"):
+        # Whether a helper call sits inside a subTest block is a decision, not a formatting choice.
+        # These helpers assert for themselves - select_radio raises if the button did not end up
+        # checked - so inside a block the raise is recorded as a failed observation and the rest of
+        # the scenario still runs, while outside one it ends the test on the spot. Selecting is the
+        # thing being observed here, so it goes inside; the set_group_box(False) further down is
+        # only setting up the observation after it, and a failure there means the remaining checks
+        # would be meaningless, so it stays outside.
+        with self.subTest("Example / a radio button can be selected by its label"):
             select_radio(self.widget.group_bank, "South")
             self.assertTrue(self.widget.radio_south.isChecked())
-        with self.check("Example / and selecting one deselects the other"):
+        with self.subTest("Example / and selecting one deselects the other"):
             self.assertFalse(self.widget.radio_north.isChecked())
 
-        with self.check("Example / radio buttons can also be found through their parent widget"):
+        with self.subTest("Example / radio buttons can also be found through their parent widget"):
             select_radio(self.widget, "North")
             self.assertTrue(self.widget.radio_north.isChecked())
 
-        with self.check("Example / an absent radio button is reported rather than ignored"):
+        with self.subTest("Example / an absent radio button is reported rather than ignored"):
             self.assertRaises(AssertionError, select_radio, self.widget.group_bank, "East")
 
-        with self.check("Example / a checkable group box can be switched on"):
+        with self.subTest("Example / a checkable group box can be switched on"):
             self.assertTrue(set_group_box(self.widget.box_advanced, True))
-        with self.check("Example / and its toggled handler runs"):
+        with self.subTest("Example / and its toggled handler runs"):
             self.assertEqual(self.widget.label_advanced.text(), "on")
 
         set_group_box(self.widget.box_advanced, False)
-        with self.check("Example / switching a group box off disables what it contains"):
+        with self.subTest("Example / switching a group box off disables what it contains"):
             self.assertFalse(self.widget.check_nested.isEnabled())
 
     def test_tabs_and_lists(self):
         # deliberately no assertion on the whole list of tab titles: that only restates the tab bar
         # and needs updating whenever a tab is added. Selecting a tab is what proves it exists.
         page = select_tab(self.widget.tabs, "Diagnostics")
-        with self.check("Example / a tab is selected by title, not by index"):
+        with self.subTest("Example / a tab is selected by title, not by index"):
             self.assertEqual(self.widget.tabs.tabText(self.widget.tabs.currentIndex()), "Diagnostics")
-        with self.check("Example / and the page it returns is the current one"):
+        with self.subTest("Example / and the page it returns is the current one"):
             self.assertIs(page, self.widget.tabs.currentWidget())
 
-        with self.check("Example / an absent tab title is reported"):
+        with self.subTest("Example / an absent tab title is reported"):
             self.assertRaises(AssertionError, select_tab, self.widget.tabs, "Nonexistent")
 
-        with self.check("Example / every list entry is listed"):
+        with self.subTest("Example / every list entry is listed"):
             self.assertEqual(list_items(self.widget.list_pages), list(_PAGE_NAMES))
 
         select_list_item(self.widget.list_pages, "Masking")
-        with self.check("Example / selecting a list entry drives the stack beside it"):
+        with self.subTest("Example / selecting a list entry drives the stack beside it"):
             self.assertEqual(self.widget.stack_pages.currentIndex(), 1)
 
-        with self.check("Example / an absent list entry is reported"):
+        with self.subTest("Example / an absent list entry is reported"):
             self.assertRaises(AssertionError, select_list_item, self.widget.list_pages, "Nonexistent")
 
     def test_table_items_and_cell_widgets(self):
         table = self.widget.table
 
-        with self.check("Example / a checkable item is not an embedded check box"):
+        with self.subTest("Example / a checkable item is not an embedded check box"):
             # column 3 holds a checkable QTableWidgetItem, so there is no cell widget to find
             self.assertRaises(AssertionError, table_checkbox, table, 0, 3)
 
-        with self.check("Example / checkable items start unticked"):
+        with self.subTest("Example / checkable items start unticked"):
             self.assertEqual([item_check_state(table, row, 3) for row in range(table.rowCount())], [False] * 3)
 
         set_item_checked(table, 2, 3, True)
-        with self.check("Example / a checkable item can be ticked on its own"):
+        with self.subTest("Example / a checkable item can be ticked on its own"):
             self.assertEqual([item_check_state(table, row, 3) for row in range(table.rowCount())], [False, False, True])
 
-        with self.check("Example / a combo box embedded in a cell is reachable"):
+        with self.subTest("Example / a combo box embedded in a cell is reachable"):
             combo = cell_combo(table, 1, 4)
             self.assertEqual(combo_items(combo), ["plain", "bold"])
             select_combo(combo, "bold")
             self.assertEqual(combo.currentText(), "bold")
 
-        with self.check("Example / a cell holding no widget of that kind gives None"):
+        with self.subTest("Example / a cell holding no widget of that kind gives None"):
             self.assertIsNone(cell_combo(table, 1, 1))
 
     def test_item_views(self):
         view = self.widget.table_view
 
-        with self.check("Example / a model-backed column reads like a table column"):
+        with self.subTest("Example / a model-backed column reads like a table column"):
             self.assertEqual(model_column(view, 0), [row[0] for row in _MODEL_ROWS])
-        with self.check("Example / the row count comes from the model"):
+        with self.subTest("Example / the row count comes from the model"):
             self.assertEqual(model_row_count(view), len(_MODEL_ROWS))
 
-        with self.check("Example / the QTableWidget helpers do not work on a QTableView"):
+        with self.subTest("Example / the QTableWidget helpers do not work on a QTableView"):
             # the distinction the two sections of the helper module exist to keep straight
             self.assertRaises(AttributeError, table_column, view, 0)
 
-        with self.check("Example / check states come from the model, not from a cell widget"):
+        with self.subTest("Example / check states come from the model, not from a cell widget"):
             self.assertEqual([index_check_state(view, row, 1) for row in range(3)], [True, False, False])
 
         click_index(view, 2, 0)
-        with self.check("Example / clicking an index selects it"):
+        with self.subTest("Example / clicking an index selects it"):
             # a click on the view rather than its viewport would leave the selection untouched
             self.assertEqual(view.currentIndex().row(), 2)
 
         select_index(view, 0, 2)
-        with self.check("Example / an index can be made current without a click"):
+        with self.subTest("Example / an index can be made current without a click"):
             self.assertEqual((view.currentIndex().row(), view.currentIndex().column()), (0, 2))
 
         click_row_header(view, 1)
-        with self.check("Example / clicking a row header selects the whole row"):
+        with self.subTest("Example / clicking a row header selects the whole row"):
             self.assertEqual(sorted(i.column() for i in view.selectionModel().selectedIndexes()), [0, 1, 2])
 
         click_column_header(view, 2)
-        with self.check("Example / clicking a column header selects the whole column"):
+        with self.subTest("Example / clicking a column header selects the whole column"):
             self.assertEqual(sorted(i.row() for i in view.selectionModel().selectedIndexes()), [0, 1, 2])
 
         edit_index(view, 0, 2, "edited")
-        with self.check("Example / typing into a cell reaches the model through its delegate"):
+        with self.subTest("Example / typing into a cell reaches the model through its delegate"):
             self.assertEqual(model_cell(view, 0, 2), "edited")
 
-        with self.check("Example / an index outside the model is reported"):
+        with self.subTest("Example / an index outside the model is reported"):
             self.assertRaises(AssertionError, model_cell, view, 99, 0)
 
         rows = tree_rows(self.widget.tree_view)
-        with self.check("Example / a tree walks depth-first with its nesting"):
+        with self.subTest("Example / a tree walks depth-first with its nesting"):
             self.assertEqual([(depth, text) for depth, text, _ in rows], [(0, "North"), (1, "N1"), (1, "N2"), (0, "South"), (1, "S1")])
 
         # last, because it leaves an editor open - nothing after it would see a settled view
-        with self.check("Example / double-clicking an editable cell opens its delegate's editor"):
+        with self.subTest("Example / double-clicking an editable cell opens its delegate's editor"):
             # what edit_index is built on: a single click only selects, so there would be nothing to type into
             double_click_index(view, 1, 2)
             editor = view.focusWidget()
@@ -541,19 +548,19 @@ class ExampleUITest(AutomatedUITestBase):
 
     def test_waiting_for_work_that_finishes_on_the_event_loop(self):
         click(self.widget.button_start_task)
-        with self.check("Example / the task has not finished by the time the click returns"):
+        with self.subTest("Example / the task has not finished by the time the click returns"):
             self.assertEqual(self.widget.label_task.text(), "running")
 
         wait_until(lambda: self.widget.label_task.text() == "done", timeout=30.0, msg="the example task")
-        with self.check("Example / waiting pumps the event loop until the task completes"):
+        with self.subTest("Example / waiting pumps the event loop until the task completes"):
             self.assertEqual(self.widget.label_task.text(), "done")
 
     def test_a_failed_check_does_not_hide_the_ones_after_it(self):
         """The property the whole suite relies on, asserted rather than assumed.
 
-        ``check`` has to keep going after a failure, otherwise a run reports one regression at a
-        time. Verified against a throwaway ``TestCase`` so this test can pass while containing a
-        deliberate failure.
+        A scenario has to keep going after a failed observation, otherwise a run reports one
+        regression at a time. Verified against a throwaway ``TestCase`` so this test can pass while
+        containing a deliberate failure.
         """
         observed = []
 
@@ -571,10 +578,10 @@ class ExampleUITest(AutomatedUITestBase):
                 pass
 
             def test_inner(inner_self):
-                with inner_self.check("first"):
+                with inner_self.subTest("first"):
                     observed.append("first")
                     inner_self.fail("deliberate")
-                with inner_self.check("second"):
+                with inner_self.subTest("second"):
                     observed.append("second")
                     raise RuntimeError("deliberate")
                 observed.append("after")
@@ -582,11 +589,11 @@ class ExampleUITest(AutomatedUITestBase):
         result = unittest.TestResult()
         _Inner("test_inner").run(result)
 
-        with self.check("Example / every check runs even after one fails"):
+        with self.subTest("Example / every check runs even after one fails"):
             self.assertEqual(observed, ["first", "second", "after"])
-        with self.check("Example / each failed check is reported separately"):
+        with self.subTest("Example / each failed check is reported separately"):
             self.assertEqual(len(result.failures) + len(result.errors), 2)
-        with self.check("Example / a failed check names the step it belongs to"):
+        with self.subTest("Example / a failed check names the step it belongs to"):
             self.assertIn("[first]", str(result.failures[0][0]))
 
 

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -553,6 +553,18 @@ class ExampleUITest(AutomatedUITestBase):
         observed = []
 
         class _Inner(AutomatedUITestBase):
+            # The base lifecycle is deliberately replaced rather than run. This throwaway case
+            # executes inside a live test, and the base setUp/tearDown act on process-global state:
+            # they repoint the QSettings ini path and, on the way out, clear the ADS and close every
+            # figure - pulling the enclosing test's own state out from under it. Nothing checked
+            # here needs either. A test case copied from this module as a template should not
+            # inherit that pattern.
+            def setUp(inner_self):
+                pass
+
+            def tearDown(inner_self):
+                pass
+
             def test_inner(inner_self):
                 with inner_self.check("first"):
                     observed.append("first")

--- a/Testing/AutomatedUITests/Example/ExampleUITest.py
+++ b/Testing/AutomatedUITests/Example/ExampleUITest.py
@@ -20,14 +20,33 @@ import unittest
 from automated_ui_test_base import AutomatedUITestBase
 from qt_interaction_helpers import (
     cell_button,
+    cell_combo,
     click,
     click_checkbox,
+    click_index,
+    click_row_header,
     combo_items,
+    edit_index,
+    index_check_state,
+    item_check_state,
+    list_items,
+    model_cell,
+    model_column,
+    model_row_count,
     process_events,
     select_combo,
+    select_list_item,
+    select_radio,
+    select_tab,
     set_checkbox,
+    set_group_box,
+    set_item_checked,
+    set_line_edit,
+    set_spin_box,
+    tab_titles,
     table_checkbox,
     table_column,
+    tree_rows,
     wait_until,
 )
 
@@ -37,6 +56,88 @@ _TASK_DURATION_MS = 250
 
 _GREETINGS = ("Hello", "Goodbye", "Good morning")
 
+# tab titles, deliberately not in alphabetical or any other order that could be guessed from an
+# index - selecting a tab by title has to actually look the title up
+_TAB_TITLES = ("Results", "Setup", "Diagnostics")
+
+# pages of the list-driven navigation, the shape some interfaces use instead of a tab bar
+_PAGE_NAMES = ("Runs", "Masking", "Output")
+
+# rows of the model behind the QTableView. (name, ticked, note) - note is the editable column
+_MODEL_ROWS = (("alpha", True, "first"), ("beta", False, "second"), ("gamma", False, "third"))
+
+# the tree, as (parent, [children]) - two levels is enough to exercise a recursive walk
+_TREE = (("North", ("N1", "N2")), ("South", ("S1",)))
+
+
+def _build_table_model():
+    """A small editable, checkable table model.
+
+    Defined here rather than reusing ``QStandardItemModel`` because the helpers have to work against
+    a hand-written ``QAbstractTableModel`` - which is what every model-backed Mantid interface has -
+    and those implement ``data``/``setData``/``flags`` themselves.
+    """
+    from qtpy.QtCore import QAbstractTableModel, QModelIndex, Qt
+
+    class _ExampleTableModel(QAbstractTableModel):
+        HEADERS = ("Name", "Use", "Note")
+
+        def __init__(self):
+            super(_ExampleTableModel, self).__init__()
+            self.rows = [list(row) for row in _MODEL_ROWS]
+
+        def rowCount(self, parent=QModelIndex()):
+            return 0 if parent.isValid() else len(self.rows)
+
+        def columnCount(self, parent=QModelIndex()):
+            return 0 if parent.isValid() else len(self.HEADERS)
+
+        def headerData(self, section, orientation, role=Qt.DisplayRole):
+            if role == Qt.DisplayRole and orientation == Qt.Horizontal:
+                return self.HEADERS[section]
+            return None
+
+        def data(self, index, role=Qt.DisplayRole):
+            name, ticked, note = self.rows[index.row()]
+            if role in (Qt.DisplayRole, Qt.EditRole):
+                return {0: name, 1: "", 2: note}[index.column()]
+            if role == Qt.CheckStateRole and index.column() == 1:
+                return Qt.Checked if ticked else Qt.Unchecked
+            return None
+
+        def setData(self, index, value, role=Qt.EditRole):
+            if role == Qt.CheckStateRole and index.column() == 1:
+                self.rows[index.row()][1] = Qt.CheckState(value) == Qt.Checked
+            elif role == Qt.EditRole and index.column() == 2:
+                self.rows[index.row()][2] = str(value)
+            else:
+                return False
+            self.dataChanged.emit(index, index)
+            return True
+
+        def flags(self, index):
+            flags = Qt.ItemIsEnabled | Qt.ItemIsSelectable
+            if index.column() == 1:
+                flags |= Qt.ItemIsUserCheckable
+            if index.column() == 2:
+                flags |= Qt.ItemIsEditable
+            return flags
+
+    return _ExampleTableModel()
+
+
+def _build_tree_model():
+    from qtpy.QtGui import QStandardItem, QStandardItemModel
+
+    model = QStandardItemModel()
+    model.setHorizontalHeaderLabels(["Bank"])
+    for parent_name, child_names in _TREE:
+        parent = QStandardItem(parent_name)
+        for child_name in child_names:
+            parent.appendRow(QStandardItem(child_name))
+        model.appendRow(parent)
+    return model
+
 
 def _build_widget():
     """The interface under test: one of every widget kind the helpers know how to drive.
@@ -44,14 +145,46 @@ def _build_widget():
     Built inside a function rather than at module scope because a ``QWidget`` cannot be constructed
     before the ``QApplication`` exists, and the harness creates that lazily in ``setUp``.
     """
-    from qtpy.QtCore import QTimer
-    from qtpy.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QPushButton, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
+    from qtpy.QtCore import QTimer, Qt
+    from qtpy.QtGui import QDoubleValidator
+    from qtpy.QtWidgets import (
+        QButtonGroup,
+        QCheckBox,
+        QComboBox,
+        QGroupBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QListWidget,
+        QPushButton,
+        QRadioButton,
+        QSpinBox,
+        QStackedWidget,
+        QTableWidget,
+        QTableWidgetItem,
+        QTableView,
+        QTabWidget,
+        QTreeView,
+        QVBoxLayout,
+        QWidget,
+    )
 
     class _ExampleWidget(QWidget):
         def __init__(self):
             super(_ExampleWidget, self).__init__()
             self.setObjectName("ExampleWidget")
 
+            layout = QVBoxLayout(self)
+            layout.addWidget(self._build_greeting_section())
+            layout.addWidget(self._build_entry_section())
+            layout.addWidget(self._build_choice_section())
+            layout.addWidget(self._build_navigation_section())
+            layout.addWidget(self._build_table())
+            layout.addWidget(self._build_item_views())
+
+        # -------------------------------------------------------------- sections
+
+        def _build_greeting_section(self):
             self.combo_greeting = QComboBox()
             self.combo_greeting.addItems(_GREETINGS)
             self.check_shout = QCheckBox("Shout")
@@ -60,35 +193,113 @@ def _build_widget():
             self.button_start_task = QPushButton("Start task")
             self.label_task = QLabel("idle")
 
-            # one row per greeting, each with a select box in a centred cell widget and a per-row
-            # button - the awkward table layout the helpers exist to reach into
-            self.table = QTableWidget(len(_GREETINGS), 3)
-            self.table.setHorizontalHeaderLabels(["Select", "Greeting", "Action"])
-            for row, greeting in enumerate(_GREETINGS):
-                cell = QWidget()
-                layout = QHBoxLayout(cell)
-                layout.setContentsMargins(0, 0, 0, 0)
-                layout.addWidget(QCheckBox())
-                self.table.setCellWidget(row, 0, cell)
-                self.table.setItem(row, 1, QTableWidgetItem(greeting))
-                button = QPushButton("Use")
-                button.clicked.connect(lambda _checked=False, text=greeting: self._set_greeting(text))
-                self.table.setCellWidget(row, 2, button)
+            self.button_greet.clicked.connect(self._greet)
+            self.button_start_task.clicked.connect(self._start_task)
 
-            layout = QVBoxLayout(self)
-            for widget in (
+            return _stack(
                 self.combo_greeting,
                 self.check_shout,
                 self.button_greet,
                 self.label_greeting,
                 self.button_start_task,
                 self.label_task,
-                self.table,
-            ):
-                layout.addWidget(widget)
+            )
 
-            self.button_greet.clicked.connect(self._greet)
-            self.button_start_task.clicked.connect(self._start_task)
+        def _build_entry_section(self):
+            # a validator, so a test can prove set_line_edit checks against one
+            self.edit_threshold = QLineEdit()
+            self.edit_threshold.setValidator(QDoubleValidator(0.0, 100.0, 2))
+            # only editingFinished, never textChanged: the point is that typing fires it and
+            # assigning with setText does not
+            self.label_threshold = QLabel("unset")
+            self.edit_threshold.editingFinished.connect(lambda: self.label_threshold.setText(self.edit_threshold.text()))
+
+            # a deliberately narrow range, so a test can prove set_spin_box notices the clamp
+            self.spin_count = QSpinBox()
+            self.spin_count.setRange(1, 10)
+
+            return _stack(self.edit_threshold, self.label_threshold, self.spin_count)
+
+        def _build_choice_section(self):
+            self.radio_north = QRadioButton("North")
+            self.radio_south = QRadioButton("South")
+            self.radio_north.setChecked(True)
+            self.group_bank = QButtonGroup(self)
+            self.group_bank.addButton(self.radio_north)
+            self.group_bank.addButton(self.radio_south)
+
+            self.box_advanced = QGroupBox("Advanced")
+            self.box_advanced.setCheckable(True)
+            self.box_advanced.setChecked(False)
+            self.check_nested = QCheckBox("Nested option")
+            QVBoxLayout(self.box_advanced).addWidget(self.check_nested)
+            self.label_advanced = QLabel("off")
+            self.box_advanced.toggled.connect(lambda on: self.label_advanced.setText("on" if on else "off"))
+
+            return _stack(self.radio_north, self.radio_south, self.box_advanced, self.label_advanced)
+
+        def _build_navigation_section(self):
+            self.tabs = QTabWidget()
+            for title in _TAB_TITLES:
+                page = QLabel(f"page for {title}")
+                page.setObjectName(f"page_{title}")
+                self.tabs.addTab(page, title)
+
+            # the other way interfaces navigate: a list beside a stack, rather than a tab bar
+            self.list_pages = QListWidget()
+            self.list_pages.addItems(_PAGE_NAMES)
+            self.stack_pages = QStackedWidget()
+            for name in _PAGE_NAMES:
+                self.stack_pages.addWidget(QLabel(f"contents of {name}"))
+            self.list_pages.currentRowChanged.connect(self.stack_pages.setCurrentIndex)
+
+            return _stack(self.tabs, self.list_pages, self.stack_pages)
+
+        def _build_table(self):
+            """A QTableWidget offering a tick box both ways round, plus a button and a combo."""
+            self.table = QTableWidget(len(_GREETINGS), 5)
+            self.table.setHorizontalHeaderLabels(["Select", "Greeting", "Action", "Enabled", "Style"])
+            for row, greeting in enumerate(_GREETINGS):
+                # an embedded check box, centred inside a container widget - the awkward layout
+                cell = QWidget()
+                cell_layout = QHBoxLayout(cell)
+                cell_layout.setContentsMargins(0, 0, 0, 0)
+                cell_layout.addWidget(QCheckBox())
+                self.table.setCellWidget(row, 0, cell)
+
+                self.table.setItem(row, 1, QTableWidgetItem(greeting))
+
+                button = QPushButton("Use")
+                button.clicked.connect(lambda _checked=False, text=greeting: self._set_greeting(text))
+                self.table.setCellWidget(row, 2, button)
+
+                # the same idea as column 0, expressed as a checkable *item* instead - no cell widget
+                item = QTableWidgetItem()
+                item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+                item.setCheckState(Qt.Unchecked)
+                self.table.setItem(row, 3, item)
+
+                combo = QComboBox()
+                combo.addItems(["plain", "bold"])
+                self.table.setCellWidget(row, 4, combo)
+            return self.table
+
+        def _build_item_views(self):
+            self.table_model = _build_table_model()
+            self.table_view = QTableView()
+            self.table_view.setModel(self.table_model)
+
+            self.tree_view = QTreeView()
+            self.tree_view.setModel(_build_tree_model())
+            self.tree_view.expandAll()
+
+            # give them room: visualRect is empty for a row with nowhere to be drawn, and a click
+            # aimed at an empty rectangle silently lands in the corner
+            for view in (self.table_view, self.tree_view):
+                view.setMinimumSize(320, 160)
+            return _stack(self.table_view, self.tree_view)
+
+        # -------------------------------------------------------------- behaviour
 
         def _greet(self):
             text = f"{self.combo_greeting.currentText()}, world"
@@ -102,6 +313,14 @@ def _build_widget():
             next line, so a test has to wait for it with ``wait_until``."""
             self.label_task.setText("running")
             QTimer.singleShot(_TASK_DURATION_MS, lambda: self.label_task.setText("done"))
+
+    def _stack(*widgets):
+        holder = QWidget()
+        holder_layout = QVBoxLayout(holder)
+        holder_layout.setContentsMargins(0, 0, 0, 0)
+        for widget in widgets:
+            holder_layout.addWidget(widget)
+        return holder
 
     return _ExampleWidget()
 
@@ -168,6 +387,133 @@ class ExampleUITest(AutomatedUITestBase):
         click(cell_button(table, 2, 2))
         with self.check("Example / a per-row button acts on its own row"):
             self.assertEqual(self.widget.label_greeting.text(), _GREETINGS[2])
+
+    def test_line_edits_and_spin_boxes(self):
+        set_line_edit(self.widget.edit_threshold, "12.5")
+        with self.check("Example / typing puts the text in the line edit"):
+            self.assertEqual(self.widget.edit_threshold.text(), "12.5")
+        with self.check("Example / and fires editingFinished, which setText would not"):
+            # the whole reason set_line_edit replays keystrokes instead of assigning
+            self.assertEqual(self.widget.label_threshold.text(), "12.5")
+
+        with self.check("Example / a second entry replaces the first rather than appending"):
+            set_line_edit(self.widget.edit_threshold, "7")
+            self.assertEqual(self.widget.edit_threshold.text(), "7")
+
+        with self.check("Example / a value the validator refuses is reported"):
+            # the validator caps at 100, so the widget would hold something unexpected and the
+            # interface would quietly do nothing - that has to surface here instead
+            self.assertRaises(AssertionError, set_line_edit, self.widget.edit_threshold, "999")
+
+        with self.check("Example / a spin box takes a value inside its range"):
+            self.assertEqual(set_spin_box(self.widget.spin_count, 4), 4)
+
+        with self.check("Example / a value outside the range is reported, not silently clamped"):
+            self.assertRaises(AssertionError, set_spin_box, self.widget.spin_count, 99)
+
+    def test_radio_buttons_and_group_boxes(self):
+        with self.check("Example / a radio button can be selected by its label"):
+            select_radio(self.widget.group_bank, "South")
+            self.assertTrue(self.widget.radio_south.isChecked())
+        with self.check("Example / and selecting one deselects the other"):
+            self.assertFalse(self.widget.radio_north.isChecked())
+
+        with self.check("Example / radio buttons can also be found through their parent widget"):
+            select_radio(self.widget, "North")
+            self.assertTrue(self.widget.radio_north.isChecked())
+
+        with self.check("Example / an absent radio button is reported rather than ignored"):
+            self.assertRaises(AssertionError, select_radio, self.widget.group_bank, "East")
+
+        with self.check("Example / a checkable group box can be switched on"):
+            self.assertTrue(set_group_box(self.widget.box_advanced, True))
+        with self.check("Example / and its toggled handler runs"):
+            self.assertEqual(self.widget.label_advanced.text(), "on")
+
+        set_group_box(self.widget.box_advanced, False)
+        with self.check("Example / switching a group box off disables what it contains"):
+            self.assertFalse(self.widget.check_nested.isEnabled())
+
+    def test_tabs_and_lists(self):
+        with self.check("Example / every tab is listed by title"):
+            self.assertEqual(tab_titles(self.widget.tabs), list(_TAB_TITLES))
+
+        page = select_tab(self.widget.tabs, "Diagnostics")
+        with self.check("Example / a tab is selected by title, not by index"):
+            self.assertEqual(self.widget.tabs.tabText(self.widget.tabs.currentIndex()), "Diagnostics")
+        with self.check("Example / and the page it returns is the current one"):
+            self.assertIs(page, self.widget.tabs.currentWidget())
+
+        with self.check("Example / an absent tab title is reported"):
+            self.assertRaises(AssertionError, select_tab, self.widget.tabs, "Nonexistent")
+
+        with self.check("Example / every list entry is listed"):
+            self.assertEqual(list_items(self.widget.list_pages), list(_PAGE_NAMES))
+
+        select_list_item(self.widget.list_pages, "Masking")
+        with self.check("Example / selecting a list entry drives the stack beside it"):
+            self.assertEqual(self.widget.stack_pages.currentIndex(), 1)
+
+        with self.check("Example / an absent list entry is reported"):
+            self.assertRaises(AssertionError, select_list_item, self.widget.list_pages, "Nonexistent")
+
+    def test_table_items_and_cell_widgets(self):
+        table = self.widget.table
+
+        with self.check("Example / a checkable item is not an embedded check box"):
+            # column 3 holds a checkable QTableWidgetItem, so there is no cell widget to find
+            self.assertRaises(AssertionError, table_checkbox, table, 0, 3)
+
+        with self.check("Example / checkable items start unticked"):
+            self.assertEqual([item_check_state(table, row, 3) for row in range(table.rowCount())], [False] * 3)
+
+        set_item_checked(table, 2, 3, True)
+        with self.check("Example / a checkable item can be ticked on its own"):
+            self.assertEqual([item_check_state(table, row, 3) for row in range(table.rowCount())], [False, False, True])
+
+        with self.check("Example / a combo box embedded in a cell is reachable"):
+            combo = cell_combo(table, 1, 4)
+            self.assertEqual(combo_items(combo), ["plain", "bold"])
+            select_combo(combo, "bold")
+            self.assertEqual(combo.currentText(), "bold")
+
+        with self.check("Example / a cell holding no widget of that kind gives None"):
+            self.assertIsNone(cell_combo(table, 1, 1))
+
+    def test_item_views(self):
+        view = self.widget.table_view
+
+        with self.check("Example / a model-backed column reads like a table column"):
+            self.assertEqual(model_column(view, 0), [row[0] for row in _MODEL_ROWS])
+        with self.check("Example / the row count comes from the model"):
+            self.assertEqual(model_row_count(view), len(_MODEL_ROWS))
+
+        with self.check("Example / the QTableWidget helpers do not work on a QTableView"):
+            # the distinction the two sections of the helper module exist to keep straight
+            self.assertRaises(AttributeError, table_column, view, 0)
+
+        with self.check("Example / check states come from the model, not from a cell widget"):
+            self.assertEqual([index_check_state(view, row, 1) for row in range(3)], [True, False, False])
+
+        click_index(view, 2, 0)
+        with self.check("Example / clicking an index selects it"):
+            # a click on the view rather than its viewport would leave the selection untouched
+            self.assertEqual(view.currentIndex().row(), 2)
+
+        click_row_header(view, 1)
+        with self.check("Example / clicking a row header selects the whole row"):
+            self.assertEqual(sorted(i.column() for i in view.selectionModel().selectedIndexes()), [0, 1, 2])
+
+        edit_index(view, 0, 2, "edited")
+        with self.check("Example / typing into a cell reaches the model through its delegate"):
+            self.assertEqual(model_cell(view, 0, 2), "edited")
+
+        with self.check("Example / an index outside the model is reported"):
+            self.assertRaises(AssertionError, model_cell, view, 99, 0)
+
+        rows = tree_rows(self.widget.tree_view)
+        with self.check("Example / a tree walks depth-first with its nesting"):
+            self.assertEqual([(depth, text) for depth, text, _ in rows], [(0, "North"), (1, "N1"), (1, "N2"), (0, "South"), (1, "S1")])
 
     def test_waiting_for_work_that_finishes_on_the_event_loop(self):
         click(self.widget.button_start_task)

--- a/Testing/AutomatedUITests/automated_ui_test_base.py
+++ b/Testing/AutomatedUITests/automated_ui_test_base.py
@@ -35,12 +35,12 @@ Four details shape everything here, and each of them contradicts the obvious app
 """
 
 import os
-import shutil
 import sys
 import tempfile
 import time
 import unittest
 from contextlib import contextmanager
+from pathlib import Path
 from unittest import mock
 
 # make the shared helpers importable when this file is run by hand rather than through CMake, which
@@ -134,16 +134,21 @@ class AutomatedUITestBase(unittest.TestCase):
     # ------------------------------------------------------------------ lifecycle
 
     def setUp(self):
+        # recorded text of any message box a patch intercepts; see patch_error_messages
+        self.message_box_messages = []
         if not qt_is_available():
             self.skipTest("this build has no Qt interfaces")
         self._saved_qsettings_state = None
-        self._settings_dir = None
+        self._settings_tmpdir = None
         self._saved_data_dirs = None
         ensure_qapp()
         self._isolate_qsettings()
         self._add_configured_data_search_dirs()
-        self.tmp_root = tempfile.mkdtemp(prefix="automated_ui_test_")
-        self.addCleanup(shutil.rmtree, self.tmp_root, True)
+        # ignore_cleanup_errors because a widget can still hold a file open on Windows when the
+        # test ends, and failing to delete a temporary directory is not a test failure
+        self._tmp_root = tempfile.TemporaryDirectory(prefix="automated_ui_test_", ignore_cleanup_errors=True)
+        self.tmp_root = self._tmp_root.name
+        self.addCleanup(self._tmp_root.cleanup)
 
     def tearDown(self):
         # setUp may have failed part way through, so nothing here may assume it completed
@@ -183,7 +188,7 @@ class AutomatedUITestBase(unittest.TestCase):
         """
         from qtpy.QtCore import QCoreApplication, QSettings
 
-        self._settings_dir = tempfile.mkdtemp(prefix="automated_ui_qsettings_")
+        self._settings_tmpdir = tempfile.TemporaryDirectory(prefix="automated_ui_qsettings_", ignore_cleanup_errors=True)
         self._saved_qsettings_state = (
             QSettings.defaultFormat(),
             QCoreApplication.organizationName(),
@@ -191,7 +196,7 @@ class AutomatedUITestBase(unittest.TestCase):
         )
         # on Windows the default format is the registry, which setPath cannot redirect
         QSettings.setDefaultFormat(QSettings.IniFormat)
-        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, self._settings_dir)
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, self._settings_tmpdir.name)
         QCoreApplication.setOrganizationName(self.SETTINGS_ORG)
         QCoreApplication.setApplicationName(self.SETTINGS_APP)
 
@@ -208,14 +213,14 @@ class AutomatedUITestBase(unittest.TestCase):
         # point the ini path somewhere that still exists before the temporary directory goes, so a
         # later bare QSettings() in this process does not write into a deleted directory
         QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, tempfile.gettempdir())
-        shutil.rmtree(self._settings_dir, ignore_errors=True)
-        self._settings_dir = None
+        self._settings_tmpdir.cleanup()
+        self._settings_tmpdir = None
 
     def settings_file(self):
         """Path of the isolated ini file, for asserting on what an interface stored."""
-        if self._settings_dir is None:
+        if self._settings_tmpdir is None:
             raise RuntimeError("settings are not isolated - settings_file() is only valid between setUp and tearDown")
-        return os.path.join(self._settings_dir, self.SETTINGS_ORG, f"{self.SETTINGS_APP}.ini")
+        return os.path.join(self._settings_tmpdir.name, self.SETTINGS_ORG, f"{self.SETTINGS_APP}.ini")
 
     # ------------------------------------------------------------------ data search directories
 
@@ -258,8 +263,11 @@ class AutomatedUITestBase(unittest.TestCase):
 
     # ------------------------------------------------------------------ waiting
 
-    def wait_for_async_task(self, worker, timeout=1800.0, what="worker"):
+    def wait_for_async_task(self, worker, timeout=10.0, what="worker"):
         """Block until an ``AsyncTask`` finishes, pumping the event loop throughout.
+
+        The default timeout is deliberately short: a test that drives genuinely slow work has to
+        say so, rather than every test inheriting a timeout long enough to hide a hang.
 
         ``AsyncTask.run`` calls its success/error callback on the worker thread. Mantid presenters
         typically notify their observers from that callback, and ``Observable.notify_subscribers``
@@ -275,7 +283,7 @@ class AutomatedUITestBase(unittest.TestCase):
         deadline = time.time() + timeout
         while worker.is_alive():
             process_events()
-            worker.join(0.01)
+            worker.join(0.1)
             if time.time() > deadline:
                 raise RuntimeError(f"{what} did not finish within {timeout}s")
         # drain the callbacks the worker queued on its way out (e.g. re-enabling controls)
@@ -294,7 +302,6 @@ class AutomatedUITestBase(unittest.TestCase):
         ``modules`` are module paths that import the popup helper *by name*, so each one needs its
         own patch - patching the definition would not affect any of them.
         """
-        self.message_box_messages = []
 
         def record(_parent, message):
             self.message_box_messages.append(str(message))
@@ -323,9 +330,6 @@ class AutomatedUITestBase(unittest.TestCase):
         nothing, so an interface that asks for ``QMessageBox.Yes`` would read ``answer=True`` as a
         rejection - so every button name a confirmation prompt might use is assigned here.
         """
-        if not hasattr(self, "message_box_messages"):
-            self.message_box_messages = []
-
         patcher = mock.patch(f"{module}.QMessageBox")
         mocked = patcher.start()
         accepted, declined = object(), object()
@@ -407,14 +411,11 @@ class AutomatedUITestBase(unittest.TestCase):
         Used for the save-layout checks, where the point is both which files appear and which
         directories they appear in.
         """
-        if not os.path.isdir(directory):
+        root = Path(directory)
+        if not root.is_dir():
             return []
-        found = []
-        for root, _dirs, files in os.walk(directory):
-            for name in files:
-                if extension is None or name.endswith(extension):
-                    found.append(os.path.relpath(os.path.join(root, name), directory))
-        return sorted(found)
+        pattern = "*" if extension is None else f"*{extension}"
+        return sorted(str(path.relative_to(root)) for path in root.rglob(pattern) if path.is_file())
 
     @staticmethod
     def basenames_under(directory, extension=None):

--- a/Testing/AutomatedUITests/automated_ui_test_base.py
+++ b/Testing/AutomatedUITests/automated_ui_test_base.py
@@ -26,8 +26,12 @@ Four details shape everything here, and each of them contradicts the obvious app
    ``setUp``/``tearDown``, and module scope must stay cheap and free of side effects - in
    particular there must be no module-level ``QApplication``.
 3. A manual test guide is dozens of small observations, and a suite that stopped at the first
-   failure would need as many runs as there are regressions. ``check`` wraps ``subTest`` so one
-   failed observation does not hide the rest of them.
+   failure would need as many runs as there are regressions. Each observation therefore goes in
+   its own ``unittest`` ``subTest`` block, which records a failure against the block's label and
+   carries on, so one failed observation does not hide the rest of them. Preconditions - "the run
+   number resolved", "the worker finished" - stay outside a block, where a failure ends the test
+   rather than producing a cascade of meaningless ones. See ``dev-docs/source/AutomatedUITests.rst``
+   for where the widget helpers fall either side of that line.
 4. ``unittest``'s loader collects every ``TestCase`` subclass visible in a module, imported ones
    included, and falls back to a ``runTest`` method when a class has no ``test_*`` methods. This
    class therefore defines **neither**, which is what keeps it from being collected as a test in
@@ -88,8 +92,8 @@ class AutomatedUITestBase(unittest.TestCase):
 
     Subclasses write one ``test_*`` method per scenario and, usually, override ``setUp`` to build
     their interface after calling ``super().setUp()``. Building the interface is expensive, so a
-    scenario is normally a whole guide section rather than a single observation - use ``check`` to
-    keep the observations inside it independent.
+    scenario is normally a whole guide section rather than a single observation - use ``subTest``
+    to keep the observations inside it independent.
     """
 
     # organisation/application used for the isolated settings store. Deliberately unlike
@@ -99,29 +103,19 @@ class AutomatedUITestBase(unittest.TestCase):
 
     # ------------------------------------------------------------------ test protocol
 
-    def check(self, label):
-        """Report a failed observation without abandoning the rest of them.
-
-        A manual test guide is a long list of largely independent observations, and a test that
-        stopped at the first one would need as many runs as there are regressions. ``subTest``
-        records both assertion failures and unexpected exceptions and then carries on, reporting
-        each one against ``label`` - which should name the step being checked, e.g.
-        "Test 1 / Calibration step 12 (three prm files)".
-
-        Use plain ``self.assertX`` instead for preconditions - "the run number resolved", "the
-        worker finished" - where continuing would only produce a cascade of meaningless failures.
-        """
-        return self.subTest(msg=label)
-
     def record_failure(self, label, message):
-        """Record a failure directly, for checks that are not expressed as an assertion."""
-        with self.check(label):
+        """Record a failure directly, for checks that are not expressed as an assertion.
+
+        The subTest is what keeps it an observation rather than the end of the test: the rest of
+        the scenario still runs, and the failure is reported against ``label``.
+        """
+        with self.subTest(label):
             self.fail(message)
 
     def require_files(self, *filenames):
         """Skip this test unless every named data file can be found.
 
-        The data lives in the ExternalData store and is downloaded by the ``StandardTestData``
+        The data lives in the ExternalData store and is downloaded by the ``AutomatedUITestData``
         target, so a developer who has not built that target gets a clean skip rather than a
         failure inside the interface.
         """
@@ -129,7 +123,7 @@ class AutomatedUITestBase(unittest.TestCase):
 
         missing = [name for name in filenames if not FileFinder.getFullPath(name)]
         if missing:
-            self.skipTest(f"missing data file(s): {', '.join(missing)}. Build the StandardTestData target.")
+            self.skipTest(f"missing data file(s): {', '.join(missing)}. Build the AutomatedUITestData target.")
 
     # ------------------------------------------------------------------ lifecycle
 

--- a/Testing/AutomatedUITests/automated_ui_test_base.py
+++ b/Testing/AutomatedUITests/automated_ui_test_base.py
@@ -14,7 +14,7 @@ second interface can subclass ``AutomatedUITestBase`` and only supply its own se
 They are ordinary ``unittest`` tests, registered with CTest under the ``AutomatedUITest`` label by
 ``pyunittest_add_test_ui``. They are deliberately not unit tests and not system tests: they are slow and
 GUI-driven, so they run weekly and report-only rather than on every pull request. See
-``dev-docs/source/Testing/AutomatedUITests.rst``.
+``dev-docs/source/AutomatedUITests.rst``.
 
 Four details shape everything here, and each of them contradicts the obvious approach:
 

--- a/Testing/AutomatedUITests/automated_ui_test_base.py
+++ b/Testing/AutomatedUITests/automated_ui_test_base.py
@@ -1,0 +1,403 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Base class for automated UI tests: tests that drive a real Qt interface.
+
+These tests replace manual test guides: they build the genuine view/presenter/model, click real
+widgets with ``QTest`` and run real algorithms, mocking only what would otherwise block on user
+input. This module holds the parts that are not specific to any one interface, so a suite for a
+second interface can subclass ``AutomatedUITestBase`` and only supply its own setup.
+
+They are ordinary ``unittest`` tests, registered with CTest under the ``AutomatedUITest`` label by
+``pyunittest_add_test_ui``. They are deliberately not unit tests and not system tests: they are slow and
+GUI-driven, so they run weekly and report-only rather than on every pull request. See
+``dev-docs/source/Testing/AutomatedUITests.rst``.
+
+Four details shape everything here, and each of them contradicts the obvious approach:
+
+1. ``AsyncTask`` invokes its success/error callbacks *on the worker thread*, and Mantid's
+   ``Observable.notify_subscribers`` marshals back to the GUI thread with a **blocking** queued
+   connection. A plain ``worker.join()`` therefore deadlocks - the worker waits for the GUI thread
+   to pump events while the GUI thread waits in ``join()``. See ``wait_for_async_task``.
+2. Every test in a module runs in the *same* Python process, so isolation has to happen per test in
+   ``setUp``/``tearDown``, and module scope must stay cheap and free of side effects - in
+   particular there must be no module-level ``QApplication``.
+3. A manual test guide is dozens of small observations, and a suite that stopped at the first
+   failure would need as many runs as there are regressions. ``check`` wraps ``subTest`` so one
+   failed observation does not hide the rest of them.
+4. ``unittest``'s loader collects every ``TestCase`` subclass visible in a module, imported ones
+   included, and falls back to a ``runTest`` method when a class has no ``test_*`` methods. This
+   class therefore defines **neither**, which is what keeps it from being collected as a test in
+   its own right.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import contextmanager
+from unittest import mock
+
+# make the shared helpers importable when this file is run by hand rather than through CMake, which
+# puts this directory on PYTHONPATH via PYUNITTEST_PYTHONPATH_EXTRA
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+# offscreen rendering must be requested before the first QApplication is built, and this module is
+# imported before any test constructs one
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+# matplotlib must not try to open a window either; several interfaces plot as a side effect
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def qt_is_available():
+    """Whether this build can construct widgets at all. Used to report a clean skip on a
+    framework-only build instead of an import error during collection."""
+    try:
+        import qtpy.QtWidgets  # noqa: F401
+        import mantidqt  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def ensure_qapp():
+    """Return the process-wide QApplication, creating it on first use.
+
+    Deliberately lazy. Creating it at module scope - as some older Qt system tests do - builds a
+    QApplication inside the collector process too, because the runner imports every test module
+    before running anything.
+
+    Built through ``mantidqt``'s helper rather than ``QApplication(sys.argv)`` because that helper
+    calls ``setup_library_paths()`` first; without it Qt's plugin path is unset and constructing a
+    Mantid C++ widget such as ``FileFinderWidget`` fails with a bare ``RuntimeError``.
+    """
+    from mantidqt.utils.qt.testing import get_application
+
+    return get_application()
+
+
+class AutomatedUITestBase(unittest.TestCase):
+    """Harness for an automated UI test.
+
+    Subclasses write one ``test_*`` method per scenario and, usually, override ``setUp`` to build
+    their interface after calling ``super().setUp()``. Building the interface is expensive, so a
+    scenario is normally a whole guide section rather than a single observation - use ``check`` to
+    keep the observations inside it independent.
+    """
+
+    # organisation/application used for the isolated settings store. Deliberately unlike
+    # workbench's ("mantidproject"/"mantidworkbench") so a test can never reach the real ini file.
+    SETTINGS_ORG = "mantidproject-automated-ui-tests"
+    SETTINGS_APP = "AutomatedUITest"
+
+    # ------------------------------------------------------------------ test protocol
+
+    def check(self, label):
+        """Report a failed observation without abandoning the rest of them.
+
+        A manual test guide is a long list of largely independent observations, and a test that
+        stopped at the first one would need as many runs as there are regressions. ``subTest``
+        records both assertion failures and unexpected exceptions and then carries on, reporting
+        each one against ``label`` - which should name the step being checked, e.g.
+        "Test 1 / Calibration step 12 (three prm files)".
+
+        Use plain ``self.assertX`` instead for preconditions - "the run number resolved", "the
+        worker finished" - where continuing would only produce a cascade of meaningless failures.
+        """
+        return self.subTest(msg=label)
+
+    def record_failure(self, label, message):
+        """Record a failure directly, for checks that are not expressed as an assertion."""
+        with self.check(label):
+            self.fail(message)
+
+    def require_files(self, *filenames):
+        """Skip this test unless every named data file can be found.
+
+        The data lives in the ExternalData store and is downloaded by the ``StandardTestData``
+        target, so a developer who has not built that target gets a clean skip rather than a
+        failure inside the interface.
+        """
+        from mantid.api import FileFinder
+
+        missing = [name for name in filenames if not FileFinder.getFullPath(name)]
+        if missing:
+            self.skipTest(f"missing data file(s): {', '.join(missing)}. Build the StandardTestData target.")
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def setUp(self):
+        if not qt_is_available():
+            self.skipTest("this build has no Qt interfaces")
+        self._saved_qsettings_state = None
+        self._settings_dir = None
+        self._saved_data_dirs = None
+        ensure_qapp()
+        self._isolate_qsettings()
+        self._add_configured_data_search_dirs()
+        self.tmp_root = tempfile.mkdtemp(prefix="automated_ui_test_")
+        self.addCleanup(shutil.rmtree, self.tmp_root, True)
+
+    def tearDown(self):
+        # setUp may have failed part way through, so nothing here may assume it completed
+        from qt_interaction_helpers import close_all_figures, process_events
+
+        try:
+            close_all_figures()
+            process_events(2)
+        finally:
+            self._restore_data_search_dirs()
+            self._restore_qsettings()
+            self._clear_ads()
+
+    @staticmethod
+    def _clear_ads():
+        """Clear the ADS between tests.
+
+        Necessary rather than tidy: the interfaces keep hidden ``__``-prefixed workspaces that
+        would otherwise be silently reused by the next test in the same process.
+        """
+        from mantid.api import AnalysisDataService as ADS
+
+        ADS.clear()
+
+    # ------------------------------------------------------------------ settings isolation
+
+    def _isolate_qsettings(self):
+        """Redirect every bare ``QSettings()`` in this process into a temporary ini file.
+
+        Must run before the interface is constructed - interfaces typically read and write their
+        stored settings during ``__init__``.
+
+        Patching the interface's own settings helper is not enough: helpers are normally imported
+        by name into many modules, so one patch intercepts none of them, and it would still miss
+        the settings that Qt widgets (e.g. a file finder's last-used directory) write for
+        themselves. Redirecting at the QSettings level catches all of it.
+        """
+        from qtpy.QtCore import QCoreApplication, QSettings
+
+        self._settings_dir = tempfile.mkdtemp(prefix="automated_ui_qsettings_")
+        self._saved_qsettings_state = (
+            QSettings.defaultFormat(),
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+        # on Windows the default format is the registry, which setPath cannot redirect
+        QSettings.setDefaultFormat(QSettings.IniFormat)
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, self._settings_dir)
+        QCoreApplication.setOrganizationName(self.SETTINGS_ORG)
+        QCoreApplication.setApplicationName(self.SETTINGS_APP)
+
+    def _restore_qsettings(self):
+        if self._saved_qsettings_state is None:
+            return
+        from qtpy.QtCore import QCoreApplication, QSettings
+
+        fmt, org, app = self._saved_qsettings_state
+        QSettings.setDefaultFormat(fmt)
+        QCoreApplication.setOrganizationName(org)
+        QCoreApplication.setApplicationName(app)
+        self._saved_qsettings_state = None
+        # point the ini path somewhere that still exists before the temporary directory goes, so a
+        # later bare QSettings() in this process does not write into a deleted directory
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, tempfile.gettempdir())
+        shutil.rmtree(self._settings_dir, ignore_errors=True)
+        self._settings_dir = None
+
+    def settings_file(self):
+        """Path of the isolated ini file, for asserting on what an interface stored."""
+        if self._settings_dir is None:
+            raise RuntimeError("settings are not isolated - settings_file() is only valid between setUp and tearDown")
+        return os.path.join(self._settings_dir, self.SETTINGS_ORG, f"{self.SETTINGS_APP}.ini")
+
+    # ------------------------------------------------------------------ data search directories
+
+    def _add_configured_data_search_dirs(self):
+        """Add the data directories CMake named in ``MANTID_TEST_DATA_DIRS``.
+
+        The built properties file only puts ``Testing/Data/UnitTest`` and ``Testing/Data/DocTest`` on
+        the search path, but a UI test replaces a manual test guide and so uses whatever data that
+        guide told a tester to load - usually the SystemTest set. Adding them here rather than
+        writing a properties file keeps the change inside the test process, and ``tearDown`` puts the
+        search path back either way.
+
+        Empty when a module is run by hand rather than through CTest, which is why the tests that
+        need the extra directories declare their files and skip if they are missing.
+        """
+        for directory in os.environ.get("MANTID_TEST_DATA_DIRS", "").split(os.pathsep):
+            if directory and os.path.isdir(directory):
+                self.add_data_search_dir(directory)
+
+    def add_data_search_dir(self, directory):
+        """Add a directory to Mantid's data search path for the duration of this test.
+
+        This is how a test gets the interface's own file finder to resolve fabricated run files:
+        the interface then loads them exactly as it would a real run, rather than the test reaching
+        past the view to inject a workspace.
+        """
+        from mantid.kernel import config
+
+        if self._saved_data_dirs is None:
+            self._saved_data_dirs = config["datasearch.directories"]
+        config.appendDataSearchDir(directory)
+
+    def _restore_data_search_dirs(self):
+        if self._saved_data_dirs is None:
+            return
+        from mantid.kernel import config
+
+        config["datasearch.directories"] = self._saved_data_dirs
+        self._saved_data_dirs = None
+
+    # ------------------------------------------------------------------ waiting
+
+    def wait_for_async_task(self, worker, timeout=1800.0, what="worker"):
+        """Block until an ``AsyncTask`` finishes, pumping the event loop throughout.
+
+        ``AsyncTask.run`` calls its success/error callback on the worker thread. Mantid presenters
+        typically notify their observers from that callback, and ``Observable.notify_subscribers``
+        goes through ``QAppThreadCall(..., blocking=True)``, i.e. a ``BlockingQueuedConnection``.
+        The worker is therefore parked until the GUI thread runs its event loop - so a plain
+        ``worker.join()`` here would deadlock both threads. Short joins interleaved with
+        ``processEvents`` are what make it terminate.
+        """
+        from qt_interaction_helpers import process_events
+
+        if worker is None:
+            raise RuntimeError(f"no {what} was started - was the click rejected by validation?")
+        deadline = time.time() + timeout
+        while worker.is_alive():
+            process_events()
+            worker.join(0.01)
+            if time.time() > deadline:
+                raise RuntimeError(f"{what} did not finish within {timeout}s")
+        # drain the callbacks the worker queued on its way out (e.g. re-enabling controls)
+        process_events(3)
+
+    # ------------------------------------------------------------------ modal dialogs
+
+    def patch_error_messages(self, modules, helper_name="create_error_message"):
+        """Stop a module's error popup from blocking, and record what it would have said.
+
+        An unattended test that pops a modal message box hangs until the suite times out, so every
+        module that can raise one must be neutralised before the first click. The recorded text
+        goes to ``self.message_box_messages``, which turns "the interface rejected this input" from
+        a hang into something a check can assert on.
+
+        ``modules`` are module paths that import the popup helper *by name*, so each one needs its
+        own patch - patching the definition would not affect any of them.
+        """
+        self.message_box_messages = []
+
+        def record(_parent, message):
+            self.message_box_messages.append(str(message))
+
+        for module in modules:
+            patcher = mock.patch(f"{module}.{helper_name}", side_effect=record)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def patch_confirmation_box(self, module, answer):
+        """Answer a blocking ``QMessageBox.warning`` confirmation prompt with ``answer``.
+
+        Distinct from ``patch_error_messages`` because the interface *uses* the return value to
+        decide whether to continue, so the test has to choose which button the user pressed.
+        """
+        if not hasattr(self, "message_box_messages"):
+            self.message_box_messages = []
+
+        patcher = mock.patch(f"{module}.QMessageBox")
+        mocked = patcher.start()
+        # Ok and Cancel must be distinct sentinels: callers decide by comparing the returned value
+        # against QMessageBox.Ok, so a shared value would make a rejection read as an acceptance.
+        mocked.Ok = object()
+        mocked.Cancel = object()
+
+        def record(*args, **_kwargs):
+            # QMessageBox.warning(parent, title, text, buttons, default_button)
+            self.message_box_messages.append(str(args[2]) if len(args) > 2 else "")
+            return mocked.Ok if answer else mocked.Cancel
+
+        mocked.warning.side_effect = record
+        self.addCleanup(patcher.stop)
+        return mocked
+
+    @contextmanager
+    def algorithm_dialog_runs(self, presenter_module, run_algorithm):
+        """Emulate a user accepting one of the ``InterfaceManager`` algorithm dialogs.
+
+        Several tabs open a generated algorithm dialog (``SetGoniometer``, ``LoadSampleShape``,
+        ``SetSampleMaterial``, ...) and then react to the algorithm finishing. Showing a real
+        dialog would block, so ``InterfaceManager`` is replaced and its dialog is told that, when
+        shown, it should run ``run_algorithm`` for real and then notify the observer the presenter
+        registered - which is exactly the sequence the real dialog drives on accept. Everything
+        downstream of that (the presenter's ``finishHandle``, the queued redraw) runs unmodified.
+        """
+        from qt_interaction_helpers import process_events
+
+        with mock.patch(f"{presenter_module}.InterfaceManager") as manager:
+            dialog = manager.return_value.createDialogFromName.return_value
+
+            def show_dialog():
+                run_algorithm()
+                dialog.addAlgorithmObserver.call_args.args[0].finishHandle()
+
+            dialog.show.side_effect = show_dialog
+            yield dialog
+        # finishHandle emits a queued signal so the redraw happens on the GUI thread
+        process_events(3)
+
+    # ------------------------------------------------------------------ log capture
+
+    @contextmanager
+    def captured_logs(self, level="notice"):
+        """Capture Mantid log output, for the checks that assert on what was reported.
+
+        Yields a holder whose ``text`` attribute is filled in when the block exits, rather than the
+        underlying buffer: ``mantid.utils.logging.capture_logs`` closes its buffer on the way out,
+        so reading it afterwards - which is the natural way to write the assertion - raises
+        "I/O operation on closed file". Reading ``text`` after the block is the supported use.
+        """
+        from mantid.utils.logging import capture_logs
+
+        class _CapturedLogs:
+            text = ""
+
+            def getvalue(self):
+                return self.text
+
+        holder = _CapturedLogs()
+        with capture_logs(level=level) as logs:
+            try:
+                yield holder
+            finally:
+                holder.text = logs.getvalue()
+
+    # ------------------------------------------------------------------ filesystem assertions
+
+    @staticmethod
+    def files_under(directory, extension=None):
+        """Every file below ``directory``, as paths relative to it, sorted.
+
+        Used for the save-layout checks, where the point is both which files appear and which
+        directories they appear in.
+        """
+        if not os.path.isdir(directory):
+            return []
+        found = []
+        for root, _dirs, files in os.walk(directory):
+            for name in files:
+                if extension is None or name.endswith(extension):
+                    found.append(os.path.relpath(os.path.join(root, name), directory))
+        return sorted(found)
+
+    @staticmethod
+    def basenames_under(directory, extension=None):
+        return sorted(os.path.basename(p) for p in AutomatedUITestBase.files_under(directory, extension))

--- a/Testing/AutomatedUITests/automated_ui_test_base.py
+++ b/Testing/AutomatedUITests/automated_ui_test_base.py
@@ -304,28 +304,46 @@ class AutomatedUITestBase(unittest.TestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
 
+    # button names that mean "the user agreed" and "the user declined". Every accepting name shares
+    # one sentinel and every declining name shares the other, so the answer holds whichever
+    # constant the interface happens to compare its result against.
+    _ACCEPTING_BUTTONS = ("Ok", "Yes", "YesToAll", "Apply", "Save", "SaveAll", "Open", "Retry")
+    _DECLINING_BUTTONS = ("Cancel", "No", "NoToAll", "Close", "Abort", "Discard", "Ignore")
+
     def patch_confirmation_box(self, module, answer):
-        """Answer a blocking ``QMessageBox.warning`` confirmation prompt with ``answer``.
+        """Answer a blocking ``QMessageBox`` confirmation prompt with ``answer``.
 
         Distinct from ``patch_error_messages`` because the interface *uses* the return value to
         decide whether to continue, so the test has to choose which button the user pressed.
+
+        The accepting and declining button constants must be distinct sentinels: an interface
+        decides by comparing the returned value against one of them, so a shared value would make
+        a rejection read as an acceptance. Leaving any of them as the auto-created attribute of the
+        ``QMessageBox`` mock is just as bad in the other direction - a fresh ``Mock`` equals
+        nothing, so an interface that asks for ``QMessageBox.Yes`` would read ``answer=True`` as a
+        rejection - so every button name a confirmation prompt might use is assigned here.
         """
         if not hasattr(self, "message_box_messages"):
             self.message_box_messages = []
 
         patcher = mock.patch(f"{module}.QMessageBox")
         mocked = patcher.start()
-        # Ok and Cancel must be distinct sentinels: callers decide by comparing the returned value
-        # against QMessageBox.Ok, so a shared value would make a rejection read as an acceptance.
-        mocked.Ok = object()
-        mocked.Cancel = object()
+        accepted, declined = object(), object()
+        for name in self._ACCEPTING_BUTTONS:
+            setattr(mocked, name, accepted)
+        for name in self._DECLINING_BUTTONS:
+            setattr(mocked, name, declined)
 
-        def record(*args, **_kwargs):
+        def record(*args, **kwargs):
             # QMessageBox.warning(parent, title, text, buttons, default_button)
-            self.message_box_messages.append(str(args[2]) if len(args) > 2 else "")
-            return mocked.Ok if answer else mocked.Cancel
+            text = args[2] if len(args) > 2 else kwargs.get("text", "")
+            self.message_box_messages.append(str(text))
+            return accepted if answer else declined
 
+        # question as well as warning: both are used for confirmation prompts, and an unpatched one
+        # would return a Mock that matches no button at all
         mocked.warning.side_effect = record
+        mocked.question.side_effect = record
         self.addCleanup(patcher.stop)
         return mocked
 

--- a/Testing/AutomatedUITests/qt_interaction_helpers.py
+++ b/Testing/AutomatedUITests/qt_interaction_helpers.py
@@ -1,0 +1,179 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Widget-level helpers for driving a Qt interface from a test.
+
+These are free functions with no dependency on the system test framework, so they can be used from
+an ordinary unit test as readily as from an ``AutomatedUITestBase`` subclass. Most of them exist
+because the naive Qt call does not do what you want in a headless test:
+
+* a ``QCheckBox`` only toggles when the click lands on its *indicator*, not its label,
+* ``FileFinderWidget`` searches on a background thread, so its result is not available on the next
+  line, and
+* anything that waits must keep pumping the Qt event loop (see ``wait_until``).
+"""
+
+import time
+
+# Qt is imported inside the functions that need it, never at module scope: this module is imported
+# by test modules that the system test collector loads on every build, including framework-only
+# builds with no Qt, and an import error there would break collection before ``skipTests`` could
+# report a clean skip.
+
+# a click that has to travel through the event loop is delivered by processEvents; 20 ms is long
+# enough to drain a burst of queued signals without making the polling loops feel sluggish
+_EVENT_SLICE_MS = 20
+
+
+def process_events(rounds=1):
+    """Drain the Qt event queue. Several rounds are sometimes needed because handlers post further
+    events (a queued signal whose slot emits another queued signal)."""
+    from qtpy.QtCore import QEventLoop
+    from qtpy.QtWidgets import QApplication
+
+    for _ in range(rounds):
+        QApplication.processEvents(QEventLoop.AllEvents, _EVENT_SLICE_MS)
+
+
+def click(widget):
+    """Left-click the centre of a widget."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
+    QTest.mouseClick(widget, Qt.LeftButton)
+    process_events()
+
+
+def click_checkbox(checkbox):
+    """Toggle a checkbox by clicking its indicator.
+
+    A click on the centre of a wide checkbox lands on the label, which does toggle it in most
+    styles but not reliably in the offscreen platform plugin. The indicator at the left edge is the
+    dependable hot-spot, and it is also where the checkboxes embedded in table cells live.
+    """
+    from qtpy.QtCore import QPoint, Qt
+    from qtpy.QtTest import QTest
+    from qtpy.QtWidgets import QStyle
+
+    indicator_w = checkbox.style().pixelMetric(QStyle.PM_IndicatorWidth)
+    QTest.mouseClick(checkbox, Qt.LeftButton, pos=QPoint(max(indicator_w // 2, 4), checkbox.height() // 2))
+    process_events()
+
+
+def set_checkbox(checkbox, checked):
+    """Click a checkbox only if it is not already in the wanted state, so the caller does not have
+    to know the current state to end up in a known one."""
+    if checkbox.isChecked() != checked:
+        click_checkbox(checkbox)
+    if checkbox.isChecked() != checked:
+        raise AssertionError(f"checkbox '{checkbox.text()}' is {checkbox.isChecked()} after asking for {checked}")
+    return checkbox.isChecked()
+
+
+def combo_items(combo):
+    return [combo.itemText(i) for i in range(combo.count())]
+
+
+def select_combo(combo, text):
+    """Select a combo entry by its visible text, failing loudly rather than silently leaving the
+    selection unchanged (which is what ``setCurrentText`` does for a non-editable combo)."""
+    index = combo.findText(text)
+    if index < 0:
+        raise AssertionError(f"'{text}' is not in the combo box; available: {combo_items(combo)}")
+    combo.setCurrentIndex(index)
+    process_events()
+
+
+def table_column(table, col):
+    """Text of every cell in a column, top to bottom."""
+    return [table.item(row, col).text() if table.item(row, col) else None for row in range(table.rowCount())]
+
+
+def table_checkbox(table, row, col):
+    """The QCheckBox inside a table cell.
+
+    Both the correction and texture tables put their select box inside a QWidget/QHBoxLayout so it
+    can be centred, so the checkbox is a grandchild of the cell rather than the cell widget itself.
+    """
+    from qtpy.QtWidgets import QCheckBox
+
+    cell_widget = table.cellWidget(row, col)
+    if cell_widget is None:
+        raise AssertionError(f"no cell widget at row {row}, column {col}")
+    checkbox = cell_widget.findChild(QCheckBox)
+    if checkbox is None:
+        raise AssertionError(f"no checkbox inside the cell widget at row {row}, column {col}")
+    return checkbox
+
+
+def cell_button(table, row, col):
+    """The QPushButton inside a table cell, e.g. the '[View Shape]' buttons."""
+    from qtpy.QtWidgets import QPushButton
+
+    cell_widget = table.cellWidget(row, col)
+    if cell_widget is None:
+        return None
+    return cell_widget if isinstance(cell_widget, QPushButton) else cell_widget.findChild(QPushButton)
+
+
+def wait_until(predicate, timeout=120.0, msg=""):
+    """Block until ``predicate()`` is true, pumping the event loop while waiting.
+
+    Never use a bare ``sleep`` or ``thread.join()`` in a GUI test: work that finishes on a
+    background thread usually reports back through a queued - sometimes *blocking* queued - Qt
+    connection, which cannot be delivered unless this thread is running its event loop.
+    """
+    deadline = time.time() + timeout
+    while not predicate():
+        process_events()
+        if time.time() > deadline:
+            raise RuntimeError(f"timed out after {timeout}s waiting for {msg or 'condition'}")
+        time.sleep(0.005)
+    process_events()
+
+
+def wait_for_file_finder(finder, msg=""):
+    """Wait for a FileFinderWidget to finish its background search."""
+    wait_until(lambda: not finder.isSearching(), msg=msg or "file finder search")
+
+
+def set_finder_text(finder, text, expect_valid=True):
+    """Type a run number or path into a FileFinderWidget and wait for the search to resolve.
+
+    The Engineering presenters refuse to act (and pop a modal warning) while a finder is still
+    searching or is invalid, so a test that does not wait here fails in a way that looks like a
+    logic bug rather than a race.
+    """
+    finder.setFileTextWithSearch(text)
+    # the search is started from a queued signal, so isSearching() can still be false for the
+    # *previous* text on the next line; wait for the widget to take the new text first
+    wait_until(lambda: finder.getText() == text, msg=f"file finder accepting '{text}'")
+    wait_for_file_finder(finder, msg=f"file finder resolving '{text}'")
+    if expect_valid and not finder.isValid():
+        raise AssertionError(f"file finder could not resolve '{text}'")
+    return finder
+
+
+def figure_numbers():
+    """Open matplotlib figure numbers. Used to assert that a 'plot output' checkbox really did (or
+    really did not) create a plot."""
+    import matplotlib.pyplot as plt
+
+    return set(plt.get_fignums())
+
+
+def close_all_figures():
+    import matplotlib.pyplot as plt
+
+    plt.close("all")
+
+
+def top_level_widget_names():
+    """Object names of the currently open top-level widgets, for asserting that a button opened a
+    new window."""
+    from qtpy.QtWidgets import QApplication
+
+    return [w.objectName() for w in QApplication.topLevelWidgets() if w.isVisible()]

--- a/Testing/AutomatedUITests/qt_interaction_helpers.py
+++ b/Testing/AutomatedUITests/qt_interaction_helpers.py
@@ -11,17 +11,23 @@ an ordinary unit test as readily as from an ``AutomatedUITestBase`` subclass. Mo
 because the naive Qt call does not do what you want in a headless test:
 
 * a ``QCheckBox`` only toggles when the click lands on its *indicator*, not its label,
+* ``setText`` on a ``QLineEdit`` emits none of the signals that typing into it does,
+* a click on an item view has to be delivered to its *viewport*, at the index's ``visualRect``,
 * ``FileFinderWidget`` searches on a background thread, so its result is not available on the next
   line, and
 * anything that waits must keep pumping the Qt event loop (see ``wait_until``).
+
+Two families of helper look similar and are not interchangeable. The ``table_*`` ones work on a
+``QTableWidget``, which owns its cells; the ``model_*`` and ``*_index`` ones work on anything backed
+by a ``QAbstractItemModel`` (``QTableView``, ``QTreeView``, ``QListView``), where the cells belong to
+the model and ``item()``/``cellWidget()`` do not exist at all.
 """
 
 import time
 
 # Qt is imported inside the functions that need it, never at module scope: this module is imported
-# by test modules that the system test collector loads on every build, including framework-only
-# builds with no Qt, and an import error there would break collection before ``skipTests`` could
-# report a clean skip.
+# by test modules that the collector loads on every build, including framework-only builds with no
+# Qt, and an import error there would break collection before the test could report a clean skip.
 
 # a click that has to travel through the event loop is delivered by processEvents; 20 ms is long
 # enough to drain a burst of queued signals without making the polling loops feel sluggish
@@ -73,6 +79,143 @@ def set_checkbox(checkbox, checked):
     return checkbox.isChecked()
 
 
+def click_radio(radio):
+    """Select a radio button by clicking its indicator.
+
+    The ``click_checkbox`` problem exactly, with the other style metric: a click on the centre of a
+    wide radio button lands on its label, which is not a dependable hot-spot offscreen.
+    """
+    from qtpy.QtCore import QPoint, Qt
+    from qtpy.QtTest import QTest
+    from qtpy.QtWidgets import QStyle
+
+    indicator_w = radio.style().pixelMetric(QStyle.PM_ExclusiveIndicatorWidth)
+    QTest.mouseClick(radio, Qt.LeftButton, pos=QPoint(max(indicator_w // 2, 4), radio.height() // 2))
+    process_events()
+
+
+def radio_buttons(parent):
+    """Every radio button under ``parent``, which may be a widget or a ``QButtonGroup``."""
+    from qtpy.QtWidgets import QButtonGroup, QRadioButton
+
+    if isinstance(parent, QButtonGroup):
+        return list(parent.buttons())
+    return parent.findChildren(QRadioButton)
+
+
+def select_radio(parent, text):
+    """Choose the radio button labelled ``text`` from those under ``parent``.
+
+    Radio buttons are nearly always one option out of a group, so the useful call selects by the
+    label the user reads rather than by holding a reference to each button. ``parent`` may be a
+    widget or the ``QButtonGroup`` itself.
+    """
+    buttons = radio_buttons(parent)
+    for button in buttons:
+        if button.text() == text:
+            click_radio(button)
+            if not button.isChecked():
+                raise AssertionError(f"radio button '{text}' is still unchecked after being clicked")
+            return button
+    raise AssertionError(f"'{text}' is not among the radio buttons; available: {[b.text() for b in buttons]}")
+
+
+def set_group_box(group_box, checked):
+    """Turn a checkable ``QGroupBox`` on or off.
+
+    The odd one out: this sets rather than clicks. A group box's check indicator is drawn as a
+    sub-control of the frame, so its position is style-dependent and there is no reliable hot-spot to
+    aim at. Setting is faithful enough because handlers connect to ``toggled``, which ``setChecked``
+    emits - a group box is a section switch, not something a presenter watches for ``clicked``.
+    """
+    if not group_box.isCheckable():
+        raise AssertionError(f"group box '{group_box.title()}' is not checkable")
+    group_box.setChecked(checked)
+    process_events()
+    if group_box.isChecked() != checked:
+        raise AssertionError(f"group box '{group_box.title()}' is {group_box.isChecked()} after asking for {checked}")
+    return group_box.isChecked()
+
+
+def set_line_edit(line_edit, text, expect_valid=True):
+    """Type into a line edit, rather than assigning to it.
+
+    ``setText`` emits neither ``textEdited``, ``returnPressed`` nor ``editingFinished``, and
+    interfaces hang their reactions off all three - so assigning leaves the interface unaware that
+    anything was entered. Replaying the keystrokes is what makes it behave as it would for a user.
+    The sequence is the one Mantid's own line edit tests use.
+
+    ``expect_valid`` asserts against any validator on the widget, so a value the widget would refuse
+    fails here rather than several steps later as a puzzling absence of output.
+    """
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
+    line_edit.setFocus()
+    line_edit.selectAll()
+    QTest.keyClick(line_edit, Qt.Key_Backspace)
+    QTest.keyClicks(line_edit, str(text))
+    QTest.keyClick(line_edit, Qt.Key_Enter)
+    process_events()
+    if expect_valid and line_edit.validator() is not None and not line_edit.hasAcceptableInput():
+        raise AssertionError(f"'{text}' was rejected by the validator on '{line_edit.objectName() or line_edit}'")
+    return line_edit.text()
+
+
+def set_spin_box(spin_box, value):
+    """Set a ``QSpinBox`` or ``QDoubleSpinBox``, checking the value survived.
+
+    Spin boxes clamp silently to their range and round to their number of decimals, so a value
+    outside either would otherwise be read back as the interface having ignored the input.
+    """
+    spin_box.setValue(value)
+    process_events()
+    if spin_box.value() != value:
+        raise AssertionError(
+            f"spin box '{spin_box.objectName() or spin_box}' holds {spin_box.value()} after asking for {value}; "
+            f"its range is {spin_box.minimum()} to {spin_box.maximum()}"
+        )
+    return spin_box.value()
+
+
+def tab_titles(tab_widget):
+    return [tab_widget.tabText(i) for i in range(tab_widget.count())]
+
+
+def select_tab(tab_widget, title):
+    """Make a tab current by its title.
+
+    By title rather than index because indices move: interfaces add tabs conditionally and save and
+    restore the current one between sessions. Widgets only report ``isVisible()`` on the current tab,
+    so any visibility check has to select the tab first.
+    """
+    for index in range(tab_widget.count()):
+        if tab_widget.tabText(index) == title:
+            tab_widget.setCurrentIndex(index)
+            process_events()
+            return tab_widget.widget(index)
+    raise AssertionError(f"no tab titled '{title}'; found {tab_titles(tab_widget)}")
+
+
+def list_items(list_widget):
+    return [list_widget.item(row).text() for row in range(list_widget.count())]
+
+
+def select_list_item(list_widget, text):
+    """Select a ``QListWidget`` row by its text.
+
+    Not only for lists of data: some interfaces navigate with a list beside a ``QStackedWidget``
+    instead of a tab bar, so this is how a test reaches their pages.
+    """
+    for row in range(list_widget.count()):
+        item = list_widget.item(row)
+        if item.text() == text:
+            list_widget.setCurrentItem(item)
+            process_events()
+            return item
+    raise AssertionError(f"'{text}' is not in the list; available: {list_items(list_widget)}")
+
+
 def combo_items(combo):
     return [combo.itemText(i) for i in range(combo.count())]
 
@@ -87,36 +230,263 @@ def select_combo(combo, text):
     process_events()
 
 
+# ---------------------------------------------------------------------------------------------
+# QTableWidget. For a QTableView or any other model-backed view see the model/view section below -
+# none of these work there, because item() and cellWidget() belong to QTableWidget alone.
+# ---------------------------------------------------------------------------------------------
+
+
 def table_column(table, col):
     """Text of every cell in a column, top to bottom."""
     return [table.item(row, col).text() if table.item(row, col) else None for row in range(table.rowCount())]
 
 
+def cell_widget(table, row, col, widget_type):
+    """The widget of ``widget_type`` in a table cell, or ``None`` if the cell has no widget.
+
+    Tables usually put an embedded control inside a QWidget/QHBoxLayout so it can be centred, which
+    makes the control a grandchild of the cell rather than the cell widget itself - but not always,
+    so both layouts are accepted. Interfaces embed check boxes, buttons, combo boxes, line edits and
+    spin boxes this way.
+    """
+    container = table.cellWidget(row, col)
+    if container is None:
+        return None
+    if isinstance(container, widget_type):
+        return container
+    return container.findChild(widget_type)
+
+
 def table_checkbox(table, row, col):
     """The QCheckBox inside a table cell.
 
-    Both the correction and texture tables put their select box inside a QWidget/QHBoxLayout so it
-    can be centred, so the checkbox is a grandchild of the cell rather than the cell widget itself.
+    For a cell that is a *checkable item* rather than an embedded check box - no cell widget at all -
+    use ``item_check_state``/``set_item_checked`` instead.
     """
     from qtpy.QtWidgets import QCheckBox
 
-    cell_widget = table.cellWidget(row, col)
-    if cell_widget is None:
+    if table.cellWidget(row, col) is None:
         raise AssertionError(f"no cell widget at row {row}, column {col}")
-    checkbox = cell_widget.findChild(QCheckBox)
+    checkbox = cell_widget(table, row, col, QCheckBox)
     if checkbox is None:
         raise AssertionError(f"no checkbox inside the cell widget at row {row}, column {col}")
     return checkbox
 
 
 def cell_button(table, row, col):
-    """The QPushButton inside a table cell, e.g. the '[View Shape]' buttons."""
+    """The QPushButton inside a table cell, e.g. the '[View Shape]' buttons.
+
+    Returns ``None`` for a cell with no widget, because "this row offers no button" is a state worth
+    asserting on rather than an error.
+    """
     from qtpy.QtWidgets import QPushButton
 
-    cell_widget = table.cellWidget(row, col)
-    if cell_widget is None:
-        return None
-    return cell_widget if isinstance(cell_widget, QPushButton) else cell_widget.findChild(QPushButton)
+    return cell_widget(table, row, col, QPushButton)
+
+
+def cell_combo(table, row, col):
+    from qtpy.QtWidgets import QComboBox
+
+    return cell_widget(table, row, col, QComboBox)
+
+
+def cell_line_edit(table, row, col):
+    from qtpy.QtWidgets import QLineEdit
+
+    return cell_widget(table, row, col, QLineEdit)
+
+
+def cell_spin_box(table, row, col):
+    from qtpy.QtWidgets import QAbstractSpinBox
+
+    return cell_widget(table, row, col, QAbstractSpinBox)
+
+
+def item_check_state(table, row, col):
+    """Whether a checkable *item* in a cell is ticked.
+
+    The other way a table offers a tick box: instead of embedding a QCheckBox, the cell's own
+    QTableWidgetItem is given ``Qt.ItemIsUserCheckable`` and a check state. There is no cell widget
+    at all, so ``table_checkbox`` cannot see it.
+    """
+    from qtpy.QtCore import Qt
+
+    item = table.item(row, col)
+    if item is None:
+        raise AssertionError(f"no item at row {row}, column {col}")
+    return item.checkState() == Qt.Checked
+
+
+def set_item_checked(table, row, col, checked):
+    """Tick or untick a checkable item in a cell. See ``item_check_state``."""
+    from qtpy.QtCore import Qt
+
+    item = table.item(row, col)
+    if item is None:
+        raise AssertionError(f"no item at row {row}, column {col}")
+    item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+    process_events()
+    if item_check_state(table, row, col) != checked:
+        raise AssertionError(f"item at row {row}, column {col} is not {checked} after being set; is it user-checkable?")
+    return checked
+
+
+# ---------------------------------------------------------------------------------------------
+# Model-backed views: QTableView, QTreeView, QListView.
+#
+# The cells belong to the model, not the view, so nothing in the QTableWidget section above applies.
+# The part that cannot be guessed is the clicking: QTest.mouseClick on the view itself does nothing,
+# because the view is only a frame around a viewport that draws the delegates. A click has to be
+# delivered to that viewport, at the rectangle the view says the index occupies.
+# ---------------------------------------------------------------------------------------------
+
+
+def model_row_count(view, parent=None):
+    from qtpy.QtCore import QModelIndex
+
+    return view.model().rowCount(parent if parent is not None else QModelIndex())
+
+
+def model_column_count(view, parent=None):
+    from qtpy.QtCore import QModelIndex
+
+    return view.model().columnCount(parent if parent is not None else QModelIndex())
+
+
+def model_index(view, row, col=0, parent=None):
+    from qtpy.QtCore import QModelIndex
+
+    index = view.model().index(row, col, parent if parent is not None else QModelIndex())
+    if not index.isValid():
+        raise AssertionError(f"row {row}, column {col} is outside the model, which is {model_row_count(view)} rows")
+    return index
+
+
+def model_cell(view, row, col, role=None):
+    """The data at a cell, displayed text by default."""
+    from qtpy.QtCore import Qt
+
+    return model_index(view, row, col).data(Qt.DisplayRole if role is None else role)
+
+
+def model_column(view, col):
+    """Displayed text of every cell in a column, top to bottom. The ``table_column`` counterpart."""
+    return [model_cell(view, row, col) for row in range(model_row_count(view))]
+
+
+def index_check_state(view, row, col=0):
+    """Whether a model index is ticked, for models that expose ``Qt.CheckStateRole``."""
+    from qtpy.QtCore import Qt
+
+    return model_index(view, row, col).data(Qt.CheckStateRole) == Qt.Checked
+
+
+def click_index(view, row, col=0, modifier=None, parent=None):
+    """Click a cell in a model-backed view.
+
+    Goes to the viewport at the index's ``visualRect`` - a click on the view itself lands on its
+    frame and does nothing. ``scrollTo`` first because ``visualRect`` is an empty rectangle for an
+    index that is scrolled out of sight, which would quietly send the click to the top-left corner
+    and select the wrong row.
+    """
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
+    index = model_index(view, row, col, parent)
+    view.scrollTo(index)
+    QTest.mouseClick(view.viewport(), Qt.LeftButton, Qt.NoModifier if modifier is None else modifier, view.visualRect(index).center())
+    process_events()
+    return index
+
+
+def double_click_index(view, row, col=0, parent=None):
+    """Double-click a cell, which is what opens its delegate's editor."""
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
+    index = click_index(view, row, col, parent=parent)
+    QTest.mouseDClick(view.viewport(), Qt.LeftButton, Qt.NoModifier, view.visualRect(index).center())
+    process_events()
+    return index
+
+
+def edit_index(view, row, col, text, parent=None):
+    """Type into a cell of a model-backed view.
+
+    There is no widget to reach until the cell is being edited: the delegate builds its editor on
+    demand. So this double-clicks to open the editor, takes whatever widget then has focus, and
+    types into that.
+
+    Deliberately not written in terms of ``set_line_edit``, even though the editor is usually a
+    ``QLineEdit``. The Enter that commits the edit also *destroys* the editor, so anything that
+    touches it afterwards - as ``set_line_edit`` does, to return the text - raises "wrapped C/C++
+    object has been deleted". Read the value back from the model instead, which is where it now
+    lives.
+    """
+    from qtpy.QtCore import Qt
+    from qtpy.QtTest import QTest
+
+    double_click_index(view, row, col, parent)
+    editor = view.focusWidget()
+    if editor is None or editor is view:
+        raise AssertionError(f"double-clicking row {row}, column {col} opened no editor; is the cell editable?")
+    if hasattr(editor, "selectAll"):
+        editor.selectAll()
+        QTest.keyClick(editor, Qt.Key_Backspace)
+    QTest.keyClicks(editor, str(text))
+    QTest.keyClick(editor, Qt.Key_Enter)
+    process_events(2)
+    return model_cell(view, row, col)
+
+
+def select_index(view, row, col=0, parent=None):
+    """Make a cell current without clicking, for when the selection matters but the click does not."""
+    index = model_index(view, row, col, parent)
+    view.setCurrentIndex(index)
+    process_events()
+    return index
+
+
+def click_row_header(view, row, modifier=None):
+    """Click a row's header, which selects the whole row."""
+    from qtpy.QtCore import QPoint, Qt
+    from qtpy.QtTest import QTest
+
+    header = view.verticalHeader()
+    pos = QPoint(int(header.length() / 2), int(header.sectionPosition(row) + header.sectionSize(row) / 2))
+    QTest.mouseClick(header.viewport(), Qt.LeftButton, Qt.NoModifier if modifier is None else modifier, pos)
+    process_events()
+
+
+def click_column_header(view, col, modifier=None):
+    """Click a column's header, which selects the whole column - or sorts by it, if sorting is on."""
+    from qtpy.QtCore import QPoint, Qt
+    from qtpy.QtTest import QTest
+
+    header = view.horizontalHeader()
+    pos = QPoint(int(header.sectionPosition(col) + header.sectionSize(col) / 2), int(header.length() / 2))
+    QTest.mouseClick(header.viewport(), Qt.LeftButton, Qt.NoModifier if modifier is None else modifier, pos)
+    process_events()
+
+
+def tree_rows(view, parent=None, depth=0, col=0):
+    """Walk a tree's rows depth-first, as ``(depth, text, index)`` triples.
+
+    A flat listing is what an assertion usually wants - "these entries, indented like this" - and it
+    is also the only practical way to reach a child index, since the caller needs the parent index to
+    build one and would otherwise have to recurse themselves.
+    """
+    from qtpy.QtCore import QModelIndex, Qt
+
+    model = view.model()
+    parent = QModelIndex() if parent is None else parent
+    rows = []
+    for row in range(model.rowCount(parent)):
+        index = model.index(row, col, parent)
+        rows.append((depth, index.data(Qt.DisplayRole), index))
+        if model.hasChildren(index):
+            rows.extend(tree_rows(view, index, depth + 1, col))
+    return rows
 
 
 def wait_until(predicate, timeout=120.0, msg=""):

--- a/Testing/AutomatedUITests/qt_interaction_helpers.py
+++ b/Testing/AutomatedUITests/qt_interaction_helpers.py
@@ -33,6 +33,10 @@ import time
 # enough to drain a burst of queued signals without making the polling loops feel sluggish
 _EVENT_SLICE_MS = 20
 
+# how long ``wait_until`` waits between checks of its predicate. Events are still processed
+# throughout (QTest.qWait pumps the loop), so this only sets how often the predicate is re-run
+_POLL_INTERVAL_MS = 100
+
 
 def process_events(rounds=1):
     """Drain the Qt event queue. Several rounds are sometimes needed because handlers post further
@@ -45,10 +49,20 @@ def process_events(rounds=1):
 
 
 def click(widget):
-    """Left-click the centre of a widget."""
+    """Left-click a widget, using the dependable hot-spot for its kind.
+
+    The centre is right for a push button but wrong for a check box or a radio button, whose hot
+    spot is the indicator (see ``click_checkbox``), so those two are dispatched to their own helper
+    rather than left as a trap for a caller who reaches for the obvious ``click``.
+    """
     from qtpy.QtCore import Qt
     from qtpy.QtTest import QTest
+    from qtpy.QtWidgets import QCheckBox, QRadioButton
 
+    if isinstance(widget, QCheckBox):
+        return click_checkbox(widget)
+    if isinstance(widget, QRadioButton):
+        return click_radio(widget)
     QTest.mouseClick(widget, Qt.LeftButton)
     process_events()
 
@@ -178,7 +192,10 @@ def set_spin_box(spin_box, value):
     return spin_box.value()
 
 
-def tab_titles(tab_widget):
+def _tab_titles(tab_widget):
+    """Private: a tab bar is fixed by the .ui file, so a test asserting on the whole list of titles
+    is only restating it. Prove a tab exists by selecting it with ``select_tab`` instead - which is
+    also what reports the available titles when it is not there."""
     return [tab_widget.tabText(i) for i in range(tab_widget.count())]
 
 
@@ -194,7 +211,7 @@ def select_tab(tab_widget, title):
             tab_widget.setCurrentIndex(index)
             process_events()
             return tab_widget.widget(index)
-    raise AssertionError(f"no tab titled '{title}'; found {tab_titles(tab_widget)}")
+    raise AssertionError(f"no tab titled '{title}'; found {_tab_titles(tab_widget)}")
 
 
 def list_items(list_widget):
@@ -501,25 +518,34 @@ def tree_rows(view, parent=None, depth=0, col=0):
     return rows
 
 
-def wait_until(predicate, timeout=120.0, msg=""):
+def wait_until(predicate, timeout=10.0, msg=""):
     """Block until ``predicate()`` is true, pumping the event loop while waiting.
 
     Never use a bare ``sleep`` or ``thread.join()`` in a GUI test: work that finishes on a
     background thread usually reports back through a queued - sometimes *blocking* queued - Qt
-    connection, which cannot be delivered unless this thread is running its event loop.
+    connection, which cannot be delivered unless this thread is running its event loop. ``qWait``
+    is what does both here: it sleeps *and* keeps processing events for the duration.
+
+    The default timeout is short on purpose - waiting on something genuinely slow should be a
+    deliberate choice at the call site rather than the default for everything.
     """
+    from qtpy.QtTest import QTest
+
     deadline = time.time() + timeout
     while not predicate():
-        process_events()
+        QTest.qWait(_POLL_INTERVAL_MS)
         if time.time() > deadline:
             raise RuntimeError(f"timed out after {timeout}s waiting for {msg or 'condition'}")
-        time.sleep(0.005)
     process_events()
 
 
-def wait_for_file_finder(finder, msg=""):
-    """Wait for a FileFinderWidget to finish its background search."""
-    wait_until(lambda: not finder.isSearching(), msg=msg or "file finder search")
+def wait_for_file_finder(finder, timeout=60.0, msg=""):
+    """Wait for a FileFinderWidget to finish its background search.
+
+    Longer than the ``wait_until`` default by deliberate choice: the search walks every data search
+    directory, which on a real instrument mount is a network round trip per candidate name.
+    """
+    wait_until(lambda: not finder.isSearching(), timeout=timeout, msg=msg or "file finder search")
 
 
 def set_finder_text(finder, text, expect_valid=True):

--- a/Testing/AutomatedUITests/qt_interaction_helpers.py
+++ b/Testing/AutomatedUITests/qt_interaction_helpers.py
@@ -453,7 +453,11 @@ def click_row_header(view, row, modifier=None):
     from qtpy.QtTest import QTest
 
     header = view.verticalHeader()
-    pos = QPoint(int(header.length() / 2), int(header.sectionPosition(row) + header.sectionSize(row) / 2))
+    # sectionViewportPosition, not sectionPosition: the click is delivered to the viewport, and the
+    # two differ by the scroll offset as soon as the view has been scrolled. The cross-axis
+    # coordinate is the viewport's width - length() is the sum of every section, which for anything
+    # but a one-row view lands outside the header entirely.
+    pos = QPoint(int(header.viewport().width() / 2), int(header.sectionViewportPosition(row) + header.sectionSize(row) / 2))
     QTest.mouseClick(header.viewport(), Qt.LeftButton, Qt.NoModifier if modifier is None else modifier, pos)
     process_events()
 
@@ -464,7 +468,8 @@ def click_column_header(view, col, modifier=None):
     from qtpy.QtTest import QTest
 
     header = view.horizontalHeader()
-    pos = QPoint(int(header.sectionPosition(col) + header.sectionSize(col) / 2), int(header.length() / 2))
+    # see click_row_header for why this is the viewport position and the viewport's height
+    pos = QPoint(int(header.sectionViewportPosition(col) + header.sectionSize(col) / 2), int(header.viewport().height() / 2))
     QTest.mouseClick(header.viewport(), Qt.LeftButton, Qt.NoModifier if modifier is None else modifier, pos)
     process_events()
 

--- a/Testing/AutomatedUITests/qt_interaction_helpers.py
+++ b/Testing/AutomatedUITests/qt_interaction_helpers.py
@@ -375,10 +375,17 @@ def model_column(view, col):
 
 
 def index_check_state(view, row, col=0):
-    """Whether a model index is ticked, for models that expose ``Qt.CheckStateRole``."""
+    """Whether a model index is ticked, for models that expose ``Qt.CheckStateRole``.
+
+    The role is normalised through ``Qt.CheckState`` before comparing: a C++-backed model such as
+    ``QStandardItemModel`` hands back a plain ``int``, which never compares equal to the scoped
+    enum ``Qt.Checked`` under PyQt6, so a direct comparison silently reports every ticked item as
+    unticked. ``None`` means the model does not answer the role at all, i.e. not ticked.
+    """
     from qtpy.QtCore import Qt
 
-    return model_index(view, row, col).data(Qt.CheckStateRole) == Qt.Checked
+    state = model_index(view, row, col).data(Qt.CheckStateRole)
+    return state is not None and Qt.CheckState(state) == Qt.Checked
 
 
 def click_index(view, row, col=0, modifier=None, parent=None):

--- a/buildconfig/CMake/PyUnitTest.cmake
+++ b/buildconfig/CMake/PyUnitTest.cmake
@@ -33,8 +33,29 @@ function(PYSYSTEMTEST_ADD_TEST _test_src_dir _testname_prefix)
 
 endfunction()
 
+# PYUNITTEST_ADD_TEST_UI (public macro to add automated UI tests) Adds a set of python tests that drive a real Qt
+# interface. These are ordinary unittest modules, so they use the same runner as PYUNITTEST_ADD_TEST, but they are given
+# their own CTest label. That label is the whole mechanism keeping them out of the pipelines: CI's ctest step selects
+# with `ctest -L UnitTest`, so an "AutomatedUITest" test is never run by it, and the suite lives outside
+# Testing/SystemTests/tests so runSystemTests.py cannot collect it for the nightly either. Select them deliberately with
+# `ctest -L AutomatedUITest`.
+#
+# The name has to start with "pyunittest_add_test": the cmake-missing-pytest-files pre-commit hook finds the CMakeLists
+# that register python tests by grepping for that string, and a test registered through a function it cannot see would
+# be reported as unregistered on every commit.
+function(PYUNITTEST_ADD_TEST_UI _test_src_dir _testname_prefix)
+  if(NOT PYUNITTEST_RUNNER)
+    set(_test_runner_module ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/test/testhelpers/testrunner.py)
+  else()
+    set(_test_runner_module ${PYUNITTEST_RUNNER})
+  endif()
+
+  py_add_test("AutomatedUITest" ${_test_runner_module} "" ${ARGV})
+
+endfunction()
+
 # PY_ADD_TEST is used by the above test-adding methods. It SHOULD NOT be used directly in CMakeLists.txt files. Use
-# PYSYSTEMTEST_ADD_TEST or PYUNITTEST_ADD_TEST instead.
+# PYSYSTEMTEST_ADD_TEST, PYUNITTEST_ADD_TEST_UI or PYUNITTEST_ADD_TEST instead.
 function(PY_ADD_TEST _test_type _test_runner_module _additional_flags _test_src_dir _testname_prefix)
   # Property for the module directory
   if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode")
@@ -58,6 +79,19 @@ function(PY_ADD_TEST _test_type _test_runner_module _additional_flags _test_src_
     list(APPEND _test_environment "QT_API=${PYUNITTEST_QT_API}")
   endif()
 
+  # Extra data directories for suites whose fixtures are not on the built properties file's search path, which holds
+  # only Testing/Data/{UnitTest,DocTest}. Separated like PYTHONPATH above, and read back by the test at run time rather
+  # than baked into a properties file, so nothing outside the test process is changed.
+  if(PYUNITTEST_DATA_DIRS)
+    if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+      # cmake list separator and Windows environment separator are the same so escape the cmake one
+      string(REPLACE ";" "\\;" _data_dirs "${PYUNITTEST_DATA_DIRS}")
+    else()
+      string(REPLACE ";" ":" _data_dirs "${PYUNITTEST_DATA_DIRS}")
+    endif()
+    list(APPEND _test_environment "MANTID_TEST_DATA_DIRS=${_data_dirs}")
+  endif()
+
   # set preload as tbbmalloc, unless if using address sanitizer as this confuses things
   if(NOT WITH_ASAN)
     set(LOCAL_PRELOAD ${TBBMALLOC_RUNTIME_LIB})
@@ -65,6 +99,13 @@ function(PY_ADD_TEST _test_type _test_runner_module _additional_flags _test_src_
       set(LOCAL_PRELOAD ${LOCAL_PRELOAD}:$ENV{LD_PRELOAD})
     endif()
     list(APPEND _test_environment "LD_PRELOAD=${LOCAL_PRELOAD}")
+  endif()
+
+  # A directory of unusually slow tests can raise its own limit; everything else gets the global one
+  if(PYUNITTEST_TIMEOUT)
+    set(_test_timeout ${PYUNITTEST_TIMEOUT})
+  else()
+    set(_test_timeout ${TESTING_TIMEOUT})
   endif()
 
   # Add all of the individual tests so that they can be run in parallel
@@ -79,7 +120,7 @@ function(PY_ADD_TEST _test_type _test_runner_module _additional_flags _test_src_
     )
     # Set the PYTHONPATH so that the built modules can be found
     set_tests_properties(
-      ${_pyunit_separate_name} PROPERTIES ENVIRONMENT "${_test_environment}" TIMEOUT ${TESTING_TIMEOUT} LABELS
+      ${_pyunit_separate_name} PROPERTIES ENVIRONMENT "${_test_environment}" TIMEOUT ${_test_timeout} LABELS
                                           ${_test_type}
     )
     if(PYUNITTEST_RUN_SERIAL)

--- a/buildconfig/CMake/PyUnitTest.cmake
+++ b/buildconfig/CMake/PyUnitTest.cmake
@@ -1,3 +1,20 @@
+# _PYUNITTEST_RUNNER resolves the runner module the unittest-based suites use: PYUNITTEST_RUNNER if the caller set one,
+# otherwise the standard testrunner. Shared by PYUNITTEST_ADD_TEST and PYUNITTEST_ADD_TEST_UI, which differ only in the
+# CTest label they hand to py_add_test.
+function(_PYUNITTEST_RUNNER _out_var)
+  if(NOT PYUNITTEST_RUNNER)
+    set(${_out_var}
+        ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/test/testhelpers/testrunner.py
+        PARENT_SCOPE
+    )
+  else()
+    set(${_out_var}
+        ${PYUNITTEST_RUNNER}
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
 # PYUNITTEST_ADD_TEST (public macro to add unit tests) Adds a set of python tests based upon the unittest module
 #
 # The variable PYUNITTEST_PYTHONPATH_EXTRA can be defined with extra paths to add to PYTHONPATH during the tests
@@ -5,11 +22,7 @@
 # test. This directory is added to the PYTHONPATH when tests are executed _testname_prefix :: A prefix for each test
 # that is added to ctest, the name will be ${_testname_prefix}_TestName ${ARGN} :: List of test files
 function(PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix)
-  if(NOT PYUNITTEST_RUNNER)
-    set(_test_runner_module ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/test/testhelpers/testrunner.py)
-  else()
-    set(_test_runner_module ${PYUNITTEST_RUNNER})
-  endif()
+  _pyunittest_runner(_test_runner_module)
 
   py_add_test("UnitTest" ${_test_runner_module} "" ${ARGV})
 
@@ -44,11 +57,7 @@ endfunction()
 # that register python tests by grepping for that string, and a test registered through a function it cannot see would
 # be reported as unregistered on every commit.
 function(PYUNITTEST_ADD_TEST_UI _test_src_dir _testname_prefix)
-  if(NOT PYUNITTEST_RUNNER)
-    set(_test_runner_module ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/test/testhelpers/testrunner.py)
-  else()
-    set(_test_runner_module ${PYUNITTEST_RUNNER})
-  endif()
+  _pyunittest_runner(_test_runner_module)
 
   py_add_test("AutomatedUITest" ${_test_runner_module} "" ${ARGV})
 

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -10,6 +10,7 @@
 #   4. ENABLE_DOCS: Whether or not the docs have been built
 #   5. ENABLE_DOC_TESTS: Whether or not the doc tests should be run
 #   6. BUILD_THREADS: The number of threads to use during testing
+#   7. ENABLE_UI_TESTS: whether or not the automated UI tests should be run (optional, defaults to false)
 
 WORKSPACE=$1
 ENABLE_SYSTEM_TESTS=$2
@@ -17,6 +18,8 @@ ENABLE_UNIT_TESTS=$3
 ENABLE_DOCS=$4
 ENABLE_DOC_TESTS=$5
 BUILD_THREADS=$6
+# appended last and defaulted so the existing callers, which pass six arguments, are unaffected
+ENABLE_UI_TESTS=${7:-false}
 
 XVFB_SERVER_NUM=101
 
@@ -132,4 +135,20 @@ if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
     fi
 
     run_with_xvfb $SYSTEM_TEST_EXECUTABLE $WINDOWS_TEST_OPTIONS $SYSTEM_TEST_OPTIONS
+fi
+
+# Run the automated UI tests. Selected by their own CTest label, so this never overlaps with the
+# unit tests above. Only the weekly workflow passes true here; that workflow treats a failure as
+# something to report rather than something to block on, so this block stays honest and fails.
+if [[ $ENABLE_UI_TESTS == true ]]; then
+    rm -fr $userconfig_dir
+    rm -f $workbench_ini
+
+    # Turn off any auto updating on startup
+    mkdir -p $userconfig_dir
+    echo "UpdateInstrumentDefinitions.OnStartup = 0" > $userprops
+    echo "usagereports.enabled = 0" >> $userprops
+    echo "CheckMantidVersion.OnStartup = 0" >> $userprops
+
+    run_with_xvfb ctest -L AutomatedUITest -j${UI_TEST_THREADS:-2} --no-compress-output -T Test -O test_logs/ctest_uitest_$OSTYPE.log --output-on-failure $WINDOWS_TEST_OPTIONS --output-junit Testing/junit-uitest.xml
 fi

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -65,7 +65,9 @@ matrix has a placeholder for one.
 Running them
 ############
 
-They are registered with CTest, so from the build directory:
+The suite is only added to the build when ``ENABLE_WORKBENCH`` is on, which is the default;
+configure with it enabled or CTest will not know about these tests at all. From the build
+directory:
 
 .. code-block:: sh
 
@@ -79,9 +81,10 @@ They are registered with CTest, so from the build directory:
    ctest -R AutomatedUITest.Example.ExampleUITest --output-on-failure
 
 Most suites need data from the ExternalData store; build the ``StandardTestData`` and
-``SystemTestData`` targets first, or they will report a skip. Tests run offscreen (the harness sets
-``QT_QPA_PLATFORM=offscreen`` and ``MPLBACKEND=Agg`` on import), so nothing appears on screen and no
-display is needed.
+``SystemTestData`` targets first, or they will report a skip. Tests run offscreen (the harness
+*defaults* ``QT_QPA_PLATFORM`` to ``offscreen`` and ``MPLBACKEND`` to ``Agg`` on import, leaving
+either alone if it is already set), so nothing appears on screen and no display is needed. Set
+``QT_QPA_PLATFORM`` yourself if you want to watch a test run.
 
 The data directories are named by ``PYUNITTEST_DATA_DIRS`` in
 ``Testing/AutomatedUITests/CMakeLists.txt``, passed to each test as ``MANTID_TEST_DATA_DIRS`` and
@@ -90,11 +93,21 @@ added to Mantid's search path in ``setUp`` - the built properties file lists onl
 SystemTest set. The search path is restored in ``tearDown``.
 
 A module is an ordinary ``unittest`` file, so it can also be run directly for debugging - which is
-usually easier, because you get a normal traceback:
+usually easier, because you get a normal traceback. It still needs the environment CTest would have
+given it: the build's ``bin`` and the harness directory on ``PYTHONPATH``, the configured ``QT_API``,
+and ``MANTID_TEST_DATA_DIRS`` if the test calls ``require_files``. From the source directory, with
+``$BUILD`` the build directory:
 
 .. code-block:: sh
 
+   export PYTHONPATH=$BUILD/bin:$PWD/Testing/AutomatedUITests:$PYTHONPATH
+   export QT_API=pyqt6
+   export MANTID_TEST_DATA_DIRS=$BUILD/ExternalData/Testing/Data/SystemTest:$BUILD/ExternalData/Testing/Data/DocTest:$BUILD/ExternalData/Testing/Data/UnitTest
+
    python Testing/AutomatedUITests/Example/ExampleUITest.py ExampleUITest.test_tables
+
+``ctest -R AutomatedUITest.Example.ExampleUITest -V -N`` prints the exact command and environment
+that CTest uses, which is the reference if any of the above has moved.
 
 Writing a test
 ##############

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -153,11 +153,11 @@ threads.
 
 **Neutralise anything modal before the first click.** An unattended test that pops a modal message
 box hangs until the suite times out. ``patch_error_messages``, ``patch_confirmation_box`` and
-``algorithm_dialog_runs`` on the base class cover the three cases that come up.
+``algorithm_dialog_runs`` on the base class cover three common cases that come up.
 
-**Go through the interface, not around it.** Use ``add_data_search_dir`` and let the interface's own
-file finder resolve a run, rather than reaching past the view to inject a workspace - what is being
-tested is the path a user takes.
+**Go through the interface, not around it.** Where possible use ``add_data_search_dir`` and let the
+interface's own file finder resolve a run, rather than reaching past the view to inject a workspace -
+what is being tested is the path a user takes.
 
 **Do not create a ``QApplication`` at module scope.** The base class creates one lazily in ``setUp``
 via ``ensure_qapp()``. Settings are isolated per test into a temporary ini file, so a test can never

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -162,7 +162,9 @@ carrying on would only produce a cascade of meaningless failures.
 queued - sometimes *blocking* queued - Qt connection, which cannot be delivered unless the calling
 thread is running its event loop. Use ``wait_until`` from ``qt_interaction_helpers`` or
 ``self.wait_for_async_task(worker)`` from the base class; a bare ``worker.join()`` deadlocks both
-threads.
+threads. Both default to a short timeout, so a wait on something genuinely slow has to pass a
+longer ``timeout`` explicitly rather than every wait in the suite inheriting one long enough to
+hide a hang.
 
 **Neutralise anything modal before the first click.** An unattended test that pops a modal message
 box hangs until the suite times out. ``patch_error_messages``, ``patch_confirmation_box`` and
@@ -210,7 +212,7 @@ something other than what a test wants - usually failing silently rather than lo
    * - ``QSpinBox`` / ``QDoubleSpinBox``
      - ``set_spin_box`` - checks the value was not clamped away
    * - ``QTabWidget``
-     - ``tab_titles``, ``select_tab`` - by title, because indices move
+     - ``select_tab`` - by title, because indices move
    * - ``QListWidget``
      - ``list_items``, ``select_list_item``
    * - ``QTableWidget``

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -1,0 +1,185 @@
+.. _AutomatedUITests:
+
+===================
+Automated UI Tests
+===================
+
+.. contents::
+  :local:
+
+Overview
+########
+
+Automated UI tests drive a real Qt interface. They build the genuine view, presenter and model,
+click real widgets with ``QTest``, run real algorithms and inspect the workspaces and files that
+come out. The only things mocked are the ones that would otherwise block waiting for a user: modal
+error popups, confirmation prompts and generated algorithm dialogs.
+
+They exist to replace the manual test guides in :ref:`Testing`. A guide section that a developer
+used to work through by hand before a release becomes one test method, with one ``check`` per
+observation the guide asked for.
+
+The code lives in ``Testing/AutomatedUITests``:
+
+.. code-block:: none
+
+   Testing/AutomatedUITests/
+     automated_ui_test_base.py    the harness - settings isolation, waiting, dialog patching
+     qt_interaction_helpers.py    free functions for driving widgets (click, combo, table, wait)
+     Example/ExampleUITest.py     a worked example, which is also the smoke test for the harness
+     <Interface>/                 one directory per interface
+
+How they relate to the other test suites
+########################################
+
+Automated UI tests are neither unit tests nor system tests, and they are deliberately kept out of
+both pipelines. They are slow, they drive a GUI, and a flaky one must not be able to block a pull
+request or a nightly package.
+
++---------------------+-------------------------+-------------------------------------------------+
+| Suite               | CTest label             | When it runs                                    |
++=====================+=========================+=================================================+
+| Unit tests          | ``UnitTest``            | every pull request, every nightly               |
++---------------------+-------------------------+-------------------------------------------------+
+| System tests        | ``SystemTest``          | every pull request (Linux), every nightly, via  |
+|                     |                         | ``runSystemTests.py`` rather than CTest         |
++---------------------+-------------------------+-------------------------------------------------+
+| Automated UI tests  | ``AutomatedUITest``     | weekly, report-only                             |
++---------------------+-------------------------+-------------------------------------------------+
+
+Three things keep them off the critical path, and a change to any one of them would put them back
+on it:
+
+* the ``AutomatedUITest`` CTest label. CI selects unit tests with ``ctest -L UnitTest``, so a test
+  with any other label is invisible to it;
+* the location. ``runSystemTests.py`` collects by walking ``Testing/SystemTests/tests/framework``
+  and ``Testing/SystemTests/tests/qt``, so a suite under either of those would be run by the
+  nightly whatever label it carried. ``Testing/AutomatedUITests`` is outside both;
+* ``.github/workflows/weekly_ui_tests.yml``, which has no ``pull_request`` trigger, marks its test
+  step ``continue-on-error`` and publishes the results as a check run rather than gating on them.
+  It must not be added to the repository's required status checks.
+
+macOS is not currently covered: there is no self-hosted macOS GitHub Actions runner. The workflow's
+matrix has a placeholder for one.
+
+Running them
+############
+
+They are registered with CTest, so from the build directory:
+
+.. code-block:: sh
+
+   # everything
+   ctest -L AutomatedUITest --output-on-failure
+
+   # one interface
+   ctest -R AutomatedUITest.EngineeringDiffraction --output-on-failure
+
+   # one module
+   ctest -R AutomatedUITest.Example.ExampleUITest --output-on-failure
+
+Most suites need data from the ExternalData store; build the ``StandardTestData`` and
+``SystemTestData`` targets first, or they will report a skip. Tests run offscreen (the harness sets
+``QT_QPA_PLATFORM=offscreen`` and ``MPLBACKEND=Agg`` on import), so nothing appears on screen and no
+display is needed.
+
+The data directories are named by ``PYUNITTEST_DATA_DIRS`` in
+``Testing/AutomatedUITests/CMakeLists.txt``, passed to each test as ``MANTID_TEST_DATA_DIRS`` and
+added to Mantid's search path in ``setUp`` - the built properties file lists only
+``Testing/Data/UnitTest`` and ``Testing/Data/DocTest``, and a manual test guide typically uses the
+SystemTest set. The search path is restored in ``tearDown``.
+
+A module is an ordinary ``unittest`` file, so it can also be run directly for debugging - which is
+usually easier, because you get a normal traceback:
+
+.. code-block:: sh
+
+   python Testing/AutomatedUITests/Example/ExampleUITest.py ExampleUITest.test_tables
+
+Writing a test
+##############
+
+Start from ``Testing/AutomatedUITests/Example/ExampleUITest.py``. It drives a widget defined in its
+own module, so it depends on no interface and no data - if it fails, the harness is broken rather
+than the code under test.
+
+The shape is:
+
+.. code-block:: python
+
+   from automated_ui_test_base import AutomatedUITestBase
+   from qt_interaction_helpers import click, process_events, select_combo
+
+   class MyInterfaceTest(AutomatedUITestBase):
+       def setUp(self):
+           super(MyInterfaceTest, self).setUp()
+           self.require_files("SOMEDATA00001.nxs")   # skip cleanly if the data is not there
+           self.patch_error_messages(("some.module.that.pops.a.dialog",))
+           self.gui = MyInterface()
+           self.gui.show()
+           process_events(2)
+
+       def tearDown(self):
+           self.gui.close()
+           process_events(2)
+           super(MyInterfaceTest, self).tearDown()
+
+       def test_the_guide_section_this_replaces(self):
+           select_combo(self.gui.combo_instrument, "ENGINX")
+           click(self.gui.button_run)
+
+           with self.check("Guide step 4 / the output workspace is created"):
+               self.assertTrue(ADS.doesExist("output"))
+           with self.check("Guide step 5 / it is in d-spacing"):
+               self.assertEqual(ADS.retrieve("output").getAxis(0).getUnit().unitID(), "dSpacing")
+
+Points worth knowing before you write one:
+
+**One ``test_`` method per scenario, not per observation.** Building an interface is expensive, and
+a scenario in a manual test guide is a sequence - calibrate, then focus, then look at what was
+written. Split by guide section, not by assertion.
+
+**Use** ``self.check(label)`` **for observations.** It wraps :py:meth:`unittest.TestCase.subTest`,
+so a failed observation is reported against its label and the ones after it still run. A test that
+stopped at the first failure would need as many weekly runs as there are regressions. Use a plain
+``self.assertX`` for preconditions - "the run number resolved", "the worker finished" - where
+carrying on would only produce a cascade of meaningless failures.
+
+**Never sleep or join.** Anything that finishes on a background thread reports back through a
+queued - sometimes *blocking* queued - Qt connection, which cannot be delivered unless the calling
+thread is running its event loop. Use ``wait_until`` from ``qt_interaction_helpers`` or
+``self.wait_for_async_task(worker)`` from the base class; a bare ``worker.join()`` deadlocks both
+threads.
+
+**Neutralise anything modal before the first click.** An unattended test that pops a modal message
+box hangs until the suite times out. ``patch_error_messages``, ``patch_confirmation_box`` and
+``algorithm_dialog_runs`` on the base class cover the three cases that come up.
+
+**Go through the interface, not around it.** Use ``add_data_search_dir`` and let the interface's own
+file finder resolve a run, rather than reaching past the view to inject a workspace - what is being
+tested is the path a user takes.
+
+**Do not create a ``QApplication`` at module scope.** The base class creates one lazily in ``setUp``
+via ``ensure_qapp()``. Settings are isolated per test into a temporary ini file, so a test can never
+read or write the real one.
+
+**The base class must stay uncollected.** ``unittest``'s loader picks up every ``TestCase`` subclass
+visible in a module, imported ones included, and falls back to a ``runTest`` method when a class has
+no ``test_*`` methods. ``AutomatedUITestBase`` therefore defines neither. Keep it that way, and give
+any per-interface base class you add the same treatment.
+
+Adding a new interface
+######################
+
+Create ``Testing/AutomatedUITests/<Interface>/`` with a ``CMakeLists.txt``:
+
+.. code-block:: cmake
+
+   set(TEST_NAMES MyInterfaceTest.py)
+
+   pyunittest_add_test_ui(${CMAKE_CURRENT_SOURCE_DIR} AutomatedUITest.MyInterface ${TEST_NAMES})
+
+and add ``add_subdirectory(<Interface>)`` to ``Testing/AutomatedUITests/CMakeLists.txt``. The parent
+directory puts the shared harness on ``PYTHONPATH``, sets the Qt API and raises the test timeout, so
+nothing further is needed. Anything shared between the modules of one interface goes in a
+non-test module in that directory, next to them.

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -16,7 +16,7 @@ come out. The only things mocked are the ones that would otherwise block waiting
 error popups, confirmation prompts and generated algorithm dialogs.
 
 They exist to replace the manual test guides in :ref:`Testing`. A guide section that a developer
-used to work through by hand before a release becomes one test method, with one ``check`` per
+used to work through by hand before a release becomes one test method, with one ``subTest`` per
 observation the guide asked for.
 
 The code lives in ``Testing/AutomatedUITests``:
@@ -71,6 +71,9 @@ directory:
 
 .. code-block:: sh
 
+   # the data the suites load, once - CTest builds nothing itself, so this has to be asked for
+   cmake --build . --target AutomatedUITestData
+
    # everything
    ctest -L AutomatedUITest --output-on-failure
 
@@ -80,9 +83,10 @@ directory:
    # one module
    ctest -R AutomatedUITest.Example.ExampleUITest --output-on-failure
 
-Most suites need data from the ExternalData store; build the ``StandardTestData`` and
-``SystemTestData`` targets first, or they will report a skip. Tests run offscreen (the harness
-*defaults* ``QT_QPA_PLATFORM`` to ``offscreen`` and ``MPLBACKEND`` to ``Agg`` on import, leaving
+Most suites need data from the ExternalData store, which is what the ``AutomatedUITestData`` target
+above downloads (it is nothing more than ``StandardTestData`` and ``SystemTestData`` together);
+without it the tests that need a file report a skip rather than a failure. Tests run offscreen (the
+harness *defaults* ``QT_QPA_PLATFORM`` to ``offscreen`` and ``MPLBACKEND`` to ``Agg`` on import, leaving
 either alone if it is already set), so nothing appears on screen and no display is needed. Set
 ``QT_QPA_PLATFORM`` yourself if you want to watch a test run.
 
@@ -141,9 +145,9 @@ The shape is:
            select_combo(self.gui.combo_instrument, "ENGINX")
            click(self.gui.button_run)
 
-           with self.check("Guide step 4 / the output workspace is created"):
+           with self.subTest("Guide step 4 / the output workspace is created"):
                self.assertTrue(ADS.doesExist("output"))
-           with self.check("Guide step 5 / it is in d-spacing"):
+           with self.subTest("Guide step 5 / it is in d-spacing"):
                self.assertEqual(ADS.retrieve("output").getAxis(0).getUnit().unitID(), "dSpacing")
 
 Points worth knowing before you write one:
@@ -152,11 +156,22 @@ Points worth knowing before you write one:
 a scenario in a manual test guide is a sequence - calibrate, then focus, then look at what was
 written. Split by guide section, not by assertion.
 
-**Use** ``self.check(label)`` **for observations.** It wraps :py:meth:`unittest.TestCase.subTest`,
-so a failed observation is reported against its label and the ones after it still run. A test that
-stopped at the first failure would need as many weekly runs as there are regressions. Use a plain
-``self.assertX`` for preconditions - "the run number resolved", "the worker finished" - where
+**Use** :py:meth:`unittest.TestCase.subTest` **for observations.** A failed observation inside
+``with self.subTest(label)`` is reported against its label and the ones after it still run. A test
+that stopped at the first failure would need as many weekly runs as there are regressions. Use a
+plain ``self.assertX`` for preconditions - "the run number resolved", "the worker finished" - where
 carrying on would only produce a cascade of meaningless failures.
+
+**What goes inside a** ``subTest`` **block is a decision, not a formatting choice.** Most of the
+helpers assert for themselves: ``select_radio`` raises if the button did not become checked,
+``set_group_box``, ``set_line_edit`` and ``set_spin_box`` likewise. Inside a block that raise is
+recorded as a failed observation and the next block still runs; outside one it propagates and ends
+the test there and then. So put a call **inside** when the selection or setting is itself the thing
+under test, and **outside** when it is only getting the interface into the state a later check
+needs - a broken fixture makes the remaining observations meaningless, whereas a failed observation
+should let the others still fire. Note that the block is also the blast radius: a failure skips the
+rest of *that* block too, so only put setup inside a block whose remaining lines you are content to
+lose.
 
 **Never sleep or join.** Anything that finishes on a background thread reports back through a
 queued - sometimes *blocking* queued - Qt connection, which cannot be delivered unless the calling
@@ -197,12 +212,13 @@ something other than what a test wants - usually failing silently rather than lo
    * - Widget
      - Helpers
    * - Anything
-     - ``click``, ``process_events``, ``wait_until``, ``top_level_widget_names``
+     - ``click``, ``process_events``, ``wait_until``, ``top_level_widget_names`` - ``click``
+       aims at the dependable hot-spot for the widget's kind, which for a check box or a radio
+       button is the *indicator* rather than the label
    * - ``QCheckBox``
-     - ``click_checkbox``, ``set_checkbox`` - click the *indicator*, not the label
+     - ``set_checkbox`` - reach a known state without knowing the current one
    * - ``QRadioButton``
-     - ``click_radio``, ``select_radio``, ``radio_buttons`` - by label, from a widget or a
-       ``QButtonGroup``
+     - ``select_radio``, ``radio_buttons`` - by label, from a widget or a ``QButtonGroup``
    * - ``QGroupBox`` (checkable)
      - ``set_group_box``
    * - ``QComboBox``

--- a/dev-docs/source/AutomatedUITests.rst
+++ b/dev-docs/source/AutomatedUITests.rst
@@ -168,6 +168,69 @@ visible in a module, imported ones included, and falls back to a ``runTest`` met
 no ``test_*`` methods. ``AutomatedUITestBase`` therefore defines neither. Keep it that way, and give
 any per-interface base class you add the same treatment.
 
+The helpers
+###########
+
+``qt_interaction_helpers`` holds free functions for driving widgets. They have no dependency on the
+harness, so an ordinary unit test can use them too. Each one exists because the obvious Qt call does
+something other than what a test wants - usually failing silently rather than loudly.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Widget
+     - Helpers
+   * - Anything
+     - ``click``, ``process_events``, ``wait_until``, ``top_level_widget_names``
+   * - ``QCheckBox``
+     - ``click_checkbox``, ``set_checkbox`` - click the *indicator*, not the label
+   * - ``QRadioButton``
+     - ``click_radio``, ``select_radio``, ``radio_buttons`` - by label, from a widget or a
+       ``QButtonGroup``
+   * - ``QGroupBox`` (checkable)
+     - ``set_group_box``
+   * - ``QComboBox``
+     - ``combo_items``, ``select_combo``
+   * - ``QLineEdit``
+     - ``set_line_edit`` - replays keystrokes, so ``editingFinished`` fires and any validator applies
+   * - ``QSpinBox`` / ``QDoubleSpinBox``
+     - ``set_spin_box`` - checks the value was not clamped away
+   * - ``QTabWidget``
+     - ``tab_titles``, ``select_tab`` - by title, because indices move
+   * - ``QListWidget``
+     - ``list_items``, ``select_list_item``
+   * - ``QTableWidget``
+     - ``table_column``, ``cell_widget``, ``table_checkbox``, ``cell_button``, ``cell_combo``,
+       ``cell_line_edit``, ``cell_spin_box``, ``item_check_state``, ``set_item_checked``
+   * - ``QTableView`` / ``QTreeView`` / ``QListView``
+     - ``model_row_count``, ``model_column_count``, ``model_index``, ``model_cell``,
+       ``model_column``, ``index_check_state``, ``click_index``, ``double_click_index``,
+       ``edit_index``, ``select_index``, ``click_row_header``, ``click_column_header``,
+       ``tree_rows``
+   * - ``FileFinderWidget``
+     - ``set_finder_text``, ``wait_for_file_finder`` - both wait out the background search
+   * - matplotlib
+     - ``figure_numbers``, ``close_all_figures`` (pyplot-managed figures only)
+
+Two things are worth knowing before reaching for one of them.
+
+**The two table families are not interchangeable.** ``table_*`` works on a ``QTableWidget``, which
+owns its cells through ``item()`` and ``cellWidget()``. Anything backed by a ``QAbstractItemModel``
+- ``QTableView``, ``QTreeView``, ``QListView`` - has neither method, and needs the ``model_*`` and
+``*_index`` helpers instead. Several Mantid interfaces are model-backed, so check which kind of view
+you have before writing the assertion.
+
+**A click on an item view has to go to its viewport.** The view is only a frame; the cells are drawn
+by delegates inside ``view.viewport()``, so ``click(view)`` does nothing at all. ``click_index``
+handles this - and scrolls the index into sight first, because ``visualRect`` is an empty rectangle
+for a row that is not currently drawn, which would send the click to the top-left corner and select
+the wrong thing.
+
+A few widgets are best not driven with ``QTest`` at all. ``FunctionBrowser`` and
+``FitPropertyBrowser`` are Qt property browsers whose cells are nested editors; use their Python API
+(``setFunction``, ``getParameter``, ``loadFunction``) instead.
+
 Adding a new interface
 ######################
 

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -45,6 +45,12 @@ then be included in the suite of tests from the following night.
 Alternatively, any tests relating to testing qt interfaces should be added to
 the ``Testing/SystemTests/tests/qt`` directory.
 
+A test that drives an interface by clicking its widgets - replacing a manual test
+guide rather than checking a workflow's numbers - belongs in
+``Testing/AutomatedUITests`` instead. Those run weekly and report-only, so they can
+be slower and more numerous than a system test is allowed to be; see
+:ref:`AutomatedUITests`.
+
 Specifying Validation
 ---------------------
 

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -42,12 +42,13 @@ The tests should be added to the ``Testing/SystemTests/tests/framework``,
 with the template result going in the ``reference`` sub-folder. It will
 then be included in the suite of tests from the following night.
 
-Alternatively, any tests relating to testing qt interfaces should be added to
-the ``Testing/SystemTests/tests/qt`` directory.
+Alternatively, a system test that needs Qt to be present - one that exercises an
+interface's presenter or model, or a workflow whose code imports ``mantidqt`` -
+should be added to the ``Testing/SystemTests/tests/qt`` directory.
 
-A test that drives an interface by clicking its widgets - replacing a manual test
-guide rather than checking a workflow's numbers - belongs in
-``Testing/AutomatedUITests`` instead. Those run weekly and report-only, so they can
+A test that drives an interface by *clicking its widgets* - replacing a manual test
+guide rather than checking a workflow's numbers - is not a system test at all and
+belongs in ``Testing/AutomatedUITests``. Those run weekly and report-only, so they can
 be slower and more numerous than a system test is allowed to be; see
 :ref:`AutomatedUITests`.
 

--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -187,6 +187,7 @@ Testing
    Gatekeeping
    WritingPerformanceTests
    SystemTests
+   AutomatedUITests
    DataFilesForTesting
    TestingUtilities
    RunningSanitizers
@@ -212,6 +213,9 @@ Testing
 
 :doc:`SystemTests`
    Guidance on working with the system tests.
+
+:doc:`AutomatedUITests`
+   Guidance on working with the automated UI tests, which drive a real Qt interface.
 
 :doc:`DataFilesForTesting`
    How to work with test data files in the mantid repository.


### PR DESCRIPTION
### Description of work

As part of a discussion around https://github.com/mantidproject/mantid/pull/41976 it was decided that the best course of action was to split that PR into two with the infrastructure changes (this PR) to create a suite for these UI tests that can be run weekly (separately from the existing pipeline - to get a feel for reliability) and then a separate PR for the Eng Diff specific tests (see stack).

The changes here are to set up the c test suite and target, and add a workflow to run the suite once a week without blocking any production.

Additionally a base class and some helper functions are created for routine GUI interaction which may be required across different UIs

## `AutomatedUITestBase`

Subclass it, write one `test_*` per scenario, override `setUp` after calling `super().setUp()`.

| Method | Purpose |
| --- | --- |
| `record_failure(label, message)` | A failure not expressed as an assertion. |
| `require_files(*filenames)` | Skip cleanly unless every file resolves through `FileFinder`. |
| `add_data_search_dir(directory)` | Added for the test, restored in `tearDown`. |
| `settings_file()` | The isolated ini file, for asserting what an interface stored. |
| `wait_for_async_task(worker, timeout=1800.0, what="worker")` | Block on an `AsyncTask`, pumping the event loop. A plain `join()` **deadlocks**. |
| `patch_error_messages(modules, helper_name=...)` | Stop popups blocking; records text in `self.message_box_messages`. |
| `patch_confirmation_box(module, answer)` | Answer a blocking prompt whose return value decides what happens next. |
| `algorithm_dialog_runs(presenter_module, run_algorithm)` | Emulate accepting an `InterfaceManager` algorithm dialog. |
| `captured_logs(level="notice")` | Capture Mantid log output; read `.text` after the block. |
| `files_under` / `basenames_under` | Save-layout assertions. |

Automatic in `setUp`/`tearDown`: lazy `QApplication`, per-test `QSettings` isolation, the data
search directories from `MANTID_TEST_DATA_DIRS`, `self.tmp_root`, closing figures, clearing the ADS.

## `qt_interaction_helpers`

Free functions, no dependency on the harness. Each exists because the obvious Qt call fails silently
rather than loudly.

- **General** — `process_events`, `click`, `wait_until`, `top_level_widget_names`
- **Buttons** — `click_checkbox`/`set_checkbox`, `click_radio`/`select_radio`/`radio_buttons`,
  `set_group_box`. Both click the *indicator*, the only dependable hot-spot offscreen.
- **Entry** — `set_line_edit` (replays keystrokes: `setText` emits none of
  `textEdited`/`returnPressed`/`editingFinished`, and also checks any validator), `set_spin_box`
  (catches silent clamping)
- **Selection** — `combo_items`/`select_combo`, `tab_titles`/`select_tab` (by title, indices move),
  `list_items`/`select_list_item`
- **`QTableWidget`** — `table_column`, `cell_widget` + shorthands
  `table_checkbox`/`cell_button`/`cell_combo`/`cell_line_edit`/`cell_spin_box`, and
  `item_check_state`/`set_item_checked` for checkable items with no cell widget
- **Model-backed views** — none of the `table_*` helpers work here. `model_row_count`,
  `model_column_count`, `model_index`, `model_cell`, `model_column`, `index_check_state`,
  `click_index`, `double_click_index`, `edit_index`, `select_index`, `click_row_header`,
  `click_column_header`, `tree_rows`. `click_index` is the one that can't be guessed: the click goes
  to `view.viewport()` at the index's `visualRect`, after a `scrollTo`.
- **Mantid** — `set_finder_text`/`wait_for_file_finder`, `figure_numbers`/`close_all_figures`

Not covered on purpose: `FunctionBrowser`/`FitPropertyBrowser` — use their Python API.



<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
