### PR TITLE
Deprecate Histogram 1.0 methods in C++

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -46,24 +46,38 @@ public:
   /// Copy data from another ISpectrum with double-dynamic dispatch.
   virtual void copyDataFrom(const ISpectrum &source) = 0;
 
+  [[deprecated("use setSharedX() instead")]]
   virtual void setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) = 0;
+  [[deprecated("use mutableX() instead")]]
   virtual MantidVec &dataX() = 0;
+  [[deprecated("use x() instead")]]
   virtual const MantidVec &dataX() const = 0;
+  [[deprecated("use x() instead")]]
   virtual const MantidVec &readX() const = 0;
+  [[deprecated("use sharedX() instead")]]
   virtual Kernel::cow_ptr<HistogramData::HistogramX> ptrX() const = 0;
 
+  [[deprecated("use mutableDx() instead")]]
   virtual MantidVec &dataDx() = 0;
+  [[deprecated("use dx() instead")]]
   virtual const MantidVec &dataDx() const = 0;
+  [[deprecated("use dx() instead")]]
   virtual const MantidVec &readDx() const = 0;
 
   virtual void clearData() = 0;
 
+  [[deprecated("use mutableY() instead")]]
   virtual MantidVec &dataY() = 0;
+  [[deprecated("use mutableE() instead")]]
   virtual MantidVec &dataE() = 0;
 
+  [[deprecated("use y() instead")]]
   virtual const MantidVec &dataY() const = 0;
+  [[deprecated("use e() instead")]]
   virtual const MantidVec &dataE() const = 0;
+  [[deprecated("use y() instead")]]
   virtual const MantidVec &readY() const;
+  [[deprecated("use e() instead")]]
   virtual const MantidVec &readE() const;
 
   virtual size_t getMemorySize() const = 0;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/EmptyValues.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <atomic>
 #include <map>
@@ -299,30 +300,32 @@ public:
   /// @param index :: workspace index to retrieve.
   [[deprecated("use x() instead")]]
   const MantidVec &readX(std::size_t const index) const {
-    return getSpectrum(index).dataX();
+    return getSpectrum(index).x().rawData();
   }
   /// Deprecated, use y() instead. Returns a read-only (i.e. const) reference to
   /// the specified Y array
   /// @param index :: workspace index to retrieve.
   [[deprecated("use y() instead")]]
   const MantidVec &readY(std::size_t const index) const {
-    return getSpectrum(index).dataY();
+    return getSpectrum(index).y().rawData();
   }
   /// Deprecated, use e() instead. Returns a read-only (i.e. const) reference to
   /// the specified E array
   /// @param index :: workspace index to retrieve.
   [[deprecated("use e() instead")]]
   const MantidVec &readE(std::size_t const index) const {
-    return getSpectrum(index).dataE();
+    return getSpectrum(index).e().rawData();
   }
   /// Deprecated, use dx() instead. Returns a read-only (i.e. const) reference
   /// to the specified X error array
   /// @param index :: workspace index to retrieve.
   [[deprecated("use dx() instead")]]
   const MantidVec &readDx(size_t const index) const {
-    return getSpectrum(index).dataDx();
+    return getSpectrum(index).dx().rawData();
   }
 
+  // The mutable legacy accessors require ISpectrum's own legacy interface
+  GNU_DIAG_OFF("deprecated-declarations")
   /// Deprecated, use mutableX() instead. Returns the x data
   [[deprecated("use mutableX() instead")]]
   virtual MantidVec &dataX(const std::size_t index) {
@@ -343,26 +346,27 @@ public:
   virtual MantidVec &dataDx(const std::size_t index) {
     return getSpectrumWithoutInvalidation(index).dataDx();
   }
+  GNU_DIAG_ON("deprecated-declarations")
 
   /// Deprecated, use x() instead. Returns the x data const
   [[deprecated("use x() instead")]]
   virtual const MantidVec &dataX(const std::size_t index) const {
-    return getSpectrum(index).dataX();
+    return getSpectrum(index).x().rawData();
   }
   /// Deprecated, use y() instead. Returns the y data const
   [[deprecated("use y() instead")]]
   virtual const MantidVec &dataY(const std::size_t index) const {
-    return getSpectrum(index).dataY();
+    return getSpectrum(index).y().rawData();
   }
   /// Deprecated, use e() instead. Returns the error const
   [[deprecated("use e() instead")]]
   virtual const MantidVec &dataE(const std::size_t index) const {
-    return getSpectrum(index).dataE();
+    return getSpectrum(index).e().rawData();
   }
   /// Deprecated, use dx() instead. Returns the error const
   [[deprecated("use dx() instead")]]
   virtual const MantidVec &dataDx(const std::size_t index) const {
-    return getSpectrum(index).dataDx();
+    return getSpectrum(index).dx().rawData();
   }
 
   virtual double getXMin() const;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -582,7 +582,7 @@ private:
                             size_t indexEnd) const;
   /// Copy data from an image.
   template <class Accessor>
-  void setImage(Accessor mutableVec, const MantidImage &image, size_t start, [[maybe_unused]] bool parallelExecution);
+  void setImage(Accessor mutableData, const MantidImage &image, size_t start, [[maybe_unused]] bool parallelExecution);
 
   void setIndexInfoWithoutISpectrumUpdate(const Indexing::IndexInfo &indexInfo);
   void buildDefaultSpectrumDefinitions();

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -297,55 +297,94 @@ public:
   /// Deprecated, use x() instead. Returns a read-only (i.e. const) reference to
   /// the specified X array
   /// @param index :: workspace index to retrieve.
-  const MantidVec &readX(std::size_t const index) const { return getSpectrum(index).dataX(); }
+  [[deprecated("use x() instead")]]
+  const MantidVec &readX(std::size_t const index) const {
+    return getSpectrum(index).dataX();
+  }
   /// Deprecated, use y() instead. Returns a read-only (i.e. const) reference to
   /// the specified Y array
   /// @param index :: workspace index to retrieve.
-  const MantidVec &readY(std::size_t const index) const { return getSpectrum(index).dataY(); }
+  [[deprecated("use y() instead")]]
+  const MantidVec &readY(std::size_t const index) const {
+    return getSpectrum(index).dataY();
+  }
   /// Deprecated, use e() instead. Returns a read-only (i.e. const) reference to
   /// the specified E array
   /// @param index :: workspace index to retrieve.
-  const MantidVec &readE(std::size_t const index) const { return getSpectrum(index).dataE(); }
+  [[deprecated("use e() instead")]]
+  const MantidVec &readE(std::size_t const index) const {
+    return getSpectrum(index).dataE();
+  }
   /// Deprecated, use dx() instead. Returns a read-only (i.e. const) reference
   /// to the specified X error array
   /// @param index :: workspace index to retrieve.
-  const MantidVec &readDx(size_t const index) const { return getSpectrum(index).dataDx(); }
+  [[deprecated("use dx() instead")]]
+  const MantidVec &readDx(size_t const index) const {
+    return getSpectrum(index).dataDx();
+  }
 
   /// Deprecated, use mutableX() instead. Returns the x data
-  virtual MantidVec &dataX(const std::size_t index) { return getSpectrum(index).dataX(); }
+  [[deprecated("use mutableX() instead")]]
+  virtual MantidVec &dataX(const std::size_t index) {
+    return getSpectrum(index).dataX();
+  }
   /// Deprecated, use mutableY() instead. Returns the y data
-  virtual MantidVec &dataY(const std::size_t index) { return getSpectrumWithoutInvalidation(index).dataY(); }
+  [[deprecated("use mutableY() instead")]]
+  virtual MantidVec &dataY(const std::size_t index) {
+    return getSpectrumWithoutInvalidation(index).dataY();
+  }
   /// Deprecated, use mutableE() instead. Returns the error data
-  virtual MantidVec &dataE(const std::size_t index) { return getSpectrumWithoutInvalidation(index).dataE(); }
+  [[deprecated("use mutableE() instead")]]
+  virtual MantidVec &dataE(const std::size_t index) {
+    return getSpectrumWithoutInvalidation(index).dataE();
+  }
   /// Deprecated, use mutableDx() instead. Returns the x error data
-  virtual MantidVec &dataDx(const std::size_t index) { return getSpectrumWithoutInvalidation(index).dataDx(); }
+  [[deprecated("use mutableDx() instead")]]
+  virtual MantidVec &dataDx(const std::size_t index) {
+    return getSpectrumWithoutInvalidation(index).dataDx();
+  }
 
   /// Deprecated, use x() instead. Returns the x data const
-  virtual const MantidVec &dataX(const std::size_t index) const { return getSpectrum(index).dataX(); }
+  [[deprecated("use x() instead")]]
+  virtual const MantidVec &dataX(const std::size_t index) const {
+    return getSpectrum(index).dataX();
+  }
   /// Deprecated, use y() instead. Returns the y data const
-  virtual const MantidVec &dataY(const std::size_t index) const { return getSpectrum(index).dataY(); }
+  [[deprecated("use y() instead")]]
+  virtual const MantidVec &dataY(const std::size_t index) const {
+    return getSpectrum(index).dataY();
+  }
   /// Deprecated, use e() instead. Returns the error const
-  virtual const MantidVec &dataE(const std::size_t index) const { return getSpectrum(index).dataE(); }
+  [[deprecated("use e() instead")]]
+  virtual const MantidVec &dataE(const std::size_t index) const {
+    return getSpectrum(index).dataE();
+  }
   /// Deprecated, use dx() instead. Returns the error const
-  virtual const MantidVec &dataDx(const std::size_t index) const { return getSpectrum(index).dataDx(); }
+  [[deprecated("use dx() instead")]]
+  virtual const MantidVec &dataDx(const std::size_t index) const {
+    return getSpectrum(index).dataDx();
+  }
 
   virtual double getXMin() const;
   virtual double getXMax() const;
   virtual void getXMinMax(double &xmin, double &xmax) const;
 
   /// Deprecated, use sharedX() instead. Returns a pointer to the x data
