### PR TITLE
Add option to resubmit a clean build

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
       CLEAN:
-        description: 'Run clean-builder before building'
+        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
         required: false
         default: false
         type: boolean
@@ -200,7 +200,7 @@ jobs:
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
         run: |
           CLEAN_ARGS=""
-          if ${{ inputs.CLEAN }}; then
+          if [ "${{ inputs.CLEAN }}" == "true" ]; then
             CLEAN_ARGS="--clean-build"
           fi
           ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
@@ -330,7 +330,7 @@ jobs:
         if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
         run: |
           CLEAN_ARGS=""
-          if ${{ inputs.CLEAN }}; then
+          if [ "${{ inputs.CLEAN }}" == "true" ]; then
             CLEAN_ARGS="--clean-build"
           fi
           ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -10,6 +10,11 @@ on:
         description: 'Match Runner Label'
         required: false
         type: string
+      CLEAN:
+        description: 'Run clean-builder before building'
+        required: false
+        default: false
+        type: boolean
 
 
 # cancel previous job if a new commit is pushed
@@ -193,8 +198,12 @@ jobs:
 
       - name: Clean build tree
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        # supplying --clean-build or CLEAN_BUILD=true should be added here
-        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+        run: |
+          CLEAN_ARGS=""
+          if ${{ inputs.CLEAN }}; then
+            CLEAN_ARGS="--clean-build"
+          fi
+          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
 
       - name: Determine if a PR build
         if: ${{ github.event_name == 'pull_request' && needs.check-filters.outputs.code_changes == 'true' }}
@@ -319,8 +328,12 @@ jobs:
 
       - name: Clean build tree
         if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
-        # supplying --clean-build or CLEAN_BUILD=true should be added here
-        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+        run: |
+          CLEAN_ARGS=""
+          if ${{ inputs.CLEAN }}; then
+            CLEAN_ARGS="--clean-build"
+          fi
+          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
 
       - name: Build code and user docs
         if: ${{ needs.check-filters.outputs.user_docs == 'true' }}


### PR DESCRIPTION
Make cleaning the PR an option when resubmitting a build.

There is no associated issue.

### To test:

This will only appear in the `workflow_dispatch` portion of things when this PR is merged into `main`.

*This does not require release notes* because it is a change to CI

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
