### PR TITLE
Texture Planning UI - Save and Load Texture Directions

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -111,6 +111,7 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         presenter.setup_texture(self)
         presenter.setup_gsas2(self)
         presenter.setup_calibration_notifier()
+        presenter.setup_reference_frame_notifier()
         presenter.statusbar_observable.add_subscriber(self.update_statusbar_text_observable)
         presenter.savedir_observable.add_subscriber(self.update_savedir_observable)
         self.set_on_settings_clicked(presenter.open_settings)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/presenter.py
@@ -32,7 +32,7 @@ from .tabs.common.rb_scope import RbScope
 from .tabs.common.instrument_scope import InstrumentScope
 
 from mantidqt.interfacemanager import InterfaceManager
-from mantidqt.utils.observer_pattern import GenericObservable
+from mantidqt.utils.observer_pattern import GenericObservable, GenericObserver
 
 from typing import TYPE_CHECKING
 
@@ -85,6 +85,15 @@ class EngineeringDiffractionPresenter(object):
     def setup_calibration_notifier(self) -> None:
         self.calibration_presenter.calibration_notifier.add_subscriber(self.focus_presenter.calibration_observer)
         self.calibration_presenter.calibration_notifier.add_subscriber(self.calibration_observer)
+
+    def setup_reference_frame_notifier(self) -> None:
+        """Let the settings dialog know when a loaded reference workspace has rewritten the sample
+        directions, so its cached copy does not overwrite them on the next Apply.
+
+        Wired here rather than in setup_correction because it needs both presenters to exist."""
+        self.correction_presenter.reference_frame_notifier.add_subscriber(
+            GenericObserver(self.settings_presenter.reload_settings_from_file)
+        )
 
     def setup_correction(self, view: "EngineeringDiffractionGui") -> None:
         correction_model = CorrectionModel()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -38,6 +38,7 @@ SETTINGS_DICT = {
     "plot_exp_pf": bool,
     "contour_kernel": str,
     "auto_pop_texture": bool,
+    "read_texture_dirs_from_ref": bool,
 }
 
 
@@ -65,6 +66,7 @@ DEFAULT_SETTINGS = {
     "plot_exp_pf": True,
     "contour_kernel": "2.0",
     "auto_pop_texture": False,
+    "read_texture_dirs_from_ref": True,
 }
 
 for instr in INSTRUMENT_DICT.values():
@@ -233,6 +235,7 @@ class SettingsPresenter(RbScopeConsumer, InstrumentScopeConsumer):
         self.settings["plot_exp_pf"] = self.view.get_plot_exp_pf()
         self.settings["contour_kernel"] = self.view.get_contour_kernel()
         self.settings["auto_pop_texture"] = self.view.get_auto_populate_texture()
+        self.settings["read_texture_dirs_from_ref"] = self.view.get_read_texture_dirs_from_ref()
         self._validate_settings(set_nullables_to_default=False)
 
     def _show_settings_in_view(self):
@@ -262,6 +265,7 @@ class SettingsPresenter(RbScopeConsumer, InstrumentScopeConsumer):
         self.view.set_plot_exp_pf(self.settings["plot_exp_pf"])
         self.view.set_contour_kernel(self.settings["contour_kernel"])
         self.view.set_auto_populate_texture(self.settings["auto_pop_texture"])
+        self.view.set_read_texture_dirs_from_ref(self.settings["read_texture_dirs_from_ref"])
         self._find_files()
 
     def update_full_calib_with_instrument(self):
@@ -292,6 +296,16 @@ class SettingsPresenter(RbScopeConsumer, InstrumentScopeConsumer):
         if self.settings != self.model.get_settings_dict(SETTINGS_DICT, self.rb_num):
             self._save_settings_to_file()
         self._find_files()
+
+    def reload_settings_from_file(self):
+        """Drop the cached settings and re-read them, refreshing the dialog if it happens to be open.
+
+        Called when something outside this dialog has written a setting (loading a reference
+        workspace rewrites the sample directions). Without it the cache would still hold the
+        pre-write values and the next Apply would put them straight back."""
+        self.load_settings_from_file_or_default()
+        if self.view.isVisible():
+            self._show_settings_in_view()
 
     # def validation intermediates
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -58,6 +58,11 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
         self.lineedit_TD0.setToolTip("X component of the third intrinsic sample direction")
         self.lineedit_TD1.setToolTip("Y component of the third intrinsic sample direction")
         self.lineedit_TD2.setToolTip("Z component of the third intrinsic sample direction")