+  [[deprecated("use sharedX() instead")]]
   virtual Kernel::cow_ptr<HistogramData::HistogramX> refX(const std::size_t index) const {
     return getSpectrum(index).sharedX();
   }
 
   /// Deprecated, use setSharedX() instead. Set the specified X array to point
   /// to the given existing array
+  [[deprecated("use setSharedX() instead")]]
   virtual void setX(const std::size_t index, const Kernel::cow_ptr<HistogramData::HistogramX> &X) {
     getSpectrum(index).setSharedX(X);
   }
 
   /// Deprecated, use setSharedX() instead. Set the specified X array to point
   /// to the given existing array
+  [[deprecated("use setSharedX() instead")]]
   virtual void setX(const std::size_t index, const std::shared_ptr<HistogramData::HistogramX> &X) {
     getSpectrum(index).setSharedX(X);
   }
@@ -536,12 +575,14 @@ private:
   MatrixWorkspace *doClone() const override = 0;
   MatrixWorkspace *doCloneEmpty() const override = 0;
 
-  /// Create an MantidImage instance.
-  MantidImage_sptr getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const, size_t start,
-                            size_t stop, size_t width, size_t indexStart, size_t indexEnd) const;
+  /// Create an MantidImage instance. Templated on the accessor so that the histogram data types,
+  /// which are distinct per axis, can be used: y() and e() do not share a return type.
+  template <class Accessor>
+  MantidImage_sptr getImage(Accessor read, size_t start, size_t stop, size_t width, size_t indexStart,
+                            size_t indexEnd) const;
   /// Copy data from an image.
-  void setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t), const MantidImage &image, size_t start,
-                [[maybe_unused]] bool parallelExecution);
+  template <class Accessor>
+  void setImage(Accessor mutableVec, const MantidImage &image, size_t start, [[maybe_unused]] bool parallelExecution);
 
   void setIndexInfoWithoutISpectrumUpdate(const Indexing::IndexInfo &indexInfo);
   void buildDefaultSpectrumDefinitions();

--- a/Framework/API/src/ISpectrum.cpp
+++ b/Framework/API/src/ISpectrum.cpp
@@ -39,10 +39,10 @@ std::pair<double, double> ISpectrum::getXDataRange() const {
 }
 
 /// Deprecated, use y() instead. Returns the y data const
-const MantidVec &ISpectrum::readY() const { return this->dataY(); }
+const MantidVec &ISpectrum::readY() const { return y().rawData(); }
 
 /// Deprecated, use e() instead. Returns the y error data const
-const MantidVec &ISpectrum::readE() const { return this->dataE(); }
+const MantidVec &ISpectrum::readE() const { return e().rawData(); }
 
 /** Add a detector ID to the set of detector IDs
  *

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1827,8 +1827,9 @@ bool MatrixWorkspace::hasOrientedLattice() const { return Mantid::API::Experimen
 
 /**
  * Creates a 2D image.
- * @param read :: Pointer to a method returning a MantidVec to provide data for
- * the image.
+ * @tparam Accessor :: Pointer to a const member function returning a spectrum's histogram
+ * data, e.g. &MatrixWorkspace::y. Templated because y() and e() do not share a return type.
+ * @param read :: Accessor for the data to provide for the image.
  * @param start :: First workspace index for the image.
  * @param stop :: Last workspace index for the image.
  * @param width :: Image width. Must divide (stop - start + 1) exactly.
@@ -2054,14 +2055,15 @@ std::pair<size_t, double> MatrixWorkspace::getXIndex(size_t i, double x, bool is
 
 /**
  * Copy data from an image.
- * @param dataVec :: A method returning non-const references to data vectors to
- * copy the image to.
+ * @tparam Accessor :: Pointer to a member function returning mutable references to a spectrum's
+ * histogram data, e.g. &MatrixWorkspace::mutableY.
+ * @param mutableData :: Accessor for the data to copy the image to.
  * @param image :: An image to copy the data from.
  * @param start :: Startinf workspace indx to copy data to.
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
 template <class Accessor>
-void MatrixWorkspace::setImage(Accessor mutableVec, const MantidImage &image, size_t start,
+void MatrixWorkspace::setImage(Accessor mutableData, const MantidImage &image, size_t start,
                                [[maybe_unused]] bool parallelExecution) {
 
   if (image.empty())
@@ -2090,7 +2092,7 @@ void MatrixWorkspace::setImage(Accessor mutableVec, const MantidImage &image, si
     size_t spec = start + static_cast<size_t>(i) * width;
     auto rowEnd = row.end();
     for (auto pixel = row.begin(); pixel != rowEnd; ++pixel, ++spec) {
-      (this->*mutableVec)(spec)[0] = *pixel;
+      (this->*mutableData)(spec)[0] = *pixel;
     }
   }
 }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1835,8 +1835,8 @@ bool MatrixWorkspace::hasOrientedLattice() const { return Mantid::API::Experimen
  * @param indexStart :: First index of the x integration range.
  * @param indexEnd :: Last index of the x integration range.
  */
