### PR TITLE
Modify pr build and test workflow to include macOS

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -142,14 +142,14 @@ jobs:
 
     strategy:
       matrix:
-        # Skip Windows when the PR targets ornl-next (ORNL-specific branch, Linux only)
-        include: ${{ fromJson(github.base_ref == 'ornl-next' && '[{"os":"Linux","cmake_preset":"linux-64-ci"}]' || '[{"os":"Linux","cmake_preset":"linux-64-ci"},{"os":"Windows","cmake_preset":"win-64-ci"}]') }}
+        # Skip Windows and macOS when the PR targets ornl-next (ORNL-specific branch, Linux only)
+        include: ${{ fromJson(github.base_ref == 'ornl-next' && '[{"os":"Linux","cmake_preset":"linux-64-ci","arch":"X64"}]' || '[{"os":"Linux","cmake_preset":"linux-64-ci","arch":"X64"},{"os":"Windows","cmake_preset":"win-64-ci","arch":"X64"},{"os":"macOS","cmake_preset":"osx-arm64-ci","arch":"ARM64"}]') }}
 
     runs-on:
       - ${{ (inputs.RUNNER_LABEL == '' && 'self-hosted') || inputs.RUNNER_LABEL }}
       - self-hosted
       - ${{ matrix.os }}
-      - X64
+      - ${{ matrix.arch }}
     #
     # If the user who clicked "Run Workflow" button left the RUNNER_LABEL field blank,
     # the default evaluated output is the string 'self-hosted'.
@@ -216,7 +216,11 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}
           # Not physical but logical cores, includes hyper threaded - different for darwin
-          BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          if [ "$(uname)" = "Darwin" ]; then
+            BUILD_THREADS="$(sysctl -n hw.ncpu)"
+          else
+            BUILD_THREADS="$(grep -c ^processor /proc/cpuinfo)"
+          fi
           # bool flags for this are
           # SYSTEM_TESTS UNIT_TESTS DOCS DOC_TESTS
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/run-tests ${GITHUB_WORKSPACE} false true $ENABLE_DOCS $ENABLE_DOC_TESTS ${BUILD_THREADS}
@@ -234,6 +238,14 @@ jobs:
         if: ${{ matrix.os == 'Windows' && failure() && steps.testunit.conclusion == 'failure' }}
         with:
           name: junit-unit-Windows
+          if-no-files-found: ignore
+          path: ${{ github.workspace }}/build/Testing/*unittest.xml
+
+      - name: Archive unit test output (macOS)
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.os == 'macOS' && failure() && steps.testunit.conclusion == 'failure' }}
+        with:
+          name: junit-unit-macOS
           if-no-files-found: ignore
           path: ${{ github.workspace }}/build/Testing/*unittest.xml
 


### PR DESCRIPTION
### Description of work

Once https://github.com/mantidproject/dockerfiles/pull/176 is merged and there is at least one macOS GitHub runner registered for the Mantid repo, this PR can be reviewed and merged. It modifies the PR build and test workflow so that macOS runners can be used. 

- This means it needs to differentiate between X64 and ARM64 architectures. 
- Just like Windows, macOS is excluded from `ornl-next` builds. 
- `BUILD_THREADS` had to be modified slightly for macOS, but stays the same for Windows and Linux. 
- In addition, unit test output for macOS is archived in a similar way as for the other OS.


### To test:

Setup at least one macOS GitHub runner for the repo and run this workflow. Please note that without a macOS GitHub runner [PR Build and Test / build-and-test (macOS, osx-arm64-ci, ARM64) (pull_request)](https://github.com/mantidproject/mantid/actions/runs/31704334633/job/94462107672?pr=42031) cannot complete successfully.

  *This does not require release notes* because it is a modification of our CI pipeline and not user-facing.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
