### PR TITLE
Enable summing of banks in group workspaces in RROA

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -14,6 +14,7 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceHistory.h"
+#include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspacePropertyUtils.h"
 
 #include "MantidJson/Json.h"
@@ -1405,6 +1406,10 @@ bool Algorithm::processGroups() {
       outGroups.emplace_back(outWSGrp);
       // Put the GROUP in the ADS
       AnalysisDataService::Instance().addOrReplace(prop->value(), outWSGrp);
+      if (auto workspaceProperty = dynamic_cast<WorkspaceProperty<Workspace> *>(pureOutputWorkspaceProp)) {
+        Workspace_sptr outputWorkspace = outWSGrp;
+        *workspaceProperty = outputWorkspace;
+      }
       outWSGrp->observeADSNotifications(false);
     }
   }

--- a/Framework/API/test/AlgorithmTest.h
+++ b/Framework/API/test/AlgorithmTest.h
@@ -75,6 +75,25 @@ public:
 };
 DECLARE_ALGORITHM(StubbedWorkspaceAlgorithm)
 
+class GenericOutputWorkspaceAlgorithm : public Algorithm {
+public:
+  const std::string name() const override { return "GenericOutputWorkspaceAlgorithm"; }
+  int version() const override { return 1; }
+  const std::string category() const override { return "Test"; }
+  const std::string summary() const override { return "Test generic output workspace properties"; }
+
+  void init() override {
+    declareProperty(std::make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input));
+    declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("OutputWorkspace", "", Direction::Output));
+  }
+
+  void exec() override {
+    Workspace_sptr outputWorkspace = std::make_shared<WorkspaceTester>();
+    setProperty("OutputWorkspace", outputWorkspace);
+  }
+};
+DECLARE_ALGORITHM(GenericOutputWorkspaceAlgorithm)
+
 class ProcessGroupsHistoryAlgorithm : public Algorithm {
 public:
   const std::string name() const override { return "ProcessGroupsHistoryAlgorithm"; }
@@ -712,6 +731,21 @@ public:
     TS_ASSERT_EQUALS(ws2->getTitle(), "A_2+B_2+C_2");
     TS_ASSERT_EQUALS(ws3->getName(), "D_3");
     TS_ASSERT_EQUALS(ws3->getTitle(), "A_3+B_3+C_3");
+  }
+
+  void test_processGroups_sets_generic_output_workspace_property_to_group() {
+    makeWorkspaceGroup("genericInput", "genericInput_1,genericInput_2");
+    GenericOutputWorkspaceAlgorithm alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", "genericInput");
+    alg.setPropertyValue("OutputWorkspace", "genericOutput");
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    Workspace_sptr outputWorkspace = alg.getProperty("OutputWorkspace");
+    auto outputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(outputWorkspace);
+    TS_ASSERT(outputGroup)
+    TS_ASSERT_EQUALS(outputGroup->size(), 2)
   }
 
   /// All groups are the same size, but they don't all match the rigid naming

--- a/Framework/Algorithms/src/RenameWorkspace.cpp
+++ b/Framework/Algorithms/src/RenameWorkspace.cpp
@@ -101,7 +101,10 @@ void RenameWorkspace::exec() {
   setProperty("OutputWorkspace", inputWS);
 
   // rename the input workspace using the rename method
-  ADS.rename(inputwsName, outputwsName);
+  if (inputwsName.empty())
+    ADS.addOrReplace(outputwsName, inputWS);
+  else
+    ADS.rename(inputwsName, outputwsName);
 
   const bool renameMonitors = getProperty("RenameMonitors");
   if (!renameMonitors)

--- a/Framework/Algorithms/test/RenameWorkspaceTest.h
+++ b/Framework/Algorithms/test/RenameWorkspaceTest.h
@@ -63,6 +63,21 @@ public:
     AnalysisDataService::Instance().remove("WSRenamed");
   }
 