-MantidImage_sptr MatrixWorkspace::getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const,
-                                           size_t start, size_t stop, size_t width, size_t indexStart,
+template <class Accessor>
+MantidImage_sptr MatrixWorkspace::getImage(Accessor read, size_t start, size_t stop, size_t width, size_t indexStart,
                                            size_t indexEnd) const {
   // width must be provided (for now)
   if (width == 0) {
@@ -1979,7 +1979,7 @@ std::pair<size_t, size_t> MatrixWorkspace::getImageStartEndXIndices(size_t i, do
  */
 MantidImage_sptr MatrixWorkspace::getImageY(size_t start, size_t stop, size_t width, double startX, double endX) const {
   auto p = getImageStartEndXIndices(0, startX, endX);
-  return getImage(&MatrixWorkspace::readY, start, stop, width, p.first, p.second);
+  return getImage(&MatrixWorkspace::y, start, stop, width, p.first, p.second);
 }
 
 /**
@@ -1992,7 +1992,7 @@ MantidImage_sptr MatrixWorkspace::getImageY(size_t start, size_t stop, size_t wi
  */
 MantidImage_sptr MatrixWorkspace::getImageE(size_t start, size_t stop, size_t width, double startX, double endX) const {
   auto p = getImageStartEndXIndices(0, startX, endX);
-  return getImage(&MatrixWorkspace::readE, start, stop, width, p.first, p.second);
+  return getImage(&MatrixWorkspace::e, start, stop, width, p.first, p.second);
 }
 
 /**
@@ -2060,8 +2060,9 @@ std::pair<size_t, double> MatrixWorkspace::getXIndex(size_t i, double x, bool is
  * @param start :: Startinf workspace indx to copy data to.
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
-void MatrixWorkspace::setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t), const MantidImage &image,
-                               size_t start, [[maybe_unused]] bool parallelExecution) {
+template <class Accessor>
+void MatrixWorkspace::setImage(Accessor mutableVec, const MantidImage &image, size_t start,
+                               [[maybe_unused]] bool parallelExecution) {
 
   if (image.empty())
     return;
@@ -2089,7 +2090,7 @@ void MatrixWorkspace::setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std:
     size_t spec = start + static_cast<size_t>(i) * width;
     auto rowEnd = row.end();
     for (auto pixel = row.begin(); pixel != rowEnd; ++pixel, ++spec) {
-      (this->*dataVec)(spec)[0] = *pixel;
+      (this->*mutableVec)(spec)[0] = *pixel;
     }
   }
 }
@@ -2101,7 +2102,7 @@ void MatrixWorkspace::setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std:
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
 void MatrixWorkspace::setImageY(const MantidImage &image, size_t start, bool parallelExecution) {
-  setImage(&MatrixWorkspace::dataY, image, start, parallelExecution);
+  setImage(&MatrixWorkspace::mutableY, image, start, parallelExecution);
 }
 
 /**
@@ -2111,7 +2112,7 @@ void MatrixWorkspace::setImageY(const MantidImage &image, size_t start, bool par
  * @param parallelExecution :: Should inner loop run as parallel operation
  */
 void MatrixWorkspace::setImageE(const MantidImage &image, size_t start, bool parallelExecution) {
-  setImage(&MatrixWorkspace::dataE, image, start, parallelExecution);
+  setImage(&MatrixWorkspace::mutableE, image, start, parallelExecution);
 }
 
 void MatrixWorkspace::invalidateCachedSpectrumNumbers() { m_indexInfoNeedsUpdate = true; }

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1744,7 +1744,7 @@ public:
     for (size_t spec = 0; spec < numspec; ++spec) {
       TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(spec));
     }
-    ws.dataDx(workspaceIndexWithDx[0]) = dxSpec0;
+    ws.mutableDx(workspaceIndexWithDx[0]) = dxSpec0;
     ws.setSharedDx(workspaceIndexWithDx[1], dxSpec1);
     ws.setSharedDx(workspaceIndexWithDx[2], dxSpec2);
 
@@ -1752,10 +1752,10 @@ public:
     auto compareValue = [&values](double data, size_t index) { return data == values[index]; };
     for (auto &index : workspaceIndexWithDx) {
       TSM_ASSERT("Should have x resolution values", ws.hasDx(index));
-      TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(index).size(), j);
+      TSM_ASSERT_EQUALS("Should have a length of 3", ws.dx(index).size(), j);
       auto compareValueForSpecificWorkspaceIndex = std::bind(compareValue, std::placeholders::_1, index);
 
-      auto &dataDx = ws.dataDx(index);
+      auto &dataDx = ws.dx(index);
       TSM_ASSERT("dataDx should allow access to the spectrum",
                  std::all_of(std::begin(dataDx), std::end(dataDx), compareValueForSpecificWorkspaceIndex));
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/MatrixWorkspaceAccess.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MatrixWorkspaceAccess.h
@@ -12,8 +12,7 @@ namespace Mantid {
 namespace Algorithms {
 
 struct MatrixWorkspaceAccess {
-  static decltype(std::mem_fn((std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) &
-                              API::MatrixWorkspace::dataX)) x;
+  static decltype(std::mem_fn(&API::MatrixWorkspace::mutableX)) x;
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/ChangeBinOffset.cpp
+++ b/Framework/Algorithms/src/ChangeBinOffset.cpp
@@ -45,8 +45,8 @@ void ChangeBinOffset::exec() {
                                           [offset](EventList &eventList) { eventList.addTof(offset); });
   } else {
     this->for_each<Indices::FromProperty>(
-        *outputW, std::make_tuple(MatrixWorkspaceAccess::x), [offset](std::vector<double> &dataX) {
-          std::transform(dataX.begin(), dataX.end(), dataX.begin(), [offset](double x) { return x + offset; });
+        *outputW, std::make_tuple(MatrixWorkspaceAccess::x), [offset](HistogramData::HistogramX &X) {
+          std::transform(X.begin(), X.end(), X.begin(), [offset](double x) { return x + offset; });
         });
   }
 }

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -208,7 +208,7 @@ void ExtractSpectra::cropCommon(API::MatrixWorkspace &workspace,
   auto cropped(hist);
   cropped.resize(end - begin);
 
-  cropped.setX(XHistogram);
+  cropped.setSharedX(XHistogram);
 
   if (cropped.sharedY())
     cropped.mutableY().assign(hist.y().begin() + begin, hist.y().begin() + end);

--- a/Framework/Algorithms/src/MatrixWorkspaceAccess.cpp
+++ b/Framework/Algorithms/src/MatrixWorkspaceAccess.cpp
@@ -9,9 +9,8 @@
 namespace Mantid::Algorithms {
 
 ///@cond Doxygen has problems for decltype for some reason.
-/// Returns std::mem_fn object refering to MatrixWorkspace:dataX().
-decltype(std::mem_fn((std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) &
-                     API::MatrixWorkspace::dataX)) MatrixWorkspaceAccess::x =
-    std::mem_fn((std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) & API::MatrixWorkspace::dataX);
+/// Returns std::mem_fn object refering to MatrixWorkspace::mutableX().
+decltype(std::mem_fn(&API::MatrixWorkspace::mutableX)) MatrixWorkspaceAccess::x =
+    std::mem_fn(&API::MatrixWorkspace::mutableX);
 ///@endcond
 } // namespace Mantid::Algorithms

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -40,6 +40,7 @@
 
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -1576,9 +1577,12 @@ private:
       inputWs->setPointStandardDeviations(1, dx2);
       if (legacyXErrors) {
         // Deliberately grow Dx to the legacy length (one longer than Y). Only the legacy
-        // accessor can do this; the size-checked histogram types forbid it by design.
+        // accessor can do this; the size-checked histogram types forbid it by design, so the
+        // deprecation warning is suppressed rather than migrated.
+        GNU_DIAG_OFF("deprecated-declarations")
         inputWs->dataDx(0).emplace_back(1);
         inputWs->dataDx(1).emplace_back(1);
+        GNU_DIAG_ON("deprecated-declarations")
       }
     }
     if (numericAxis) {

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -170,29 +170,45 @@ public:
   EventSortType getSortType() const;
 
   // X-vector accessors. These reset the MRU for this spectrum
+  [[deprecated("use setSharedX() instead")]]
   void setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) override;
+  [[deprecated("use mutableX() instead")]]
   MantidVec &dataX() override;
+  [[deprecated("use x() instead")]]
   const MantidVec &dataX() const override;
+  [[deprecated("use x() instead")]]
   const MantidVec &readX() const override;
+  [[deprecated("use sharedX() instead")]]
   Kernel::cow_ptr<HistogramData::HistogramX> ptrX() const override;
 
+  [[deprecated("use mutableDx() instead")]]
   MantidVec &dataDx() override;
+  [[deprecated("use dx() instead")]]
   const MantidVec &dataDx() const override;
+  [[deprecated("use dx() instead")]]
   const MantidVec &readDx() const override;
 
   /// Deprecated, use mutableY() instead. Disallowed data accessors - can't
   /// modify Y/E on a EventList
-  MantidVec &dataY() override { throw std::runtime_error("EventList: non-const access to Y data is not possible."); }
+  [[deprecated("use mutableY() instead")]]
+  MantidVec &dataY() override {
+    throw std::runtime_error("EventList: non-const access to Y data is not possible.");
+  }
   /// Deprecated, use mutableE() instead. Disallowed data accessors - can't
   /// modify Y/E on a EventList
-  MantidVec &dataE() override { throw std::runtime_error("EventList: non-const access to E data is not possible."); }
+  [[deprecated("use mutableE() instead")]]
+  MantidVec &dataE() override {
+    throw std::runtime_error("EventList: non-const access to E data is not possible.");
+  }
 
   // Allowed data accessors - read-only Y/E histogram VIEWS of an event list
   /// Deprecated, use y() instead. Return a read-only Y histogram view of an
   /// event list
+  [[deprecated("use y() instead")]]
   const MantidVec &dataY() const override;
   /// Deprecated, use e() instead. Return a read-only E histogram view of an
   /// event list
+  [[deprecated("use e() instead")]]
   const MantidVec &dataE() const override;
 
   MantidVec *makeDataY() const;

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -97,14 +97,23 @@ public:
   double getEventXMax() const;
   void getEventXMinMax(double &xmin, double &xmax) const;
 
+  [[deprecated("use mutableX() instead")]]
   MantidVec &dataX(const std::size_t) override;
+  [[deprecated("use mutableY() instead")]]
   MantidVec &dataY(const std::size_t) override;
+  [[deprecated("use mutableE() instead")]]
   MantidVec &dataE(const std::size_t) override;
+  [[deprecated("use mutableDx() instead")]]
   MantidVec &dataDx(const std::size_t) override;
+  [[deprecated("use x() instead")]]
   const MantidVec &dataX(const std::size_t) const override;
+  [[deprecated("use y() instead")]]
   const MantidVec &dataY(const std::size_t) const override;
+  [[deprecated("use e() instead")]]
   const MantidVec &dataE(const std::size_t) const override;
+  [[deprecated("use dx() instead")]]
   const MantidVec &dataDx(const std::size_t) const override;
+  [[deprecated("use sharedX() instead")]]
   Kernel::cow_ptr<HistogramData::HistogramX> refX(const std::size_t) const override;
 
   /// Generate a new histogram from specified event list at the given index.

--- a/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/ISpectrum.h"
 #include "MantidDataObjects/DllConfig.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidKernel/cow_ptr.h"
 
 namespace Mantid {
@@ -33,33 +34,58 @@ public:
 
   void copyDataFrom(const ISpectrum &source) override;
 
+  [[deprecated("use setSharedX() instead")]]
   void setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) override;
+  [[deprecated("use mutableX() instead")]]
   MantidVec &dataX() override;
+  [[deprecated("use x() instead")]]
   const MantidVec &dataX() const override;
+  [[deprecated("use x() instead")]]
   const MantidVec &readX() const override;
+  [[deprecated("use sharedX() instead")]]
   Kernel::cow_ptr<HistogramData::HistogramX> ptrX() const override;
 
+  [[deprecated("use mutableDx() instead")]]
   MantidVec &dataDx() override;
+  [[deprecated("use dx() instead")]]
   const MantidVec &dataDx() const override;
+  [[deprecated("use dx() instead")]]
   const MantidVec &readDx() const override;
 
   /// Zero the data (Y&E) in this spectrum
   void clearData() override;
 
   /// Deprecated, use y() instead. Returns the y data const
-  const MantidVec &dataY() const override { return m_histogram.dataY(); }
+  [[deprecated("use y() instead")]]
+  const MantidVec &dataY() const override {
+    return m_histogram.y().rawData();
+  }
   /// Deprecated, use e() instead. Returns the error data const
-  const MantidVec &dataE() const override { return m_histogram.dataE(); }
+  [[deprecated("use e() instead")]]
+  const MantidVec &dataE() const override {
+    return m_histogram.e().rawData();
+  }
 
+  // The mutable legacy accessors below can only be expressed in terms of Histogram's own legacy
+  // interface: handing out a mutable MantidVec would allow the length to be changed, so
+  // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
+  GNU_DIAG_OFF("deprecated-declarations")
   /// Deprecated, use mutableY() instead. Returns the y data
-  MantidVec &dataY() override { return m_histogram.dataY(); }
+  [[deprecated("use mutableY() instead")]]
+  MantidVec &dataY() override {
+    return m_histogram.dataY();
+  }
   /// Deprecated, use mutableE() instead. Returns the error data
-  MantidVec &dataE() override { return m_histogram.dataE(); }
+  [[deprecated("use mutableE() instead")]]
+  MantidVec &dataE() override {
+    return m_histogram.dataE();
+  }
+  GNU_DIAG_ON("deprecated-declarations")
 
   virtual std::size_t size() const { return m_histogram.y().size(); } ///< get pseudo size
 
   /// Checks for errors
-  bool isError() const { return readE().empty(); }
+  bool isError() const { return e().empty(); }
 
   /// Gets the memory size of the histogram
   size_t getMemorySize() const override { return ((x().size() + y().size() + e().size()) * sizeof(double)); }

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -13,6 +13,7 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/TimeROI.h"
 #include "MantidKernel/Unit.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #ifdef _MSC_VER
 // qualifier applied to function type has no meaning; ignored
@@ -1386,12 +1387,17 @@ void EventList::setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) {
 MantidVec &EventList::dataX() {
   if (mru)
     mru->deleteIndex(this);
+  // Handing out a mutable MantidVec would allow the length to be changed, so
+  // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend. The
+  // deprecated legacy accessor is therefore the only way to express this.
+  GNU_DIAG_OFF("deprecated-declarations")
   return m_histogram.dataX();
+  GNU_DIAG_ON("deprecated-declarations")
 }
 
 /** Deprecated, use x() instead. Returns a const reference to the x data.
  *  @return a reference to the X (bin) vector. */
-const MantidVec &EventList::dataX() const { return m_histogram.dataX(); }
+const MantidVec &EventList::dataX() const { return m_histogram.x().rawData(); }
 
 /// Deprecated, use x() instead. Returns the x data const
 const MantidVec &EventList::readX() const { return m_histogram.x().rawData(); }
@@ -1400,11 +1406,13 @@ const MantidVec &EventList::readX() const { return m_histogram.x().rawData(); }
 Kernel::cow_ptr<HistogramData::HistogramX> EventList::ptrX() const { return m_histogram.sharedX(); }
 
 /// Deprecated, use mutableDx() instead.
+GNU_DIAG_OFF("deprecated-declarations")
 MantidVec &EventList::dataDx() { return m_histogram.dataDx(); }
+GNU_DIAG_ON("deprecated-declarations")
 /// Deprecated, use dx() instead.
-const MantidVec &EventList::dataDx() const { return m_histogram.dataDx(); }
+const MantidVec &EventList::dataDx() const { return m_histogram.dx().rawData(); }
 /// Deprecated, use dx() instead.
-const MantidVec &EventList::readDx() const { return m_histogram.readDx(); }
+const MantidVec &EventList::readDx() const { return m_histogram.dx().rawData(); }
 
 // ==============================================================================================
 // --- Return Data Vectors --------------------------------------------------
@@ -1419,7 +1427,7 @@ MantidVec *EventList::makeDataY() const {
   auto Y = new MantidVec();
   MantidVec E;
   // Generate the Y histogram while skipping the E if possible.
-  generateHistogram(readX(), *Y, E, true);
+  generateHistogram(x().rawData(), *Y, E, true);
   return Y;
 }
 
@@ -1431,7 +1439,7 @@ MantidVec *EventList::makeDataY() const {
 MantidVec *EventList::makeDataE() const {
   MantidVec Y;
   auto E = new MantidVec();
-  generateHistogram(readX(), Y, *E);
+  generateHistogram(x().rawData(), Y, *E);
   // Y is unused.
   return E;
 }
@@ -1489,7 +1497,7 @@ Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
   if (!yData) {
     MantidVec Y;
     MantidVec E;
-    this->generateHistogram(readX(), Y, E);
+    this->generateHistogram(x().rawData(), Y, E);
 
     // Create the MRU object
     yData = Kernel::make_cow<HistogramData::HistogramY>(std::move(Y));
@@ -1520,7 +1528,7 @@ Kernel::cow_ptr<HistogramData::HistogramE> EventList::sharedE() const {
     // Now use that to get E -- Y values are generated from another function
     MantidVec Y_ignored;
     MantidVec E;
-    this->generateHistogram(readX(), Y_ignored, E);
+    this->generateHistogram(x().rawData(), Y_ignored, E);
     eData = Kernel::make_cow<HistogramData::HistogramE>(std::move(E));
 
     // Lets save it in the MRU

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1270,8 +1270,11 @@ EventSortType EventList::getSortType() const { return this->order; }
  * Does nothing if sorted otherwise or unsorted.
  * */
 void EventList::reverse() {
-  // reverse the histogram bin parameters
-  MantidVec &x = dataX();
+  // reverse the histogram bin parameters. Changing X invalidates any histogram cached in the MRU,
+  // so drop it first -- this is what the deprecated dataX() used to do implicitly.
+  if (mru)
+    mru->deleteIndex(this);
+  auto &x = mutableX();
   std::reverse(x.begin(), x.end());
 
   // flip the events if they are tof sorted
@@ -2864,8 +2867,11 @@ void EventList::integrate(const double minX, const double maxX, const bool entir
  * positive = unchanged, negative = reverse.
  */
 void EventList::convertTof(std::function<double(double)> func, const int sorting) {
-  // fix the histogram parameter
-  MantidVec &x = dataX();
+  // fix the histogram parameter. Changing X invalidates any histogram cached in the MRU, so drop
+  // it first -- this is what the deprecated dataX() used to do implicitly.
+  if (mru)
+    mru->deleteIndex(this);
+  auto &x = mutableX();
   transform(x.cbegin(), x.cend(), x.begin(), func);
 
   // do nothing if sorting > 0

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -23,6 +23,7 @@
 #include "MantidKernel/IPropertyManager.h"
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include "tbb/parallel_for.h"
 #include <algorithm>
@@ -496,6 +497,11 @@ size_t EventWorkspace::getMemorySize() const {
   return total;
 }
 
+// The two mutable accessors below can only be expressed in terms of EventList's own legacy
+// interface: handing out a mutable MantidVec would allow the length to be changed, so
+// FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
+GNU_DIAG_OFF("deprecated-declarations")
+
 /// Deprecated, use mutableX() instead. Return the data X vector at a given
 /// workspace index
 /// @param index :: the workspace index to return
@@ -507,6 +513,8 @@ MantidVec &EventWorkspace::dataX(const std::size_t index) { return getSpectrum(i
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned error values
 MantidVec &EventWorkspace::dataDx(const std::size_t index) { return getSpectrum(index).dataDx(); }
+
+GNU_DIAG_ON("deprecated-declarations")
 
 /// Deprecated, use mutableY() instead. Return the data Y vector at a given
 /// workspace index
@@ -529,22 +537,22 @@ MantidVec &EventWorkspace::dataE(const std::size_t /*index*/) {
 /** Deprecated, use x() instead.
  * @return the const data X vector at a given workspace index
  * @param index :: workspace index   */
-const MantidVec &EventWorkspace::dataX(const std::size_t index) const { return getSpectrum(index).readX(); }
+const MantidVec &EventWorkspace::dataX(const std::size_t index) const { return getSpectrum(index).x().rawData(); }
 
 /** Deprecated, use dx() instead.
  * @return the const data X error vector at a given workspace index
  * @param index :: workspace index   */
-const MantidVec &EventWorkspace::dataDx(const std::size_t index) const { return getSpectrum(index).readDx(); }
+const MantidVec &EventWorkspace::dataDx(const std::size_t index) const { return getSpectrum(index).dx().rawData(); }
 
 /** Deprecated, use y() instead.
  * @return the const data Y vector at a given workspace index
  * @param index :: workspace index   */
-const MantidVec &EventWorkspace::dataY(const std::size_t index) const { return getSpectrum(index).readY(); }
+const MantidVec &EventWorkspace::dataY(const std::size_t index) const { return getSpectrum(index).y().rawData(); }
 
 /** Deprecated, use e() instead.
  * @return the const data E (error) vector at a given workspace index
  * @param index :: workspace index   */
-const MantidVec &EventWorkspace::dataE(const std::size_t index) const { return getSpectrum(index).readE(); }
+const MantidVec &EventWorkspace::dataE(const std::size_t index) const { return getSpectrum(index).e().rawData(); }
 
 /** Deprecated, use sharedX() instead.
  * @return a pointer to the X data vector at a given workspace index

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataObjects/Histogram1D.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 namespace Mantid::DataObjects {
 
@@ -40,9 +41,9 @@ void Histogram1D::copyDataFrom(const ISpectrum &source) { source.copyDataInto(*t
 void Histogram1D::copyDataInto(Histogram1D &sink) const { sink.m_histogram = m_histogram; }
 
 void Histogram1D::clearData() {
-  MantidVec &yValues = this->dataY();
+  auto &yValues = this->mutableY();
   std::fill(yValues.begin(), yValues.end(), 0.0);
-  MantidVec &eValues = this->dataE();
+  auto &eValues = this->mutableE();
   std::fill(eValues.begin(), eValues.end(), 0.0);
 }
 
@@ -50,11 +51,18 @@ void Histogram1D::clearData() {
 /// @param X :: vector of X data
 void Histogram1D::setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) { m_histogram.setSharedX(X); }
 
+// The mutable legacy accessors below can only be expressed in terms of Histogram's own legacy
+// interface: handing out a mutable MantidVec would allow the length to be changed, so
+// FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
+GNU_DIAG_OFF("deprecated-declarations")
+
 /// Deprecated, use mutableX() instead. Returns the x data
 MantidVec &Histogram1D::dataX() { return m_histogram.dataX(); }
 
+GNU_DIAG_ON("deprecated-declarations")
+
 /// Deprecated, use x() instead. Returns the x data const
-const MantidVec &Histogram1D::dataX() const { return m_histogram.dataX(); }
+const MantidVec &Histogram1D::dataX() const { return m_histogram.x().rawData(); }
 
 /// Deprecated, use x() instead. Returns the x data const
 const MantidVec &Histogram1D::readX() const { return m_histogram.x().rawData(); }
@@ -62,12 +70,14 @@ const MantidVec &Histogram1D::readX() const { return m_histogram.x().rawData(); 
 /// Deprecated, use sharedX() instead. Returns a pointer to the x data
 Kernel::cow_ptr<HistogramData::HistogramX> Histogram1D::ptrX() const { return m_histogram.sharedX(); }
 
+GNU_DIAG_OFF("deprecated-declarations")
 /// Deprecated, use mutableDx() instead.
 MantidVec &Histogram1D::dataDx() { return m_histogram.dataDx(); }
+GNU_DIAG_ON("deprecated-declarations")
 /// Deprecated, use dx() instead.
-const MantidVec &Histogram1D::dataDx() const { return m_histogram.dataDx(); }
+const MantidVec &Histogram1D::dataDx() const { return m_histogram.dx().rawData(); }
 /// Deprecated, use dx() instead.
-const MantidVec &Histogram1D::readDx() const { return m_histogram.readDx(); }
+const MantidVec &Histogram1D::readDx() const { return m_histogram.dx().rawData(); }
 
 /**
  * Makes sure a histogram has valid Y and E data.

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -16,6 +16,7 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/VectorHelper.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <cxxtest/TestSuite.h>
 
@@ -904,7 +905,11 @@ public:
     el = EventList();
     MantidVec inVec(10, 1.0);
     el.mutableX() = inVec;
+    // This test exists to cover the deprecated accessor itself, so the warning is suppressed
+    // rather than migrated to x().
+    GNU_DIAG_OFF("deprecated-declarations")
     const MantidVec &vec = el.dataX();
+    GNU_DIAG_ON("deprecated-declarations")
     TS_ASSERT_EQUALS(vec, inVec);
   }
 

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -29,6 +29,7 @@
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/Memory.h"
 #include "MantidKernel/Timer.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "PropertyManagerHelper.h"
 
 using namespace Mantid;
@@ -275,10 +276,15 @@ public:
     TS_ASSERT_EQUALS(el5.getNumberEvents(), 55);
 
     // Out of range
-    TS_ASSERT_THROWS(uneven->dataX(-3), const std::range_error &);
-    TS_ASSERT_THROWS(uneven->dataX(NUMPIXELS / 10), const std::range_error &);
+    TS_ASSERT_THROWS(uneven->mutableX(-3), const std::range_error &);
+    TS_ASSERT_THROWS(uneven->mutableX(NUMPIXELS / 10), const std::range_error &);
   }
 
+  // This test pins the error contract of the deprecated accessors themselves, which differs from
+  // the modern ones: dataY()/dataE() throw NotImplementedError, whereas mutableY()/mutableE() reach
+  // EventList::checkIsYAndEWritable() and throw std::runtime_error. The warnings are therefore
+  // suppressed rather than migrated.
+  GNU_DIAG_OFF("deprecated-declarations")
   void test_data_access() {
     // Non-const access throws errors for Y & E - not for X
     TS_ASSERT_THROWS_NOTHING(ew->dataX(1));
@@ -292,6 +298,7 @@ public:
 
     // Can't try the const access; copy constructors are not allowed.
   }
+  GNU_DIAG_ON("deprecated-declarations")
 
   void test_setX_individually() {
     // Create A DIFFERENT x-axis for histogramming.
@@ -356,13 +363,13 @@ public:
     EventWorkspace_const_sptr ew2 = std::dynamic_pointer_cast<const EventWorkspace>(ew);
 
     // Are the returned arrays the right size?
-    MantidVec data1 = ew2->dataY(1);
+    MantidVec data1 = ew2->y(1).rawData();
     TS_ASSERT_EQUALS(data1.size(), NUMBINS - 1);
     // A single cached value now
     TS_ASSERT_EQUALS(ew2->MRUSize(), 1);
 
     // This should get the cached one
-    MantidVec data2 = ew2->dataY(1);
+    MantidVec data2 = ew2->y(1).rawData();
     TS_ASSERT_EQUALS(data2.size(), NUMBINS - 1);
     // Still a single cached value
     TS_ASSERT_EQUALS(ew2->MRUSize(), 1);
@@ -373,11 +380,11 @@ public:
 
     // Now test the caching. The first 100 will load in memory
     for (int i = 0; i < 100; i++)
-      data1 = ew2->dataY(i);
+      data1 = ew2->y(i).rawData();
 
     // Check the bins contain 2
-    data1 = ew2->dataY(0);
-    TS_ASSERT_DELTA(ew2->dataY(0)[1], 2.0, 1e-6);
+    data1 = ew2->y(0).rawData();
+    TS_ASSERT_DELTA(ew2->y(0)[1], 2.0, 1e-6);
     TS_ASSERT_DELTA(data1[1], 2.0, 1e-6);
     // Cache should now be full
     TS_ASSERT_EQUALS(ew2->MRUSize(), 50);
@@ -385,7 +392,7 @@ public:
     int last = 100;
     // Read more;
     for (int i = last; i < last + 100; i++)
-      data1 = ew2->dataY(i);
+      data1 = ew2->y(i).rawData();
 
     // Cache should now be full still
     TS_ASSERT_EQUALS(ew2->MRUSize(), 50);
@@ -393,7 +400,7 @@ public:
     // Do it some more
     last = 200;
     for (int i = last; i < last + 100; i++)
-      data1 = ew2->dataY(i);
+      data1 = ew2->y(i).rawData();
 
     //----- Now we test that setAllX clears the memory ----
 
@@ -411,10 +418,10 @@ public:
     // Try caching and most-recently-used MRU list.
     EventWorkspace_const_sptr ew2 = ew;
     // Are the returned arrays the right size?
-    MantidVec data1 = ew2->dataE(1);
+    MantidVec data1 = ew2->e(1).rawData();
     TS_ASSERT_EQUALS(data1.size(), NUMBINS - 1);
     // This should get the cached one
-    MantidVec data2 = ew2->dataE(1);
+    MantidVec data2 = ew2->e(1).rawData();
     TS_ASSERT_EQUALS(data2.size(), NUMBINS - 1);
     // All elements are the same
     for (std::size_t i = 0; i < data1.size(); i++)
@@ -422,24 +429,24 @@ public:
 
     // Now test the caching. The first 100 will load in memory
     for (int i = 0; i < 100; i++)
-      data1 = ew2->dataE(i);
+      data1 = ew2->e(i).rawData();
 
     // Check the bins contain 2
-    data1 = ew2->dataE(0);
-    TS_ASSERT_DELTA(ew2->dataE(0)[1], M_SQRT2, 1e-6);
+    data1 = ew2->e(0).rawData();
+    TS_ASSERT_DELTA(ew2->e(0)[1], M_SQRT2, 1e-6);
     TS_ASSERT_DELTA(data1[1], M_SQRT2, 1e-6);
     // But the Y is still 2.0
-    TS_ASSERT_DELTA(ew2->dataY(0)[1], 2.0, 1e-6);
+    TS_ASSERT_DELTA(ew2->y(0)[1], 2.0, 1e-6);
 
     int last = 100;
     // Read more; memory use should be the same?
     for (int i = last; i < last + 100; i++)
-      data1 = ew2->dataE(i);
+      data1 = ew2->e(i).rawData();
 
     // Do it some more
     last = 200;
     for (int i = last; i < last + 100; i++)
-      data1 = ew2->dataE(i);
+      data1 = ew2->e(i).rawData();
   }
 
   void test_histogram_pulse_time_throws_if_index_too_large() {
@@ -788,6 +795,9 @@ public:
     TS_ASSERT(ws->isCommonBins())
   }
 
+  // This test deliberately covers the deprecated accessors alongside the modern ones, so the
+  // warnings are suppressed rather than migrated.
+  GNU_DIAG_OFF("deprecated-declarations")
   void test_readYE() {
     int numEvents = 2;
     int numHistograms = 2;
@@ -797,6 +807,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(ws->e(0));
     TS_ASSERT_THROWS_NOTHING(ws->dataE(0));
   }
+  GNU_DIAG_ON("deprecated-declarations")
 
   void test_histogram() {
     int numEvents = 2;

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -280,10 +280,8 @@ public:
     TS_ASSERT_THROWS(uneven->mutableX(NUMPIXELS / 10), const std::range_error &);
   }
 
-  // This test pins the error contract of the deprecated accessors themselves, which differs from
-  // the modern ones: dataY()/dataE() throw NotImplementedError, whereas mutableY()/mutableE() reach
-  // EventList::checkIsYAndEWritable() and throw std::runtime_error. The warnings are therefore
-  // suppressed rather than migrated.
+  // This test pins the error contract of the deprecated accessors themselves
+  // The warnings are therefore suppressed rather than migrated.
   GNU_DIAG_OFF("deprecated-declarations")
   void test_data_access() {
     // Non-const access throws errors for Y & E - not for X

--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -112,27 +112,27 @@ public:
 
   void testsetgetXvector() {
     h.setPoints(x1);
-    TS_ASSERT_EQUALS(x1, h.dataX());
+    TS_ASSERT_EQUALS(x1, h.x().rawData());
   }
   void testcopyX() {
     h2.setPoints(x1);
-    h.mutableX() = h2.dataX();
-    TS_ASSERT_EQUALS(h.dataX(), x1);
+    h.mutableX() = h2.x();
+    TS_ASSERT_EQUALS(h.x().rawData(), x1);
   }
   void testsetgetDataYVector() {
     h.setCounts(y1);
-    TS_ASSERT_EQUALS(h.dataY(), y1);
+    TS_ASSERT_EQUALS(h.y().rawData(), y1);
   }
   void testsetgetDataYEVector() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
-    TS_ASSERT_EQUALS(h.dataY(), y1);
-    TS_ASSERT_EQUALS(h.dataE(), e1);
+    TS_ASSERT_EQUALS(h.y().rawData(), y1);
+    TS_ASSERT_EQUALS(h.e().rawData(), e1);
   }
   void testmaskSpectrum() {
     h.clearData();
-    TS_ASSERT_EQUALS(h.dataY()[5], 0.0);
-    TS_ASSERT_EQUALS(h.dataE()[12], 0.0);
+    TS_ASSERT_EQUALS(h.y()[5], 0.0);
+    TS_ASSERT_EQUALS(h.e()[12], 0.0);
   }
   void testsetgetXPointer() {
     auto px = std::make_shared<HistogramX>(nel);
@@ -141,39 +141,39 @@ public:
   }
   void testsetgetDataYPointer() {
     h.setCounts(pa);
-    TS_ASSERT_EQUALS(h.dataY(), pa->rawData());
+    TS_ASSERT_EQUALS(h.y().rawData(), pa->rawData());
   }
   void testsetgetDataYEPointer() {
     h.setCounts(pa);
     h.setCountStandardDeviations(pb);
-    TS_ASSERT_EQUALS(h.dataY(), pa->rawData());
-    TS_ASSERT_EQUALS(h.dataE(), pb->rawData());
+    TS_ASSERT_EQUALS(h.y().rawData(), pa->rawData());
+    TS_ASSERT_EQUALS(h.e().rawData(), pb->rawData());
   }
   void testgetXindex() {
     h.setPoints(x1);
-    TS_ASSERT_EQUALS(h.dataX()[4], x1[4]);
+    TS_ASSERT_EQUALS(h.x()[4], x1[4]);
   }
   void testgetYindex() {
     h.setCounts(y1);
-    TS_ASSERT_EQUALS(h.dataY()[4], y1[4]);
+    TS_ASSERT_EQUALS(h.y()[4], y1[4]);
   }
   void testgetEindex() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
-    TS_ASSERT_EQUALS(h.dataE()[4], e1[4]);
+    TS_ASSERT_EQUALS(h.e()[4], e1[4]);
   }
   void testrangeexceptionX() {
     h.setPoints(x1);
-    TS_ASSERT_THROWS(h.dataX().at(nel), const std::out_of_range &);
+    TS_ASSERT_THROWS(h.x().at(nel), const std::out_of_range &);
   }
   void testrangeexceptionY() {
     h.setCounts(y1);
-    TS_ASSERT_THROWS(h.dataY().at(nel), const std::out_of_range &);
+    TS_ASSERT_THROWS(h.y().at(nel), const std::out_of_range &);
   }
   void testrangeexceptionE() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
-    TS_ASSERT_THROWS(h.dataE().at(nel), const std::out_of_range &);
+    TS_ASSERT_THROWS(h.e().at(nel), const std::out_of_range &);
   }
 
   void test_copy_constructor() {

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -232,7 +232,7 @@ public:
     TS_ASSERT_EQUALS(ws->dx(0).size(), 5);
     TS_ASSERT_EQUALS(ws->dx(6)[3], 0.0);
 
-    TS_ASSERT_THROWS_NOTHING(ws->dataDx(6)[3] = 9.9);
+    TS_ASSERT_THROWS_NOTHING(ws->mutableDx(6)[3] = 9.9);
     TS_ASSERT_EQUALS(ws->dx(6)[3], 9.9);
   }
 

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -142,38 +142,86 @@ public:
   void resize(size_t n);
 
   // Temporary legacy interface to X
-  void setX(const Kernel::cow_ptr<HistogramX> &X) & { m_x = X; }
-  MantidVec &dataX() & { return m_x.access().mutableRawData(); }
-  const MantidVec &dataX() const & { return m_x->rawData(); }
-  const MantidVec &readX() const { return m_x->rawData(); }
-  Kernel::cow_ptr<HistogramX> ptrX() const { return m_x; }
+  [[deprecated("use setSharedX() instead")]]
+  void setX(const Kernel::cow_ptr<HistogramX> &X) & {
+    m_x = X;
+  }
+  [[deprecated("use mutableX() instead")]]
+  MantidVec &dataX() & {
+    return m_x.access().mutableRawData();
+  }
+  [[deprecated("use x() instead")]]
+  const MantidVec &dataX() const & {
+    return m_x->rawData();
+  }
+  [[deprecated("use x() instead")]]
+  const MantidVec &readX() const {
+    return m_x->rawData();
+  }
+  [[deprecated("use sharedX() instead")]]
+  Kernel::cow_ptr<HistogramX> ptrX() const {
+    return m_x;
+  }
 
   // Temporary legacy interface to Y
-  void setY(const Kernel::cow_ptr<HistogramY> &Y) & { m_y = Y; }
-  MantidVec &dataY() & { return m_y.access().mutableRawData(); }
-  const MantidVec &dataY() const & { return m_y->rawData(); }
-  const MantidVec &readY() const { return m_y->rawData(); }
-  Kernel::cow_ptr<HistogramY> ptrY() const { return m_y; }
+  [[deprecated("use setSharedY() instead")]]
+  void setY(const Kernel::cow_ptr<HistogramY> &Y) & {
+    m_y = Y;
+  }
+  [[deprecated("use mutableY() instead")]]
+  MantidVec &dataY() & {
+    return m_y.access().mutableRawData();
+  }
+  [[deprecated("use y() instead")]]
+  const MantidVec &dataY() const & {
+    return m_y->rawData();
+  }
+  [[deprecated("use y() instead")]]
+  const MantidVec &readY() const {
+    return m_y->rawData();
+  }
+  [[deprecated("use sharedY() instead")]]
+  Kernel::cow_ptr<HistogramY> ptrY() const {
+    return m_y;
+  }
 
   // Temporary legacy interface to E
-  void setE(const Kernel::cow_ptr<HistogramE> &E) & { m_e = E; }
-  MantidVec &dataE() & { return m_e.access().mutableRawData(); }
-  const MantidVec &dataE() const & { return m_e->rawData(); }
-  const MantidVec &readE() const { return m_e->rawData(); }
-  Kernel::cow_ptr<HistogramE> ptrE() const { return m_e; }
+  [[deprecated("use setSharedE() instead")]]
+  void setE(const Kernel::cow_ptr<HistogramE> &E) & {
+    m_e = E;
+  }
+  [[deprecated("use mutableE() instead")]]
+  MantidVec &dataE() & {
+    return m_e.access().mutableRawData();
+  }
+  [[deprecated("use e() instead")]]
+  const MantidVec &dataE() const & {
+    return m_e->rawData();
+  }
+  [[deprecated("use e() instead")]]
+  const MantidVec &readE() const {
+    return m_e->rawData();
+  }
+  [[deprecated("use sharedE() instead")]]
+  Kernel::cow_ptr<HistogramE> ptrE() const {
+    return m_e;
+  }
 
   // Temporary legacy interface to Dx. Note that accessors mimic the current
   // behavior which always has Dx allocated.
+  [[deprecated("use mutableDx() instead")]]
   MantidVec &dataDx() & {
     if (!m_dx)
       m_dx = Kernel::make_cow<HistogramDx>(size(), 0.0);
     return m_dx.access().mutableRawData();
   }
+  [[deprecated("use dx() instead")]]
   const MantidVec &dataDx() const & {
     if (!m_dx)
       m_dx = Kernel::make_cow<HistogramDx>(size(), 0.0);
     return m_dx->rawData();
   }
+  [[deprecated("use dx() instead")]]
   const MantidVec &readDx() const {
     if (!m_dx)
       m_dx = Kernel::make_cow<HistogramDx>(size(), 0.0);

--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -39,6 +39,8 @@ enum DataField { XValues = 0, YValues = 1, EValues = 2, DxValues = 3 };
  * @return A const reference to the histogram data of that field
  */
 template <DataField Field> decltype(auto) fieldData(MatrixWorkspace const &workspace, size_t const index) {
+  UNUSED_ARG(workspace);
+  UNUSED_ARG(index);
   throw std::logic_error("fieldData does not handle this DataField");
 }
 
@@ -66,6 +68,8 @@ template <> decltype(auto) fieldData<DxValues>(MatrixWorkspace const &workspace,
  * @return The number of values the field holds for that spectrum
  */
 template <DataField Field> size_t fieldSize(MatrixWorkspace const &workspace, size_t const index) {
+  UNUSED_ARG(workspace);
+  UNUSED_ARG(index);
   throw std::logic_error("fieldSize does not handle this DataField");
 }
 

--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -118,7 +118,6 @@ PyArrayObject *cloneArray(MatrixWorkspace const &workspace, size_t const start, 
   if (nparray == nullptr) {
     throw boost::python::error_already_set();
   }
-  // cppcheck-suppress constVariablePointer
   auto *dest = reinterpret_cast<double *>(PyArray_DATA(nparray)); // HEAD of the contiguous numpy data array
 
   PARALLEL_FOR_IF(threadSafe(workspace))

--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -11,7 +11,10 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/MultiThreaded.h"
 
+#include <boost/python/errors.hpp>
 #include <boost/python/extract.hpp>
+
+#include <stdexcept>
 
 // See
 // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
@@ -29,50 +32,98 @@ namespace {
 enum DataField { XValues = 0, YValues = 1, EValues = 2, DxValues = 3 };
 
 /**
+ * Read-only access to the values one spectrum holds for the field being extracted.
+ * @tparam Field :: Which field should be extracted
+ * @param workspace :: The workspace that contains the data
+ * @param index :: The workspace index to read
+ * @return A const reference to the histogram data of that field
+ */
+template <DataField Field> decltype(auto) fieldData(MatrixWorkspace const &workspace, size_t const index) {
+  throw std::logic_error("fieldData does not handle this DataField");
+}
+
+template <> decltype(auto) fieldData<XValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.x(index);
+}
+
+template <> decltype(auto) fieldData<YValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.y(index);
+}
+
+template <> decltype(auto) fieldData<EValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.e(index);
+}
+
+template <> decltype(auto) fieldData<DxValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.dx(index);
+}
+
+/**
+ * The number of values one spectrum holds for the field being extracted
+ * @tparam Field :: Which field should be extracted
+ * @param workspace :: The workspace that contains the data
+ * @param index :: The workspace index to read
+ * @return The number of values the field holds for that spectrum
+ */
+template <DataField Field> size_t fieldSize(MatrixWorkspace const &workspace, size_t const index) {
+  throw std::logic_error("fieldSize does not handle this DataField");
+}
+
+template <> size_t fieldSize<XValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.x(index).size();
+}
+
+template <> size_t fieldSize<YValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.histogramSize(index);
+}
+
+template <> size_t fieldSize<EValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.histogramSize(index);
+}
+
+template <> size_t fieldSize<DxValues>(MatrixWorkspace const &workspace, size_t const index) {
+  return workspace.histogramSize(index);
+}
+
+/**
  * Helper method for extraction to numpy.
+ * @tparam Field :: Which field should be extracted
  * @param workspace :: A pointer to the workspace that contains the data
- * @param field :: Which field should be extracted
  * @param start :: The index in the workspace to start at when reading the data
  * @param endp1 :: One past the end index in the workspace to finish at when
  *reading the data (similar to .end() for STL)
  *
  */
-PyArrayObject *cloneArray(const MatrixWorkspace &workspace, DataField field, const size_t start, const size_t endp1) {
-  const npy_intp numHist(endp1 - start);
-  npy_intp stride{0};
+template <DataField Field>
+PyArrayObject *cloneArray(MatrixWorkspace const &workspace, size_t const start, size_t const endp1) {
+  npy_intp const numHist(endp1 - start);
+  npy_intp const stride = numHist > 0 ? static_cast<npy_intp>(fieldSize<Field>(workspace, start)) : 0;
 
-  // Find out which function we need to call to access the data
-  using ArrayAccessFn = MantidVec const &(MatrixWorkspace::*)(size_t const) const;
-  ArrayAccessFn dataAccesor;
-  /**
-   * Can do better than this with a templated object that knows how to access
-   * the data
-   */
-  if (field == XValues) {
-    stride = workspace.x(0).size();
-    dataAccesor = &MatrixWorkspace::readX;
-  } else if (field == DxValues) {
-    stride = workspace.dx(0).size();
-    dataAccesor = &MatrixWorkspace::readDx;
-  } else {
-    stride = workspace.blocksize();
-    if (field == YValues)
-      dataAccesor = &MatrixWorkspace::readY;
-    else
-      dataAccesor = &MatrixWorkspace::readE;
+  // For numpy 2D array ensure all spectra have same number of values
+  for (npy_intp i = 1; i < numHist; ++i) {
+    if (static_cast<npy_intp>(fieldSize<Field>(workspace, start + i)) != stride) {
+      throw std::length_error("Cannot extract data from a ragged workspace: the histograms do not all have the same "
+                              "number of values.");
+    }
   }
+
   npy_intp arrayDims[2] = {numHist, stride};
   auto *nparray =
       reinterpret_cast<PyArrayObject *>(PyArray_NewFromDescr(&PyArray_Type, PyArray_DescrFromType(NPY_DOUBLE),
                                                              2,         // rank 2
                                                              arrayDims, // Length in each dimension
                                                              nullptr, nullptr, 0, nullptr));
+  // prevent segfault by ensuring that the array was created successfully
+  // otherwise, numpy has set the error indicator already, e.g. MemoryError for a workspace too large to fit
+  if (nparray == nullptr) {
+    throw boost::python::error_already_set();
+  }
   // cppcheck-suppress constVariablePointer
   auto *dest = reinterpret_cast<double *>(PyArray_DATA(nparray)); // HEAD of the contiguous numpy data array
 
   PARALLEL_FOR_IF(threadSafe(workspace))
   for (npy_intp i = 0; i < numHist; ++i) {
-    const MantidVec &src = (workspace.*(dataAccesor))(start + i);
+    auto const &src = fieldData<Field>(workspace, start + i);
     std::copy(src.begin(), src.end(), std::next(dest, i * stride));
   }
   return nparray;
@@ -87,7 +138,7 @@ PyArrayObject *cloneArray(const MatrixWorkspace &workspace, DataField field, con
  * @return A 2D numpy array created from the X values
  */
 PyObject *cloneX(const MatrixWorkspace &self) {
-  return reinterpret_cast<PyObject *>(cloneArray(self, XValues, 0, self.getNumberHistograms()));
+  return reinterpret_cast<PyObject *>(cloneArray<XValues>(self, 0, self.getNumberHistograms()));
 }
 /* Create a numpy array from the Y values of the given workspace reference
  * This acts like a python method on a Matrixworkspace object
@@ -95,7 +146,7 @@ PyObject *cloneX(const MatrixWorkspace &self) {
  * @return A 2D numpy array created from the Y values
  */
 PyObject *cloneY(const MatrixWorkspace &self) {
-  return reinterpret_cast<PyObject *>(cloneArray(self, YValues, 0, self.getNumberHistograms()));
+  return reinterpret_cast<PyObject *>(cloneArray<YValues>(self, 0, self.getNumberHistograms()));
 }
 
 /* Create a numpy array from the E values of the given workspace reference
@@ -104,7 +155,7 @@ PyObject *cloneY(const MatrixWorkspace &self) {
  * @return A 2D numpy array created from the E values
  */
 PyObject *cloneE(const MatrixWorkspace &self) {
-  return reinterpret_cast<PyObject *>(cloneArray(self, EValues, 0, self.getNumberHistograms()));
+  return reinterpret_cast<PyObject *>(cloneArray<EValues>(self, 0, self.getNumberHistograms()));
 }
 
 /* Create a numpy array from the E values of the given workspace reference
@@ -113,6 +164,6 @@ PyObject *cloneE(const MatrixWorkspace &self) {
  * @return A 2D numpy array created from the E values
  */
 PyObject *cloneDx(const MatrixWorkspace &self) {
-  return reinterpret_cast<PyObject *>(cloneArray(self, DxValues, 0, self.getNumberHistograms()));
+  return reinterpret_cast<PyObject *>(cloneArray<DxValues>(self, 0, self.getNumberHistograms()));
 }
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -82,7 +82,7 @@ template <> size_t fieldSize<EValues>(MatrixWorkspace const &workspace, size_t c
 }
 
 template <> size_t fieldSize<DxValues>(MatrixWorkspace const &workspace, size_t const index) {
-  return workspace.histogramSize(index);
+  return workspace.dx(index).size();
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -822,7 +822,7 @@ void export_MatrixWorkspace() {
            "the data. "
            "Note: This will fail for ragged workspaces.")
       .def("extractDx", Mantid::PythonInterface::cloneDx, args("self"),
-           "Extracts (copies) the E data from the workspace into a 2D numpy array. "
+           "Extracts (copies) the Dx data from the workspace into a 2D numpy array. "
            "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
            "the data. "
            "Note: This will fail for ragged workspaces.")

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -809,22 +809,22 @@ void export_MatrixWorkspace() {
       .def("extractX", Mantid::PythonInterface::cloneX, args("self"),
            "Extracts (copies) the X data from the workspace into a 2D numpy array. "
            "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
-           "the data."
+           "the data. "
            "Note: This will fail for ragged workspaces.")
       .def("extractY", Mantid::PythonInterface::cloneY, args("self"),
            "Extracts (copies) the Y data from the workspace into a 2D numpy array. "
            "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
-           "the data."
+           "the data. "
            "Note: This will fail for ragged workspaces.")
       .def("extractE", Mantid::PythonInterface::cloneE, args("self"),
            "Extracts (copies) the E data from the workspace into a 2D numpy array. "
            "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
-           "the data."
+           "the data. "
            "Note: This will fail for ragged workspaces.")
       .def("extractDx", Mantid::PythonInterface::cloneDx, args("self"),
            "Extracts (copies) the E data from the workspace into a 2D numpy array. "
            "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
-           "the data."
+           "the data. "
            "Note: This will fail for ragged workspaces.")
       .def("getSignalAtCoord", &getSignalAtCoord, args("self", "coords", "normalization"),
            "Return signal for array of coordinates")

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -53,9 +53,6 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(MatrixWorkspace)
 
 namespace {
-/// Typedef for data access, i.e. dataX,Y,E members
-using data_modifier = Mantid::MantidVec &(MatrixWorkspace::*)(const std::size_t);
-
 /// return_value_policy for read-only numpy array
 using return_readonly_numpy = return_value_policy<VectorRefToNumpy<WrapReadOnly>>;
 /// return_value_policy for read-write numpy array
@@ -75,23 +72,27 @@ GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 
 /**
- * Set the values from an python array-style object into the given spectrum in
- * the workspace
- * @param self :: A reference to the calling object
- * @param accessor :: A member-function pointer to the data{X,Y,E} member that
- * will extract the writable values.
- * @param wsIndex :: The workspace index for the spectrum to set
- * @param values :: A numpy array. The length must match the size of the
+ * Set the values from an python array-style object into the given histogram data
+ * @param histogram :: The writable data of a single spectrum, obtained from one of the
+ * MatrixWorkspace::mutable{X,Y,E,Dx} accessors
+ * @param values :: A numpy array. The length must match the size of the histogram
+ *
+ * The converters fill a destination that is already the right length, and throw
+ * std::invalid_argument (ValueError in Python) if the lengths differ. The current values are
+ * therefore copied out, filled in place and handed back through the histogram, which keeps its
+ * length invariant intact; mutableRawData() is deliberately not part of the public interface.
  */
-void setSpectrumFromPyObject(MatrixWorkspace &self, data_modifier accessor, const size_t wsIndex,
-                             const boost::python::object &values) {
+template <typename HistogramType>
+void setSpectrumFromPyObject(HistogramType &histogram, const boost::python::object &values) {
+  auto data = histogram.rawData();
   if (NDArray::check(values)) {
     NDArrayToVector<double> converter(values);
-    converter.copyTo((self.*accessor)(wsIndex));
+    converter.copyTo(data);
   } else {
     PySequenceToVector<double> converter(values);
-    converter.copyTo((self.*accessor)(wsIndex));
+    converter.copyTo(data);
   }
+  histogram = HistogramType(std::move(data));
 }
 
 /**
@@ -285,7 +286,7 @@ const Mantid::MantidVec &dataDxDeprecated(MatrixWorkspace &self, const size_t in
  * @param values :: A numpy array. The length must match the size of the
  */
 void setXFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
-  setSpectrumFromPyObject(self, &MatrixWorkspace::dataX, wsIndex, values);
+  setSpectrumFromPyObject(self.mutableX(wsIndex), values);
 }
 
 /**
@@ -295,7 +296,7 @@ void setXFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::
  * @param values :: A numpy array. The length must match the size of the
  */
 void setYFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
-  setSpectrumFromPyObject(self, &MatrixWorkspace::dataY, wsIndex, values);
+  setSpectrumFromPyObject(self.mutableY(wsIndex), values);
 }
 
 /**
@@ -305,7 +306,7 @@ void setYFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::
  * @param values :: A numpy array. The length must match the size of the
  */
 void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
-  setSpectrumFromPyObject(self, &MatrixWorkspace::dataE, wsIndex, values);
+  setSpectrumFromPyObject(self.mutableE(wsIndex), values);
 }
 
 /**
@@ -315,7 +316,7 @@ void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::
  * @param values :: A numpy array. The length must match the size of the
  */
 void setDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
-  setSpectrumFromPyObject(self, &MatrixWorkspace::dataDx, wsIndex, values);
+  setSpectrumFromPyObject(self.mutableDx(wsIndex), values);
 }
 
 /**
@@ -806,29 +807,25 @@ void export_MatrixWorkspace() {
       // --------------------------------------- Extract data
       // ------------------------------
       .def("extractX", Mantid::PythonInterface::cloneX, args("self"),
-           "Extracts (copies) the X data from the workspace into a 2D numpy "
-           "array. "
-           "Note: This can fail for large workspaces as numpy will require a "
-           "block "
-           "of memory free that will fit all of the data.")
+           "Extracts (copies) the X data from the workspace into a 2D numpy array. "
+           "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
+           "the data."
+           "Note: This will fail for ragged workspaces.")
       .def("extractY", Mantid::PythonInterface::cloneY, args("self"),
-           "Extracts (copies) the Y data from the workspace into a 2D numpy "
-           "array. "
-           "Note: This can fail for large workspaces as numpy will require a "
-           "block "
-           "of memory free that will fit all of the data.")
+           "Extracts (copies) the Y data from the workspace into a 2D numpy array. "
+           "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
+           "the data."
+           "Note: This will fail for ragged workspaces.")
       .def("extractE", Mantid::PythonInterface::cloneE, args("self"),
-           "Extracts (copies) the E data from the workspace into a 2D numpy "
-           "array. "
-           "Note: This can fail for large workspaces as numpy will require a "
-           "block "
-           "of memory free that will fit all of the data.")
+           "Extracts (copies) the E data from the workspace into a 2D numpy array. "
+           "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
+           "the data."
+           "Note: This will fail for ragged workspaces.")
       .def("extractDx", Mantid::PythonInterface::cloneDx, args("self"),
-           "Extracts (copies) the E data from the workspace into a 2D numpy "
-           "array. "
-           "Note: This can fail for large workspaces as numpy will require a "
-           "block "
-           "of memory free that will fit all of the data.")
+           "Extracts (copies) the E data from the workspace into a 2D numpy array. "
+           "Note: This can fail for large workspaces as numpy will require a block of memory free that will fit all of "
+           "the data."
+           "Note: This will fail for ragged workspaces.")
       .def("getSignalAtCoord", &getSignalAtCoord, args("self", "coords", "normalization"),
            "Return signal for array of coordinates")
       .def("getIntegratedCountsForWorkspaceIndices", &getIntegratedCountsForWorkspaceIndices,

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -17,7 +17,7 @@ from mantid.api import (
 )
 from mantid.geometry import Detector
 from mantid.kernel import V3D
-from mantid.simpleapi import CreateSampleWorkspace, Rebin
+from mantid.simpleapi import CreateSampleWorkspace, Rebin, RebinRagged
 import numpy as np
 
 
@@ -338,6 +338,15 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
         self.assertTrue(len(dx), 0)
         self._do_numpy_comparison(self._test_ws, x, y, e)
+
+    def test_data_cannot_be_extracted_to_numpy_from_a_ragged_workspace(self):
+        # A numpy array is rectangular, so there is no valid output for histograms of differing lengths
+        ws = CreateSampleWorkspace(NumBanks=1, BankPixelWidth=2, XMin=0, XMax=100, BinWidth=10, StoreInADS=False)
+        ragged = RebinRagged(InputWorkspace=ws, XMin=[0, 0, 0, 0], XMax=[100, 90, 80, 70], Delta=[10, 10, 10, 10], StoreInADS=False)
+        self.assertTrue(ragged.isRaggedWorkspace())
+
+        for extract in (ragged.extractX, ragged.extractY, ragged.extractE, ragged.extractDx):
+            self.assertRaises(RuntimeError, extract)
 
     def _do_numpy_comparison(self, workspace, x_np, y_np, e_np, index=None):
         if index is None:

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -252,6 +252,32 @@ class MatrixWorkspaceTest(unittest.TestCase):
             with self.assertWarns(DeprecationWarning):
                 getattr(test_ws, method_name)(0, values)
 
+    def test_deprecated_set_x_y_e_dx_replace_the_spectrum_values(self):
+        # setX/setY/setE/setDx funnel through setSpectrumFromPyObject, which has one branch for
+        # numpy arrays and another for arbitrary python sequences. Both branches must actually
+        # replace the data, not merely emit the deprecation warning.
+        xlength = 11
+        ylength = 10
+        counts = np.arange(1.0, ylength + 1.0)
+        expected = {
+            "X": np.linspace(2.0, 12.0, xlength),
+            "Y": counts,
+            "E": np.sqrt(counts),
+            "Dx": 0.5 * counts,
+        }
+
+        for as_sequence in (False, True):
+            test_ws = WorkspaceFactory.create("Workspace2D", 1, xlength, ylength)
+            for field, values in expected.items():
+                given = list(values) if as_sequence else values
+                with self.assertWarns(DeprecationWarning):
+                    getattr(test_ws, "set" + field)(0, given)
+
+            self.assertTrue(np.array_equal(expected["X"], test_ws.x(0)))
+            self.assertTrue(np.array_equal(expected["Y"], test_ws.y(0)))
+            self.assertTrue(np.array_equal(expected["E"], test_ws.e(0)))
+            self.assertTrue(np.array_equal(expected["Dx"], test_ws.dx(0)))
+
     def test_setting_spectra_from_array_of_incorrect_length_raises_error(self):
         nvectors = 2
         xlength = 11

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
@@ -40,6 +40,7 @@
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidKernel/cow_ptr.h"
 
 using namespace Mantid::API;
@@ -70,17 +71,20 @@ public:
   void copyDataFrom(const ISpectrum &other) override { other.copyDataInto(*this); }
 
   void setX(const Mantid::Kernel::cow_ptr<Mantid::HistogramData::HistogramX> &X) override { m_histogram.setSharedX(X); }
+  // The mutable legacy accessors below require Histogram's legacy interface
+  GNU_DIAG_OFF("deprecated-declarations")
   MantidVec &dataX() override { return m_histogram.dataX(); }
+  MantidVec &dataDx() override { return m_histogram.dataDx(); }
+  MantidVec &dataY() override { return m_histogram.dataY(); }
+  MantidVec &dataE() override { return m_histogram.dataE(); }
+  GNU_DIAG_ON("deprecated-declarations")
+
   const MantidVec &dataX() const override { return m_histogram.x().rawData(); }
   const MantidVec &readX() const override { return m_histogram.x().rawData(); }
   Mantid::Kernel::cow_ptr<Mantid::HistogramData::HistogramX> ptrX() const override { return m_histogram.sharedX(); }
 
-  MantidVec &dataDx() override { return m_histogram.dataDx(); }
-  const MantidVec &dataDx() const override { return m_histogram.dataDx(); }
-  const MantidVec &readDx() const override { return m_histogram.readDx(); }
-
-  MantidVec &dataY() override { return m_histogram.dataY(); }
-  MantidVec &dataE() override { return m_histogram.dataE(); }
+  const MantidVec &dataDx() const override { return m_histogram.dx().rawData(); }
+  const MantidVec &readDx() const override { return m_histogram.dx().rawData(); }
 
   const MantidVec &dataY() const override { return m_histogram.y().rawData(); }
   const MantidVec &dataE() const override { return m_histogram.e().rawData(); }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -95,9 +95,6 @@ pureVirtualCall:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common
 // primary cppcheck location is the virtual function declaration in the header
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiDetectorDecorator.h
 
-// cstyleCast: using declaration for a pointer-to-member-function type is misidentified as a C-style cast
-cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
-
 // publicAllocationError: m_mainLayout is owned by the Qt parent widget (QGridLayout(parent) transfers ownership);
 // cppcheck does not model Qt parent-child memory management
 publicAllocationError:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp


### PR DESCRIPTION
### Description of work

We have been working to deprecate the Histogram 1.0 methods and remove them from the code base.

Since they have been removed from both python and C++, it should be safe now to add deprecation tags to the C++ methods.

This had to fix a call site in `CloneMatrixWorkspace`.  This surfaced a previously-existing error with calling the python method `extractX()` on a ragged wokspace, which had undefined behavior.  I have fixed this to throw an error, matching behavior for `extractY()`.  Thsi behavior was more properly noted in the docstring.

### To test:

Check there are deprecation tags.

We have now turned on warnings failing the builds, so if a deprecated C++ function is being used, it will fail the build.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