+        self.readDirsFromRef_checkBox.setToolTip(
+            "If checked, loading a reference workspace on the Absorption Correction tab replaces the "
+            "sample directions above with the ones saved on it (only for the active RB number, and "
+            "only if the reference workspace carries them)"
+        )
 
         self.monte_carlo_lineedit.setToolTip(
             "Python dictionary-style string for input parameters to the MonteCarloAbsorption algorithm, "
@@ -207,6 +212,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def get_auto_populate_texture(self):
         return self.textureAutoPopulate.isChecked()
 
+    def get_read_texture_dirs_from_ref(self):
+        return self.readDirsFromRef_checkBox.isChecked()
+
     # =================
     # Component Setters
     # =================
@@ -321,6 +329,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def set_auto_populate_texture(self, val):
         self.textureAutoPopulate.setChecked(val)
+
+    def set_read_texture_dirs_from_ref(self, val):
+        self.readDirsFromRef_checkBox.setChecked(val)
 
     # =================
     # Force Actions

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -8,6 +8,7 @@ from qtpy import QtWidgets, QtCore
 from qtpy.QtGui import QIntValidator, QDoubleValidator
 
 from mantidqt.utils.qt import load_ui
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.direction_fields import autosize_direction_fields
 
 Ui_settings, _ = load_ui(__file__, "settings_widget.ui")
 
@@ -31,6 +32,21 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
         self.finder_path_to_gsas2.isForRunFiles(False)
         self.finder_path_to_gsas2.isForDirectory(True)
         self.finder_path_to_gsas2.isOptional(True)
+
+        self.direction_fields = (
+            self.lineedit_RD0,
+            self.lineedit_RD1,
+            self.lineedit_RD2,
+            self.lineedit_ND0,
+            self.lineedit_ND1,
+            self.lineedit_ND2,
+            self.lineedit_TD0,
+            self.lineedit_TD1,
+            self.lineedit_TD2,
+        )
+        # directions adopted from a reference workspace are written to full precision, so a fixed
+        # narrow box would hide most of the value
+        autosize_direction_fields(self.direction_fields)
 
         self.timeout_lineedit.setValidator(QIntValidator(0, 200))
         self.dSpacing_min_lineedit.setValidator(QDoubleValidator(0.0, 200.0, 3))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
@@ -290,6 +290,13 @@ QGroupBox:title {
     </property>
    </spacer>
   </item>
+      <item row="3" column="0" colspan="6">
+       <widget class="QCheckBox" name="readDirsFromRef_checkBox">
+        <property name="text">
+         <string>Read directions from a loaded reference workspace</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -203,6 +203,37 @@ class SettingsPresenterTest(unittest.TestCase):
         self.presenter.close_dialog()
         self.model.set_settings_dict.assert_not_called()
 
+    @patch(dir_path + ".path.isfile")
+    def test_reload_settings_from_file_refreshes_the_cache(self, mock_isfile):
+        # something outside the dialog (a reference workspace load) has rewritten a setting; the
+        # cached copy must be dropped or the next Apply would write the stale values back
+        mock_isfile.return_value = True
+        self.presenter.settings = {"stale": True}
+        reloaded = self.settings.copy()
+        reloaded["rd_dir"] = "0,1,0"
+        self.model.get_settings_dict.return_value = reloaded
+        self.model.validate_settings.return_value = reloaded
+        self.view.isVisible.return_value = False
+
+        self.presenter.reload_settings_from_file()
+
+        self.assertEqual(self.presenter.settings["rd_dir"], "0,1,0")
+        # the dialog is closed, so there is nothing to repopulate
+        self.view.set_rd_dir.assert_not_called()
+
+    @patch(dir_path + ".path.isfile")
+    def test_reload_settings_from_file_repopulates_an_open_dialog(self, mock_isfile):
+        mock_isfile.return_value = True
+        reloaded = self.settings.copy()
+        reloaded["rd_dir"] = "0,1,0"
+        self.model.get_settings_dict.return_value = reloaded
+        self.model.validate_settings.return_value = reloaded
+        self.view.isVisible.return_value = True
+
+        self.presenter.reload_settings_from_file()
+
+        self.view.set_rd_dir.assert_called_with("0,1,0")
+
     def test_default_calib_file_correct_location(self):
         self.assertTrue(path.exists(settings_presenter.DEFAULT_SETTINGS[f"full_calibration_{self.presenter.instrument}"]))
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -51,6 +51,7 @@ class SettingsPresenterTest(unittest.TestCase):
             "timeout": 10,
             "use_euler_angles": False,
             "auto_pop_texture": False,
+            "read_texture_dirs_from_ref": True,
         }
 
     def setup_view_getters(self, blank_log=False):
@@ -79,6 +80,7 @@ class SettingsPresenterTest(unittest.TestCase):
         self.view.get_plot_exp_pf.return_value = self.settings["plot_exp_pf"]
         self.view.get_contour_kernel.return_value = self.settings["contour_kernel"]
         self.view.get_auto_populate_texture.return_value = self.settings["auto_pop_texture"]
+        self.view.get_read_texture_dirs_from_ref.return_value = self.settings["read_texture_dirs_from_ref"]
 
     @patch(dir_path + ".path.isfile")
     def test_load_existing_settings(self, mock_isfile):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_view.py
@@ -27,6 +27,32 @@ class SettingsViewTest(unittest.TestCase):
 
         self.assertTrue(view.isModal())
 
+    @staticmethod
+    def _grid_widths(view):
+        # min and max are pinned together, so the boxes are exactly this wide once laid out
+        return {(field.minimumWidth(), field.maximumWidth()) for field in view.direction_fields}
+
+    def test_direction_boxes_are_wide_enough_for_a_three_decimal_component(self):
+        view = SettingsView()
+
+        widths = self._grid_widths(view)
+        self.assertEqual(len(widths), 1)  # a grid: every box the same width
+        self.assertGreater(widths.pop()[1], view.lineedit_RD0.fontMetrics().horizontalAdvance("-0.000"))
+
+    def test_direction_boxes_grow_to_fit_the_longest_entry(self):
+        view = SettingsView()
+        before = view.lineedit_RD0.maximumWidth()
+
+        # a direction adopted from a rotated reference frame is written to full precision
+        view.set_rd_dir("0.8660254037844387,0.5,0.0")
+
+        widths = self._grid_widths(view)
+        # the whole grid follows the longest entry, so the columns stay aligned
+        self.assertEqual(len(widths), 1)
+        width = widths.pop()[1]
+        self.assertGreater(width, before)
+        self.assertGreaterEqual(width, view.lineedit_RD0.fontMetrics().horizontalAdvance("0.8660254037844387"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/direction_fields.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/direction_fields.py
@@ -1,0 +1,54 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Sizing for the texture direction component boxes.
+
+The Texture Planner and the Engineering Diffraction settings both lay the three sample directions
+out as a grid of one-component boxes. The values are not always short: a direction carried round by
+an initial shape rotation is written to full precision, so a fixed narrow box hides most of it.
+
+These boxes are widened to fit the longest value currently in the grid, and every box in the grid is
+given the same width so the columns stay aligned.
+"""
+
+from typing import Sequence
+
+from qtpy.QtWidgets import QLineEdit
+
+# room for a signed 3 dp component, so a grid of short values does not collapse to an unreadable box
+MIN_FIT_TEXT = "-0.000"
+# a full precision double is ~18 characters; beyond that the box scrolls rather than the grid growing
+# without bound on a pasted or mistyped entry
+MAX_FIT_TEXT = "-0.12345678901234567"
+# frame, text margin and cursor space, none of which the font metrics account for
+_PADDING = 12
+
+
+def fit_direction_fields(fields: Sequence[QLineEdit]) -> None:
+    """Give every field in the grid the width of the longest entry in it."""
+    if not fields:
+        return
+    metrics = fields[0].fontMetrics()
+    longest = max(metrics.horizontalAdvance(field.text()) for field in fields)
+    width = _clamp(longest, metrics) + _PADDING
+    for field in fields:
+        # the .ui files cap these boxes, so the maximum has to move as well as the minimum
+        field.setMinimumWidth(width)
+        field.setMaximumWidth(width)
+
+
+def autosize_direction_fields(fields: Sequence[QLineEdit]) -> None:
+    """Size the grid now and keep it fitted as the values change.
+
+    textChanged covers both the user typing and the values being written by the presenter, so this
+    is the only hook needed."""
+    for field in fields:
+        field.textChanged.connect(lambda _text, f=fields: fit_direction_fields(f))
+    fit_direction_fields(fields)
+
+
+def _clamp(width: int, metrics) -> int:
+    return max(min(width, metrics.horizontalAdvance(MAX_FIT_TEXT)), metrics.horizontalAdvance(MIN_FIT_TEXT))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/model.py
@@ -8,7 +8,10 @@
 import os
 from typing import Sequence, Tuple, Dict, List, Any
 
+import numpy as np
+
 from Engineering.texture.correction.correction_model import TextureCorrectionModel
+from Engineering.texture.texture_helper import has_texture_direction_info, read_texture_direction_info_from_log
 from mantid.kernel import logger
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import Load
@@ -43,6 +46,18 @@ class CorrectionModel(TextureCorrectionModel):
             self.set_reference_ws(ws_name)
         except Exception as e:
             logger.warning(f"Failed to load {path}: {e}")
+
+    def get_reference_texture_directions(self) -> Tuple[np.ndarray, Tuple[str, str, str]] | None:
+        """The sample directions saved on the current reference workspace, or None when it carries
+        none (one built here by Create Reference Workspace, or predating these logs).
+
+        None means "this reference says nothing about the sample frame", which is deliberately
+        distinct from "it defines the identity frame" - the caller leaves the configured directions
+        alone in the first case."""
+        ref_ws = self.get_reference_ws()
+        if not ref_ws or not has_texture_direction_info(ref_ws):
+            return None
+        return read_texture_direction_info_from_log(ref_ws)
 
     @staticmethod
     def get_out_ws_names(wss: Sequence[str]) -> List[str]:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/presenter.py
@@ -183,10 +183,23 @@ class TextureCorrectionPresenter(RbScopeConsumer, InstrumentScopeConsumer, Algor
         changes = []
         for key, new_value in new_values.items():
             old_value = self._get_setting(key)
-            if old_value != new_value:
+            unchanged = self._same_direction(old_value, new_value) if key.endswith("_dir") else old_value == new_value
+            if not unchanged:
                 changes.append(f"{key} {old_value} -> {new_value}")
             set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, key, new_value, rb=self.rb_num)
         return changes
+
+    @staticmethod
+    def _same_direction(old_value: str, new_value: str) -> bool:
+        """Whether two direction settings describe the same vector at the precision written here.
+
+        The stored value may have been typed by hand ("1,0,0") while these are always written as
+        floats ("1.0,0.0,0.0"), so a string comparison would report an unchanged frame as a change."""
+        try:
+            old = [round(float(x), 6) for x in old_value.split(",")]
+        except (AttributeError, ValueError):
+            return False  # unreadable (or unset) settings are always worth overwriting
+        return old == [float(x) for x in new_value.split(",")]
 
     def on_apply_clicked(self) -> None:
         wss = self.view.get_selected_workspaces()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/presenter.py
@@ -15,13 +15,14 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common impo
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.rb_scope import RbScope, RbScopeConsumer
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.instrument_scope import InstrumentScope, InstrumentScopeConsumer
-from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting, set_setting
 
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.show_sample.show_sample_presenter import ShowSamplePresenter
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.correction.model import CorrectionModel
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.correction.view import TextureCorrectionView
 
 from functools import wraps
+from numpy import ndarray
 from typing import Callable, Type, List, Dict, Tuple, Sequence, Any
 
 
@@ -54,6 +55,9 @@ class TextureCorrectionPresenter(RbScopeConsumer, InstrumentScopeConsumer, Algor
         self.current_calibration = CalibrationInfo(instrument=self.instrument)
 
         self.correction_notifier = GenericObservable()
+        # fired when a loaded reference workspace rewrites the sample directions, so the settings
+        # dialog can drop its cached copy rather than saving the pre-load values back over them
+        self.reference_frame_notifier = GenericObservable()
 
         self.view.set_on_load_clicked(self.load_files_into_table)
         self.view.set_on_load_orientation_clicked(self.load_all_orientations)
@@ -138,6 +142,51 @@ class TextureCorrectionPresenter(RbScopeConsumer, InstrumentScopeConsumer, Algor
     def _on_load_ref_clicked(self) -> None:
         self.model.load_ref(self.view.get_reference_file())
         self.update_reference_info()
+        if self._get_setting("read_texture_dirs_from_ref", bool):
+            self._adopt_reference_texture_directions()
+
+    def _adopt_reference_texture_directions(self) -> None:
+        """Replace the sample directions with the ones saved on the just-loaded reference workspace.
+
+        The directions are written under the active RB number, so this only re-frames the current
+        experiment and leaves the user's global defaults intact. A reference carrying no direction
+        logs says nothing about the sample frame, so the configured directions are left alone."""
+        directions = self.model.get_reference_texture_directions()
+        if directions is None:
+            logger.notice(
+                f"Reference workspace '{self.model.get_reference_ws()}' carries no texture direction "
+                "information; the configured sample directions are unchanged."
+            )
+            return
+        ax_transform, dir_names = directions
+        changes = self._write_texture_direction_settings(ax_transform, dir_names)
+        if not changes:
+            # the reference agrees with what is already set, so there is nothing worth reporting
+            return
+        scope = f"RB {self.rb_num}" if self.rb_num else "the default settings"
+        logger.notice(
+            f"Sample directions for {scope} were overwritten from reference workspace "
+            f"'{self.model.get_reference_ws()}': " + "; ".join(changes)
+        )
+        self.reference_frame_notifier.notify_subscribers()
+
+    def _write_texture_direction_settings(self, ax_transform: ndarray, dir_names: Sequence[str]) -> List[str]:
+        """Write the six direction settings under the active RB, returning a description of each
+        value that actually changed (so an unchanged reload stays silent)."""
+        # ax_transform holds one direction per COLUMN (see TexturePlannerModel.set_ax_transform)
+        new_values = {}
+        for i, key in enumerate(("rd_dir", "nd_dir", "td_dir")):
+            new_values[key] = ",".join(str(round(float(x), 6)) for x in ax_transform[:, i])
+        for i, key in enumerate(("rd_name", "nd_name", "td_name")):
+            new_values[key] = dir_names[i]
+
+        changes = []
+        for key, new_value in new_values.items():
+            old_value = self._get_setting(key)
+            if old_value != new_value:
+                changes.append(f"{key} {old_value} -> {new_value}")
+            set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, key, new_value, rb=self.rb_num)
+        return changes
 
     def on_apply_clicked(self) -> None:
         wss = self.view.get_selected_workspaces()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_model.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #
 import unittest
+import numpy as np
 from unittest.mock import patch, MagicMock, call
 
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.correction.model import (
@@ -164,6 +165,41 @@ class TestCorrectionModel(unittest.TestCase):
         # Expect concatenated error messages to include only the failing param text
         args, _ = mock_logger.error.call_args
         self.assertIn("Vertical Divergence must be interpretable as a float.", args[0])
+
+
+class TestReferenceTextureDirections(unittest.TestCase):
+    """Reading the sample directions off the current reference workspace.
+
+    None distinguishes "this reference carries no sample frame" from "it carries the identity
+    frame"; the caller leaves the configured directions alone only in the first case.
+    """
+
+    def setUp(self):
+        self.model = CorrectionModel()
+
+    def test_returns_none_when_no_reference_is_set(self):
+        self.model.set_reference_ws(None)
+
+        self.assertIsNone(self.model.get_reference_texture_directions())
+
+    @patch(model_path + ".has_texture_direction_info", return_value=False)
+    def test_returns_none_when_the_reference_carries_no_direction_logs(self, mock_has_info):
+        self.model.set_reference_ws("ref_ws")
+
+        self.assertIsNone(self.model.get_reference_texture_directions())
+        mock_has_info.assert_called_once_with("ref_ws")
+
+    @patch(model_path + ".read_texture_direction_info_from_log")
+    @patch(model_path + ".has_texture_direction_info", return_value=True)
+    def test_returns_the_logged_directions(self, mock_has_info, mock_read):
+        mock_read.return_value = (np.eye(3), ("RD", "ND", "TD"))
+        self.model.set_reference_ws("ref_ws")
+
+        matrix, names = self.model.get_reference_texture_directions()
+
+        mock_read.assert_called_once_with("ref_ws")
+        np.testing.assert_allclose(matrix, np.eye(3))
+        self.assertEqual(names, ("RD", "ND", "TD"))
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_presenter.py
@@ -242,6 +242,17 @@ class TestAdoptReferenceTextureDirections(unittest.TestCase):
         mock_logger.notice.assert_not_called()
         self.presenter.reference_frame_notifier.notify_subscribers.assert_not_called()
 
+    @patch(presenter_path + ".logger")
+    def test_the_default_direction_strings_are_not_reported_as_a_change(self, mock_logger, mock_set_setting):
+        # the stored defaults are typed as "1,0,0" while these are always written as floats, so
+        # comparing the strings would report an identity reference as a re-framing
+        self.model.get_reference_texture_directions.return_value = (np.eye(3), ("RD", "ND", "TD"))
+
+        self.presenter._adopt_reference_texture_directions()
+
+        mock_logger.notice.assert_not_called()
+        self.presenter.reference_frame_notifier.notify_subscribers.assert_not_called()
+
     def test_the_settings_dialog_is_told_to_drop_its_cache(self, mock_set_setting):
         # otherwise the dialog's pre-load cache would be written back over these values on Apply
         self.model.get_reference_texture_directions.return_value = (self._AX_TRANSFORM, self._DIR_NAMES)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/correction/test/test_correction_presenter.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #
 import unittest
+import numpy as np
+from scipy.spatial.transform import Rotation
 from unittest.mock import MagicMock, patch, call
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.correction.presenter import TextureCorrectionPresenter
 
@@ -78,9 +80,21 @@ class TestTextureCorrectionPresenter(unittest.TestCase):
         self.view.get_reference_file.return_value = "ref_file.nxs"
         self.model.load_ref = MagicMock()
         self.presenter.update_reference_info = MagicMock()
+        # the setting is read from real QSettings otherwise, making the test depend on the machine
+        self.presenter._get_setting = MagicMock(return_value=False)
         self.presenter._on_load_ref_clicked()
         self.model.load_ref.assert_called_once_with("ref_file.nxs")
         self.presenter.update_reference_info.assert_called_once()
+
+    def test_load_ref_adopts_directions_when_the_setting_is_on(self):
+        self.presenter.update_reference_info = MagicMock()
+        self.presenter._adopt_reference_texture_directions = MagicMock()
+        self.presenter._get_setting = MagicMock(return_value=True)
+
+        self.presenter._on_load_ref_clicked()
+
+        self.presenter._get_setting.assert_called_once_with("read_texture_dirs_from_ref", bool)
+        self.presenter._adopt_reference_texture_directions.assert_called_once_with()
 
     def test_update_reference_info_calls_view_update(self):
         self.view.reset_mock()
@@ -154,6 +168,104 @@ class TestTextureCorrectionPresenter(unittest.TestCase):
         val = self.presenter._get_setting("key")
         self.assertEqual(val, "default")
         mock_get.assert_called_once()
+
+
+@patch(presenter_path + ".set_setting")
+class TestAdoptReferenceTextureDirections(unittest.TestCase):
+    """Loading a reference workspace re-frames the sample directions for the active experiment."""
+
+    # RD=(0,1,0), ND=(0,0,1), TD=(1,0,0) stored as COLUMNS, so a transposed write would show up
+    _AX_TRANSFORM = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    _DIR_NAMES = ("AD", "BD", "CD")
+
+    def setUp(self):
+        self.model = MagicMock()
+        self.view = MagicMock()
+        self.presenter = TextureCorrectionPresenter(self.model, self.view)
+        self.presenter.set_rb_num("RB123")
+        self.presenter.reference_frame_notifier = MagicMock()
+        self.model.get_reference_ws.return_value = "ref_ws"
+        # every direction setting currently holds the default frame
+        self._stored = {"rd_dir": "1,0,0", "nd_dir": "0,1,0", "td_dir": "0,0,1", "rd_name": "RD", "nd_name": "ND", "td_name": "TD"}
+        self.presenter._get_setting = MagicMock(side_effect=lambda name, *a: self._stored.get(name, ""))
+
+    @staticmethod
+    def _written(mock_set_setting):
+        # {setting_name: (value, rb)} from the set_setting calls
+        return {c.args[2]: (c.args[3], c.kwargs.get("rb")) for c in mock_set_setting.call_args_list}
+
+    def test_directions_are_written_under_the_active_rb(self, mock_set_setting):
+        self.model.get_reference_texture_directions.return_value = (self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.presenter._adopt_reference_texture_directions()
+
+        written = self._written(mock_set_setting)
+        # columns of the matrix map onto RD/ND/TD in order
+        self.assertEqual(written["rd_dir"], ("0.0,1.0,0.0", "RB123"))
+        self.assertEqual(written["nd_dir"], ("0.0,0.0,1.0", "RB123"))
+        self.assertEqual(written["td_dir"], ("1.0,0.0,0.0", "RB123"))
+        self.assertEqual(written["rd_name"], ("AD", "RB123"))
+        self.assertEqual(written["nd_name"], ("BD", "RB123"))
+        self.assertEqual(written["td_name"], ("CD", "RB123"))
+
+    @patch(presenter_path + ".logger")
+    def test_a_reference_without_directions_leaves_the_settings_alone(self, mock_logger, mock_set_setting):
+        # a reference built by Create Reference Workspace carries no direction logs; that says
+        # nothing about the sample frame and must not wipe a configured one
+        self.model.get_reference_texture_directions.return_value = None
+
+        self.presenter._adopt_reference_texture_directions()
+
+        mock_set_setting.assert_not_called()
+        self.presenter.reference_frame_notifier.notify_subscribers.assert_not_called()
+        mock_logger.notice.assert_called_once()
+
+    @patch(presenter_path + ".logger")
+    def test_the_change_is_logged_with_the_old_and_new_values(self, mock_logger, mock_set_setting):
+        self.model.get_reference_texture_directions.return_value = (self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.presenter._adopt_reference_texture_directions()
+
+        message = mock_logger.notice.call_args.args[0]
+        self.assertIn("RB123", message)
+        self.assertIn("ref_ws", message)
+        self.assertIn("rd_dir 1,0,0 -> 0.0,1.0,0.0", message)
+        self.assertIn("rd_name RD -> AD", message)
+
+    @patch(presenter_path + ".logger")
+    def test_a_reference_matching_the_current_settings_is_not_reported(self, mock_logger, mock_set_setting):
+        self.model.get_reference_texture_directions.return_value = (np.eye(3), ("RD", "ND", "TD"))
+        self._stored.update({"rd_dir": "1.0,0.0,0.0", "nd_dir": "0.0,1.0,0.0", "td_dir": "0.0,0.0,1.0"})
+
+        self.presenter._adopt_reference_texture_directions()
+
+        mock_logger.notice.assert_not_called()
+        self.presenter.reference_frame_notifier.notify_subscribers.assert_not_called()
+
+    def test_the_settings_dialog_is_told_to_drop_its_cache(self, mock_set_setting):
+        # otherwise the dialog's pre-load cache would be written back over these values on Apply
+        self.model.get_reference_texture_directions.return_value = (self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.presenter._adopt_reference_texture_directions()
+
+        self.presenter.reference_frame_notifier.notify_subscribers.assert_called_once_with()
+
+    def test_without_an_rb_the_directions_are_written_globally(self, mock_set_setting):
+        self.presenter.set_rb_num(None)
+        self.model.get_reference_texture_directions.return_value = (self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.presenter._adopt_reference_texture_directions()
+
+        self.assertEqual(self._written(mock_set_setting)["rd_dir"], ("0.0,1.0,0.0", None))
+
+    def test_rotated_directions_are_written_at_a_usable_precision(self, mock_set_setting):
+        rotated = Rotation.from_euler("z", 30, degrees=True).as_matrix()
+        self.model.get_reference_texture_directions.return_value = (rotated, self._DIR_NAMES)
+
+        self.presenter._adopt_reference_texture_directions()
+
+        rd_value, _ = self._written(mock_set_setting)["rd_dir"]
+        np.testing.assert_allclose([float(x) for x in rd_value.split(",")], rotated[:, 0], atol=1e-6)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/test/presenter_test.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/test/presenter_test.py
@@ -79,7 +79,20 @@ class EngineeringDiffractionPresenterTest(unittest.TestCase):
         # Should add both observers as subscribers
         notifier.add_subscriber.assert_any_call(self.presenter.focus_presenter.calibration_observer)
         notifier.add_subscriber.assert_any_call(self.presenter.calibration_observer)
-        self.assertEqual(notifier.add_subscriber.call_count, 2)
+
+    def test_setup_reference_frame_notifier_reloads_the_settings_cache(self):
+        self.presenter.correction_presenter = MagicMock()
+        self.presenter.settings_presenter = MagicMock()
+        notifier = MagicMock()
+        self.presenter.correction_presenter.reference_frame_notifier = notifier
+
+        self.presenter.setup_reference_frame_notifier()
+
+        notifier.add_subscriber.assert_called_once()
+        # firing the observer must re-read the settings the reference load has just rewritten
+        observer = notifier.add_subscriber.call_args.args[0]
+        observer.update(notifier, None)
+        self.presenter.settings_presenter.reload_settings_from_file.assert_called_once_with()
 
     @patch(presenter_path + ".TextureCorrectionPresenter")
     @patch(presenter_path + ".TextureCorrectionView")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -41,7 +41,7 @@ class AbsorptionCalculator:
     def calc_for_index(self, index: int) -> None:
         wsm = self._model.workspaces
         # create a workspace to run the absorption calculation on
-        mc_ws = self._create_mc_ws(wsm)
+        mc_ws = self._create_mc_ws()
 
         # extract goniometer for run index
         R = self._model.orientations[index].R
@@ -60,9 +60,15 @@ class AbsorptionCalculator:
             transmission = [0] * len(self._model.geometry.spec_inds)
         self._model.orientations.set_transmission_at_index(transmission, index)
 
-    @staticmethod
-    def _create_mc_ws(wsm: WorkspaceManager) -> MatrixWorkspace:
-        mc_ws = ConvertUnits(InputWorkspace=wsm.wsname, Target="Wavelength", OutputWorkspace=wsm.WS_MC_INPUT)
+    def _create_mc_ws(self) -> MatrixWorkspace:
+        wsm = self._model.workspaces
+        # create a ws with params binned around the evaluation point
+        src_ws = wsm.create_simulation_workspace(
+            wsm.WS_MC_INPUT,
+            unit=wsm.attenuation_kwargs["unit"],
+            bin_params=wsm.create_bin_params_around_point(wsm.attenuation_kwargs["point"]),
+        )
+        mc_ws = ConvertUnits(InputWorkspace=src_ws, Target="Wavelength", OutputWorkspace=wsm.WS_MC_INPUT)
         mc_ws.run().getGoniometer().setR(np.eye(3))
         return mc_ws
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/exporter.py
@@ -15,7 +15,7 @@ from mantid.simpleapi import (
 )
 from mantid.api import AnalysisDataService as ADS
 from mantid.kernel import logger
-from Engineering.texture.texture_helper import convert_to_sscanss_frame
+from Engineering.texture.texture_helper import convert_to_sscanss_frame, write_texture_direction_info_to_log
 from typing import TYPE_CHECKING, Generator
 
 if TYPE_CHECKING:
@@ -109,6 +109,7 @@ class OrientationExporter:
         ref_wsname = self._model.workspaces.WS_REFERENCE
         try:
             self._build_reference_ws(ref_wsname)
+            write_texture_direction_info_to_log(ref_wsname, self._model.effective_ax_transform, self._model.dir_names)
             save_file = os.path.join(save_dir, filename + ".nxs")
             SaveNexus(InputWorkspace=ref_wsname, Filename=save_file)
             logger.notice(f"Reference workspace saved to '{save_file}'")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
 
 @dataclass
 class PlotProperties:
+    point_size: float = 20
+    gonio_point_size: float = 30
+    # size multiplier for the ring drawn around the current orientation in the transmission plot
+    current_point_scale: float = 2
     sample_vec_scaler: float = 1.2
     num_points_in_ring: int = 360
     sample_opacity: float = 0.5
@@ -62,6 +66,7 @@ class TexturePlotter:
         self.vis_settings = {"directions": True, "goniometers": True, "incident": True, "ks": True, "scattered": False}
         # when True the transmission plot colour scale spans the data range; otherwise it is fixed to [0, 1]
         self.transmission_use_data_range = False
+        self.att_show_current = True
         self._transmission_cax = None
         self._plot_properties = PlotProperties()
 
@@ -242,7 +247,7 @@ class TexturePlotter:
             if np.isclose(np.linalg.norm(gP), 1):
                 proj_ax.plot((gP[1], -gP[1]), (gP[0], -gP[0]), color=pc, ls=("-", "--")[int(i != self._model.gonio_index)])
             else:
-                proj_ax.scatter(gP[1], gP[0], s=30, edgecolor=pc, facecolor=fc)
+                proj_ax.scatter(gP[1], gP[0], s=self._plot_properties.gonio_point_size, edgecolor=pc, facecolor=fc)
 
         # if there aren't transmission values
         if not self._model.plot_transmission:
@@ -254,14 +259,18 @@ class TexturePlotter:
                     pf_xy = orientation.pf_points
                     # plot current selected orientation with full circles
                     if i == current_index:
-                        proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, c="dodgerblue")
+                        proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=self._plot_properties.point_size, c="dodgerblue")
                     # plot all other orientations as just edges
                     else:
-                        proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="dodgerblue")
+                        proj_ax.scatter(
+                            pf_xy[:, 1], pf_xy[:, 0], s=self._plot_properties.point_size, facecolor="None", edgecolor="dodgerblue"
+                        )
                 # if the current selected orientation is not set to be included plot it as a grey edge
                 elif i == current_index:
                     pf_xy = orientation.pf_points
-                    proj_ax.scatter(pf_xy[:, 1], pf_xy[:, 0], s=20, facecolor="None", edgecolor="grey", alpha=0.5)
+                    proj_ax.scatter(
+                        pf_xy[:, 1], pf_xy[:, 0], s=self._plot_properties.point_size, facecolor="None", edgecolor="grey", alpha=0.5
+                    )
         # if there are transmission values to be plotted
         else:
             # get the included runs
@@ -277,9 +286,27 @@ class TexturePlotter:
             # constrain the cmap range if desired
             clim_kwargs = {} if self.transmission_use_data_range else {"vmin": 0, "vmax": 1}
             # plot the points
-            scatt = proj_ax.scatter(all_pf_xy[:, 1], all_pf_xy[:, 0], s=20, c=all_transmissions, cmap="jet", **clim_kwargs)
+            scatt = proj_ax.scatter(
+                all_pf_xy[:, 1], all_pf_xy[:, 0], s=self._plot_properties.point_size, c=all_transmissions, cmap="jet", **clim_kwargs
+            )
+            # the colour-coded points carry no per-orientation identity, so optionally ring the current one
+            if self.att_show_current:
+                self._show_current_index(proj_ax, current_index)
             self._transmission_cax = proj_ax.inset_axes(self._plot_properties.cbar_inset_location)
             proj_ax.figure.colorbar(scatt, cax=self._transmission_cax)
+
+    def _show_current_index(self, proj_ax: Axes, current_index: int) -> None:
+        pf_xy = self._model.orientations[current_index].pf_points
+        if pf_xy is None:
+            return
+        # ring the current selected orientation with oversized open circles so the colours stay readable
+        proj_ax.scatter(
+            pf_xy[:, 1],
+            pf_xy[:, 0],
+            s=self._plot_properties.point_size * self._plot_properties.current_point_scale,
+            facecolor="None",
+            edgecolor="grey",
+        )
 
     def _decorate_pole_figure(self, proj_ax: Axes) -> None:
         proj_ax.set(xlim=self._plot_properties.pf_ax_lims, ylim=self._plot_properties.pf_ax_lims, aspect="equal")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/plotter.py
@@ -181,7 +181,7 @@ class TexturePlotter:
 
         # if the setting want the sample directions plotted, plot them
         if self.vis_settings["directions"]:
-            sample_model.plot_sample_directions(self._model.ax_transform, self._model.dir_names, scat_centre=scat_centre)
+            sample_model.plot_sample_directions(self._model.effective_ax_transform, self._model.dir_names, scat_centre=scat_centre)
 
         # scale the lab frame
         lim = [-(abs_lim := extent * n_gon / 1.5), abs_lim]
@@ -229,7 +229,7 @@ class TexturePlotter:
         lab_ax.scatter(tips[:, 0], tips[:, 1], tips[:, 2], color=tip_color, s=2)
 
     def _project_goniometer_poles(self, R: Rotation, g_vecs: List[np.ndarray | int]) -> np.ndarray:
-        g_pole = R.inv().apply(np.array(g_vecs)) @ self._model.ax_transform
+        g_pole = R.inv().apply(np.array(g_vecs)) @ self._model.effective_ax_transform
         cart_g_pole = get_alpha_beta_from_cart(g_pole.T)
         return ster_proj_xy(*cart_g_pole.T) if self._model.projection == "ster" else azim_proj_xy(*cart_g_pole.T)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
@@ -49,24 +49,62 @@ def _make_model(R=None, n_orientations=1, spec_inds=None):
 
 @patch(file_path + ".ConvertUnits")
 class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
-    def test_converts_units_to_wavelength_into_mc_input(self, mock_convert):
-        wsm = _make_wsm()
-        mc_ws = MagicMock()
-        mock_convert.return_value = mc_ws
+    @staticmethod
+    def _make_calculator(point=1.5, unit="dSpacing"):
+        model, _ = _make_model()
+        model.workspaces.attenuation_kwargs = {"point": point, "unit": unit}
+        model.workspaces.create_bin_params_around_point.return_value = "1.4775,0.015,1.5225"
+        return AbsorptionCalculator(model), model.workspaces
 
-        result = AbsorptionCalculator._create_mc_ws(wsm)
+    def test_bins_the_source_ws_around_the_evaluation_point(self, mock_convert):
+        # the source grid must bracket the point so that read_attenuation_coefficient_at_value can
+        # interpolate there - a grid that does not reach the point raises instead
+        calc, wsm = self._make_calculator(point=7.5, unit="dSpacing")
 
-        mock_convert.assert_called_once_with(InputWorkspace=WS_DATA, Target="Wavelength", OutputWorkspace=WS_MC_INPUT)
-        self.assertIs(result, mc_ws)
+        calc._create_mc_ws()
+
+        wsm.create_bin_params_around_point.assert_called_once_with(7.5)
+        wsm.create_simulation_workspace.assert_called_once_with(
+            WS_MC_INPUT, unit="dSpacing", bin_params=wsm.create_bin_params_around_point.return_value
+        )
+
+    def test_builds_source_ws_in_the_requested_unit_not_in_wavelength(self, mock_convert):
+        # a single dSpacing point maps to a different wavelength in every detector (lambda = 2 d sin(theta)),
+        # so the grid is built in the requested unit and converted per spectrum; binning directly in
+        # wavelength would evaluate the whole bank at one detector's wavelength
+        calc, wsm = self._make_calculator(unit="dSpacing")
+
+        calc._create_mc_ws()
+
+        self.assertEqual(wsm.create_simulation_workspace.call_args.kwargs["unit"], "dSpacing")
+
+    def test_converts_source_ws_to_wavelength_for_the_mc_input(self, mock_convert):
+        calc, wsm = self._make_calculator()
+
+        result = calc._create_mc_ws()
+
+        mock_convert.assert_called_once_with(
+            InputWorkspace=wsm.create_simulation_workspace.return_value, Target="Wavelength", OutputWorkspace=WS_MC_INPUT
+        )
+        self.assertIs(result, mock_convert.return_value)
+
+    def test_still_converts_when_point_is_already_in_wavelength(self, mock_convert):
+        # MonteCarloAbsorption needs a wavelength axis, and ConvertUnits is a no-op when already there
+        calc, wsm = self._make_calculator(point=4.0, unit="Wavelength")
+
+        calc._create_mc_ws()
+
+        self.assertEqual(wsm.create_simulation_workspace.call_args.kwargs["unit"], "Wavelength")
+        mock_convert.assert_called_once()
 
     def test_resets_goniometer_to_identity(self, mock_convert):
-        wsm = _make_wsm()
-        mc_ws = MagicMock()
+        # _set_mc_sample_state CopySamples onto this ws, and CopySample bakes the *destination's*
+        # goniometer into the shape, so a stale rotation here would be applied twice
+        calc, _ = self._make_calculator()
         gonio = MagicMock()
-        mc_ws.run.return_value.getGoniometer.return_value = gonio
-        mock_convert.return_value = mc_ws
+        mock_convert.return_value.run.return_value.getGoniometer.return_value = gonio
 
-        AbsorptionCalculator._create_mc_ws(wsm)
+        calc._create_mc_ws()
 
         gonio.setR.assert_called_once()
         np.testing.assert_array_equal(gonio.setR.call_args.args[0], np.eye(3))
@@ -175,7 +213,7 @@ class TestAbsorptionCalculator_CalcForIndex(unittest.TestCase):
 
         calc.calc_for_index(0)
 
-        calc._create_mc_ws.assert_called_once_with(model.workspaces)
+        calc._create_mc_ws.assert_called_once_with()
         calc._set_mc_sample_state.assert_called_once_with(model.workspaces, mc_ws, orient.R)
         mock_mc.assert_called_once_with(**calc.mc_kwargs)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_exporter.py
@@ -305,14 +305,18 @@ class TestOrientationExporter_BuildReferenceWs(unittest.TestCase):
 @patch(FILE_PATH + ".logger")
 @patch(FILE_PATH + ".ADS")
 @patch(FILE_PATH + ".SaveNexus")
+@patch(FILE_PATH + ".write_texture_direction_info_to_log")
 class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
+    # _build_reference_ws and the ADS are mocked out here, so the reference workspace never really
+    # exists; the direction-log write is therefore patched too (its own round-trip is covered in
+    # test_texture_helper and in the planner's functional export tests).
     def _make_exporter(self):
         model = _make_model()
         exp = OrientationExporter(model)
         exp._build_reference_ws = MagicMock()
         return exp
 
-    def test_orchestrates_build_then_save(self, mock_save, mock_ads, mock_logger):
+    def test_orchestrates_build_then_save(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
         exp = self._make_exporter()
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -325,7 +329,29 @@ class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
             mock_save.assert_called_once_with(InputWorkspace=WS_REFERENCE, Filename=expected_path)
             mock_logger.notice.assert_called_once()
 
-    def test_removes_ref_ws_from_ads_when_it_exists(self, mock_save, mock_ads, mock_logger):
+    def test_writes_the_directions_the_saved_shape_is_in(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            exp.output_as_reference_workspace(tmp, "out")
+
+        # the saved shape already has the initial rotation baked in, so the directions written
+        # alongside it must be the effective (post-rotation) ones, not the raw entered transform
+        mock_write_dirs.assert_called_once_with(WS_REFERENCE, exp._model.effective_ax_transform, exp._model.dir_names)
+
+    def test_directions_are_written_before_the_file_is_saved(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
+        exp = self._make_exporter()
+        call_order = []
+        mock_write_dirs.side_effect = lambda *a, **k: call_order.append("write_dirs")
+        mock_save.side_effect = lambda *a, **k: call_order.append("save")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            exp.output_as_reference_workspace(tmp, "out")
+
+        # otherwise the logs would never reach the file
+        self.assertEqual(call_order, ["write_dirs", "save"])
+
+    def test_removes_ref_ws_from_ads_when_it_exists(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
         exp = self._make_exporter()
         mock_ads.doesExist.return_value = True
 
@@ -335,7 +361,7 @@ class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
         mock_ads.doesExist.assert_called_with(WS_REFERENCE)
         mock_ads.remove.assert_called_once_with(WS_REFERENCE)
 
-    def test_does_not_remove_ref_ws_if_absent(self, mock_save, mock_ads, mock_logger):
+    def test_does_not_remove_ref_ws_if_absent(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
         exp = self._make_exporter()
         mock_ads.doesExist.return_value = False
 
@@ -344,7 +370,7 @@ class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
 
         mock_ads.remove.assert_not_called()
 
-    def test_cleans_up_ref_ws_even_when_build_raises(self, mock_save, mock_ads, mock_logger):
+    def test_cleans_up_ref_ws_even_when_build_raises(self, mock_write_dirs, mock_save, mock_ads, mock_logger):
         exp = self._make_exporter()
         exp._build_reference_ws.side_effect = RuntimeError("boom")
         mock_ads.doesExist.return_value = True
@@ -355,6 +381,7 @@ class TestOrientationExporter_OutputAsReferenceWorkspace(unittest.TestCase):
 
         mock_ads.remove.assert_called_once_with(WS_REFERENCE)
         mock_save.assert_not_called()
+        mock_write_dirs.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
@@ -57,7 +57,7 @@ def _make_model(
     return model
 
 
-def _make_plotter(model, *, vis_settings=None, gon_colors=None, dir_cols=None, transmission_use_data_range=None):
+def _make_plotter(model, *, vis_settings=None, gon_colors=None, dir_cols=None, transmission_use_data_range=None, att_show_current=None):
     # the plotter owns its visual config; by default we leave the constructor defaults in place so
     # __init__ wiring is actually exercised. Tests that intentionally drive a specific config pass
     # the relevant override(s), which are applied on top of the real defaults.
@@ -70,7 +70,22 @@ def _make_plotter(model, *, vis_settings=None, gon_colors=None, dir_cols=None, t
         plotter.dir_cols = dir_cols
     if transmission_use_data_range is not None:
         plotter.transmission_use_data_range = transmission_use_data_range
+    if att_show_current is not None:
+        plotter.att_show_current = att_show_current
     return plotter
+
+
+def _transmission_scatter_call(proj_ax):
+    # the colour-mapped scatter is the only one passed a cmap; the current-orientation highlight
+    # (when enabled) is a separate, later scatter call
+    calls = [c for c in proj_ax.scatter.call_args_list if "cmap" in c.kwargs]
+    assert len(calls) == 1, f"expected exactly one colour-mapped scatter, got {len(calls)}"
+    return calls[0]
+
+
+def _highlight_scatter_calls(proj_ax):
+    # the current-orientation highlight is the grey open-circle scatter drawn in transmission mode
+    return [c for c in proj_ax.scatter.call_args_list if c.kwargs.get("edgecolor") == "grey" and "cmap" not in c.kwargs]
 
 
 class TestTexturePlotter_UpdatePlot(unittest.TestCase):
@@ -527,7 +542,7 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
 
         plotter._draw_pole_figure(proj_ax, [], current_index=0)
 
-        scatter_call = proj_ax.scatter.call_args
+        scatter_call = _transmission_scatter_call(proj_ax)
         np.testing.assert_array_equal(scatter_call.args[0], np.array([0.2, 0.4]))
         np.testing.assert_array_equal(scatter_call.args[1], np.array([0.1, 0.3]))
         np.testing.assert_array_equal(scatter_call.kwargs["c"], np.array([0.3, 0.7]))
@@ -548,10 +563,119 @@ class TestTexturePlotter_DrawPoleFigure(unittest.TestCase):
 
         plotter._draw_pole_figure(proj_ax, [], current_index=0)
 
-        scatter_call = proj_ax.scatter.call_args
+        scatter_call = _transmission_scatter_call(proj_ax)
         self.assertNotIn("vmin", scatter_call.kwargs)
         self.assertNotIn("vmax", scatter_call.kwargs)
         self.assertEqual(scatter_call.kwargs["cmap"], "jet")
+
+
+class TestTexturePlotter_TransmissionCurrentIndexHighlight(unittest.TestCase):
+    """In transmission mode the points are coloured by value, so the current orientation is
+    optionally ringed with oversized grey open circles instead of being drawn filled."""
+
+    @staticmethod
+    def _model_with_two_orientations(**model_kwargs):
+        cur = MagicMock()
+        cur.include = True
+        cur.pf_points = np.array([[0.1, 0.2], [0.3, 0.4]])
+        cur.transmission = np.array([0.3, 0.5])
+        other = MagicMock()
+        other.include = True
+        other.pf_points = np.array([[0.5, 0.6]])
+        other.transmission = np.array([0.7])
+        return _make_model(orientations={0: cur, 1: other}, plot_transmission=True, **model_kwargs)
+
+    def test_enabled_by_default(self):
+        self.assertTrue(TexturePlotter(_make_model()).att_show_current)
+
+    def test_highlights_current_orientation_points_when_enabled(self):
+        model = self._model_with_two_orientations()
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        (highlight,) = _highlight_scatter_calls(proj_ax)
+        # only the current orientation's points are ringed, with the columns swapped as elsewhere
+        np.testing.assert_array_equal(highlight.args[0], np.array([0.2, 0.4]))
+        np.testing.assert_array_equal(highlight.args[1], np.array([0.1, 0.3]))
+        # open circles, drawn at twice the normal point size so the colour stays visible inside
+        self.assertEqual(highlight.kwargs["facecolor"], "None")
+        self.assertEqual(highlight.kwargs["s"], 40)
+
+    def test_highlight_follows_the_current_index(self):
+        model = self._model_with_two_orientations()
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=1)
+
+        (highlight,) = _highlight_scatter_calls(proj_ax)
+        np.testing.assert_array_equal(highlight.args[0], np.array([0.6]))
+        np.testing.assert_array_equal(highlight.args[1], np.array([0.5]))
+
+    def test_no_highlight_when_disabled(self):
+        model = self._model_with_two_orientations()
+        plotter = _make_plotter(model, att_show_current=False)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        self.assertEqual(_highlight_scatter_calls(proj_ax), [])
+        # the colour-mapped scatter and its colour bar are unaffected
+        self.assertEqual(_transmission_scatter_call(proj_ax).kwargs["cmap"], "jet")
+        proj_ax.figure.colorbar.assert_called_once()
+
+    def test_highlights_excluded_current_orientation_whose_points_are_not_in_the_colour_map(self):
+        # an excluded current orientation contributes no coloured points, but the user still needs
+        # to see where it sits - as in the non-transmission plot, it stays visible
+        model = self._model_with_two_orientations()
+        model.orientations[0].include = False
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        (highlight,) = _highlight_scatter_calls(proj_ax)
+        np.testing.assert_array_equal(highlight.args[0], np.array([0.2, 0.4]))
+        # only the *other* orientation's value is colour-mapped
+        np.testing.assert_array_equal(_transmission_scatter_call(proj_ax).kwargs["c"], np.array([0.7]))
+
+    def test_no_highlight_when_current_orientation_has_no_pole_figure_points(self):
+        # regression: an orientation whose pf_points have not been calculated must not be indexed
+        model = self._model_with_two_orientations()
+        model.orientations[0].pf_points = None
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        self.assertEqual(_highlight_scatter_calls(proj_ax), [])
+        proj_ax.figure.colorbar.assert_called_once()
+
+    def test_no_highlight_when_there_is_nothing_to_colour_map(self):
+        # with no included orientations the transmission branch returns before drawing anything
+        model = self._model_with_two_orientations()
+        model.orientations[0].include = False
+        model.orientations[1].include = False
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        self.assertEqual(_highlight_scatter_calls(proj_ax), [])
+        proj_ax.figure.colorbar.assert_not_called()
+
+    def test_not_drawn_outside_transmission_mode(self):
+        # without transmission values the current orientation is already drawn filled, so no ring
+        model = self._model_with_two_orientations()
+        model.plot_transmission = False
+        plotter = _make_plotter(model, att_show_current=True)
+        proj_ax = MagicMock()
+
+        plotter._draw_pole_figure(proj_ax, [], current_index=0)
+
+        self.assertEqual(_highlight_scatter_calls(proj_ax), [])
 
 
 @patch(file_path + ".plt")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_plotter.py
@@ -32,7 +32,10 @@ def _make_model(
     # configured on the plotter itself via _make_plotter(...), not on the model.
     model = MagicMock()
     model.dir_names = dir_names or ["RD", "ND", "TD"]
-    model.ax_transform = np.eye(3) if ax_transform is None else ax_transform
+    # the plotter reads effective_ax_transform (the entered directions, carried round by the initial
+    # shape rotation when that option is on) - never the raw ax_transform, which is left unset so a
+    # regression back to it fails loudly rather than silently drawing a MagicMock
+    model.effective_ax_transform = np.eye(3) if ax_transform is None else ax_transform
     model.projection = projection
     model.gonio_index = gonio_index
     model.plot_transmission = plot_transmission

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -169,7 +169,7 @@ class TestWorkspaceManager_InitWss(unittest.TestCase):
 
         mock_create_sim.assert_called_once_with(
             Instrument="ENGINX",
-            BinParams="0,0.1,5",
+            BinParams=WorkspaceManager.DEFAULT_BIN_PARAMS,
             OutputWorkspace=wm.WS_DATA,
             UnitX="dSpacing",
         )
@@ -288,7 +288,9 @@ class TestWorkspaceManager_CreateNewWsWithCopiedSample(unittest.TestCase):
 
         result = wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
 
-        mock_create_sim.assert_called_once_with(Instrument="ENGINX", BinParams="0,0.1,5", OutputWorkspace="dest_ws", UnitX="dSpacing")
+        mock_create_sim.assert_called_once_with(
+            Instrument="ENGINX", BinParams=WorkspaceManager.DEFAULT_BIN_PARAMS, OutputWorkspace="dest_ws", UnitX="dSpacing"
+        )
         mock_copy.assert_called_once_with(InputWorkspace="shape_tmp", OutputWorkspace="dest_ws", **COPY_KWARGS)
         self.assertEqual(result, "new_ws")
 
@@ -771,6 +773,85 @@ class TestWorkspaceManager_SetGaugeVolumeStr(unittest.TestCase):
 
         mock_define_gv.assert_not_called()
         mock_delete_log.assert_not_called()
+
+
+@patch(file_path + ".CreateSimulationWorkspace")
+class TestWorkspaceManager_CreateSimulationWorkspace(unittest.TestCase):
+    def test_defaults_to_the_generic_dspacing_grid(self, mock_create_sim):
+        wm = _make_manager("ENGINX")
+
+        result = wm.create_simulation_workspace("some_ws")
+
+        mock_create_sim.assert_called_once_with(
+            Instrument="ENGINX", BinParams=WorkspaceManager.DEFAULT_BIN_PARAMS, OutputWorkspace="some_ws", UnitX="dSpacing"
+        )
+        self.assertIs(result, mock_create_sim.return_value)
+
+    def test_forwards_explicit_unit_and_bin_params(self, mock_create_sim):
+        wm = _make_manager("IMAT")
+
+        wm.create_simulation_workspace("some_ws", unit="Wavelength", bin_params="1,2,3")
+
+        mock_create_sim.assert_called_once_with(Instrument="IMAT", BinParams="1,2,3", OutputWorkspace="some_ws", UnitX="Wavelength")
+
+    def test_reads_instrument_from_the_model_at_call_time(self, mock_create_sim):
+        # the instrument is a live property, so a switch must be picked up without rebuilding the manager
+        model = MagicMock()
+        model.instrument.get_instrument.return_value = "ENGINX"
+        wm = WorkspaceManager(model)
+        model.instrument.get_instrument.return_value = "IMAT"
+
+        wm.create_simulation_workspace("some_ws")
+
+        self.assertEqual(mock_create_sim.call_args.kwargs["Instrument"], "IMAT")
+
+
+class TestWorkspaceManager_CreateBinParamsAroundPoint(unittest.TestCase):
+    @staticmethod
+    def _edges(params):
+        start, step, stop = (float(p) for p in params.split(","))
+        return np.arange(start, stop + step / 2, step)
+
+    def _centres(self, params):
+        edges = self._edges(params)
+        return np.convolve(edges, np.ones(2), "valid") / 2
+
+    def test_point_lands_on_the_middle_bin_centre(self):
+        # read_attenuation_coefficient_at_value interpolates the MC output at the point, so the point
+        # must sit on a bin centre, not merely inside the range
+        for point in (0.2, 1.5, 7.5, 100.0):
+            with self.subTest(point=point):
+                centres = self._centres(WorkspaceManager.create_bin_params_around_point(point))
+                self.assertEqual(len(centres), 3)
+                self.assertAlmostEqual(centres[1], point)
+
+    def test_builds_three_bins(self):
+        # CreateSimulationWorkspace rejects anything with fewer than three bin boundaries, and
+        # interpolation needs at least two points either side to be well defined
+        edges = self._edges(WorkspaceManager.create_bin_params_around_point(1.5))
+
+        self.assertEqual(len(edges), 4)
+
+    def test_bracket_is_narrow_and_scales_with_the_point(self):
+        # a fixed-width bracket would be far too wide for a small point and too narrow for a large one
+        for point in (0.2, 1.5, 7.5):
+            with self.subTest(point=point):
+                edges = self._edges(WorkspaceManager.create_bin_params_around_point(point))
+                self.assertAlmostEqual((edges[-1] - edges[0]) / point, 0.03)
+
+    def test_bracket_stays_strictly_positive(self):
+        # negative dSpacing/wavelength is meaningless and CreateSimulationWorkspace would reject it
+        for point in (0.2, 1.5, 7.5):
+            with self.subTest(point=point):
+                self.assertGreater(self._edges(WorkspaceManager.create_bin_params_around_point(point))[0], 0)
+
+    def test_non_positive_point_is_clamped_rather_than_raising(self):
+        # a stray non-physical point should degrade to a garbage number, not kill the whole calculation
+        for point in (0.0, -1.5):
+            with self.subTest(point=point):
+                params = WorkspaceManager.create_bin_params_around_point(point)
+                self.assertGreater(self._edges(params)[0], 0)
+                self.assertAlmostEqual(self._centres(params)[1], 1e-6)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -38,6 +38,8 @@ class WorkspaceManager:
     """
 
     DEFAULT_MATERIAL = "Fe"
+    # Bin params for most workspaces are irrelevant, just set some generic defaults
+    DEFAULT_BIN_PARAMS = "0,0.1,5"
 
     def __init__(self, model: TexturePlannerModel):
         self._model = model
@@ -155,7 +157,7 @@ class WorkspaceManager:
         self.updated_mesh_ws = updated_mesh_ws
 
     def _init_wss(self) -> None:
-        ws = CreateSimulationWorkspace(Instrument=self.instr, BinParams="0,0.1,5", OutputWorkspace=self.wsname, UnitX="dSpacing")
+        ws = self.create_simulation_workspace(self.wsname)
         for ispec in range(ws.getNumberHistograms()):
             ws.setSharedY(ispec, np.ones_like(ws.y(ispec)))
         mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_RAW)
@@ -311,7 +313,7 @@ class WorkspaceManager:
         else:
             shape_ws = sample_to_copy
         try:
-            new_ws = CreateSimulationWorkspace(Instrument=self.instr, BinParams="0,0.1,5", OutputWorkspace=new_wsname, UnitX="dSpacing")
+            new_ws = self.create_simulation_workspace(new_wsname)
             if preserve_initial_rotation:
                 self.copy_sample_preserving_initial_rotation(shape_ws, new_ws)
             else:
@@ -341,3 +343,18 @@ class WorkspaceManager:
         dest_ws.run().getGoniometer().setR(gonio_R)
         CopySample(InputWorkspace=source_ws, OutputWorkspace=dest_ws, CopyName=False, CopyEnvironment=False, CopyLattice=False)
         dest_ws.run().getGoniometer().setR(np.eye(3))
+
+    def create_simulation_workspace(self, name: str, unit: str = "dSpacing", bin_params: str | None = None) -> MatrixWorkspace:
+        return CreateSimulationWorkspace(
+            Instrument=self.instr, BinParams=bin_params or self.DEFAULT_BIN_PARAMS, OutputWorkspace=name, UnitX=unit
+        )
+
+    @staticmethod
+    def create_bin_params_around_point(point: float) -> str:
+        point = point if point > 0 else 1e-6
+        bin_width = 0.01 * point
+        # create 3 bins with p in the centre of the middle bin
+        #
+        # -1.5bw      -0.5bw   p   0.5bw      1.5bw
+        #    |-----------|-----x-----|-----------|
+        return f"{point - 1.5 * bin_width},{bin_width},{point + 1.5 * bin_width}"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/model.py
@@ -33,6 +33,7 @@ class TexturePlannerModel(object):
         # cross-cutting projection settings (shared between the plotter and the projection orchestration)
         self.ax_transform = np.eye(3)
         self.dir_names = ["D1", "D2", "D3"]
+        self.transform_dirs = False
         self.projection = projection
 
         # currently-selected goniometer (controls which axis is highlighted in the plot)
@@ -57,10 +58,27 @@ class TexturePlannerModel(object):
     def get_default_texture_directions() -> Tuple[Tuple[str, str, str], FlatArrayTuple]:
         return ("RD", "ND", "TD"), ((1, 0, 0), (0, 1, 0), (0, 0, 1))
 
+    def get_texture_directions(self, lab_frame: bool) -> Tuple[Tuple[str, str, str], np.ndarray]:
+        """The three texture directions as *rows* (one vector per row), matching the layout of
+        get_default_texture_directions so both feed the view the same way.
+
+        Note the transpose: ax_transform holds the directions as COLUMNS (see set_ax_transform)."""
+        transform = self.effective_ax_transform if lab_frame else self.ax_transform
+        return self.get_dir_names(), transform.T
+
+    def get_dir_names(self) -> Tuple[str, str, str]:
+        return self.dir_names[0], self.dir_names[1], self.dir_names[2]
+
     # cross-cutting settings setters -----------------------------------
     def set_ax_transform(self, vec1: str, vec2: str, vec3: str) -> None:
         vec1, vec2, vec3 = vec_string_to_norm_array(vec1), vec_string_to_norm_array(vec2), vec_string_to_norm_array(vec3)
         self.ax_transform = np.concatenate((vec1[:, None], vec2[:, None], vec3[:, None]), axis=1)
+
+    @property
+    def effective_ax_transform(self) -> np.ndarray:
+        if not self.transform_dirs:
+            return self.ax_transform
+        return self.workspaces.init_R.as_matrix() @ self.ax_transform
 
     def set_dir_names(self, name1: str, name2: str, name3: str) -> None:
         self.dir_names = [name1, name2, name3]
@@ -76,6 +94,9 @@ class TexturePlannerModel(object):
     def set_plot_transmission(self, val: bool) -> None:
         self.plot_transmission = val
 
+    def set_transform_dirs(self, val: bool) -> None:
+        self.transform_dirs = val
+
     # projection orchestration -----------------------------------------
     def update_all_projected_data(self) -> None:
         for i in self.orientations.keys():
@@ -83,6 +104,6 @@ class TexturePlannerModel(object):
 
     def update_projected_data(self, index: int) -> None:
         orientation = self.orientations[index]
-        orientation.pf_points = project_orientation(orientation.R, self.geometry.detQs_lab, self.ax_transform, self.projection)
+        orientation.pf_points = project_orientation(orientation.R, self.geometry.detQs_lab, self.effective_ax_transform, self.projection)
         if self.plot_transmission:
             self.absorption.calc_for_index(index)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -87,12 +87,15 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.view.set_on_save_dir_changed(self.enable_outputs)
         self.view.set_on_save_file_changed(self.enable_outputs)
         self.view.set_on_show_transmission_toggled(self.set_show_transmission)
+        self.view.set_on_transform_dirs_toggled(self.set_transform_dirs)
+        self.view.set_on_lab_dirs_toggled(self.set_lab_dirs)
         self.view.set_on_gauge_vol_state_changed(self.update_gauge_volume_state)
         self.view.set_on_gauge_vol_file_changed(self.update_set_gauge_vol_enabled)
         self.view.set_on_set_gauge_volume_clicked(self.set_gauge_volume)
         self.view.set_on_clear_gauge_volume_clicked(self.clear_gauge_volume)
         self.view.set_on_gauge_vol_group_toggled(self.update_custom_shape_finder_enabled)
         self.update_custom_shape_finder_enabled()
+        self.view.set_texture_directions_enabled(not self.view.get_lab_dirs())
         self.view.set_on_instrument_changed(self.on_instrument_changed)
         self.view.set_on_group_changed(self.on_group_selection_changed)
         self.view.set_on_custom_instrument_name_changed(self.on_custom_instrument_name_changed)
@@ -110,7 +113,7 @@ class TexturePlannerPresenter(AlgorithmObserver):
     def open_settings(self) -> None:
         self.settings_presenter.show()
 
-    def set_view_texture_directions(self, names: Tuple[str, str, str], vecs: FlatArrayTuple) -> None:
+    def set_view_texture_directions(self, names: Tuple[str, str, str], vecs: FlatArrayTuple | ndarray) -> None:
         self.view.set_rd_name(names[0])
         self.view.set_nd_name(names[1])
         self.view.set_td_name(names[2])
@@ -119,8 +122,10 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.view.set_td_dir(vecs[2])
 
     def set_model_texture_directions(self) -> None:
-        self.model.set_ax_transform(self.view.get_rd_dir(), self.view.get_nd_dir(), self.view.get_td_dir())
         self.model.set_dir_names(self.view.get_rd_name(), self.view.get_nd_name(), self.view.get_td_name())
+        # if the view is showing the lab directions - only allow updating the sample names
+        if not self.view.get_lab_dirs():
+            self.model.set_ax_transform(self.view.get_rd_dir(), self.view.get_nd_dir(), self.view.get_td_dir())
 
     def set_model_group(self) -> None:
         self.model.instrument.set_group(self.view.get_group())
@@ -131,6 +136,10 @@ class TexturePlannerPresenter(AlgorithmObserver):
 
     def set_view_with_default_texture_directions(self) -> None:
         names, vecs = self.model.get_default_texture_directions()
+        self.set_view_texture_directions(names, vecs)
+
+    def set_view_with_texture_directions(self) -> None:
+        names, vecs = self.model.get_texture_directions(self.view.get_lab_dirs())
         self.set_view_texture_directions(names, vecs)
 
     def update_enabled_gonios(self, num_gonios: int) -> None:
@@ -457,6 +466,18 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.view.set_transmission_weighting_available(show_transmission)
         self.model.update_all_projected_data()
         self.update_plots()
+
+    def set_transform_dirs(self) -> None:
+        self.model.set_transform_dirs(self.view.get_transform_dirs())
+        if self.view.get_lab_dirs():
+            self.set_view_with_texture_directions()
+        self.model.update_all_projected_data()
+        self.update_plots()
+
+    def set_lab_dirs(self) -> None:
+        self.set_view_with_texture_directions()
+        # the lab-frame values are derived, so they are shown read-only
+        self.view.set_texture_directions_enabled(not self.view.get_lab_dirs())
 
     def set_initial_shape(self) -> None:
         self.model.workspaces.update_initial_shape(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -492,6 +492,10 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.refresh_scattering_geometry()
         self.model.update_all_projected_data()
         self.update_plots()
+        if self.view.get_lab_dirs():
+            # the initial rotation is what maps the sample frame onto the lab frame, so the
+            # displayed lab directions are stale until they are re-derived
+            self.set_view_with_texture_directions()
 
     def set_gauge_volume(self) -> None:
         self.model.workspaces.set_gauge_volume_str(self.view.get_shape_method(), self.view.get_custom_shape())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_model.py
@@ -33,6 +33,7 @@ SETTINGS_DICT = {
     "att_point": float,
     "att_unit": str,
     "att_use_data_range": bool,
+    "att_show_current": bool,
 }
 
 DEFAULT_SETTINGS = {
@@ -55,6 +56,7 @@ DEFAULT_SETTINGS = {
     "att_point": 1.5,
     "att_unit": "dSpacing",
     "att_use_data_range": False,
+    "att_show_current": True,
 }
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_presenter.py
@@ -71,6 +71,7 @@ class TexturePlannerSettingsPresenter(object):
             "att_point": self.view.get_att_point(),
             "att_unit": self.view.get_att_unit(),
             "att_use_data_range": self.view.get_att_use_data_range(),
+            "att_show_current": self.view.get_att_show_current(),
         }
 
     def _apply_settings_to_texture_model(self, settings: Dict[str, Any]) -> None:
@@ -98,6 +99,7 @@ class TexturePlannerSettingsPresenter(object):
         self.texture_model.workspaces.attenuation_kwargs["unit"] = settings["att_unit"]
 
         self.texture_model.plotter.transmission_use_data_range = settings["att_use_data_range"]
+        self.texture_model.plotter.att_show_current = settings["att_show_current"]
 
     def _populate_view_from_texture_model(self) -> None:
         """Populate the settings dialog fields from the current state of the texture model."""
@@ -129,3 +131,4 @@ class TexturePlannerSettingsPresenter(object):
         self.view.set_att_point(att["point"])
         self.view.set_att_unit(att["unit"])
         self.view.set_att_use_data_range(self.texture_model.plotter.transmission_use_data_range)
+        self.view.set_att_show_current(self.texture_model.plotter.att_show_current)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/settings_view.py
@@ -179,6 +179,9 @@ class TexturePlannerSettingsView(QDialog):
         self.att_use_data_range = QCheckBox()
         form.addRow("Use Data Range Scale:", self.att_use_data_range)
 
+        self.att_show_current = QCheckBox()
+        form.addRow("Highlight Current Orientation:", self.att_show_current)
+
         group.setLayout(form)
         return group
 
@@ -231,6 +234,7 @@ class TexturePlannerSettingsView(QDialog):
         self.att_use_data_range.setToolTip(
             "If checked, the estimated transmission plot colour scale spans the data range; if unchecked, it is fixed between 0 and 1"
         )
+        self.att_show_current.setToolTip("If checked, the estimated transmission plot will highlight the points of the current orientation")
 
     # ================
     # Slot Connectors
@@ -306,6 +310,9 @@ class TexturePlannerSettingsView(QDialog):
     def get_att_use_data_range(self) -> bool:
         return self.att_use_data_range.isChecked()
 
+    def get_att_show_current(self) -> bool:
+        return self.att_show_current.isChecked()
+
     # ================
     # Setters
     # ================
@@ -366,3 +373,6 @@ class TexturePlannerSettingsView(QDialog):
 
     def set_att_use_data_range(self, check: bool) -> None:
         self.att_use_data_range.setChecked(check)
+
+    def set_att_show_current(self, check: bool) -> None:
+        self.att_show_current.setChecked(check)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/test/test_settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/settings/test/test_settings_presenter.py
@@ -33,6 +33,7 @@ SETTINGS_FIXTURE = {
     "att_point": 2.5,
     "att_unit": "Wavelength",
     "att_use_data_range": True,
+    "att_show_current": False,
 }
 
 
@@ -49,6 +50,7 @@ def _make_texture_model():
     }
     m.workspaces.attenuation_kwargs = {"point": 1.5, "unit": "dSpacing"}
     m.plotter.transmission_use_data_range = False
+    m.plotter.att_show_current = True
     return m
 
 
@@ -73,6 +75,7 @@ def _make_view_returning(settings):
     view.get_att_point.return_value = settings["att_point"]
     view.get_att_unit.return_value = settings["att_unit"]
     view.get_att_use_data_range.return_value = settings["att_use_data_range"]
+    view.get_att_show_current.return_value = settings["att_show_current"]
     return view
 
 
@@ -155,6 +158,7 @@ class TestTexturePlannerSettingsPresenter_Show(unittest.TestCase):
         view.set_att_point.assert_called_once_with(1.5)
         view.set_att_unit.assert_called_once_with("dSpacing")
         view.set_att_use_data_range.assert_called_once_with(False)
+        view.set_att_show_current.assert_called_once_with(True)
 
         view.show.assert_called_once_with()
 
@@ -192,6 +196,7 @@ class TestTexturePlannerSettingsPresenter_SaveSettings(unittest.TestCase):
         self.assertEqual(texture_model.workspaces.stl_kwargs["TranslationVector"], "1,2,3")
         self.assertEqual(texture_model.orientations.orientation_kwargs["Senses"], "1,-1,1")
         self.assertIs(texture_model.absorption.mc_kwargs["ResimulateTracksForDifferentWavelengths"], True)
+        self.assertIs(texture_model.plotter.att_show_current, False)
 
     def test_invokes_on_settings_applied_callback_if_registered(self, mock_model_cls):
         view = _make_view_returning(SETTINGS_FIXTURE)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_model.py
@@ -7,6 +7,7 @@
 import unittest
 import numpy as np
 
+from scipy.spatial.transform import Rotation
 from unittest.mock import patch, MagicMock
 
 from mantidqtinterfaces.TexturePlanner.model import TexturePlannerModel
@@ -111,6 +112,122 @@ class TestTexturePlannerModel_Setters(unittest.TestCase):
         model.set_plot_transmission(False)
         self.assertFalse(model.plot_transmission)
 
+    def test_set_transform_dirs(self, mock_instr, mock_wsm, mock_ot, mock_dg, mock_abs, mock_exp, mock_plot):
+        model = TexturePlannerModel()
+
+        model.set_transform_dirs(True)
+        self.assertTrue(model.transform_dirs)
+
+        model.set_transform_dirs(False)
+        self.assertFalse(model.transform_dirs)
+
+
+@_patch_collaborators
+class TestTexturePlannerModel_EffectiveAxTransform(unittest.TestCase):
+    """The initial shape rotation only reaches the texture directions when transform_dirs is set."""
+
+    @staticmethod
+    def _model_with_init_R(rotation):
+        model = TexturePlannerModel()
+        # workspaces is a mock, so init_R has to be given a real Rotation to read a matrix from
+        model.workspaces.init_R = rotation
+        return model
+
+    def test_untransformed_returns_the_entered_transform_itself(self, *_):
+        model = self._model_with_init_R(Rotation.from_euler("z", 90, degrees=True))
+        model.ax_transform = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        model.transform_dirs = False
+
+        # the same object, not just an equal one: the projection path must not pay for a copy
+        self.assertIs(model.effective_ax_transform, model.ax_transform)
+
+    def test_transformed_rotates_each_direction_by_init_R(self, *_):
+        # RD/ND/TD along x/y/z, then a 90 deg rotation about z: x->y, y->-x, z->z
+        model = self._model_with_init_R(Rotation.from_euler("z", 90, degrees=True))
+        model.ax_transform = np.eye(3)
+        model.transform_dirs = True
+
+        # columns are the directions, so compare column-wise against the rotated basis vectors
+        effective = model.effective_ax_transform
+        np.testing.assert_allclose(effective[:, 0], (0.0, 1.0, 0.0), atol=1e-12)
+        np.testing.assert_allclose(effective[:, 1], (-1.0, 0.0, 0.0), atol=1e-12)
+        np.testing.assert_allclose(effective[:, 2], (0.0, 0.0, 1.0), atol=1e-12)
+
+    def test_transformed_with_identity_init_R_is_a_no_op(self, *_):
+        model = self._model_with_init_R(Rotation.identity())
+        model.ax_transform = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        model.transform_dirs = True
+
+        np.testing.assert_allclose(model.effective_ax_transform, model.ax_transform, atol=1e-12)
+
+    def test_is_derived_so_it_follows_a_later_init_R_change(self, *_):
+        model = self._model_with_init_R(Rotation.identity())
+        model.ax_transform = np.eye(3)
+        model.transform_dirs = True
+        np.testing.assert_allclose(model.effective_ax_transform, np.eye(3), atol=1e-12)
+
+        # init_R is rebuilt on every initial-shape edit; the property must not be caching it
+        model.workspaces.init_R = Rotation.from_euler("x", 90, degrees=True)
+
+        np.testing.assert_allclose(model.effective_ax_transform[:, 1], (0.0, 0.0, 1.0), atol=1e-12)
+
+
+@_patch_collaborators
+class TestTexturePlannerModel_GetTextureDirections(unittest.TestCase):
+    """get_texture_directions feeds the view, which takes one direction per ROW - the transpose of
+    the column-per-direction ax_transform."""
+
+    # RD=(0,1,0), ND=(0,0,1), TD=(1,0,0) as set_ax_transform would store them (as columns)
+    _COLUMNS = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    _ROWS = np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]])
+
+    def test_sample_frame_returns_entered_directions_as_rows(self, *_):
+        model = TexturePlannerModel()
+        model.workspaces.init_R = Rotation.from_euler("z", 90, degrees=True)
+        model.ax_transform = self._COLUMNS
+        model.set_dir_names("A", "B", "C")
+        model.transform_dirs = True
+
+        names, vecs = model.get_texture_directions(lab_frame=False)
+
+        self.assertEqual(names, ("A", "B", "C"))
+        # the sample frame is what the user entered - unaffected by init_R even when transforming
+        np.testing.assert_allclose(vecs, self._ROWS, atol=1e-12)
+
+    def test_lab_frame_returns_rotated_directions_as_rows(self, *_):
+        model = TexturePlannerModel()
+        model.workspaces.init_R = Rotation.from_euler("z", 90, degrees=True)
+        model.ax_transform = self._COLUMNS
+        model.transform_dirs = True
+
+        _, vecs = model.get_texture_directions(lab_frame=True)
+
+        # 90 deg about z: RD (0,1,0) -> (-1,0,0), ND (0,0,1) -> (0,0,1), TD (1,0,0) -> (0,1,0)
+        np.testing.assert_allclose(vecs, [[-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]], atol=1e-12)
+
+    def test_lab_frame_matches_sample_frame_when_not_transforming(self, *_):
+        model = TexturePlannerModel()
+        model.workspaces.init_R = Rotation.from_euler("z", 90, degrees=True)
+        model.ax_transform = self._COLUMNS
+        model.transform_dirs = False
+
+        _, lab = model.get_texture_directions(lab_frame=True)
+        _, sample = model.get_texture_directions(lab_frame=False)
+
+        np.testing.assert_allclose(lab, sample, atol=1e-12)
+
+    def test_row_layout_matches_the_defaults(self, *_):
+        # both feed set_view_texture_directions, so they must agree on the layout
+        model = TexturePlannerModel()
+        model.workspaces.init_R = Rotation.identity()
+        model.ax_transform = np.eye(3)
+        model.transform_dirs = False
+
+        _, default_vecs = TexturePlannerModel.get_default_texture_directions()
+        _, vecs = model.get_texture_directions(lab_frame=False)
+
+        np.testing.assert_allclose(vecs, np.array(default_vecs, dtype=float), atol=1e-12)
+
 
 @_patch_collaborators
 class TestTexturePlannerModel_UpdateGonioIndex(unittest.TestCase):
