### PR TITLE
Split the pr_build_and_test.yml jobs into individual workflows to allow for quicker restart of failing CI checks

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,8 +1,8 @@
 name: PR Build and Test
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -23,144 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-filters:
-    runs-on: ubuntu-latest
-    outputs:
-      code_changes: ${{ steps.changes.outputs.code_changes }}
-      doxygen: ${{ steps.changes.outputs.doxygen }}
-      user_docs: ${{ steps.changes.outputs.user_docs }}
-      files_cppcheck: ${{ steps.changes.outputs.files_cppcheck }}
-
-    steps:
-    - uses: actions/checkout@v7
-
-    - uses: dorny/paths-filter@v4
-      id: changes
-      with:
-        filters: .github/filters.yaml
-
-  doxygen:
-    needs: [check-filters]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: ./.github/actions/setup-pixi
-        if: ${{ needs.check-filters.outputs.doxygen == 'true' }}
-
-      - uses: ./.github/actions/doxygen-build
-        name: Build doxygen
-        if: ${{ needs.check-filters.outputs.doxygen == 'true' }}
-
-  conda-packaging-linux:
-    needs: [cppcheck, doxygen, check-filters]
-    runs-on:
-      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
-      - self-hosted
-      - Linux
-      - X64
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 100
-          fetch-tags: true
-          path: source
-
-      - uses: ./.github/actions/setup-pixi
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-
-      - name: Clean conda package output directory
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        run: |
-          rm -rf ${GITHUB_WORKSPACE}/conda-bld
-
-      - name: Build mantid and mantidmpi conda packages
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        run: |
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid
-
-      - name: Build mantidqt conda package
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        run: |
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-qt
-
-      - name: Build mantiddocs conda package
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        run: |
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-docs
-
-      - name: Build mantidworkbench conda package
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        run: |
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-workbench
-
-      - name: Upload conda packages
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: conda_packages
-          if-no-files-found: error
-          path: ${{ github.workspace }}/conda-bld/**/*.conda
-
-      - name: Upload conda environment logs
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: env_logs
-          if-no-files-found: warn
-          path: ${{ github.workspace }}/**/env_logs/*/*.txt
-
-  cppcheck:
-    needs: [check-filters]
-    runs-on:
-      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
-      - self-hosted
-      - Linux
-      - X64
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pixi
-        uses: ./.github/actions/setup-pixi
-        if: ${{ needs.check-filters.outputs.files_cppcheck == 'true' }}
-
-      - name: Clean build tree
-        if: ${{ needs.check-filters.outputs.files_cppcheck == 'true' }}
-        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
-
-      - name: Add cppcheck matcher
-        if: ${{ needs.check-filters.outputs.files_cppcheck == 'true' }}
-        run: echo "::add-matcher::.github/matchers/cppcheck.json"
-
-      - uses: ./.github/actions/cppcheck-build
-        if: ${{ needs.check-filters.outputs.files_cppcheck == 'true' }}
-        name: Run cppcheck
-
-      - name: Remove cppcheck matcher
-        if: ${{ always() && needs.check-filters.outputs.files_cppcheck == 'true' }}
-        run: echo "::remove-matcher owner=cppcheck::"
-
-      - name: Upload cppcheck SARIF report
-        uses: actions/upload-artifact@v7
-        if: ${{ always() && needs.check-filters.outputs.files_cppcheck == 'true' && hashFiles('build/cppcheck.sarif') != '' }}
-        with:
-          name: cppcheck_sarif_report
-          if-no-files-found: warn
-          path: ${{ github.workspace }}/build/cppcheck.sarif
-
-
   build-and-test:
-    needs: [cppcheck, doxygen, check-filters]
     permissions:
       contents: read
 
@@ -211,12 +74,17 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
       - name: Install pixi
         uses: ./.github/actions/setup-pixi
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
 
       - name: Clean build tree
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         run: |
           CLEAN_ARGS=""
           if [ "${{ inputs.CLEAN }}" == "true" ]; then
@@ -225,7 +93,7 @@ jobs:
           ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
 
       - name: Determine if a PR build
-        if: ${{ github.event_name == 'pull_request' && needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.code_changes == 'true' }}
         # telling jenkins scripts this is a PR build
         run: echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
 
@@ -238,7 +106,7 @@ jobs:
         run: echo "::add-matcher::.github/matchers/msvc.json"
 
       - name: Build code
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         run: |
           set -o pipefail
           echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
@@ -264,13 +132,13 @@ jobs:
       # TODO: Needs to be expanded for clang on osx.
       - uses: ./.github/actions/check-build-warnings
         name: Check for compiler warnings
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         with:
           log-file: build/test_logs/build_${{ matrix.os }}.log
           os: ${{ matrix.os }}
 
       - name: Run unit tests
-        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
         id: testunit
         run: |
           cd ${GITHUB_WORKSPACE}
@@ -297,7 +165,7 @@ jobs:
           path: ${{ github.workspace }}/build/Testing/*unittest.xml
 
       - name: Run system tests
-        if: ${{ matrix.os == 'Linux' && needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ matrix.os == 'Linux' && steps.changes.outputs.code_changes == 'true' }}
         id: testsystem
         run: |
           cd ${GITHUB_WORKSPACE}
@@ -335,94 +203,5 @@ jobs:
         if: always()
         with:
           name: test_logs_${{ matrix.os }}
-          if-no-files-found: ignore
-          path: ${{ github.workspace }}/build/test_logs/*.log
-
-
-  user-docs-build-and-test:
-    needs: [cppcheck, doxygen, check-filters]
-    permissions:
-      contents: read
-
-    runs-on:
-      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
-      - self-hosted
-      - Linux
-      - X64
-
-    defaults:
-      run:
-        shell: bash
-
-    env:
-      CMAKE_PRESET: linux-64-ci
-      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
-      ENABLE_BUILD_CODE: true
-      ENABLE_UNIT_TESTS: false
-      ENABLE_SYSTEM_TESTS: false
-      ENABLE_DOCS: true
-      ENABLE_DOC_TESTS: true
-      # Developer docs are built and published separately by devdocs-publish.yml
-      ENABLE_DEV_DOCS: false
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # Needed to fetch the tags for versioningit
-          fetch-depth: 100
-          fetch-tags: true
-
-      - name: Install pixi
-        uses: ./.github/actions/setup-pixi
-        if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
-
-      - name: Clean build tree
-        if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
-        run: |
-          CLEAN_ARGS=""
-          if [ "${{ inputs.CLEAN }}" == "true" ]; then
-            CLEAN_ARGS="--clean-build"
-          fi
-          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
-
-      - name: Build code and user docs
-        if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          echo "::add-matcher::.github/matchers/gcc.json"
-          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS
-          echo "::remove-matcher owner=gcc-problem-matcher::"
-
-      - name: Run doctests
-        if: ${{ needs.check-filters.outputs.user_docs == 'true' }}
-        id: testdocs
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          # Not physical but logical cores, includes hyper threaded - different for darwin
-          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
-          # bool flags for this are
-          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
-          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false false $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
-
-      - name: Upload doctest results
-        uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.testdocs.conclusion != 'skipped' }}
-        with:
-          name: junit-doctest
-          if-no-files-found: ignore
-          path: ${{ github.workspace }}/build/docs/doctest/TEST-doctest.xml
-
-      - name: Upload event payload
-        uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        with:
-          name: event-file-doctest
-          path: ${{ github.event_path }}
-
-      - name: Upload build and test log artifacts
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: user_docs_test_logs_Linux
           if-no-files-found: ignore
           path: ${{ github.workspace }}/build/test_logs/*.log

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,8 +1,8 @@
 name: PR Build and Test
 
 on:
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_conda_packaging.yml
+++ b/.github/workflows/pr_conda_packaging.yml
@@ -10,11 +10,6 @@ on:
         description: 'Match Runner Label'
         required: false
         type: string
-      CLEAN:
-        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
-        required: false
-        default: false
-        type: boolean
 
 
 # cancel previous job if a new commit is pushed

--- a/.github/workflows/pr_conda_packaging.yml
+++ b/.github/workflows/pr_conda_packaging.yml
@@ -1,8 +1,8 @@
 name: PR conda packaging (linux)
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_conda_packaging.yml
+++ b/.github/workflows/pr_conda_packaging.yml
@@ -1,0 +1,72 @@
+name: PR conda packaging (linux)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
+      CLEAN:
+        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
+        required: false
+        default: false
+        type: boolean
+
+
+# cancel previous job if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conda-packaging-linux:
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - Linux
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 100
+          fetch-tags: true
+          path: source
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+
+      - name: Build conda packages
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          rm -rf ${GITHUB_WORKSPACE}/conda-bld
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
+
+      - name: Upload conda packages
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda_packages
+          if-no-files-found: error
+          path: ${{ github.workspace }}/conda-bld/**/*.conda
+
+      - name: Upload conda environment logs
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: env_logs
+          if-no-files-found: warn
+          path: ${{ github.workspace }}/**/env_logs/*/*.txt

--- a/.github/workflows/pr_conda_packaging.yml
+++ b/.github/workflows/pr_conda_packaging.yml
@@ -44,11 +44,30 @@ jobs:
       - uses: ./.github/actions/setup-pixi
         if: ${{ steps.changes.outputs.code_changes == 'true' }}
 
-      - name: Build conda packages
+      - name: Clean conda package output directory
         if: ${{ steps.changes.outputs.code_changes == 'true' }}
         run: |
           rm -rf ${GITHUB_WORKSPACE}/conda-bld
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
+
+      - name: Build mantid and mantidmpi conda packages
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid
+
+      - name: Build mantidqt conda package
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-qt
+
+      - name: Build mantiddocs conda package
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-docs
+
+      - name: Build mantidworkbench conda package
+        if: ${{ steps.changes.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-workbench
 
       - name: Upload conda packages
         if: ${{ steps.changes.outputs.code_changes == 'true' }}

--- a/.github/workflows/pr_conda_packaging.yml
+++ b/.github/workflows/pr_conda_packaging.yml
@@ -1,8 +1,8 @@
 name: PR conda packaging (linux)
 
 on:
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_cppcheck.yml
+++ b/.github/workflows/pr_cppcheck.yml
@@ -1,0 +1,71 @@
+name: PR cpp check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
+      CLEAN:
+        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
+        required: false
+        default: false
+        type: boolean
+
+
+# cancel previous job if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cppcheck:
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - Linux
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - name: Install pixi
+        uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.files_cppcheck == 'true' }}
+
+      - name: Clean build tree
+        if: ${{ steps.changes.outputs.files_cppcheck == 'true' }}
+        run: ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE}
+
+      - name: Add cppcheck matcher
+        if: ${{ steps.changes.outputs.files_cppcheck == 'true' }}
+        run: echo "::add-matcher::.github/matchers/cppcheck.json"
+
+      - uses: ./.github/actions/cppcheck-build
+        if: ${{ steps.changes.outputs.files_cppcheck == 'true' }}
+        name: Run cppcheck
+
+      - name: Remove cppcheck matcher
+        if: ${{ always() && steps.changes.outputs.files_cppcheck == 'true' }}
+        run: echo "::remove-matcher owner=cppcheck::"
+
+      - name: Upload cppcheck SARIF report
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.changes.outputs.files_cppcheck == 'true' && hashFiles('build/cppcheck.sarif') != '' }}
+        with:
+          name: cppcheck_sarif_report
+          if-no-files-found: warn
+          path: ${{ github.workspace }}/build/cppcheck.sarif

--- a/.github/workflows/pr_cppcheck.yml
+++ b/.github/workflows/pr_cppcheck.yml
@@ -10,11 +10,6 @@ on:
         description: 'Match Runner Label'
         required: false
         type: string
-      CLEAN:
-        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
-        required: false
-        default: false
-        type: boolean
 
 
 # cancel previous job if a new commit is pushed

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,12 +1,9 @@
 name: PR doxygen
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
-
-  workflow_run:
-    workflows: ["PR cpp check"]
-    types:
-      - requested
 
 # cancel previous job if a new commit is pushed
 concurrency:

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,9 +1,10 @@
 name: PR doxygen
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
+  workflow_run:
+    workflows: [PR cpp check]
+    types: [completed]
 
 # cancel previous job if a new commit is pushed
 concurrency:
@@ -12,9 +13,12 @@ concurrency:
 
 jobs:
   doxygen:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: dorny/paths-filter@v4
         id: changes

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,7 +1,6 @@
 name: PR doxygen
 
 on:
-  workflow_dispatch:
   workflow_run:
     workflows: [PR cpp check]
     types: [completed]

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,11 +1,12 @@
 name: PR doxygen
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
   workflow_dispatch:
 
+  workflow_run:
+    workflows: ["PR cpp check"]
+    types:
+      - completed
 
 # cancel previous job if a new commit is pushed
 concurrency:

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,0 +1,41 @@
+name: PR doxygen
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
+      CLEAN:
+        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
+        required: false
+        default: false
+        type: boolean
+
+
+# cancel previous job if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}
+
+      - uses: ./.github/actions/doxygen-build
+        name: Build doxygen
+        if: ${{ steps.changes.outputs.doxygen == 'true' }}

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -1,9 +1,9 @@
 name: PR doxygen
 
 on:
-  workflow_run:
-    workflows: [PR cpp check]
-    types: [completed]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 # cancel previous job if a new commit is pushed
 concurrency:
@@ -12,12 +12,9 @@ concurrency:
 
 jobs:
   doxygen:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: dorny/paths-filter@v4
         id: changes

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -5,16 +5,6 @@ on:
     types: [opened, synchronize, reopened]
 
   workflow_dispatch:
-    inputs:
-      RUNNER_LABEL:
-        description: 'Match Runner Label'
-        required: false
-        type: string
-      CLEAN:
-        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
-        required: false
-        default: false
-        type: boolean
 
 
 # cancel previous job if a new commit is pushed

--- a/.github/workflows/pr_doxygen.yml
+++ b/.github/workflows/pr_doxygen.yml
@@ -6,7 +6,7 @@ on:
   workflow_run:
     workflows: ["PR cpp check"]
     types:
-      - completed
+      - requested
 
 # cancel previous job if a new commit is pushed
 concurrency:

--- a/.github/workflows/pr_user_docs.yml
+++ b/.github/workflows/pr_user_docs.yml
@@ -1,8 +1,8 @@
 name: PR user docs build and test
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_user_docs.yml
+++ b/.github/workflows/pr_user_docs.yml
@@ -1,8 +1,8 @@
 name: PR user docs build and test
 
 on:
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr_user_docs.yml
+++ b/.github/workflows/pr_user_docs.yml
@@ -1,0 +1,116 @@
+name: PR user docs build and test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+    inputs:
+      RUNNER_LABEL:
+        description: 'Match Runner Label'
+        required: false
+        type: string
+      CLEAN:
+        description: 'Run clean-builder before building. Only available via workflow_dispatch; use Run workflow, not Re-run jobs.'
+        required: false
+        default: false
+        type: boolean
+
+
+# cancel previous job if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  user-docs-build-and-test:
+    permissions:
+      contents: read
+
+    runs-on:
+      - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
+      - self-hosted
+      - Linux
+      - X64
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CMAKE_PRESET: linux-64-ci
+      EXTRA_CMAKE_FLAGS: "-DENABLE_PRECOMMIT=OFF"
+      ENABLE_BUILD_CODE: true
+      ENABLE_UNIT_TESTS: false
+      ENABLE_SYSTEM_TESTS: false
+      ENABLE_DOCS: true
+      ENABLE_DOC_TESTS: true
+      # Developer docs are built and published separately by devdocs-publish.yml
+      ENABLE_DEV_DOCS: false
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Needed to fetch the tags for versioningit
+          fetch-depth: 100
+          fetch-tags: true
+
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: .github/filters.yaml
+
+      - name: Install pixi
+        uses: ./.github/actions/setup-pixi
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+
+      - name: Clean build tree
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        run: |
+          CLEAN_ARGS=""
+          if [ "${{ inputs.CLEAN }}" == "true" ]; then
+            CLEAN_ARGS="--clean-build"
+          fi
+          ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/clean-builder ${GITHUB_WORKSPACE} ${CLEAN_ARGS}
+
+      - name: Build code and user docs
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          echo "::add-matcher::.github/matchers/gcc.json"
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS
+          echo "::remove-matcher owner=gcc-problem-matcher::"
+
+      - name: Run doctests
+        if: ${{ steps.changes.outputs.user_docs == 'true' }}
+        id: testdocs
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          # Not physical but logical cores, includes hyper threaded - different for darwin
+          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          # bool flags for this are
+          # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false false $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
+
+      - name: Upload doctest results
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.testdocs.conclusion != 'skipped' }}
+        with:
+          name: junit-doctest
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/docs/doctest/TEST-doctest.xml
+
+      - name: Upload event payload
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        with:
+          name: event-file-doctest
+          path: ${{ github.event_path }}
+
+      - name: Upload build and test log artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: user_docs_test_logs_Linux
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/test_logs/*.log

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -86,7 +86,7 @@ class FitFunctionsTest(unittest.TestCase):
         index_g0 = c.getIndexOfFunction("Gaussian 0")
         self.assertEqual(index_g0, 1)
         index_g1 = c.getIndexOfFunction("Gaussian 1")
-        self.assertEqual(index_g1, 4)
+        self.assertEqual(index_g1, 2)
 
     def test_compositefunction_f(self):
         lb = FunctionWrapper("LinearBackground", A0=0.5, A1=1.5)

--- a/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/FitFunctionsTest.py
@@ -86,7 +86,7 @@ class FitFunctionsTest(unittest.TestCase):
         index_g0 = c.getIndexOfFunction("Gaussian 0")
         self.assertEqual(index_g0, 1)
         index_g1 = c.getIndexOfFunction("Gaussian 1")
-        self.assertEqual(index_g1, 2)
+        self.assertEqual(index_g1, 4)
 
     def test_compositefunction_f(self):
         lb = FunctionWrapper("LinearBackground", A0=0.5, A1=1.5)


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41988. <!-- One line per closed issue. -->
This splits apart the jobs in `pr_build_and_test.yml` into separate workflows. This makes restarting the jobs easier. This is similar functionality to the one setup in **Jenkins** before the migration.

**Note -** The concurrency group setup was not causing the issue. The only way to restart the jobs quicker is to separate out the workflows. This leads to some code replication but will give greater control over the individual jobs.

Separating out the jobs is also a precursor to #41985. Because if the jobs are setup with `needs: [cppcheck, doxygen, check-filters]` then if any of these jobs are conditionally skipped then the jobs that rely on them will also be skipped.

I am hoping that the resource optimisation in #41985 will make up of the slight increase in the compute resources that this PR might introduce.

Also separating out the workflows can also help in setting up an integration workflow down the line (#42038).

(No release note is required).

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->
1) I tested by pushing breaking tests and restarting the workflows. Mainly needs a code review.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
