### PR TITLE
Strip whitespace from instrument name in MaskBTP

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -157,7 +157,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             IDF = mantid.api.ExperimentInfo.getInstrumentFilename(self.instname)
             ws = mantid.simpleapi.LoadEmptyInstrument(Filename=IDF, OutputWorkspace=self.instname + "MaskBTP")
             deleteWS = True  # if there is going to be an issue with the instrument provided
-        self.instname = ws.getInstrumentName()  # update the instrument name
+        self.instname = ws.getInstrumentName().strip()  # update the instrument name
 
         # only check against valid instrument if components isn't set
         checkInstrument = self.getProperty("Components").isDefault

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from unittest import mock
 from mantid.api import mtd, AnalysisDataService
 from mantid.kernel import config
 from mantid.simpleapi import ClearMaskFlag, DeleteWorkspace, LoadEmptyInstrument, MaskBTP
@@ -149,6 +150,18 @@ class MaskBTPTest(unittest.TestCase):
         # keep on masking the same workspace to speed up the test
         masking = MaskBTP(Workspace="TOPAZMaskBTP", Tube="edges")
         self.assertEqual(2 * 256 * 25, len(masking))
+
+    def test_wish_workspace_with_padded_instrument_name(self):
+        ws_name = "wish"
+        ws = LoadEmptyInstrument(InstrumentName="WISH", OutputWorkspace=ws_name)
+
+        expected = MaskBTP(Workspace=ws_name, Pixel="1-16,496-512")
+
+        with mock.patch.object(type(ws), "getInstrumentName", return_value="WISH    "):
+            masked = MaskBTP(Workspace=ws_name, Pixel="1-16,496-512")
+
+        self.assertTrue(array_equal(masked, expected))
+        DeleteWorkspace(ws_name)
 
     def test_eqsans_simple(self):
         ws_name = "eqsans"


### PR DESCRIPTION
For some mysterious reason, when backporting things from `main` to `ornl-next` in #42008, an issue appeared with `MaskBTP`: the instrument name from `ws.getInstrumentName()` was returned as `WISH    ` (some number of spaces). This is a local fix for `MaskBTP` to `.strip()` the result. 

There is no associated issue

### To test:

In principle, if CI works, then this is fine.

*This does not require release notes* because it is a minor bug that was introduced during the development cycle.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