+  void testExecWithUnnamedInput() {
+    Workspace_sptr inputWS = createWorkspace();
+
+    Mantid::Algorithms::RenameWorkspace rename;
+    rename.initialize();
+    TS_ASSERT_THROWS_NOTHING(rename.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(rename.setPropertyValue("OutputWorkspace", "NamedWorkspace"));
+
+    TS_ASSERT_THROWS_NOTHING(rename.execute());
+
+    auto result = AnalysisDataService::Instance().retrieveWS<Workspace>("NamedWorkspace");
+    TS_ASSERT_EQUALS(result, inputWS);
+    AnalysisDataService::Instance().remove("NamedWorkspace");
+  }
+
   void testExecSameNames() {
     AnalysisDataService::Instance().clear();
     MatrixWorkspace_sptr inputWS = createWorkspace();

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -359,10 +359,18 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             return
 
         perform_sum = []
-        for workspace_name in [inputWorkspace, firstTransWorkspace, secondTransWorkspace]:
+        for workspace_name, inspect_all_group_members in [
+            (inputWorkspace, True),
+            (firstTransWorkspace, False),
+            (secondTransWorkspace, False),
+        ]:
             if workspace_name is not None:
                 workspace = AnalysisDataService.retrieve(workspace_name)
-                perform_sum.append(self._has_single_2D_rectangular_detector(workspace))
+                if isinstance(workspace, WorkspaceGroup):
+                    workspaces = workspace if inspect_all_group_members else [workspace[0]]
+                else:
+                    workspaces = [workspace]
+                perform_sum.extend(self._has_single_2D_rectangular_detector(member) for member in workspaces)
 
         should_sum = perform_sum[0]
         if not all(sum_ws == should_sum for sum_ws in perform_sum):
@@ -373,10 +381,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             self.setProperty(Prop.ROI_DETECTOR_IDS, "")
 
     def _has_single_2D_rectangular_detector(self, workspace) -> bool:
-        """Returns true if workspace has a single 2D rectangular detector, and is not a group workspace."""
-        is_group = isinstance(workspace, WorkspaceGroup)
-        if is_group:
-            workspace = workspace[0]
+        """Returns true if workspace has a single 2D rectangular detector."""
 
         rect_detectors = workspace.getInstrument().findRectDetectors()
         num_rect_detectors = len(rect_detectors)
@@ -390,9 +395,6 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         # We don't sum banks for a linear detector
         if rect_detectors[0].xpixels() == 1 or rect_detectors[0].ypixels() == 1:
             return False
-
-        if is_group:
-            raise NotImplementedError("Not implemented for a WorkspaceGroup containing 2D detectors.")
 
         if not self._all_spectra_refer_to_rectangular_detector(workspace, rect_detectors[0]):
             return False

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanks.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanks.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from mantid.api import AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspaceProperty, MatrixWorkspace, PropertyMode
+from mantid.api import AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspace, PropertyMode, WorkspaceProperty
 from mantid.kernel import Direction
 
 
@@ -32,14 +32,13 @@ class ReflectometryISISSumBanks(DataProcessorAlgorithm):
 
     def PyInit(self):
         self.declareProperty(
-            MatrixWorkspaceProperty(self._WORKSPACE, "", direction=Direction.Input, optional=PropertyMode.Mandatory),
-            doc="An input 2D detector workspace",
+            WorkspaceProperty(self._WORKSPACE, "", direction=Direction.Input, optional=PropertyMode.Mandatory),
+            doc="An input 2D detector workspace or workspace group",
         )
         self.declareProperty(self._ROI, defaultValue="", doc="List of detector IDs to include")
         self.declareProperty(
-            MatrixWorkspaceProperty(self._OUTPUT_WS, "", direction=Direction.Output),
-            doc="The preprocessed output workspace. If multiple input runs are specified "
-            "they will be summed into a single output workspace.",
+            WorkspaceProperty(self._OUTPUT_WS, "", direction=Direction.Output),
+            doc="The preprocessed output workspace or workspace group.",
         )
 
     def PyExec(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -695,6 +695,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
             "TOF_38415_1_summed_segment",
             "TOF_38415_2",
             "TOF_38415_2_summed_segment",
+            "TOF_summed_segment",
         ]
 
         self._assert_run_algorithm_succeeds(args, outputs)
@@ -717,7 +718,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         assertRaisesNothing(self, alg.execute)
 
         self.assertEqual(
-            list(AnalysisDataService.retrieve("TOF_38415_summed_segment").getNames()),
+            list(AnalysisDataService.retrieve("TOF_summed_segment").getNames()),
             ["TOF_38415_1_summed_segment", "TOF_38415_2_summed_segment"],
         )
         self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_1", "IvsQ_38415_2"])
@@ -736,7 +737,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         assertRaisesNothing(self, alg.execute)
 
         self.assertEqual(
-            list(AnalysisDataService.retrieve("TOF_38415_summed_segment").getNames()),
+            list(AnalysisDataService.retrieve("TOF_summed_segment").getNames()),
             ["TOF_38415_up_summed_segment", "TOF_38415_down_summed_segment"],
         )
         self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_up", "IvsQ_38415_down"])
@@ -781,6 +782,10 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args)
 
         self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_1", "IvsQ_38415_2"])
+        self.assertEqual(
+            list(AnalysisDataService.retrieve("__TOF_summed_segment").getNames()),
+            ["__TOF_38415_1_summed_segment", "__TOF_38415_2_summed_segment"],
+        )
         self.assertTrue(AnalysisDataService.doesExist("__TOF_38415_1_summed_segment"))
         self.assertTrue(AnalysisDataService.doesExist("__TOF_38415_2_summed_segment"))
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -675,6 +675,130 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._check_sum_banks(AnalysisDataService.retrieve("IvsQ_binned_38415"), is_summed=True)
         _check_num_histograms_and_first_y_value("TOF_38415_summed_segment", 4, 0.6)
 
+    def test_sum_banks_runs_for_each_2D_detector_workspace_group_member(self):
+        self._create_workspace_group(38415, 2, "TOF_", self._create_2D_detector_workspace)
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["ROIDetectorIDs"] = self._TEST_2D_WS_DETECTOR_ROI
+        outputs = [
+            "IvsLam_38415",
+            "IvsLam_38415_1",
+            "IvsLam_38415_2",
+            "IvsQ_38415",
+            "IvsQ_38415_1",
+            "IvsQ_38415_2",
+            "IvsQ_binned_38415",
+            "IvsQ_binned_38415_1",
+            "IvsQ_binned_38415_2",
+            "TOF",
+            "TOF_38415_1",
+            "TOF_38415_1_summed_segment",
+            "TOF_38415_2",
+            "TOF_38415_2_summed_segment",
+        ]
+
+        self._assert_run_algorithm_succeeds(args, outputs)
+
+        self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_1", "IvsQ_38415_2"])
+        for index in (1, 2):
+            summed = AnalysisDataService.retrieve(f"TOF_38415_{index}_summed_segment")
+            self.assertEqual(summed.getNumberHistograms(), 4)
+            self._check_sum_banks(AnalysisDataService.retrieve(f"IvsQ_binned_38415_{index}"), is_summed=True)
+
+    def test_reduction_algorithm_sums_each_2D_detector_workspace_group_member(self):
+        self._create_workspace_group(38415, 2, "TOF_", self._create_2D_detector_workspace)
+        alg = create_algorithm(
+            "ReflectometryReductionOneAuto",
+            InputWorkspace="TOF_38415",
+            ROIDetectorIDs=self._TEST_2D_WS_DETECTOR_ROI,
+            **self._default_options,
+        )
+
+        assertRaisesNothing(self, alg.execute)
+
+        self.assertEqual(
+            list(AnalysisDataService.retrieve("TOF_38415_summed_segment").getNames()),
+            ["TOF_38415_1_summed_segment", "TOF_38415_2_summed_segment"],
+        )
+        self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_1", "IvsQ_38415_2"])
+
+    def test_reduction_algorithm_preserves_informative_group_member_names_when_summing(self):
+        self._create_2D_detector_workspace(38415, "TOF_", "_up")
+        self._create_2D_detector_workspace(38415, "TOF_", "_down")
+        GroupWorkspaces("TOF_38415_up,TOF_38415_down", OutputWorkspace="TOF_38415")
+        alg = create_algorithm(
+            "ReflectometryReductionOneAuto",
+            InputWorkspace="TOF_38415",
+            ROIDetectorIDs=self._TEST_2D_WS_DETECTOR_ROI,
+            **self._default_options,
+        )
+
+        assertRaisesNothing(self, alg.execute)
+
+        self.assertEqual(
+            list(AnalysisDataService.retrieve("TOF_38415_summed_segment").getNames()),
+            ["TOF_38415_up_summed_segment", "TOF_38415_down_summed_segment"],
+        )
+        self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_up", "IvsQ_38415_down"])
+
+    def test_sum_banks_rejects_workspace_group_with_mixed_detector_types(self):
+        self._create_2D_detector_workspace(38415, "TOF_", "_1")
+        self._create_workspace(38415, "TOF_", "_2")
+        GroupWorkspaces("TOF_38415_1,TOF_38415_2", OutputWorkspace="TOF_38415")
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["ROIDetectorIDs"] = self._TEST_2D_WS_DETECTOR_ROI
+
+        self._assert_run_algorithm_throws_with_correct_msg(
+            args, "some but not all input and transmission workspaces require summing across banks"
+        )
+
+    def test_sum_banks_runs_for_polarized_2D_detector_workspace_group(self):
+        self._create_workspace_group(38415, 4, "TOF_", self._create_2D_detector_workspace)
+        self._create_polarization_efficiencies_workspace("efficiencies")
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["ROIDetectorIDs"] = self._TEST_2D_WS_DETECTOR_ROI
+        args["PolarizationAnalysis"] = "1"
+        args["PolarizationEfficiencies"] = "efficiencies"
+
+        self._assert_run_algorithm_succeeds(args)
+
+        self.assertEqual(
+            list(AnalysisDataService.retrieve("IvsQ_38415").getNames()),
+            ["IvsQ_38415_1", "IvsQ_38415_2", "IvsQ_38415_3", "IvsQ_38415_4"],
+        )
+        for index in range(1, 5):
+            self._check_sum_banks(AnalysisDataService.retrieve(f"IvsQ_binned_38415_{index}"), is_summed=True)
+
+    def test_sum_banks_preserves_group_output_names_when_summed_workspaces_are_hidden(self):
+        self._create_workspace_group(38415, 2, "__TOF_", self._create_2D_detector_workspace)
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["ROIDetectorIDs"] = self._TEST_2D_WS_DETECTOR_ROI
+        args["HideInputWorkspaces"] = True
+
+        self._assert_run_algorithm_succeeds(args)
+
+        self.assertEqual(list(AnalysisDataService.retrieve("IvsQ_38415").getNames()), ["IvsQ_38415_1", "IvsQ_38415_2"])
+        self.assertTrue(AnalysisDataService.doesExist("__TOF_38415_1_summed_segment"))
+        self.assertTrue(AnalysisDataService.doesExist("__TOF_38415_2_summed_segment"))
+
+    def test_sum_banks_uses_only_first_transmission_group_member(self):
+        self._create_2D_detector_workspace(38415, "TOF_")
+        self._create_2D_detector_workspace(38416, "TRANS_", "_1")
+        self._create_workspace(38416, "TRANS_", "_2")
+        GroupWorkspaces("TRANS_38416_1,TRANS_38416_2", OutputWorkspace="TRANS_38416")
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["FirstTransmissionRunList"] = "38416"
+        args["ROIDetectorIDs"] = self._TEST_2D_WS_DETECTOR_ROI
+
+        self._assert_run_algorithm_succeeds(args)
+
+        self._check_sum_banks(AnalysisDataService.retrieve("IvsQ_binned_38415"), is_summed=True)
+        self.assertEqual(AnalysisDataService.retrieve("TRANS_38416_2").getNumberHistograms(), 3)
+
     def test_sum_banks_not_run_for_2D_detector_workspace_when_no_detector_ROI(self):
         self._create_2D_detector_workspace(38415, "TOF_")
         args = self._default_options
@@ -846,13 +970,14 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:40:00", Value=15)
         AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:50:00", Value=100)
 
-    def _create_workspace_group(self, run_number, number_of_items, prefix=""):
+    def _create_workspace_group(self, run_number, number_of_items, prefix="", workspace_creator=None):
         group_name = prefix + str(run_number)
         child_names = list()
+        workspace_creator = workspace_creator or self._create_workspace
         for index in range(0, number_of_items):
             child_suffix = "_" + str(index + 1)
             child_name = group_name + child_suffix
-            self._create_workspace(run_number, prefix, child_suffix)
+            workspace_creator(run_number, prefix, child_suffix)
             child_names.append(child_name)
         GroupWorkspaces(InputWorkspaces=",".join(child_names), OutputWorkspace=group_name)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock
 
 import numpy
 
-from mantid.api import MatrixWorkspace
-from mantid.simpleapi import CreateSampleWorkspace, CreateWorkspace
+from mantid.api import AnalysisDataService, MatrixWorkspace, WorkspaceGroup
+from mantid.simpleapi import CreateSampleWorkspace, CreateWorkspace, GroupWorkspaces
 from plugins.algorithms.WorkflowAlgorithms.ReflectometryISISSumBanks import ReflectometryISISSumBanks
 from testhelpers import WorkspaceCreationHelper
 
@@ -69,6 +69,24 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
 
         issues = alg.validateInputs()
         self.assertEqual(len(issues), 0)
+
+    def test_workspace_group_can_be_passed_and_returned_as_an_object(self):
+        self.addCleanup(AnalysisDataService.clear)
+        first = CreateSampleWorkspace(NumBanks=1, NumMonitors=2, BankPixelWidth=2, OutputWorkspace="group_member_1")
+        second = CreateSampleWorkspace(NumBanks=1, NumMonitors=2, BankPixelWidth=2, OutputWorkspace="group_member_2")
+        input_group = GroupWorkspaces([first, second], OutputWorkspace="input_group")
+        alg = ReflectometryISISSumBanks()
+        alg.initialize()
+        alg.setProperty("InputWorkspace", input_group)
+        alg.setProperty("OutputWorkspace", "summed_group")
+
+        alg.execute()
+
+        output_group = alg.getProperty("OutputWorkspace").value
+        self.assertIsInstance(output_group, WorkspaceGroup)
+        self.assertEqual(output_group.size(), 2)
+        self.assertEqual(output_group[0].getNumberHistograms(), 4)
+        self.assertEqual(output_group[1].getNumberHistograms(), 4)
 
     def test_no_summing_done_on_single_bank(self):
         test_ws = "ws"

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -119,10 +119,10 @@ private:
   WorkspaceGroup_sptr applyPolarizationCorrection(const WorkspaceGroup_sptr &outputIvsLam,
                                                   const std::string &outputGroupName);
   API::MatrixWorkspace_sptr getFloodWorkspace(const Instrument_const_sptr &instrument);
-  std::string getSummedWorkspaceName(const std::string &wsPropertyName, const bool isTransWs = false);
-  void sumBanksForWorkspace(const std::string &roiDetectorIDs, const std::string &wsPropertyName,
-                            const bool isTransWs = false);
-  void sumBanks();
+  std::string getSummedWorkspaceName(const Workspace_sptr &workspace, const bool isTransWs = false);
+  Workspace_sptr sumBanksForWorkspace(const std::string &roiDetectorIDs, const Workspace_sptr &inputWorkspace,
+                                      const std::string &outputWorkspaceName);
+  bool sumBanks(Workspace_sptr &inputWorkspace);
   double getPropertyOrDefault(const std::string &propertyName, const double defaultValue, bool &isDefault);
   WorkspaceNames getOutputNamesForGroupMember(const std::string &inputNames, const std::string &runNumber,
                                               const size_t wsGroupNumber);
@@ -133,7 +133,8 @@ private:
   void setOutputPropertyFromChild(const Algorithm_sptr &alg, std::string const &name);
   void setOutputPropertiesFromChild(const Algorithm_sptr &alg);
   processGroupMembersOutput processGroupMembers(const Algorithm::WorkspaceVector &members, std::string const &runNumber,
-                                                std::vector<std::string> const &taskOrder, const bool reduced = false);
+                                                std::vector<std::string> const &taskOrder, const bool banksSummed,
+                                                const bool reduced = false);
   WorkspaceGroup_sptr groupWorkspaces(const std::vector<std::string> &workspaceNames,
                                       std::string const &outputName = "");
   RROOutputs performCoreReduction(MatrixWorkspace_sptr inputWS, const std::vector<std::string> &taskOrder = {},

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -1083,15 +1083,13 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::getFloodWorkspace(const Ins
  */
 std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const Workspace_sptr &workspace,
                                                                    const bool isTransWs) {
-  auto matrixWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(workspace);
-  if (!matrixWorkspace)
-    matrixWorkspace =
-        std::dynamic_pointer_cast<MatrixWorkspace>(std::dynamic_pointer_cast<WorkspaceGroup>(workspace)->getItem(0));
-
   const auto &ws_prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
   const std::string hide_prefix = getProperty("HideSummedWorkspaces") ? "__" : "";
+  if (std::dynamic_pointer_cast<WorkspaceGroup>(workspace))
+    return hide_prefix + ws_prefix + SUMMED_WORKSPACE_SUFFIX;
 
-  return hide_prefix + ws_prefix + getRunNumber(*matrixWorkspace) + SUMMED_WORKSPACE_SUFFIX;
+  return hide_prefix + ws_prefix + getRunNumber(*std::dynamic_pointer_cast<MatrixWorkspace>(workspace)) +
+         SUMMED_WORKSPACE_SUFFIX;
 }
 
 /**

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -32,11 +32,6 @@ using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 
 namespace { // anonymous
-Algorithm::WorkspaceVector getGroupMembers(const std::string &groupName) {
-  auto group = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
-  return group->getAllItems();
-}
-
 bool anyWorkspaceInListExists(std::vector<std::string> const &names) {
   return std::any_of(names.cbegin(), names.cend(),
                      [](std::string const &name) { return AnalysisDataService::Instance().doesExist(name); });
@@ -313,7 +308,7 @@ void ReflectometryReductionOneAuto3::init() {
   // Sum banks
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("ROIDetectorIDs", "", Direction::Input),
                   "When detector IDs are provided, the algorithm will attempt to sum counts across each row of a "
-                  "RectangularDetector after the flood correction step. "
+                  "RectangularDetector for a matrix workspace or for each member of a workspace group. "
                   "Detectors not included in the given range will be masked before summing. "
                   "This will only work correctly when the instrument definition file(IDF) contains a single "
                   "RectangularDetector panel.");
@@ -481,10 +476,11 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::postReductionProcessing(con
 /** Execute the algorithm.
  */
 void ReflectometryReductionOneAuto3::exec() {
-  sumBanks();
+  Workspace_sptr inputWorkspace = getWorkspaceFromProperty("InputWorkspace");
+  sumBanks(inputWorkspace);
   setDefaultOutputWorkspaceNames();
 
-  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
+  auto inputWS = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace);
   determineCorrectionAlgorithm(inputWS->getInstrument());
   RROOutputs out = performCoreReduction(inputWS);
   const auto params = getRebinParams(out.IvsQ, out.theta);
@@ -875,14 +871,14 @@ void ReflectometryReductionOneAuto3::setOutputPropertiesFromChild(const Algorith
  * @param runNumber : the run number of the group (our own value is passed in
  * because this is not a property a workspace group has)
  * @param taskOrder : task execution order to pass to ReflectometryReductionOne
+ * @param banksSummed : whether the input workspaces have been summed across banks
  * @param reduced : if true, recalculate IvsQ based on previous IvsLam outputs;
  * IvsLam outputs must be passed as the members
  * @returns : the grouped output workspace names
  */
-ReflectometryReductionOneAuto3::processGroupMembersOutput
-ReflectometryReductionOneAuto3::processGroupMembers(const Algorithm::WorkspaceVector &members,
-                                                    std::string const &runNumber,
-                                                    std::vector<std::string> const &taskOrder, const bool reduced) {
+ReflectometryReductionOneAuto3::processGroupMembersOutput ReflectometryReductionOneAuto3::processGroupMembers(
+    const Algorithm::WorkspaceVector &members, std::string const &runNumber, std::vector<std::string> const &taskOrder,
+    const bool banksSummed, const bool reduced) {
   // Compile a list of output workspace names for each group member
   // No need to compile list if the output names are already provided, e.g. from a previous run of RRO
   std::vector<WorkspaceNames> allOutputNames;
@@ -894,7 +890,10 @@ ReflectometryReductionOneAuto3::processGroupMembers(const Algorithm::WorkspaceVe
     if (!matrixWs) {
       throw std::runtime_error("Group Member is not a MatrixWorkspace");
     }
-    allOutputNames.emplace_back(getOutputNamesForGroupMember(matrixWs->getName(), runNumber, i));
+    auto inputName = matrixWs->getName();
+    if (banksSummed)
+      inputName.resize(inputName.size() - SUMMED_WORKSPACE_SUFFIX.size());
+    allOutputNames.emplace_back(getOutputNamesForGroupMember(inputName, runNumber, i));
     // If data has already been reduced, as workspace is summed we need to change processing instructions.
     // Also, do not perform flood corrections as these will have been performed upon initial reduction
     if (reduced) {
@@ -936,8 +935,12 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   m_usingBaseProcessGroups = true;
   enableHistoryRecordingForProcessGroups(true);
 
-  auto const groupName = getPropertyValue("InputWorkspace");
-  auto const groupMembers = getGroupMembers(groupName);
+  Workspace_sptr inputWorkspace =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getPropertyValue("InputWorkspace"));
+  const bool banksSummed = sumBanks(inputWorkspace);
+  const auto inputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWorkspace);
+  const auto groupName = inputGroup->getName();
+  const auto groupMembers = inputGroup->getAllItems();
   std::string const runNumber = getRunNumberForWorkspaceGroup(groupName);
   determineCorrectionAlgorithm(std::dynamic_pointer_cast<MatrixWorkspace>(groupMembers[0])->getInstrument());
 
@@ -947,7 +950,7 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   // isDefault might not work on some of these, alg corr?
   if (polarizationAnalysisOn)
     taskOrder = getTaskExecutionOrder(false, summingInQ);
-  processGroupMembersOutput processGroupsOutput = processGroupMembers(groupMembers, runNumber, taskOrder);
+  processGroupMembersOutput processGroupsOutput = processGroupMembers(groupMembers, runNumber, taskOrder, banksSummed);
   const auto groupedOutputNames = getOutputWorkspaceNames();
   if (polarizationAnalysisOn) {
     // Correct the IvsLam workspaces
@@ -958,7 +961,7 @@ bool ReflectometryReductionOneAuto3::processGroups() {
     const auto corrected = applyPolarizationCorrection(groupIvsLam, groupedOutputNames.iVsLam);
     taskOrder = getTaskExecutionOrder(true, summingInQ);
     // finish the processing using RRO
-    processGroupsOutput = processGroupMembers(corrected->getAllItems(), runNumber, taskOrder, true);
+    processGroupsOutput = processGroupMembers(corrected->getAllItems(), runNumber, taskOrder, false, true);
   }
   postReductionProcessingGroups(processGroupsOutput.rroOutputs, processGroupsOutput.outputNames, groupedOutputNames,
                                 !polarizationAnalysisOn);
@@ -1075,65 +1078,87 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::getFloodWorkspace(const Ins
 
 /**
  * Gets the name to use for the summed workspace.
- * @param wsPropertyName :: Name of the workspace to be summed.
+ * @param workspace :: Workspace to be summed.
  * @param isTransWs :: Whether or not this is a transmission workspace.
  */
-std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const std::string &wsPropertyName,
+std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const Workspace_sptr &workspace,
                                                                    const bool isTransWs) {
-  MatrixWorkspace_const_sptr matrixWs = getProperty(wsPropertyName);
-
-  std::string runNumber;
-  if (matrixWs) {
-    runNumber = getRunNumber(*matrixWs);
-  } else {
-    runNumber = getRunNumberForWorkspaceGroup(getPropertyValue(wsPropertyName));
-  }
+  auto matrixWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+  if (!matrixWorkspace)
+    matrixWorkspace =
+        std::dynamic_pointer_cast<MatrixWorkspace>(std::dynamic_pointer_cast<WorkspaceGroup>(workspace)->getItem(0));
 
   const auto &ws_prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
   const std::string hide_prefix = getProperty("HideSummedWorkspaces") ? "__" : "";
 
-  return hide_prefix + ws_prefix + runNumber + SUMMED_WORKSPACE_SUFFIX;
+  return hide_prefix + ws_prefix + getRunNumber(*matrixWorkspace) + SUMMED_WORKSPACE_SUFFIX;
 }
 
 /**
- * Sum banks for a single data workspace.
+ * Sum banks for a data workspace.
  * @param roiDetectorIDs :: The detector IDs to be summed. All are included if an empty string is passed.
- * @param wsPropertyName :: Name of an input property containing a workspace
- *   that should be summed. The summed workspace replaces the old
- *   value of this property.
- * @param isTransWs :: Whether or not this is a transmission workspace.
+ * @param inputWorkspace :: The workspace to be summed.
+ * @param outputWorkspaceName :: The name for the summed workspace.
+ * @return The summed workspace.
  */
-void ReflectometryReductionOneAuto3::sumBanksForWorkspace(const std::string &roiDetectorIDs,
-                                                          const std::string &wsPropertyName, const bool isTransWs) {
-  MatrixWorkspace_sptr ws = getProperty(wsPropertyName);
-  auto output_ws_name = getSummedWorkspaceName(wsPropertyName, isTransWs);
+Workspace_sptr ReflectometryReductionOneAuto3::sumBanksForWorkspace(const std::string &roiDetectorIDs,
+                                                                    const Workspace_sptr &inputWorkspace,
+                                                                    const std::string &outputWorkspaceName) {
   auto alg = createChildAlgorithm("ReflectometryISISSumBanks");
   alg->initialize();
-  alg->setAlwaysStoreInADS(true);
-  alg->setProperty("InputWorkspace", ws);
+  alg->setProperty("InputWorkspace", inputWorkspace);
   alg->setProperty("ROIDetectorIDs", roiDetectorIDs);
-  alg->setProperty("OutputWorkspace", output_ws_name);
+  alg->setProperty("OutputWorkspace", outputWorkspaceName);
   alg->execute();
-  MatrixWorkspace_sptr out =
-      std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(output_ws_name));
-  setProperty(wsPropertyName, out);
+  Workspace_sptr outputWorkspace = alg->getProperty("OutputWorkspace");
+  const auto inputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWorkspace);
+  if (inputGroup) {
+    const auto outputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(outputWorkspace);
+    const auto outputWorkspaces = outputGroup->getAllItems();
+    const bool hideSummedWorkspaces = getProperty("HideSummedWorkspaces");
+    for (size_t i = 0; i < outputWorkspaces.size(); ++i) {
+      const auto &inputName = inputGroup->getItem(i)->getName();
+      const std::string hidePrefix = hideSummedWorkspaces && !inputName.starts_with("__") ? "__" : "";
+      auto rename = createChildAlgorithm("RenameWorkspace");
+      rename->setProperty("InputWorkspace", outputWorkspaces[i]);
+      rename->setPropertyValue("OutputWorkspace", hidePrefix + inputName + SUMMED_WORKSPACE_SUFFIX);
+      rename->execute();
+    }
+  } else {
+    auto rename = createChildAlgorithm("RenameWorkspace");
+    rename->setProperty("InputWorkspace", outputWorkspace);
+    rename->setPropertyValue("OutputWorkspace", outputWorkspaceName);
+    rename->execute();
+  }
+  return outputWorkspace;
 }
 
 /**
  * Sum banks for all workspaces that need to be summed:
  * the input data and the transmission runs.
+ * @param inputWorkspace :: The input workspace, replaced with the summed workspace when summing is performed.
+ * @return Whether bank summing was performed.
  */
-void ReflectometryReductionOneAuto3::sumBanks() {
-  if (!isDefault("ROIDetectorIDs")) {
-    const auto roiDetectorIDs = getPropertyValue("ROIDetectorIDs");
-    sumBanksForWorkspace(roiDetectorIDs, "InputWorkspace");
-    if (!isDefault("FirstTransmissionRun")) {
-      sumBanksForWorkspace(roiDetectorIDs, "FirstTransmissionRun", true);
-    }
-    if (!isDefault("SecondTransmissionRun")) {
-      sumBanksForWorkspace(roiDetectorIDs, "SecondTransmissionRun", true);
+bool ReflectometryReductionOneAuto3::sumBanks(Workspace_sptr &inputWorkspace) {
+  if (isDefault("ROIDetectorIDs"))
+    return false;
+
+  const auto roiDetectorIDs = getPropertyValue("ROIDetectorIDs");
+  inputWorkspace = sumBanksForWorkspace(roiDetectorIDs, inputWorkspace, getSummedWorkspaceName(inputWorkspace, false));
+  if (const auto matrixWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace))
+    setProperty("InputWorkspace", matrixWorkspace);
+  else
+    setPropertyValue("InputWorkspace", inputWorkspace->getName());
+
+  for (const auto &propertyName : {"FirstTransmissionRun", "SecondTransmissionRun"}) {
+    if (!isDefault(propertyName)) {
+      Workspace_sptr transmissionWorkspace = getWorkspaceFromProperty(propertyName);
+      transmissionWorkspace = sumBanksForWorkspace(roiDetectorIDs, transmissionWorkspace,
+                                                   getSummedWorkspaceName(transmissionWorkspace, true));
+      setProperty(propertyName, std::dynamic_pointer_cast<MatrixWorkspace>(transmissionWorkspace));
     }
   }
+  return true;
 }
 
 } // namespace Mantid::Reflectometry

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -36,6 +36,10 @@ If ``SliceWorkspace`` is true, the time slicing will be performed using the :ref
 
 The reduction is performed using :ref:`algm-ReflectometryReductionOneAuto`.
 
+When the input is a workspace group, ``ROIDetectorIDs`` can be used if every member contains a compatible single
+two-dimensional rectangular detector. Bank summing is applied independently to every group member while preserving
+the group order, including when polarization analysis is enabled.
+
 Finally, the TOF workspaces are cleaned up by grouping them into a workspace group named ``TOF``. If a group by this name already exists then they will be added to that group.
 
 Usage

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
@@ -89,6 +89,9 @@ individual reductions will produce three output workspaces: an output workspace 
 wavelength, an output workspace in Q with native binning, and a rebinned workspace in Q.
 Output workspaces in wavelength will be grouped together to produce an output workspace group in wavelength, and output
 workspaces in Q will be grouped together to produce an output workspace group in Q.
+If ``ROIDetectorIDs`` is provided for a workspace group containing a single two-dimensional rectangular detector per
+member, the selected detector region is summed independently for every member before reduction. The summed workspaces
+and reduced outputs retain the order of the input group.
 The diagram below illustrates this process (note that, for the sake of clarity, the rebinned output
 workspace in Q, :literal:`OutputWorkspaceBinned`, is not represented but it is handled analogously to
 :literal:`OutputWorkspace` and :literal:`OutputWorkspaceWavelength`):

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42028.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42028.rst
@@ -1,0 +1,2 @@
+- :ref:`RenameWorkspace <algm-RenameWorkspace>` can now assign a name to a workspace object that is not already in the
+  Analysis Data Service (ADS). In this case, the workspace will be added to the ADS.

--- a/docs/source/release/v7.0.0/Framework/Python/New_features/42028.rst
+++ b/docs/source/release/v7.0.0/Framework/Python/New_features/42028.rst
@@ -1,0 +1,3 @@
+- Output workspace properties of the generic type ``Workspace`` now return a ``WorkspaceGroup`` object after an
+  algorithm is automatically dispatched over an input workspace group. Previously, the value component of the
+  property would be set to equal the ``WorkspaceGroup`` name but the workspace component would be null.

--- a/docs/source/release/v7.0.0/Reflectometry/New_features/42028.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/New_features/42028.rst
@@ -1,2 +1,2 @@
-- :ref:`ReflectometryISISSumBanks <algm-ReflectometryISISSumBanks>`, :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto>`,
+- ``ReflectometryISISSumBanks``, :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto>`,
   and :ref:`ReflectometryISISLoadAndProcess <algm-ReflectometryISISLoadAndProcess>` can now apply ``ROIDetectorIDs`` bank summing to workspace groups.

--- a/docs/source/release/v7.0.0/Reflectometry/New_features/42028.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/New_features/42028.rst
@@ -1,0 +1,2 @@
+- :ref:`ReflectometryISISSumBanks <algm-ReflectometryISISSumBanks>`, :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto>`,
+  and :ref:`ReflectometryISISLoadAndProcess <algm-ReflectometryISISLoadAndProcess>` can now apply ``ROIDetectorIDs`` bank summing to workspace groups.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
@@ -28,7 +28,8 @@ using MantidQt::API::IConfiguredAlgorithm_sptr;
 namespace {
 void updateInputProperties(Mantid::API::IAlgorithmRuntimeProps &properties, MatrixWorkspace_sptr const &workspace,
                            std::optional<ProcessingInstructions> const &detIDsStr) {
-  properties.setProperty("InputWorkspace", workspace);
+  Workspace_sptr inputWorkspace = workspace;
+  properties.setProperty("InputWorkspace", inputWorkspace);
   if (detIDsStr) {
     AlgorithmProperties::update("ROIDetectorIDs", *detIDsStr, properties);
   }
@@ -73,7 +74,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
 
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
-  MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
-  row.setSummedWs(outputWs);
+  Workspace_sptr outputWorkspace = algorithm->getProperty("OutputWorkspace");
+  row.setSummedWs(std::dynamic_pointer_cast<MatrixWorkspace>(outputWorkspace));
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
@@ -31,8 +31,11 @@ class SumBanksAlgorithmTest : public CxxTest::TestSuite {
   public:
     StubbedPreProcess() {
       this->setChild(true);
-      auto prop = std::make_unique<Mantid::API::WorkspaceProperty<>>(m_propName, "", Mantid::Kernel::Direction::Output);
-      declareProperty(std::move(prop));
+      declareProperty(std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::Workspace>>(
+          "InputWorkspace", "", Mantid::Kernel::Direction::Input));
+      declareProperty("ROIDetectorIDs", "");
+      declareProperty(std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::Workspace>>(
+          m_propName, "", Mantid::Kernel::Direction::Output));
     }
 
     void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
@@ -65,16 +68,15 @@ public:
     // Create the algorithm
     auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
 
-    auto expectedProps = std::make_unique<AlgorithmRuntimeProps>();
-    expectedProps->setProperty(inputPropName, mockWs);
-    // We expect the same detector IDs that were set on the preview row to be set on the algorithm
-    expectedProps->setPropertyValue(roiPropName, "2,3");
     const auto &setProps = configuredAlg->getAlgorithmRuntimeProps();
 
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
-    TS_ASSERT_EQUALS(static_cast<decltype(mockWs)>(expectedProps->getProperty(inputPropName)),
-                     static_cast<decltype(mockWs)>(setProps.getProperty(inputPropName)))
-    TS_ASSERT_EQUALS(expectedProps->getPropertyValue(roiPropName), setProps.getPropertyValue(roiPropName))
+    Mantid::API::Workspace_sptr inputWorkspace = setProps.getProperty(inputPropName);
+    TS_ASSERT_EQUALS(inputWorkspace, mockWs)
+    TS_ASSERT_EQUALS(setProps.getPropertyValue(roiPropName), "2,3")
+    TS_ASSERT_THROWS_NOTHING(mockAlg->updatePropertyValues(setProps))
+    Mantid::API::Workspace_sptr algorithmInput = mockAlg->getProperty(inputPropName);
+    TS_ASSERT_EQUALS(algorithmInput, mockWs)
   }
 
   void test_lookup_table_properties_forwarded() {


### PR DESCRIPTION
### Description of work

As part of the PNR Epic, the Reflectometry algorithms and GUI must support workspace groups. 

The last (hopefully!) portion of functionality that does not support workspace groups is that which sums banks across input workspaces. This is not really needed for the Epic as POLREF does not have 2D detectors, so there is nothing to sum across.... but it's done now. Maybe INTER will find some use for this.

This PR enables this by:
- Allowing the wrapper `ReflectometryISISLoadAndProcess` to set it's inputs so that the relevant child algorithms perform bank summons for workspace group members
- `ReflectometryISISSumBanks` now can accept workspace groups as output and input properties. This allows us to use the algorithm on a workspace group (framework intercepts this and calls the generic processGroups), and obtain a workspace group back out as a child algorithm. A small changes has been made to the `Algorithm` object to enable this (see release note). If this was not done, then the input and output groups have to be in the ADS prior to calling the alg, which is anti-pattern for internal child algorithms.
- `ReflectometryReductionOneAuto3` - `processGroups` path now has a call to `sumBanks`. This was previously excluded. Logic has been provided so that the pattern previously employed for single workspaces is employed for group workspaces (input workspaces properties are set to equal the groups, group member names are preserved). Added tests confirm this behaviour.

Closes #42034

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Run this before and after change:

Ask me for data.
```
from mantid.simpleapi import *

# Ask me for files, there is some preprocessing
INTER_DATA=['INTER00084884', 'INTER00084885', 'INTER00084886']

for data in INTER_DATA:
    INTER_DATA_PATH=f'/Users/mial.lewis/data/{data}.nxs'
    Load(Filename=INTER_DATA_PATH, OutputWorkspace=data)
GroupWorkspaces(InputWorkspaces=f'{",".join(INTER_DATA)}', OutputWorkspace='inter_group')

ReflectometryISISLoadAndProcess(
    InputRunList='inter_group', ThetaIn=0.80000000000000004, ROIDetectorIDs='6037-6121,7037-7121',
    AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='64-90', WavelengthMin=1.5,
    WavelengthMax=17, I0MonitorIndex=2, MonitorBackgroundWavelengthMin=17,
    MonitorBackgroundWavelengthMax=18, MonitorIntegrationWavelengthMin=4,
    MonitorIntegrationWavelengthMax=10, BackgroundProcessingInstructions='166-242',
    StartOverlap=10, EndOverlap=12, ScaleRHSWorkspace=False, MomentumTransferMin=0.010321400099096547,
    MomentumTransferStep=0.055396421622090297, MomentumTransferMax=0.11695694927687957,
    OutputWorkspaceBinned='inter_group_out_binned', OutputWorkspace='inter_group_out', OutputWorkspaceWavelength='inter_group_out_lam')

```



<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