@@ -151,6 +268,23 @@ class TestTexturePlannerModel_ProjectionOrchestration(unittest.TestCase):
         model.orientations.__getitem__.assert_called_once_with(3)
         mock_proj.assert_called_once_with("R_obj", "detQs", model.ax_transform, model.projection)
         self.assertEqual(orientation.pf_points, "pf_points")
+
+    @patch(file_path + ".project_orientation")
+    def test_update_projected_data_projects_through_init_R_when_transforming_dirs(
+        self, mock_proj, mock_instr, mock_wsm, mock_ot, mock_dg, mock_abs, mock_exp, mock_plot
+    ):
+        model = TexturePlannerModel()
+        model.orientations.__getitem__.return_value = MagicMock()
+        model.geometry.detQs_lab = "detQs"
+        model.workspaces.init_R = Rotation.from_euler("z", 90, degrees=True)
+        model.ax_transform = np.eye(3)
+        model.transform_dirs = True
+
+        model.update_projected_data(0)
+
+        # the projection is handed the rotated directions, not the entered ones
+        projected_transform = mock_proj.call_args.args[2]
+        np.testing.assert_allclose(projected_transform, Rotation.from_euler("z", 90, degrees=True).as_matrix(), atol=1e-12)
 
     @patch(file_path + ".project_orientation")
     def test_update_projected_data_skips_absorption_when_transmission_off(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
@@ -24,6 +24,10 @@ def _make_view():
     view.get_rd_name.return_value = "RD"
     view.get_nd_name.return_value = "ND"
     view.get_td_name.return_value = "TD"
+    # both direction-frame checkboxes start unticked in the .ui; a bare MagicMock would report a
+    # truthy value for them and silently take the lab-frame branch
+    view.get_transform_dirs.return_value = False
+    view.get_lab_dirs.return_value = False
     view.get_group.return_value = "banks"
     view.get_vecs.return_value = ["vecs"]
     view.get_senses.return_value = ["senses"]
@@ -289,6 +293,103 @@ class TestTexturePlannerPresenter_DirectionsUpdated(unittest.TestCase):
         model.geometry.recompute.assert_called_once_with()
         model.update_all_projected_data.assert_called_once_with()
         presenter.update_plots.assert_called_once_with()
+
+    def test_renames_without_rewriting_vectors_while_showing_the_lab_frame(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_lab_dirs.return_value = True
+        presenter = TexturePlannerPresenter(model, view)
+        presenter.update_plots = MagicMock()
+
+        model.set_ax_transform.reset_mock()
+        model.set_dir_names.reset_mock()
+
+        presenter.on_directions_updated()
+
+        # the fields hold derived lab-frame values, so they must not be fed back into the model
+        model.set_ax_transform.assert_not_called()
+        model.set_dir_names.assert_called_once_with("RD", "ND", "TD")
+
+
+@patch(file_path + ".TexturePlannerSettingsPresenter")
+@patch(file_path + ".TexturePlannerSettingsView")
+class TestTexturePlannerPresenter_DirectionFrames(unittest.TestCase):
+    def test_transform_toggle_pushes_to_model_and_reprojects(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_transform_dirs.return_value = True
+        presenter = TexturePlannerPresenter(model, view)
+        presenter.update_plots = MagicMock()
+        model.update_all_projected_data.reset_mock()
+
+        presenter.set_transform_dirs()
+
+        model.set_transform_dirs.assert_called_once_with(True)
+        model.update_all_projected_data.assert_called_once_with()
+        presenter.update_plots.assert_called_once_with()
+
+    def test_transform_toggle_leaves_the_sample_frame_fields_alone(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_transform_dirs.return_value = True
+        presenter = TexturePlannerPresenter(model, view)
+        presenter.update_plots = MagicMock()
+        view.set_rd_dir.reset_mock()
+
+        presenter.set_transform_dirs()
+
+        # the displayed sample-frame values do not depend on the toggle, so rewriting them would only
+        # push the model's rounded values back over what the user typed
+        view.set_rd_dir.assert_not_called()
+
+    def test_transform_toggle_refreshes_the_fields_while_showing_the_lab_frame(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_transform_dirs.return_value = True
+        view.get_lab_dirs.return_value = True
+        model.get_texture_directions.return_value = (("RD", "ND", "TD"), ((1, 0, 0), (0, 0, 1), (0, -1, 0)))
+        presenter = TexturePlannerPresenter(model, view)
+        presenter.update_plots = MagicMock()
+        view.set_nd_dir.reset_mock()
+
+        presenter.set_transform_dirs()
+
+        model.get_texture_directions.assert_called_with(True)
+        view.set_nd_dir.assert_called_once_with((0, 0, 1))
+
+    def test_lab_frame_toggle_shows_derived_values_read_only(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_lab_dirs.return_value = True
+        model.get_texture_directions.return_value = (("RD", "ND", "TD"), ((1, 0, 0), (0, 0, 1), (0, -1, 0)))
+        presenter = TexturePlannerPresenter(model, view)
+
+        presenter.set_lab_dirs()
+
+        model.get_texture_directions.assert_called_with(True)
+        view.set_td_dir.assert_called_with((0, -1, 0))
+        view.set_texture_directions_enabled.assert_called_with(False)
+
+    def test_clearing_lab_frame_toggle_shows_entered_values_editable(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+        view.get_lab_dirs.return_value = False
+        model.get_texture_directions.return_value = (("RD", "ND", "TD"), ((1, 0, 0), (0, 1, 0), (0, 0, 1)))
+        presenter = TexturePlannerPresenter(model, view)
+
+        presenter.set_lab_dirs()
+
+        model.get_texture_directions.assert_called_with(False)
+        view.set_texture_directions_enabled.assert_called_with(True)
+
+    def test_fields_start_editable(self, mock_settings_view, mock_settings_presenter):
+        model = _make_model()
+        view = _make_view()
+
+        TexturePlannerPresenter(model, view)
+
+        # the lab-frame box starts unticked, so construction must leave the fields editable
+        view.set_texture_directions_enabled.assert_called_once_with(True)
 
 
 @patch(file_path + ".TexturePlannerSettingsPresenter")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -336,6 +336,36 @@ class _FunctionalTestBase(unittest.TestCase):
     def _lab_direction_labels(self):
         return {t.get_text(): np.asarray(t.get_position_3d(), dtype=float) for t in self.view.get_lab_ax().texts if isinstance(t, Text3D)}
 
+    def _lab_direction_unit_vectors(self):
+        """Unit direction of each labelled sample-direction arrow in the lab view.
+
+        Each label sits at scat_centre + direction * arrow_length, and the arrow length is read off
+        the mesh extent along that direction, so only the direction itself is a stable assertion."""
+        scat_centre = self.model.workspaces.scattering_centre
+        vectors = {}
+        for name, position in self._lab_direction_labels().items():
+            arrow = position - scat_centre
+            vectors[name] = arrow / np.linalg.norm(arrow)
+        return vectors
+
+    def _displayed_directions(self):
+        # the three direction fields as a (3, 3) array, one direction per row (RD, ND, TD)
+        fields = (self.view.get_rd_dir(), self.view.get_nd_dir(), self.view.get_td_dir())
+        return np.array([[float(x) for x in vec.split(",")] for vec in fields])
+
+    def _reveal_direction_controls(self):
+        # both groups start collapsed, hiding the two frame checkboxes and the direction fields
+        self.view.grpDirectionWidgets.setChecked(True)
+        self.view.initOrientation.setChecked(True)
+        QApplication.processEvents()
+
+    def _set_entered_directions(self, rd, nd, td):
+        self.view.set_rd_dir(rd)
+        self.view.set_nd_dir(nd)
+        self.view.set_td_dir(td)
+        self._click(self.view.updateDirs)
+        QApplication.processEvents()
+
 
 class TestInitialState(_FunctionalTestBase):
     def test_instrument_combo_lists_supported_instruments_plus_custom(self):
@@ -988,6 +1018,196 @@ class TestSampleDirectionsDisplay(_FunctionalTestBase):
         pf_points = self.model.orientations[0].pf_points
         self.assertEqual(len(pf_points), 20)  # ENGINX Texture20 default
         self.assertEqual(len(self._pf_scatters_matching(pf_points)), 1)
+
+
+class TestTextureDirectionFrames(_FunctionalTestBase):
+    """The two direction-frame controls in the sample setup tab.
+
+    "Apply Transformation to Sample Directions" (chkTransformDirs) decides whether the initial shape
+    orientation also carries the texture directions - i.e. whether the initial rotation models a
+    misoriented shape *definition* (unticked, the original behaviour) or a sample misaligned on the
+    beamline (ticked). "Show Directions in Lab Frame" (chkLabDirs) only changes what the direction
+    fields display; the directions are always entered in the sample frame.
+
+    A 90 deg initial rotation about x is used throughout because it maps the default directions onto
+    each other exactly: RD (1,0,0) -> (1,0,0), ND (0,1,0) -> (0,0,1), TD (0,0,1) -> (0,-1,0).
+    """
+
+    _ROT_X90_RD = (1.0, 0.0, 0.0)
+    _ROT_X90_ND = (0.0, 0.0, 1.0)
+    _ROT_X90_TD = (0.0, -1.0, 0.0)
+
+    def setUp(self):
+        super().setUp()
+        self._reveal_direction_controls()
+
+    def _rotate_initial_shape_x90(self):
+        self.view.spnInitX.setValue(90.0)
+        QApplication.processEvents()
+        # sanity: the rotation really is on the workspace manager, so the directions have something
+        # non-trivial to (not) follow
+        np.testing.assert_allclose(self.model.workspaces.init_R.as_euler("xyz", degrees=True), (90.0, 0.0, 0.0), atol=1e-9)
+
+    def _assert_lab_arrows(self, rd, nd, td):
+        arrows = self._lab_direction_unit_vectors()
+        self.assertEqual(set(arrows), {"RD", "ND", "TD"})
+        np.testing.assert_allclose(arrows["RD"], rd, atol=1e-9)
+        np.testing.assert_allclose(arrows["ND"], nd, atol=1e-9)
+        np.testing.assert_allclose(arrows["TD"], td, atol=1e-9)
+
+    # the transform toggle -------------------------------------------------
+    def test_initial_rotation_leaves_directions_alone_by_default(self):
+        # the pre-existing behaviour: the initial rotation misorients the shape definition only, so
+        # the directions stay pinned to the lab axes
+        self.assertFalse(self.view.chkTransformDirs.isChecked())
+        self.assertFalse(self.model.transform_dirs)
+
+        self._rotate_initial_shape_x90()
+
+        np.testing.assert_allclose(self.model.effective_ax_transform, np.eye(3), atol=1e-9)
+        self._assert_lab_arrows((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+    def test_ticking_transform_rotates_the_directions_with_the_shape(self):
+        self._rotate_initial_shape_x90()
+
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        self.assertTrue(self.model.transform_dirs)
+        # columns of the effective transform are the directions, now carried round by the rotation
+        effective = self.model.effective_ax_transform
+        np.testing.assert_allclose(effective[:, 0], self._ROT_X90_RD, atol=1e-9)
+        np.testing.assert_allclose(effective[:, 1], self._ROT_X90_ND, atol=1e-9)
+        np.testing.assert_allclose(effective[:, 2], self._ROT_X90_TD, atol=1e-9)
+        # and the lab view draws the arrows in their new places
+        self._assert_lab_arrows(self._ROT_X90_RD, self._ROT_X90_ND, self._ROT_X90_TD)
+
+    def test_transform_is_a_no_op_without_an_initial_rotation(self):
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        self.assertTrue(self.model.transform_dirs)
+        np.testing.assert_allclose(self.model.effective_ax_transform, np.eye(3), atol=1e-9)
+        self._assert_lab_arrows((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+    def test_directions_follow_a_later_change_of_initial_rotation(self):
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        # the toggle is applied first, so the rotation that arrives afterwards must still be picked up
+        self._rotate_initial_shape_x90()
+
+        self._assert_lab_arrows(self._ROT_X90_RD, self._ROT_X90_ND, self._ROT_X90_TD)
+
+    def test_untransformed_directions_are_restored_when_the_toggle_is_cleared(self):
+        self._rotate_initial_shape_x90()
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+        self._assert_lab_arrows(self._ROT_X90_RD, self._ROT_X90_ND, self._ROT_X90_TD)
+
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        self.assertFalse(self.model.transform_dirs)
+        self._assert_lab_arrows((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
+    def test_transform_toggle_leaves_the_entered_directions_untouched(self):
+        # the transform changes only the derived (lab) directions; the values the user typed - and
+        # the model's record of them - must survive a toggle unrounded and unrotated
+        self._set_entered_directions((0, 2, 0), (0, 0, 1), (1, 0, 0))
+        self._rotate_initial_shape_x90()
+        entered = self._displayed_directions()
+        ax_transform = self.model.ax_transform.copy()
+
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        np.testing.assert_array_equal(self._displayed_directions(), entered)
+        np.testing.assert_array_equal(self.model.ax_transform, ax_transform)
+
+    def test_transform_toggle_reprojects_the_pole_figure(self):
+        self._rotate_initial_shape_x90()
+        before = self.model.orientations[0].pf_points.copy()
+
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        after = self.model.orientations[0].pf_points
+        # rotating the directions reframes the projection, so the coverage points must move...
+        self.assertFalse(np.allclose(before, after))
+        # ...and the redrawn scatter must be the new points, not a stale artist
+        self.assertEqual(len(self._pf_scatters_matching(after)), 1)
+        self.assertEqual(len(self._pf_scatters_matching(before)), 0)
+
+    # the lab-frame display toggle ----------------------------------------
+    def test_lab_frame_display_shows_the_rotated_directions_read_only(self):
+        self._rotate_initial_shape_x90()
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+        self.assertTrue(self.view.lineedit_RD0.isEnabled())
+
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+
+        np.testing.assert_allclose(self._displayed_directions(), (self._ROT_X90_RD, self._ROT_X90_ND, self._ROT_X90_TD), atol=1e-9)
+        # the lab values are derived, so they cannot be edited
+        for field in (self.view.lineedit_RD0, self.view.lineedit_ND1, self.view.lineedit_TD2):
+            self.assertFalse(field.isEnabled())
+
+    def test_clearing_lab_frame_display_restores_the_entered_directions(self):
+        self._rotate_initial_shape_x90()
+        self._click_checkbox(self.view.chkTransformDirs)
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+
+        np.testing.assert_allclose(self._displayed_directions(), np.eye(3), atol=1e-9)
+        self.assertTrue(self.view.lineedit_RD0.isEnabled())
+
+    def test_lab_frame_display_matches_the_sample_frame_when_not_transforming(self):
+        # with the transform off the two frames coincide, so the display must not move
+        self._rotate_initial_shape_x90()
+
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+
+        np.testing.assert_allclose(self._displayed_directions(), np.eye(3), atol=1e-9)
+
+    def test_lab_frame_display_keeps_each_direction_on_its_own_row(self):
+        # guards the row/column convention: ax_transform stores the directions as columns, but the
+        # fields take one direction per row, so a missing transpose would silently permute them
+        self._set_entered_directions((0, 1, 0), (0, 0, 1), (1, 0, 0))
+        entered = self._displayed_directions()
+
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+        np.testing.assert_allclose(self._displayed_directions(), entered, atol=1e-9)
+
+        # and with a rotation applied, each row is exactly its own direction, rotated
+        self._rotate_initial_shape_x90()
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        rotated = Rotation.from_euler("x", 90, degrees=True).apply(entered)
+        np.testing.assert_allclose(self._displayed_directions(), rotated, atol=1e-9)
+
+    def test_update_directions_in_lab_frame_renames_without_rewriting_the_vectors(self):
+        # the fields are showing derived values, so Update must not feed them back into the model
+        self._set_entered_directions((0, 1, 0), (0, 0, 1), (1, 0, 0))
+        self._rotate_initial_shape_x90()
+        self._click_checkbox(self.view.chkTransformDirs)
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+        ax_transform = self.model.ax_transform.copy()
+
+        self.view.set_rd_name("AD")
+        self._click(self.view.updateDirs)
+        QApplication.processEvents()
+
+        self.assertEqual(self.model.dir_names, ["AD", "ND", "TD"])
+        np.testing.assert_array_equal(self.model.ax_transform, ax_transform)
 
 
 class TestInstrumentGeometryCounts(_FunctionalTestBase):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -223,6 +223,7 @@ class _FunctionalTestBase(unittest.TestCase):
         "get_att_point": "att_point",
         "get_att_unit": "att_unit",
         "get_att_use_data_range": "att_use_data_range",
+        "get_att_show_current": "att_show_current",
     }
 
     def _apply_settings_via_real_presenter(self, **overrides):
@@ -275,6 +276,29 @@ class _FunctionalTestBase(unittest.TestCase):
             for c in self._pf_point_scatters()
             if len(c.get_offsets()) == len(swapped) and np.allclose(np.asarray(c.get_offsets()), swapped, atol=1e-12)
         ]
+
+    def _transmission_scatter(self):
+        # the colour-mapped transmission points are the only pole-figure scatter carrying a value array
+        scatters = [c for c in self._pf_point_scatters() if c.get_array() is not None]
+        self.assertEqual(len(scatters), 1)
+        return scatters[0]
+
+    def _current_highlight_scatter(self):
+        """The ring drawn around the current orientation in transmission mode, or None if it is not
+        drawn. It is the only grey open-circle scatter: the transmission points carry a colour array
+        and the goniometer poles are colour-coded per axis."""
+        rings = [
+            c
+            for c in self._pf_point_scatters()
+            if c.get_array() is None and len(c.get_facecolor()) == 0 and np.allclose(c.get_edgecolor()[0][:3], to_rgba("grey")[:3])
+        ]
+        self.assertLessEqual(len(rings), 1)
+        return rings[0] if rings else None
+
+    def _add_rotated_orientation(self, angle):
+        self._click(self.view.addOrientation)
+        self.view.spnAngle0.setValue(angle)
+        QApplication.processEvents()
 
     def _drawn_sample_vertices(self):
         # the sample is drawn grey; a gauge volume (if any) adds a second, cyan Poly3DCollection
@@ -1176,11 +1200,6 @@ class TestGoniometerDisplay(_FunctionalTestBase):
 class TestOrientationCycling(_FunctionalTestBase):
     """Cycling / clamping the current orientation and its pole-figure highlighting."""
 
-    def _add_rotated_orientation(self, angle):
-        self._click(self.view.addOrientation)
-        self.view.spnAngle0.setValue(angle)
-        QApplication.processEvents()
-
     def _filled_state(self, pf_points):
         (scatter,) = self._pf_scatters_matching(pf_points)
         return len(scatter.get_facecolor()) > 0
@@ -1255,11 +1274,6 @@ class TestTransmissionValues(_FunctionalTestBase):
         super().setUp()
         # 2 detector groups keep the (real) MonteCarloAbsorption runs quick
         self._apply_instrument_group("banks")
-
-    def _transmission_scatter(self):
-        scatters = [c for c in self._pf_point_scatters() if c.get_array() is not None]
-        self.assertEqual(len(scatters), 1)
-        return scatters[0]
 
     def test_transmission_estimates_are_sensible(self):
         self._click_checkbox(self.view.chkTransmission)
@@ -1339,6 +1353,77 @@ class TestTransmissionValues(_FunctionalTestBase):
         scatter = self._transmission_scatter()
         self.assertNotEqual(scatter.get_clim(), (0.0, 1.0))
         np.testing.assert_allclose(scatter.get_clim(), (transmission.min(), transmission.max()), atol=1e-12)
+
+
+class TestTransmissionCurrentOrientation(_FunctionalTestBase):
+    """In transmission mode every point is coloured by its value, so the current orientation cannot be
+    picked out by fill colour as it is in the coverage plot. It is ringed instead."""
+
+    def setUp(self):
+        super().setUp()
+        # 2 detector groups keep the (real) MonteCarloAbsorption runs quick
+        self._apply_instrument_group("banks")
+        # two orientations, so a highlight of *only* the current one is distinguishable
+        self._add_rotated_orientation(45.0)
+        self._click_checkbox(self.view.chkTransmission)
+
+    def _swapped(self, index):
+        # the plotter draws (pf_xy[:, 1], pf_xy[:, 0]), i.e. columns swapped
+        return np.asarray(self.model.orientations[index].pf_points)[:, ::-1]
+
+    def test_current_orientation_is_ringed_over_the_colour_mapped_points(self):
+        # both orientations are colour-mapped together...
+        transmission_points = np.asarray(self._transmission_scatter().get_offsets())
+        np.testing.assert_allclose(transmission_points, np.concatenate([self._swapped(0), self._swapped(1)]), atol=1e-12)
+
+        # ...and the current one (orientation 1) additionally gets an open grey ring
+        ring = self._current_highlight_scatter()
+        self.assertIsNotNone(ring)
+        np.testing.assert_allclose(np.asarray(ring.get_offsets()), self._swapped(1), atol=1e-12)
+        # oversized relative to the coloured points, so the colour stays visible inside the ring
+        np.testing.assert_allclose(ring.get_sizes(), self._transmission_scatter().get_sizes() * 2)
+
+    def test_ring_follows_the_current_index(self):
+        self.view.spnIndex.setValue(1)  # the spinbox is 1-based: select orientation 0
+        QApplication.processEvents()
+
+        np.testing.assert_allclose(np.asarray(self._current_highlight_scatter().get_offsets()), self._swapped(0), atol=1e-12)
+
+        self.view.spnIndex.setValue(2)
+        QApplication.processEvents()
+
+        np.testing.assert_allclose(np.asarray(self._current_highlight_scatter().get_offsets()), self._swapped(1), atol=1e-12)
+
+    def test_excluded_current_orientation_is_still_ringed_though_it_has_no_coloured_points(self):
+        self._click_checkbox(self._checkbox(1, 6))  # exclude the current row
+        QApplication.processEvents()
+
+        # only orientation 0 is colour-mapped now
+        np.testing.assert_allclose(np.asarray(self._transmission_scatter().get_offsets()), self._swapped(0), atol=1e-12)
+        # but the ring keeps the current orientation's coverage visible
+        np.testing.assert_allclose(np.asarray(self._current_highlight_scatter().get_offsets()), self._swapped(1), atol=1e-12)
+
+    def test_highlight_setting_switches_the_ring_off_and_back_on(self):
+        self._apply_settings_via_real_presenter(att_show_current=False)
+
+        self.assertIsNone(self._current_highlight_scatter())
+        # the colour-mapped points and their scale are untouched
+        np.testing.assert_allclose(
+            np.asarray(self._transmission_scatter().get_offsets()), np.concatenate([self._swapped(0), self._swapped(1)]), atol=1e-12
+        )
+        self.assertEqual(self._transmission_scatter().get_clim(), (0.0, 1.0))
+
+        self._apply_settings_via_real_presenter(att_show_current=True)
+
+        np.testing.assert_allclose(np.asarray(self._current_highlight_scatter().get_offsets()), self._swapped(1), atol=1e-12)
+
+    def test_no_ring_outside_transmission_mode(self):
+        # in the coverage plot the current orientation is already drawn filled, so it needs no ring
+        self._click_checkbox(self.view.chkTransmission)  # transmission off
+        QApplication.processEvents()
+
+        self.assertIsNone(self._current_highlight_scatter())
+        self.assertTrue(self._pf_scatters_matching(self.model.orientations[1].pf_points))
 
 
 class TestExportContents(_FunctionalTestBase):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -1271,6 +1271,61 @@ class TestTransmissionValues(_FunctionalTestBase):
         # roughly the same attenuation (loose bound: MonteCarlo with 50 events per point)
         self.assertLess(abs(transmission[0] - transmission[1]), 0.15 * transmission.mean())
 
+    def _transmission_for(self, **att_settings):
+        self._apply_settings_via_real_presenter(**att_settings)
+        self._click_checkbox(self.view.chkTransmission)
+        return np.array(self.model.orientations[0].transmission)
+
+    def test_evaluation_point_far_outside_the_default_range_still_computes(self):
+        # regression: the absorption workspace used to be binned on a fixed 0-5 dSpacing grid, so an
+        # evaluation point beyond it fell outside the interpolation range and raised a ValueError -
+        # which calc_for_index does not catch, so it escaped to the user. The grid is now built
+        # around the point itself, so any point is in range.
+        transmission = self._transmission_for(att_point=7.5, att_unit="dSpacing")
+
+        self.assertEqual(len(transmission), len(self.model.geometry.spec_inds))
+        self.assertTrue(np.all((transmission > 0) & (transmission <= 1)))
+
+    def test_evaluation_point_far_below_the_default_range_still_computes(self):
+        transmission = self._transmission_for(att_point=0.2, att_unit="dSpacing")
+
+        self.assertTrue(np.all((transmission > 0) & (transmission <= 1)))
+
+    def test_wavelength_evaluation_point_computes(self):
+        # a wavelength point needs no per-spectrum conversion, but must still bracket correctly
+        transmission = self._transmission_for(att_point=4.0, att_unit="Wavelength")
+
+        self.assertTrue(np.all((transmission > 0) & (transmission <= 1)))
+
+    def test_longer_wavelength_attenuates_more(self):
+        # absorption cross-sections rise with wavelength, so a longer wavelength must transmit less.
+        # This is what pins the evaluation point to the *right* wavelength: binning the whole bank
+        # around one shared wavelength would wash the difference out.
+        short = self._transmission_for(att_point=0.5, att_unit="Wavelength")
+        self._click_checkbox(self.view.chkTransmission)  # off, so the next toggle recomputes
+        long = self._transmission_for(att_point=4.0, att_unit="Wavelength")
+
+        self.assertTrue(np.all(long < short))
+
+    def test_dspacing_point_is_converted_per_detector(self):
+        # lambda = 2 d sin(theta), so a dSpacing point maps to a different wavelength in each detector.
+        # Asking for d and asking for that detector's equivalent wavelength must therefore agree.
+        # Binning the whole bank around a single shared wavelength would break this for every
+        # detector except the one the shared wavelength was derived from.
+        by_d = self._transmission_for(att_point=1.5, att_unit="dSpacing")
+
+        spec_info = self.model.workspaces.ws.spectrumInfo()
+        two_thetas = np.array([spec_info.twoTheta(i) for i in self.model.geometry.spec_inds])
+        equivalent_lambda = 2 * 1.5 * np.sin(two_thetas / 2)
+        # the two ENGINX banks are at mirrored 2theta, so they share one equivalent wavelength
+        np.testing.assert_allclose(equivalent_lambda, equivalent_lambda[0], rtol=1e-6)
+
+        self._click_checkbox(self.view.chkTransmission)  # off, so the next toggle recomputes
+        by_lambda = self._transmission_for(att_point=float(equivalent_lambda[0]), att_unit="Wavelength")
+
+        # loose bound: MonteCarloAbsorption with 50 events per point is noisy
+        np.testing.assert_allclose(by_lambda, by_d, rtol=0.1)
+
     def test_colourbar_limit_setting_switches_scale_to_data_range(self):
         self._click_checkbox(self.view.chkTransmission)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -45,7 +45,7 @@ from mantid.simpleapi import (
 )
 from Engineering.common.instrument_config import SUPPORTED_INSTRUMENTS
 from Engineering.common.xml_shapes import get_cube_xml
-from Engineering.texture.texture_helper import convert_to_sscanss_frame
+from Engineering.texture.texture_helper import convert_to_sscanss_frame, read_texture_direction_info_from_log
 
 from mantidqtinterfaces.TexturePlanner.model import TexturePlannerModel
 from mantidqtinterfaces.TexturePlanner.settings.settings_model import DEFAULT_SETTINGS
@@ -1712,6 +1712,57 @@ class TestExportContents(_FunctionalTestBase):
         self.assertAlmostEqual(abs(loaded.sample().getShape().volume()), 0.01**3, places=9)
         self.assertEqual(loaded.sample().getMaterial().name(), "Fe")
         np.testing.assert_allclose(self._aabb_extent(loaded), expected_extent, atol=1e-9)
+
+    def test_reference_workspace_carries_the_texture_directions(self):
+        self.view.grpDirectionWidgets.setChecked(True)
+        QApplication.processEvents()
+        self.view.set_rd_name("AD")
+        self._set_entered_directions((0, 1, 0), (0, 0, 1), (1, 0, 0))
+
+        self.view.cmbExportFormat.setCurrentText(EXPORT_REFERENCE_WS)
+        self._click(self.view.btnExport)
+
+        loaded = LoadNexus(Filename=os.path.join(self._tmpdir, "run.nxs"), OutputWorkspace="__texplan_test_ref_dirs")
+        matrix, names = read_texture_direction_info_from_log(loaded)
+        self.assertEqual(names, ("AD", "ND", "TD"))
+        # columns are the directions, in the same order as the fields
+        np.testing.assert_allclose(matrix, [[0, 0, 1], [1, 0, 0], [0, 1, 0]], atol=1e-9)
+
+    def test_reference_workspace_carries_the_directions_the_shape_was_saved_in(self):
+        # the reference ws holds the shape with the initial rotation already baked in, so with
+        # "apply transformation to sample directions" on it must carry the *rotated* directions -
+        # anything else would describe a frame the saved shape is not actually in
+        self._reveal_direction_controls()
+        self._set_entered_directions((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        self.view.spnInitX.setValue(90.0)
+        QApplication.processEvents()
+        self._click_checkbox(self.view.chkTransformDirs)
+        QApplication.processEvents()
+
+        self.view.cmbExportFormat.setCurrentText(EXPORT_REFERENCE_WS)
+        self._click(self.view.btnExport)
+
+        loaded = LoadNexus(Filename=os.path.join(self._tmpdir, "run.nxs"), OutputWorkspace="__texplan_test_ref_effective")
+        matrix, _ = read_texture_direction_info_from_log(loaded)
+        # 90 deg about x: RD (1,0,0) -> (1,0,0), ND (0,1,0) -> (0,0,1), TD (0,0,1) -> (0,-1,0)
+        np.testing.assert_allclose(matrix[:, 0], (1.0, 0.0, 0.0), atol=1e-9)
+        np.testing.assert_allclose(matrix[:, 1], (0.0, 0.0, 1.0), atol=1e-9)
+        np.testing.assert_allclose(matrix[:, 2], (0.0, -1.0, 0.0), atol=1e-9)
+
+    def test_reference_workspace_carries_the_entered_directions_when_not_transforming(self):
+        # with the transform off the initial rotation is a shape-definition fix only, so the
+        # directions saved alongside it are the ones the user entered
+        self._reveal_direction_controls()
+        self._set_entered_directions((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        self.view.spnInitX.setValue(90.0)
+        QApplication.processEvents()
+
+        self.view.cmbExportFormat.setCurrentText(EXPORT_REFERENCE_WS)
+        self._click(self.view.btnExport)
+
+        loaded = LoadNexus(Filename=os.path.join(self._tmpdir, "run.nxs"), OutputWorkspace="__texplan_test_ref_untransformed")
+        matrix, _ = read_texture_direction_info_from_log(loaded)
+        np.testing.assert_allclose(matrix, np.eye(3), atol=1e-9)
 
 
 class TestPoleFigureReference(_FunctionalTestBase):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -1193,6 +1193,44 @@ class TestTextureDirectionFrames(_FunctionalTestBase):
         rotated = Rotation.from_euler("x", 90, degrees=True).apply(entered)
         np.testing.assert_allclose(self._displayed_directions(), rotated, atol=1e-9)
 
+    def test_lab_frame_display_follows_a_later_change_of_initial_rotation(self):
+        # the displayed values are derived from the initial rotation, so editing the rotation while
+        # the lab frame is on must refresh them rather than leave the old frame on screen
+        self._click_checkbox(self.view.chkTransformDirs)
+        self._click_checkbox(self.view.chkLabDirs)
+        QApplication.processEvents()
+        np.testing.assert_allclose(self._displayed_directions(), np.eye(3), atol=1e-9)
+
+        self._rotate_initial_shape_x90()
+
+        np.testing.assert_allclose(self._displayed_directions(), (self._ROT_X90_RD, self._ROT_X90_ND, self._ROT_X90_TD), atol=1e-9)
+
+    def test_entered_directions_keep_their_precision_through_an_update(self):
+        # the sample-frame fields are read straight back into the model, so rounding them for
+        # display would quietly rewrite the frame the user entered
+        rotated = Rotation.from_euler("z", 30, degrees=True).as_matrix()
+        self._set_entered_directions(*rotated.T)
+
+        np.testing.assert_allclose(self._displayed_directions(), rotated.T, atol=1e-9)
+        np.testing.assert_allclose(self.model.ax_transform, rotated, atol=1e-9)
+        self.assertEqual(self.model.dir_names, ["RD", "ND", "TD"])
+
+    def test_direction_boxes_grow_to_fit_the_longest_entry(self):
+        # the entered directions are kept at full precision, so the boxes have to show them
+        widths = {field.maximumWidth() for field in self.view.direction_fields}
+        self.assertEqual(len(widths), 1)  # a grid: every box the same width
+        before = widths.pop()
+
+        rotated = Rotation.from_euler("z", 30, degrees=True).as_matrix()
+        self._set_entered_directions(*rotated.T)
+
+        widths = {field.maximumWidth() for field in self.view.direction_fields}
+        self.assertEqual(len(widths), 1)
+        width = widths.pop()
+        self.assertGreater(width, before)
+        longest = max(self.view.get_rd_dir().split(","), key=len)
+        self.assertGreaterEqual(width, self.view.lineedit_RD0.fontMetrics().horizontalAdvance(longest))
+
     def test_update_directions_in_lab_frame_renames_without_rewriting_the_vectors(self):
         # the fields are showing derived values, so Update must not feed them back into the model
         self._set_entered_directions((0, 1, 0), (0, 0, 1), (1, 0, 0))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/texture_planner.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/texture_planner.ui
@@ -133,148 +133,26 @@
            </layout>
           </widget>
          </item>
-            <item>
-              <widget class="QGroupBox" name="initOrientation">
-               <property name="title">
-                <string>Update Initial Shape Orientation</string>
-               </property>
-               <layout class="QGridLayout" name="layInitAxis">
-                <item row="0" column="0">
-                 <widget class="QLabel" name="lblInitX">
-                  <property name="text">
-                   <string>Rotate Around X:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1" colspan="2">
-                 <widget class="QDoubleSpinBox" name="spnInitX">
-                  <property name="decimals">
-                   <number>3</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="lblInitY">
-                  <property name="text">
-                   <string>Rotate Around Y:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1" colspan="2">
-                 <widget class="QDoubleSpinBox" name="spnInitY">
-                  <property name="decimals">
-                   <number>3</number>
-                  </property>
-                 </widget>
-                </item>
-
-                   <item row="2" column="0">
-                 <widget class="QLabel" name="lblInitZ">
-                  <property name="text">
-                   <string>Rotate Around Z:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="1" colspan="2">
-                 <widget class="QDoubleSpinBox" name="spnInitZ">
-                  <property name="decimals">
-                   <number>3</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-
-            <item>
-              <widget class="QGroupBox" name="initPosition">
-               <property name="title">
-                <string>Update Initial Shape Position</string>
-               </property>
-               <layout class="QGridLayout" name="layInitPos">
-                <item row="0" column="0">
-                 <widget class="QLabel" name="lblInitPX">
-                  <property name="text">
-                   <string>X:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1" colspan="1">
-                 <widget class="QDoubleSpinBox" name="spnInitPX">
-                  <property name="decimals">
-                   <number>4</number>
-                  </property>
-                 </widget>
-                </item>
-
-                   <item row="0" column="2">
-   <spacer name="spacer_left">
-    <property name="orientation">
-     <enum>Qt::Horizontal</enum>
-    </property>
-    <property name="sizeHint" stdset="0">
-     <size>
-      <width>40</width>
-      <height>0</height>
-     </size>
-    </property>
-   </spacer>
-  </item>
-
-                <item row="0" column="3">
-                 <widget class="QLabel" name="lblInitPY">
-                  <property name="text">
-                   <string>Y:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="4" colspan="1">
-                 <widget class="QDoubleSpinBox" name="spnInitPY">
-                  <property name="decimals">
-                   <number>4</number>
-                  </property>
-                 </widget>
-                </item>
-
-                   <item row="0" column="5">
-   <spacer name="spacer_left">
-    <property name="orientation">
-     <enum>Qt::Horizontal</enum>
-    </property>
-    <property name="sizeHint" stdset="0">
-     <size>
-      <width>40</width>
-      <height>0</height>
-     </size>
-    </property>
-   </spacer>
-  </item>
-
-                   <item row="0" column="6">
-                 <widget class="QLabel" name="lblInitPZ">
-                  <property name="text">
-                   <string>Z:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="7" colspan="1">
-                 <widget class="QDoubleSpinBox" name="spnInitPZ">
-                  <property name="decimals">
-                   <number>4</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-
-
-        <item>
+             <item>
        <widget class="QGroupBox" name="grpDirectionWidgets">
         <property name="title">
          <string>Update Sample Directions</string>
         </property>
         <layout class="QVBoxLayout" name="vboxDirectionWidgets">
+            <item>
+          <layout class="QHBoxLayout">
+            <item>
+              <widget class="QLabel" name="lblLabDirs">
+                <property name="text">
+                  <string>Show Directions in Lab Frame:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="chkLabDirs"/>
+            </item>
+          </layout>
+         </item>
          <item>
           <widget class="QGroupBox" name="groupBox_textureVectors">
      <property name="title">
@@ -560,6 +438,151 @@
         </layout>
        </widget>
       </item>
+            <item>
+              <widget class="QGroupBox" name="initOrientation">
+               <property name="title">
+                <string>Update Initial Shape Orientation</string>
+               </property>
+               <layout class="QGridLayout" name="layInitAxis">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblInitX">
+                  <property name="text">
+                   <string>Rotate Around X:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1" colspan="2">
+                 <widget class="QDoubleSpinBox" name="spnInitX">
+                  <property name="decimals">
+                   <number>3</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="lblInitY">
+                  <property name="text">
+                   <string>Rotate Around Y:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1" colspan="2">
+                 <widget class="QDoubleSpinBox" name="spnInitY">
+                  <property name="decimals">
+                   <number>3</number>
+                  </property>
+                 </widget>
+                </item>
+
+                   <item row="2" column="0">
+                 <widget class="QLabel" name="lblInitZ">
+                  <property name="text">
+                   <string>Rotate Around Z:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1" colspan="2">
+                 <widget class="QDoubleSpinBox" name="spnInitZ">
+                  <property name="decimals">
+                   <number>3</number>
+                  </property>
+                 </widget>
+                </item>
+
+                   <item row="3" column="0">
+                 <widget class="QLabel" name="lblTransformDirs">
+                  <property name="text">
+                   <string>Apply Transformation to Sample Directions:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1" colspan="2">
+                 <widget class="QCheckBox" name="chkTransformDirs"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+
+            <item>
+              <widget class="QGroupBox" name="initPosition">
+               <property name="title">
+                <string>Update Initial Shape Position</string>
+               </property>
+               <layout class="QGridLayout" name="layInitPos">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblInitPX">
+                  <property name="text">
+                   <string>X:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1" colspan="1">
+                 <widget class="QDoubleSpinBox" name="spnInitPX">
+                  <property name="decimals">
+                   <number>4</number>
+                  </property>
+                 </widget>
+                </item>
+
+                   <item row="0" column="2">
+   <spacer name="spacer_left">
+    <property name="orientation">
+     <enum>Qt::Horizontal</enum>
+    </property>
+    <property name="sizeHint" stdset="0">
+     <size>
+      <width>40</width>
+      <height>0</height>
+     </size>
+    </property>
+   </spacer>
+  </item>
+
+                <item row="0" column="3">
+                 <widget class="QLabel" name="lblInitPY">
+                  <property name="text">
+                   <string>Y:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="4" colspan="1">
+                 <widget class="QDoubleSpinBox" name="spnInitPY">
+                  <property name="decimals">
+                   <number>4</number>
+                  </property>
+                 </widget>
+                </item>
+
+                   <item row="0" column="5">
+   <spacer name="spacer_left">
+    <property name="orientation">
+     <enum>Qt::Horizontal</enum>
+    </property>
+    <property name="sizeHint" stdset="0">
+     <size>
+      <width>40</width>
+      <height>0</height>
+     </size>
+    </property>
+   </spacer>
+  </item>
+
+                   <item row="0" column="6">
+                 <widget class="QLabel" name="lblInitPZ">
+                  <property name="text">
+                   <string>Z:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="7" colspan="1">
+                 <widget class="QDoubleSpinBox" name="spnInitPZ">
+                  <property name="decimals">
+                   <number>4</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
       <item>
        <spacer name="spSampleStretch">
         <property name="orientation">

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -230,6 +230,15 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
             "Show estimated transmission values per virtual detector (Monte Carlo) instead of pole figure coverage."
         )
 
+        self.chkTransformDirs.setToolTip(
+            "Apply Orientation to the provided Sample Direction Vectors (useful if the shape is misaligned in the beam)"
+        )
+
+        self.chkLabDirs.setToolTip(
+            "View the Sample Texture Directions in terms of the Lab Reference Frame "
+            "(currently they can only be updated in terms of the Sample Reference Frame)"
+        )
+
         # Orientation table
         self.tableWidget.setToolTip(
             "Axis information for every orientation. Use Include to choose orientations for the pole figure and outputs, "
@@ -357,6 +366,12 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
 
     def set_on_show_transmission_toggled(self, slot: Callable) -> None:
         self.chkTransmission.toggled.connect(slot)
+
+    def set_on_transform_dirs_toggled(self, slot: Callable) -> None:
+        self.chkTransformDirs.toggled.connect(slot)
+
+    def set_on_lab_dirs_toggled(self, slot: Callable) -> None:
+        self.chkLabDirs.toggled.connect(slot)
 
     def set_on_init_x_changed(self, slot: Callable) -> None:
         self.spnInitX.valueChanged.connect(slot)
@@ -487,6 +502,12 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
     def get_show_transmission(self) -> bool:
         return self.chkTransmission.isChecked()
 
+    def get_transform_dirs(self) -> bool:
+        return self.chkTransformDirs.isChecked()
+
+    def get_lab_dirs(self) -> bool:
+        return self.chkLabDirs.isChecked()
+
     def get_init_x(self) -> float:
         return self.spnInitX.value()
 
@@ -523,19 +544,19 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self.lineedit_TD.setText(text)
 
     def set_rd_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_RD0.setText(str(vec[0]))
-        self.lineedit_RD1.setText(str(vec[1]))
-        self.lineedit_RD2.setText(str(vec[2]))
+        self.lineedit_RD0.setText(str(round(vec[0], 2)))
+        self.lineedit_RD1.setText(str(round(vec[1], 2)))
+        self.lineedit_RD2.setText(str(round(vec[2], 2)))
 
     def set_td_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_TD0.setText(str(vec[0]))
-        self.lineedit_TD1.setText(str(vec[1]))
-        self.lineedit_TD2.setText(str(vec[2]))
+        self.lineedit_TD0.setText(str(round(vec[0], 2)))
+        self.lineedit_TD1.setText(str(round(vec[1], 2)))
+        self.lineedit_TD2.setText(str(round(vec[2], 2)))
 
     def set_nd_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_ND0.setText(str(vec[0]))
-        self.lineedit_ND1.setText(str(vec[1]))
-        self.lineedit_ND2.setText(str(vec[2]))
+        self.lineedit_ND0.setText(str(round(vec[0], 2)))
+        self.lineedit_ND1.setText(str(round(vec[1], 2)))
+        self.lineedit_ND2.setText(str(round(vec[2], 2)))
 
     def set_max_ind(self, ind: int) -> None:
         self.spnIndex.setMaximum(ind)
@@ -583,6 +604,12 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
 
     def set_show_transmission(self, check: bool) -> None:
         self.chkTransmission.setChecked(check)
+
+    def set_transform_dirs(self, check: bool) -> None:
+        self.chkTransformDirs.setChecked(check)
+
+    def set_lab_dirs(self, check: bool) -> None:
+        self.chkLabDirs.setChecked(check)
 
     def _setup_pf_plot(self) -> None:
         self.pf_figure = Figure(layout="constrained")
@@ -778,6 +805,19 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
 
     def set_set_gauge_vol_enabled(self, enabled: bool) -> None:
         self.setGV.setEnabled(enabled)
+
+    def set_texture_directions_enabled(self, enabled: bool) -> None:
+        self.lineedit_RD0.setEnabled(enabled)
+        self.lineedit_RD1.setEnabled(enabled)
+        self.lineedit_RD2.setEnabled(enabled)
+
+        self.lineedit_TD0.setEnabled(enabled)
+        self.lineedit_TD1.setEnabled(enabled)
+        self.lineedit_TD2.setEnabled(enabled)
+
+        self.lineedit_ND0.setEnabled(enabled)
+        self.lineedit_ND1.setEnabled(enabled)
+        self.lineedit_ND2.setEnabled(enabled)
 
     def set_on_clear_gauge_volume_clicked(self, slot: Callable) -> None:
         self.clearGV.clicked.connect(slot)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -4,11 +4,23 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from qtpy.QtWidgets import QMainWindow, QHeaderView, QTableWidgetItem, QCheckBox, QWidget, QHBoxLayout, QPushButton, QToolBar, QGroupBox
+from qtpy.QtWidgets import (
+    QMainWindow,
+    QHeaderView,
+    QTableWidgetItem,
+    QCheckBox,
+    QWidget,
+    QHBoxLayout,
+    QPushButton,
+    QToolBar,
+    QGroupBox,
+    QLineEdit,
+)
 from qtpy import QtCore
 from qtpy.QtGui import QCloseEvent
 from mantidqt.utils.qt import load_ui
 from mantidqt.icons import get_icon
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.direction_fields import autosize_direction_fields
 from mantid.kernel import FeatureType
 from mantid import UsageService
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -17,7 +29,7 @@ from matplotlib.figure import Figure
 from matplotlib.axes import Axes
 from qtpy.QtWidgets import QVBoxLayout
 from functools import partial
-from typing import Callable, List, Tuple
+from typing import Callable, List, Sequence
 
 Ui_texplan, _ = load_ui(__file__, "texture_planner.ui")
 
@@ -105,6 +117,19 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self.gonio_senses = (self.cmbSense0, self.cmbSense1, self.cmbSense2, self.cmbSense3, self.cmbSense4, self.cmbSense5)
         self.gonio_vecs = (self.edtVec0, self.edtVec1, self.edtVec2, self.edtVec3, self.edtVec4, self.edtVec5)
         self.init_angles = (self.spnInitX, self.spnInitY, self.spnInitZ)
+        self.direction_fields = (
+            self.lineedit_RD0,
+            self.lineedit_RD1,
+            self.lineedit_RD2,
+            self.lineedit_ND0,
+            self.lineedit_ND1,
+            self.lineedit_ND2,
+            self.lineedit_TD0,
+            self.lineedit_TD1,
+            self.lineedit_TD2,
+        )
+        # the sample-frame values are held to full precision, so a fixed narrow box would hide them
+        autosize_direction_fields(self.direction_fields)
 
         self._setup_pf_plot()
         self._setup_lab_plot()
@@ -543,20 +568,24 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
     def set_td_name(self, text: str) -> None:
         self.lineedit_TD.setText(text)
 
-    def set_rd_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_RD0.setText(str(round(vec[0], 2)))
-        self.lineedit_RD1.setText(str(round(vec[1], 2)))
-        self.lineedit_RD2.setText(str(round(vec[2], 2)))
+    def _set_dir_fields(self, fields: Sequence[QLineEdit], vec: Sequence[int | float]) -> None:
+        """Populate one direction row.
 
-    def set_td_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_TD0.setText(str(round(vec[0], 2)))
-        self.lineedit_TD1.setText(str(round(vec[1], 2)))
-        self.lineedit_TD2.setText(str(round(vec[2], 2)))
+        The lab-frame values are derived and shown read-only, so they are rounded for legibility.
+        The sample-frame values are editable and are read straight back into the model on Update,
+        so they must keep their full precision - rounding them would quietly rewrite the frame the
+        user entered."""
+        for field, component in zip(fields, vec):
+            field.setText(str(round(component, 2) if self.get_lab_dirs() else component))
 
-    def set_nd_dir(self, vec: Tuple[int | float, int | float, int | float]) -> None:
-        self.lineedit_ND0.setText(str(round(vec[0], 2)))
-        self.lineedit_ND1.setText(str(round(vec[1], 2)))
-        self.lineedit_ND2.setText(str(round(vec[2], 2)))
+    def set_rd_dir(self, vec: Sequence[int | float]) -> None:
+        self._set_dir_fields((self.lineedit_RD0, self.lineedit_RD1, self.lineedit_RD2), vec)
+
+    def set_td_dir(self, vec: Sequence[int | float]) -> None:
+        self._set_dir_fields((self.lineedit_TD0, self.lineedit_TD1, self.lineedit_TD2), vec)
+
+    def set_nd_dir(self, vec: Sequence[int | float]) -> None:
+        self._set_dir_fields((self.lineedit_ND0, self.lineedit_ND1, self.lineedit_ND2), vec)
 
     def set_max_ind(self, ind: int) -> None:
         self.spnIndex.setMaximum(ind)

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -163,6 +163,14 @@ def _write_ax_transform_to_log(ws: str | Workspace2D, ax_transform: np.ndarray) 
 
 
 def _write_texture_dir_names_to_log(ws: str | Workspace2D, dir_names: tuple[str, str, str]) -> None:
+    # the log is a comma separated list of exactly three labels, so a label containing a comma would
+    # be read back as several labels - silently shifting the frame rather than failing here
+    offenders = [name for name in dir_names if "," in name]
+    if offenders:
+        raise ValueError(
+            f"Texture direction labels cannot contain commas: ({','.join(offenders)}). "
+            f"The {TEXTURE_DIRECTION_LABELS_LOG} log stores the three labels comma separated."
+        )
     AddSampleLog(Workspace=ws, LogName=TEXTURE_DIRECTION_LABELS_LOG, LogText=",".join(dir_names))
 
 

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -114,6 +114,26 @@ def show_texture_sample_shape(
 ##### Utility Texture Log IO Functions ################
 # ------------------------------------------------------------#
 
+# Log names carrying the texture sample directions. Named here rather than inline so the writer
+# (the Texture Planner's reference-workspace export) and the readers cannot drift apart.
+TEXTURE_DIRECTION_MATRIX_LOG = "TextureDirectionMatrix"
+TEXTURE_DIRECTION_LABELS_LOG = "TextureDirectionLabels"
+
+
+def has_texture_direction_info(ws: str | Workspace2D) -> bool:
+    """Whether ws carries a texture direction matrix at all.
+
+    Lets callers tell "this workspace defines no sample frame" (a reference workspace made by
+    LoadEmptyInstrument, or one predating these logs) apart from "it defines the identity frame",
+    which read_texture_direction_info_from_log cannot express - it always falls back to a default.
+    The labels are not required: they default harmlessly, whereas the matrix is the meaningful part.
+    """
+    if isinstance(ws, str):
+        if not ADS.doesExist(ws):
+            return False
+        ws = ADS.retrieve(ws)
+    return ws.getRun().hasProperty(TEXTURE_DIRECTION_MATRIX_LOG)
+
 
 def write_texture_direction_info_to_log(ws: str | Workspace2D, ax_transform: np.ndarray, dir_names: tuple[str, str, str]) -> None:
     """
@@ -139,11 +159,11 @@ def read_texture_direction_info_from_log(
 
 def _write_ax_transform_to_log(ws: str | Workspace2D, ax_transform: np.ndarray) -> None:
     direction_matrix_str = ",".join([str(x) for x in ax_transform.reshape(-1)])
-    AddSampleLog(Workspace=ws, LogName="TextureDirectionMatrix", LogText=direction_matrix_str)
+    AddSampleLog(Workspace=ws, LogName=TEXTURE_DIRECTION_MATRIX_LOG, LogText=direction_matrix_str)
 
 
 def _write_texture_dir_names_to_log(ws: str | Workspace2D, dir_names: tuple[str, str, str]) -> None:
-    AddSampleLog(Workspace=ws, LogName="TextureDirectionLabels", LogText=",".join(dir_names))
+    AddSampleLog(Workspace=ws, LogName=TEXTURE_DIRECTION_LABELS_LOG, LogText=",".join(dir_names))
 
 
 # --------------- reading helpers ----------------------------------
@@ -167,14 +187,14 @@ def _read_texture_log(ws: str | Workspace2D, log_name: str, default: str) -> str
 
 def _read_texture_dir_names_from_log(ws: str | Workspace2D, default: tuple[str, str, str] = ("D1", "D2", "D3")) -> tuple[str, str, str]:
     default_str = ",".join(default)
-    dir_name_str = _read_texture_log(ws, "TextureDirectionLabels", default_str)
+    dir_name_str = _read_texture_log(ws, TEXTURE_DIRECTION_LABELS_LOG, default_str)
     return _ensure_dir_names_are_three_comma_separated_labels([x for x in dir_name_str.split(",")])
 
 
 def _read_ax_transform_from_log(ws: str | Workspace2D, default: np.ndarray | None = None) -> np.ndarray:
     default = np.eye(3) if default is None else default
     default_str = ",".join([str(x) for x in default.reshape(-1)])
-    dir_name_str = _read_texture_log(ws, "TextureDirectionMatrix", default_str)
+    dir_name_str = _read_texture_log(ws, TEXTURE_DIRECTION_MATRIX_LOG, default_str)
     return _ensure_ax_transform_is_nine_comma_separated_values([x for x in dir_name_str.split(",")])
 
 

--- a/scripts/Engineering/texture/texture_helper.py
+++ b/scripts/Engineering/texture/texture_helper.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import numpy as np
 from os import path
+
 from scipy.spatial.transform import Rotation
 from mantid.simpleapi import (
     logger,
@@ -20,6 +21,7 @@ from mantid.simpleapi import (
     Rebin,
     RebinToWorkspace,
     SaveAscii,
+    AddSampleLog,
 )
 from mantid.api import AnalysisDataService as ADS
 from typing import Optional, Sequence
@@ -106,6 +108,104 @@ def show_texture_sample_shape(
         model.set_gauge_vol_str(get_gauge_vol_str(gauge_vol_preset, custom_file))
         model.set_include_gauge_vol(gauge_vol_preset != "No Gauge Volume")
     model.show_shape_plot(ax_transform, ax_labels)
+
+
+# ------------------------------------------------------------#
+##### Utility Texture Log IO Functions ################
+# ------------------------------------------------------------#
+
+
+def write_texture_direction_info_to_log(ws: str | Workspace2D, ax_transform: np.ndarray, dir_names: tuple[str, str, str]) -> None:
+    """
+    Create SampleLogs with the Texture Sample Directions saved as:
+    -  TextureDirectionMatrix (comma separated string of row-major flattened 3x3 matrix elements where each column is a direction)
+    -  TextureDirectionLabels (comma separated string of three direction names
+    """
+    _write_ax_transform_to_log(ws, ax_transform)
+    _write_texture_dir_names_to_log(ws, dir_names)
+
+
+def read_texture_direction_info_from_log(
+    ws: str | Workspace2D, dir_matrix_default: np.ndarray | None = None, dir_names_default: tuple[str, str, str] = ("D1", "D2", "D3")
+) -> tuple[np.ndarray, tuple[str, str, str]]:
+    """
+    Read Texture Sample Direction Information off SampleLogs populating missing logs with the provided defaults
+    """
+    return _read_ax_transform_from_log(ws, dir_matrix_default), _read_texture_dir_names_from_log(ws, dir_names_default)
+
+
+# ------------- writing helpers----------------------------------
+
+
+def _write_ax_transform_to_log(ws: str | Workspace2D, ax_transform: np.ndarray) -> None:
+    direction_matrix_str = ",".join([str(x) for x in ax_transform.reshape(-1)])
+    AddSampleLog(Workspace=ws, LogName="TextureDirectionMatrix", LogText=direction_matrix_str)
+
+
+def _write_texture_dir_names_to_log(ws: str | Workspace2D, dir_names: tuple[str, str, str]) -> None:
+    AddSampleLog(Workspace=ws, LogName="TextureDirectionLabels", LogText=",".join(dir_names))
+
+
+# --------------- reading helpers ----------------------------------
+
+
+def _read_texture_log(ws: str | Workspace2D, log_name: str, default: str) -> str:
+    if isinstance(ws, str):
+        if ADS.doesExist(ws):
+            ws = ADS.retrieve(ws)
+        else:
+            # warn if a ws is provided that can't be found
+            logger.warning(f"Workspace: {ws} could not be found to read the {log_name} from. Using Default: ({default})")
+            return default
+    try:
+        return ws.getRun().getLogData(log_name).value
+    except RuntimeError:
+        # only notice if the log is missing - may be the case with some legacy data
+        logger.notice(f"{log_name} could not be found or read from the logs of Workspace: {ws}. Using provided default: ({default})")
+        return default
+
+
+def _read_texture_dir_names_from_log(ws: str | Workspace2D, default: tuple[str, str, str] = ("D1", "D2", "D3")) -> tuple[str, str, str]:
+    default_str = ",".join(default)
+    dir_name_str = _read_texture_log(ws, "TextureDirectionLabels", default_str)
+    return _ensure_dir_names_are_three_comma_separated_labels([x for x in dir_name_str.split(",")])
+
+
+def _read_ax_transform_from_log(ws: str | Workspace2D, default: np.ndarray | None = None) -> np.ndarray:
+    default = np.eye(3) if default is None else default
+    default_str = ",".join([str(x) for x in default.reshape(-1)])
+    dir_name_str = _read_texture_log(ws, "TextureDirectionMatrix", default_str)
+    return _ensure_ax_transform_is_nine_comma_separated_values([x for x in dir_name_str.split(",")])
+
+
+# ----------------- validators----------------------------------------------------------------------
+
+
+def _ensure_dir_names_are_three_comma_separated_labels(dir_names: Sequence[str]) -> tuple[str, str, str]:
+    num_dirs = len(dir_names)
+    match num_dirs:
+        case 3:
+            return dir_names[0], dir_names[1], dir_names[2]  # explicit for type hinting
+        case _ if num_dirs > 3:
+            logger.warning(f"The obtained Texture Direction Labels: ({','.join(dir_names)}) have too many labels.Using only the first 3.")
+            return dir_names[0], dir_names[1], dir_names[2]  # explicit for type hinting
+        case _:
+            logger.warning(f"The obtained Texture Direction Labels: ({','.join(dir_names)}) have too few labels.Using generic (D1,D2,D3).")
+            return "D1", "D2", "D3"
+
+
+def _ensure_ax_transform_is_nine_comma_separated_values(matrix_elements: Sequence[str]) -> np.ndarray:
+    if len(matrix_elements) == 9:
+        try:
+            return np.asarray([float(x) for x in matrix_elements]).reshape((3, 3))
+        except ValueError:
+            pass
+    # if function reaches here, log is malformed - warn and return identity
+    logger.warning(
+        f"The obtained Texture Direction Matrix: ({','.join(matrix_elements)}) cannot be read into a 3x3 matrix."
+        f"Using generic identity matrix."
+    )
+    return np.eye(3)
 
 
 # --------------------------------------------------------#

--- a/scripts/test/Engineering/texture/test_texture_helper.py
+++ b/scripts/test/Engineering/texture/test_texture_helper.py
@@ -10,7 +10,7 @@ import tempfile
 import os
 from unittest.mock import patch, MagicMock, call, mock_open
 from mantid.api import AnalysisDataService as ADS
-from mantid.simpleapi import CreateWorkspace, ConjoinWorkspaces
+from mantid.simpleapi import AddSampleLog, CreateWorkspace, ConjoinWorkspaces
 from Engineering.texture.texture_helper import (
     load_all_orientations,
     _read_xml,
@@ -36,6 +36,11 @@ from Engineering.texture.texture_helper import (
     define_gauge_volume,
     get_scattering_centre,
     convert_to_sscanss_frame,
+    has_texture_direction_info,
+    read_texture_direction_info_from_log,
+    write_texture_direction_info_to_log,
+    TEXTURE_DIRECTION_LABELS_LOG,
+    TEXTURE_DIRECTION_MATRIX_LOG,
 )
 import numpy as np
 from os import path
@@ -947,6 +952,167 @@ class TestConvertToSscanssFrame(unittest.TestCase):
         recovered = Rotation.from_euler("xyz", -angles, degrees=True).as_matrix()
         expected = M @ rot @ M.T
         np.testing.assert_allclose(recovered, expected, atol=1e-9)
+
+
+class TestTextureDirectionLogIO(unittest.TestCase):
+    """Reading/writing the texture sample directions as sample logs.
+
+    This is the contract between the Texture Planner (which writes the logs onto an exported
+    reference workspace) and the Engineering Diffraction interface (which reads them back), so the
+    round-trip and the fallbacks when a log is absent or malformed are the things worth pinning.
+    """
+
+    # a deliberately non-symmetric frame: RD=(0,1,0), ND=(0,0,1), TD=(1,0,0) stored as COLUMNS,
+    # so a transposed write or read would be caught rather than cancelling out
+    _AX_TRANSFORM = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    _DIR_NAMES = ("RD", "ND", "TD")
+
+    def setUp(self):
+        self.ws_name = "__test_texture_direction_log_ws"
+        self.ws = CreateWorkspace(DataX=[0, 1], DataY=[1], OutputWorkspace=self.ws_name)
+        self.addCleanup(self._remove_ws)
+
+    def _remove_ws(self):
+        if ADS.doesExist(self.ws_name):
+            ADS.remove(self.ws_name)
+
+    def _log_value(self, log_name):
+        return self.ws.getRun().getLogData(log_name).value
+
+    # writing ------------------------------------------------------------
+    def test_write_stores_both_logs_as_comma_separated_strings(self):
+        write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        # row-major flattening of the column-per-direction matrix
+        self.assertEqual(self._log_value(TEXTURE_DIRECTION_MATRIX_LOG), "0.0,0.0,1.0,1.0,0.0,0.0,0.0,1.0,0.0")
+        self.assertEqual(self._log_value(TEXTURE_DIRECTION_LABELS_LOG), "RD,ND,TD")
+
+    def test_write_accepts_a_workspace_object_as_well_as_a_name(self):
+        write_texture_direction_info_to_log(self.ws, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.assertTrue(has_texture_direction_info(self.ws_name))
+
+    # round trip ---------------------------------------------------------
+    def test_round_trip_preserves_the_matrix_and_the_labels(self):
+        write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        matrix, names = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, self._AX_TRANSFORM, atol=1e-12)
+        self.assertEqual(names, self._DIR_NAMES)
+
+    def test_round_trip_keeps_each_direction_in_its_own_column(self):
+        # the directions are the columns, and the flatten/reshape must not silently transpose them
+        write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        matrix, _ = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix[:, 0], (0.0, 1.0, 0.0), atol=1e-12)  # RD
+        np.testing.assert_allclose(matrix[:, 1], (0.0, 0.0, 1.0), atol=1e-12)  # ND
+        np.testing.assert_allclose(matrix[:, 2], (1.0, 0.0, 0.0), atol=1e-12)  # TD
+
+    def test_round_trip_survives_non_integer_components(self):
+        # a frame carried round by an initial shape rotation is not made of 0s and 1s
+        rotated = Rotation.from_euler("z", 30, degrees=True).as_matrix() @ self._AX_TRANSFORM
+        write_texture_direction_info_to_log(self.ws_name, rotated, self._DIR_NAMES)
+
+        matrix, _ = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, rotated, atol=1e-12)
+
+    def test_rewriting_replaces_rather_than_appends(self):
+        write_texture_direction_info_to_log(self.ws_name, np.eye(3), ("A", "B", "C"))
+        write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        matrix, names = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, self._AX_TRANSFORM, atol=1e-12)
+        self.assertEqual(names, self._DIR_NAMES)
+
+    # presence probe -----------------------------------------------------
+    def test_has_info_is_false_before_writing_and_true_after(self):
+        self.assertFalse(has_texture_direction_info(self.ws_name))
+
+        write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)
+
+        self.assertTrue(has_texture_direction_info(self.ws_name))
+
+    def test_has_info_is_false_for_an_unknown_workspace(self):
+        # a reference workspace that failed to load must not look like it defines a sample frame
+        self.assertFalse(has_texture_direction_info("__not_a_workspace"))
+
+    def test_has_info_ignores_the_labels(self):
+        # the labels default harmlessly; only the matrix carries meaning
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_LABELS_LOG, LogText="RD,ND,TD")
+
+        self.assertFalse(has_texture_direction_info(self.ws_name))
+
+    # fallbacks ----------------------------------------------------------
+    def test_missing_logs_fall_back_to_the_supplied_defaults(self):
+        default_matrix = Rotation.from_euler("x", 90, degrees=True).as_matrix()
+
+        matrix, names = read_texture_direction_info_from_log(self.ws_name, default_matrix, ("A", "B", "C"))
+
+        # a 3x3 default must be usable here - testing it as a boolean would raise
+        np.testing.assert_allclose(matrix, default_matrix, atol=1e-12)
+        self.assertEqual(names, ("A", "B", "C"))
+
+    def test_missing_logs_without_defaults_give_identity_and_generic_labels(self):
+        matrix, names = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, np.eye(3), atol=1e-12)
+        self.assertEqual(names, ("D1", "D2", "D3"))
+
+    def test_unknown_workspace_falls_back_rather_than_raising(self):
+        matrix, names = read_texture_direction_info_from_log("__not_a_workspace")
+
+        np.testing.assert_allclose(matrix, np.eye(3), atol=1e-12)
+        self.assertEqual(names, ("D1", "D2", "D3"))
+
+    def test_only_the_missing_log_falls_back(self):
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_MATRIX_LOG, LogText="0,0,1,1,0,0,0,1,0")
+
+        matrix, names = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, self._AX_TRANSFORM, atol=1e-12)
+        self.assertEqual(names, ("D1", "D2", "D3"))
+
+    # malformed logs -----------------------------------------------------
+    @patch(texture_utils_path + ".logger")
+    def test_matrix_with_the_wrong_number_of_values_falls_back_to_identity(self, mock_logger):
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_MATRIX_LOG, LogText="1,0,0,0,1,0")
+
+        matrix, _ = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, np.eye(3), atol=1e-12)
+        mock_logger.warning.assert_called_once()
+
+    @patch(texture_utils_path + ".logger")
+    def test_matrix_with_non_numeric_values_falls_back_to_identity(self, mock_logger):
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_MATRIX_LOG, LogText="1,0,0,0,1,0,0,0,not_a_number")
+
+        matrix, _ = read_texture_direction_info_from_log(self.ws_name)
+
+        np.testing.assert_allclose(matrix, np.eye(3), atol=1e-12)
+        mock_logger.warning.assert_called_once()
+
+    @patch(texture_utils_path + ".logger")
+    def test_too_many_labels_are_truncated_to_the_first_three(self, mock_logger):
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_LABELS_LOG, LogText="RD,ND,TD,XD")
+
+        _, names = read_texture_direction_info_from_log(self.ws_name)
+
+        self.assertEqual(names, ("RD", "ND", "TD"))
+        mock_logger.warning.assert_called_once()
+
+    @patch(texture_utils_path + ".logger")
+    def test_too_few_labels_fall_back_to_generic_names(self, mock_logger):
+        AddSampleLog(Workspace=self.ws_name, LogName=TEXTURE_DIRECTION_LABELS_LOG, LogText="RD,ND")
+
+        _, names = read_texture_direction_info_from_log(self.ws_name)
+
+        self.assertEqual(names, ("D1", "D2", "D3"))
+        mock_logger.warning.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/scripts/test/Engineering/texture/test_texture_helper.py
+++ b/scripts/test/Engineering/texture/test_texture_helper.py
@@ -1020,6 +1020,12 @@ class TestTextureDirectionLogIO(unittest.TestCase):
 
         np.testing.assert_allclose(matrix, rotated, atol=1e-12)
 
+    def test_a_label_containing_a_comma_is_rejected(self):
+        # the labels share one comma separated log, so "RD, rolling" would be read back as four
+        # labels and silently truncated to the wrong three
+        with self.assertRaises(ValueError):
+            write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, ("RD, rolling", "ND", "TD"))
+
     def test_rewriting_replaces_rather_than_appends(self):
         write_texture_direction_info_to_log(self.ws_name, np.eye(3), ("A", "B", "C"))
         write_texture_direction_info_to_log(self.ws_name, self._AX_TRANSFORM, self._DIR_NAMES)


### PR DESCRIPTION
### Description of work

After the work of #41935, this PR mainly enables users to update the initial sample directions using the sample set up rotations and then save these as lab frame directions on the reference workspace.

These will then be automatically loaded into the Eng Diff settings when the Reference Workspace is loaded.

This allows users to correct for misaligned samples directly in Mantid rather than as a post processing step (allowing for better absorption correction calculations as a side product)

Additionally this PR adds:

- highlighting the current orientation index on the PF when in transmission mode
- dynamic simulation histogram ranges so absorption correction doesn't go out of range

### To test:

- Open the interface (Interfaces > Diffraction > Texture Planner)
- Open the `Update Sample Directions` and `Update Initial Shape Orientation` option boxes
- In `Update Initial Shape Orientation` click `Apply Transform to Sample Directions`
- Rotate the sample some amount (view should update, the texture directions should rotate WITH the sample)
- In `Update Sample Directions` set Texture Directions to A 0 0 1, B 0 1 0, C 1 0 0 (should update the direction on the sample and the labels on both the sample and the PF)
- In `Update Sample Directions` click `Show Directions in Lab Frame` (direction values should grey out, names can still be changed) 
- Continue to rotate, the lab frame values should update (they don't currently, they do update if you toggle show in lab frame off and on - I'll fix this bug)
- Toggle `Apply Transform to Sample Directions` and the view should change whether the directions are snapped to sample or not
- Leave the setup in a state where there is some non-trivial rotation and `Apply Transform to Sample Directions` is True
- On the bottom right export panel set Save Directory and Filename somewhere you can find with the Export as `Reference Workspace`
- Click `Export`

- Open EngDiff UI (Interfaces > Diffraction > Engineering Diffraction)
- Set RB Number at top to `Test`
- Open settings and set Texture Directions to RD 1 0 0, ND 0 1 0, TD 0 0 1
- Click True `Read directions from a loaded reference workspace`
- Set RB Number at top to `TextureTest`
- Go to Absorption Correction Tab
- In `Set Sample Properties` (third box down in the tab) under `Setup Reference Frame` browse to and load the reference workspace you exported above
- In `Reference Workspace Information` (second box down) the Reference Frame should be the file name and the Shape should have a `View` button
- Click it!
- Your sample should be in the same orientation relative to the incoming beam as in Texture Planner (big grey arrow in texture planner, black arrow on the Z axis in ref ws view) the ref ws view will probably have a gauge volume, don't worry about that, the EngDiff UI adds that (under `Include Absorption Correction`)
- Open the settings and the texture directions should match the Texture Planner (albeit with the boxes too small - I will also fix this) 
- Close the settings and Set RB back to `Test`
- Open the settings and the Texture Directions should be back to RD 1 0 0, ND 0 1 0, TD 0 0 1


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
