### PR TITLE
Write qsettings to cache location for nfs home area

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -29,6 +29,32 @@ if [ -z "${MPLCONFIGDIR+x}" ]; then
     fi
 fi
 
+# Enable QSettings staging automatically when configuration is NFS-backed and
+# the XDG cache is on a distinct local filesystem. An explicit value remains
+# authoritative; Python performs the detailed safety checks.
+# This is related to https://qt-project.atlassian.net/browse/QTBUG-148845
+if [ -z "${MANTID_QSETTINGS_STAGING+x}" ] && command -v findmnt >/dev/null 2>&1; then
+    # get values for config and cache directories
+    XDG_CONFIG_ROOT=${XDG_CONFIG_HOME:-${HOME}/.config}
+    XDG_CACHE_ROOT=${XDG_CACHE_HOME:-${HOME}/.cache}
+    # determine mount types
+    CONFIG_FS_TYPE=$(findmnt -T "${XDG_CONFIG_ROOT}" -no FSTYPE 2>/dev/null)
+    CACHE_FS_TYPE=$(findmnt -T "${XDG_CACHE_ROOT}" -no FSTYPE 2>/dev/null)
+    # enable only when config is in nfs and cache isn't
+    case "${CONFIG_FS_TYPE}" in
+        nfs|nfs4)
+            case "${CACHE_FS_TYPE}" in
+                nfs|nfs4|"") ;;
+                *)
+                    if [ "${XDG_CONFIG_ROOT}" != "${XDG_CACHE_ROOT}" ]; then
+                        export MANTID_QSETTINGS_STAGING=1
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+fi
+
 # Force the xcb (X11/XWayland) Qt platform plugin to avoid rendering and
 # stability issues seen under the native Wayland plugin.
 if [ -z "${QT_QPA_PLATFORM}" ]; then

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -49,9 +49,6 @@ if [ -z "${MANTID_QSETTINGS_STAGING+x}" ] && command -v findmnt >/dev/null 2>&1;
                     if [ "${XDG_CONFIG_ROOT}" != "${XDG_CACHE_ROOT}" ]; then
                         export MANTID_QSETTINGS_STAGING=1
                     fi
-                    if [ -z "${MPLCONFIGDIR+x}" ]; then
-                        export MPLCONFIGDIR="${XDG_CACHE_ROOT}/matplotlib"
-                    fi
                     ;;
             esac
             ;;

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -49,6 +49,9 @@ if [ -z "${MANTID_QSETTINGS_STAGING+x}" ] && command -v findmnt >/dev/null 2>&1;
                     if [ "${XDG_CONFIG_ROOT}" != "${XDG_CACHE_ROOT}" ]; then
                         export MANTID_QSETTINGS_STAGING=1
                     fi
+                    if [ -z "${MPLCONFIGDIR+x}" ]; then
+                        export MPLCONFIGDIR="${XDG_CACHE_ROOT}/matplotlib"
+                    fi
                     ;;
             esac
             ;;

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
@@ -1,1 +1,3 @@
 - On Linux systems with an NFS-backed configuration directory, Workbench now stages its QSettings files in the local cache. This avoids lock-file failures when running multiple Workbench instances and preserves conflicting settings for recovery.
+
+.. NOTE: The settings used by ``qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py`` need a one-time migration to the staged INI location.

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
@@ -1,0 +1,1 @@
+- On Linux systems with an NFS-backed configuration directory, Workbench now stages its QSettings files in the local cache. This avoids lock-file failures when running multiple Workbench instances and preserves conflicting settings for recovery.

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/42037.rst
@@ -1,3 +1,1 @@
-- On Linux systems with an NFS-backed configuration directory, Workbench now stages its QSettings files in the local cache. This avoids lock-file failures when running multiple Workbench instances and preserves conflicting settings for recovery.
-
-.. NOTE: The settings used by ``qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py`` need a one-time migration to the staged INI location.
+- On Linux systems with an NFS-backed configuration directory, Workbench now stages its QSettings files in the local cache. This avoids lock-file failures when running multiple Workbench instances and preserves conflicting settings for recovery. Existing settings for the Mantid Reduction interface must be migrated once to the staged INI file.

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_FILES
     workbench/config/test/test_user.py
     workbench/test/test_mainwindow.py
     workbench/test/test_import.py
+    workbench/test/test_workbench_process.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorcolorfills.py
     workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorfigure.py

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -140,6 +140,12 @@ class MainWindow(QMainWindow):
         self.interface_list = None
 
         self.could_restore_state = False
+        self._shutdown_accepted = False
+
+    @property
+    def shutdown_accepted(self):
+        """Return whether the main window completed and accepted its shutdown sequence."""
+        return self._shutdown_accepted
 
     def setup(self):
         # menus must be done first so they can be filled by the
@@ -592,6 +598,7 @@ class MainWindow(QMainWindow):
                 # after a month
                 self.project_recovery.remove_current_pid_folder(ignore_errors=True)
 
+            self._shutdown_accepted = True
             event.accept()
         else:
             # Cancel was pressed when closing an editor

--- a/qt/applications/workbench/workbench/app/workbench_process.py
+++ b/qt/applications/workbench/workbench/app/workbench_process.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 import argparse
 import atexit
+from dataclasses import dataclass
 import os
 import sys
 from pathlib import Path
@@ -37,6 +38,12 @@ from workbench.identity import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
 SYSCHECK_INTERVAL = 50
 ORIGINAL_SYS_EXIT = sys.exit
 _QSETTINGS_STAGING_WARNING_EMITTED = False
+
+
+@dataclass(frozen=True)
+class WorkbenchLaunchResult:
+    exit_code: int
+    clean_shutdown: bool
 
 
 def _evaluate_qsettings_staging():
@@ -105,6 +112,48 @@ def _verify_qsettings_staging(session):
     from workbench.config import CONF
 
     _verify_qsettings_filename(session, CONF.filename)
+
+
+def _abort_qsettings_staging(session, reason):
+    """Release the staging coordinator and retain the session for recovery."""
+    try:
+        session.abort()
+    except Exception as error:
+        reason = f"{reason}; coordinator release also failed: {error}"
+    _warn_about_qsettings_staging(
+        f"QSettings staging was not copied back ({reason}). Recoverable files remain under {session.staging_root}."
+    )
+
+
+def _sync_and_finalize_qsettings_staging(session):
+    """Synchronize Workbench settings and copy a clean staged session back."""
+    from qtpy.QtCore import QSettings
+    from workbench.config import CONF
+
+    try:
+        CONF.qsettings.sync()
+        status = CONF.qsettings.status()
+        if status != QSettings.NoError:
+            _abort_qsettings_staging(session, f"QSettings sync failed with status {status}")
+            return
+    except Exception as error:
+        _abort_qsettings_staging(session, f"QSettings sync failed: {error}")
+        return
+
+    try:
+        finalization = session.finalize()
+    except Exception as error:
+        _abort_qsettings_staging(session, f"copy-back failed: {error}")
+        return
+
+    if not finalization.successful:
+        failed_paths = ", ".join(
+            str(result.relative_path) for result in finalization.files if result.status.value in {"conflict", "failed"}
+        )
+        detail = finalization.error or failed_paths or "unknown finalization error"
+        _warn_about_qsettings_staging(
+            f"QSettings staging copy-back was incomplete ({detail}). Recoverable files remain under {session.staging_root}."
+        )
 
 
 ORIGINAL_STDERR = sys.stderr
@@ -186,7 +235,6 @@ def create_and_launch_workbench(app, command_line_options, qsettings_staging_ses
     The optional staging session remains referenced by this stack frame for the
     lifetime of the event loop. Clean-shutdown finalization is wired separately.
     """
-    exit_value = 0
     try:
         # MainWindow needs to be imported locally to ensure the matplotlib
         # backend is not imported too early.
@@ -240,7 +288,8 @@ def create_and_launch_workbench(app, command_line_options, qsettings_staging_ses
                 main_window.close()
 
                 # for task exit code descriptions see the classes AsyncTask and TaskExitCode
-                return int(editor_task.exit_code) if editor_task else 0
+                exit_code = int(editor_task.exit_code) if editor_task else 0
+                return WorkbenchLaunchResult(exit_code, main_window.shutdown_accepted)
 
         main_window.show()
         main_window.setWindowIcon(QIcon(":/images/MantidIcon.ico"))
@@ -256,7 +305,8 @@ def create_and_launch_workbench(app, command_line_options, qsettings_staging_ses
                 AboutPresenter(main_window).show()
 
         # lift-off!
-        exit_value = app.exec()
+        exit_code = app.exec()
+        return WorkbenchLaunchResult(exit_code, main_window.shutdown_accepted)
     except BaseException:
         # We count this as a crash
         import traceback
@@ -271,40 +321,50 @@ def create_and_launch_workbench(app, command_line_options, qsettings_staging_ses
                 traceback.print_exc(file=print_file)
         except OSError:
             pass
-        exit_value = -1
-    finally:
-        ORIGINAL_SYS_EXIT(exit_value)
+        return WorkbenchLaunchResult(-1, False)
 
 
 def initialise_qapp_and_launch_workbench(command_line_options):
     # QSettings staging must be active before anything can import workbench.config.
     qsettings_staging_session = _prepare_qsettings_staging()
 
-    # Set the global figure manager before any other matplotlib initialization.
-    from workbench.plotting.config import init_mpl_gcf
+    try:
+        # Set the global figure manager before any other matplotlib initialization.
+        from workbench.plotting.config import init_mpl_gcf
 
-    init_mpl_gcf()
+        init_mpl_gcf()
 
-    # cleanup static resources at exit
-    atexit.register(cleanup_resources)
+        # cleanup static resources at exit
+        atexit.register(cleanup_resources)
 
-    # fix/validate arguments
-    if command_line_options.script is not None:
-        # convert into absolute path
-        command_line_options.script = os.path.abspath(os.path.expanduser(command_line_options.script))
-        if not os.path.exists(command_line_options.script):
-            print('script "{}" does not exist'.format(command_line_options.script))
-            command_line_options.script = None
+        # fix/validate arguments
+        if command_line_options.script is not None:
+            # convert into absolute path
+            command_line_options.script = os.path.abspath(os.path.expanduser(command_line_options.script))
+            if not os.path.exists(command_line_options.script):
+                print('script "{}" does not exist'.format(command_line_options.script))
+                command_line_options.script = None
 
-    app = initialize()
+        app = initialize()
+        if qsettings_staging_session is not None:
+            _verify_qsettings_staging(qsettings_staging_session)
+
+        # the default sys check interval leads to long lags
+        # when request scripts to be aborted
+        setswitchinterval(SYSCHECK_INTERVAL)
+
+        result = create_and_launch_workbench(app, command_line_options, qsettings_staging_session)
+    except BaseException:
+        if qsettings_staging_session is not None:
+            _abort_qsettings_staging(qsettings_staging_session, "Workbench startup failed")
+        raise
+
     if qsettings_staging_session is not None:
-        _verify_qsettings_staging(qsettings_staging_session)
-
-    # the default sys check interval leads to long lags
-    # when request scripts to be aborted
-    setswitchinterval(SYSCHECK_INTERVAL)
-
-    create_and_launch_workbench(app, command_line_options, qsettings_staging_session)
+        if result.clean_shutdown:
+            _sync_and_finalize_qsettings_staging(qsettings_staging_session)
+        else:
+            _abort_qsettings_staging(qsettings_staging_session, "Workbench did not complete a clean shutdown")
+    ORIGINAL_SYS_EXIT(result.exit_code)
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/app/workbench_process.py
+++ b/qt/applications/workbench/workbench/app/workbench_process.py
@@ -9,11 +9,12 @@ import argparse
 import atexit
 import os
 import sys
+from pathlib import Path
 from sys import setswitchinterval
 from functools import partial
 
 from mantid.api import FrameworkManagerImpl
-from mantid.kernel import ConfigService, UsageService, version_str as mantid_version_str
+from mantid.kernel import ConfigService, Logger, UsageService, version_str as mantid_version_str
 from mantidqt.utils.qt import plugins
 import mantidqt.utils.qt as qtutils
 import mantid.kernel.environment as mtd_env
@@ -35,6 +36,77 @@ from workbench.identity import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
 # Constants
 SYSCHECK_INTERVAL = 50
 ORIGINAL_SYS_EXIT = sys.exit
+_QSETTINGS_STAGING_WARNING_EMITTED = False
+
+
+def _evaluate_qsettings_staging():
+    """Evaluate staging lazily so importing this module has no settings side effects."""
+    from mantidqt.utils.qt.qsettings_staging import evaluate_qsettings_staging
+
+    return evaluate_qsettings_staging()
+
+
+def _prepare_and_activate_qsettings_staging(eligibility):
+    """Prepare and activate a staged QSettings session for this process."""
+    from mantidqt.utils.qt.qsettings_staging_session import QSettingsStagingSessionManager, StagingPreparationError
+
+    try:
+        session = QSettingsStagingSessionManager(eligibility).prepare()
+    except StagingPreparationError as error:
+        return None, error
+
+    session.activate()
+    return session, None
+
+
+def _warn_about_qsettings_staging(message):
+    global _QSETTINGS_STAGING_WARNING_EMITTED
+    if _QSETTINGS_STAGING_WARNING_EMITTED:
+        return
+
+    Logger("Mantid Workbench").warning(message)
+    _QSETTINGS_STAGING_WARNING_EMITTED = True
+
+
+def _prepare_qsettings_staging():
+    """Activate eligible QSettings staging, otherwise retain the canonical path."""
+    eligibility = _evaluate_qsettings_staging()
+    if not eligibility.active:
+        reason = eligibility.reason.value
+        if reason == "cache_is_nfs":
+            _warn_about_qsettings_staging(
+                "QSettings staging was requested, but the XDG cache directory is also on NFS. "
+                "Workbench will use the canonical configuration directory. Use a user-owned local "
+                "XDG_CACHE_HOME or unset MANTID_QSETTINGS_STAGING."
+            )
+        elif reason not in {"disabled", "unsupported_platform", "config_not_nfs"}:
+            _warn_about_qsettings_staging(
+                f"QSettings staging was requested but is unavailable ({reason}). Workbench will use the canonical configuration directory."
+            )
+        return None
+
+    session, error = _prepare_and_activate_qsettings_staging(eligibility)
+    if error is not None:
+        _warn_about_qsettings_staging(
+            f"QSettings staging preparation failed ({error}). Workbench will use the canonical configuration directory."
+        )
+    return session
+
+
+def _verify_qsettings_filename(session, filename):
+    expected = (session.staging_root / "mantidproject" / "mantidworkbench.ini").resolve(strict=False)
+    actual = Path(filename).resolve(strict=False)
+    if actual != expected:
+        raise RuntimeError(f"QSettings staging activation selected {actual}, expected {expected}")
+
+
+def _verify_qsettings_staging(session):
+    # Import only after QSettings.setPath has redirected UserScope IniFormat.
+    from workbench.config import CONF
+
+    _verify_qsettings_filename(session, CONF.filename)
+
+
 ORIGINAL_STDERR = sys.stderr
 STACKTRACE_FILE = "workbench_stacktrace.txt"
 
@@ -107,9 +179,12 @@ def initialize():
     return app
 
 
-def create_and_launch_workbench(app, command_line_options):
+def create_and_launch_workbench(app, command_line_options, qsettings_staging_session=None):
     """Given an application instance create the MainWindow,
     show it and start the main event loop
+
+    The optional staging session remains referenced by this stack frame for the
+    lifetime of the event loop. Clean-shutdown finalization is wired separately.
     """
     exit_value = 0
     try:
@@ -202,7 +277,10 @@ def create_and_launch_workbench(app, command_line_options):
 
 
 def initialise_qapp_and_launch_workbench(command_line_options):
-    # Set the global figure manager in matplotlib. Very important this happens first.
+    # QSettings staging must be active before anything can import workbench.config.
+    qsettings_staging_session = _prepare_qsettings_staging()
+
+    # Set the global figure manager before any other matplotlib initialization.
     from workbench.plotting.config import init_mpl_gcf
 
     init_mpl_gcf()
@@ -219,11 +297,14 @@ def initialise_qapp_and_launch_workbench(command_line_options):
             command_line_options.script = None
 
     app = initialize()
+    if qsettings_staging_session is not None:
+        _verify_qsettings_staging(qsettings_staging_session)
+
     # the default sys check interval leads to long lags
     # when request scripts to be aborted
     setswitchinterval(SYSCHECK_INTERVAL)
 
-    create_and_launch_workbench(app, command_line_options)
+    create_and_launch_workbench(app, command_line_options, qsettings_staging_session)
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/app/workbench_process.py
+++ b/qt/applications/workbench/workbench/app/workbench_process.py
@@ -148,7 +148,9 @@ def _sync_and_finalize_qsettings_staging(session):
 
     if not finalization.successful:
         failed_paths = ", ".join(
-            str(result.relative_path) for result in finalization.files if result.status.value in {"conflict", "failed"}
+            f"{result.relative_path} ({result.status.value})"
+            for result in finalization.files
+            if result.status.value in {"conflict", "failed"}
         )
         detail = finalization.error or failed_paths or "unknown finalization error"
         _warn_about_qsettings_staging(

--- a/qt/applications/workbench/workbench/test/test_import.py
+++ b/qt/applications/workbench/workbench/test/test_import.py
@@ -25,7 +25,8 @@ class ImportTest(unittest.TestCase):
                 "-c",
                 "import sys; import workbench.app.start; "
                 "assert 'workbench.config' not in sys.modules; "
-                "assert 'workbench.widgets.about.presenter' not in sys.modules",
+                "assert 'workbench.widgets.about.presenter' not in sys.modules; "
+                "assert 'mantidqt.utils.qt.qsettings_staging_session' not in sys.modules",
             ],
             capture_output=True,
             check=False,

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -253,6 +253,7 @@ class MainWindowTest(unittest.TestCase):
 
         mock_event.ignore.assert_called()
         mock_project.inform_user_not_possible.assert_called()
+        self.assertFalse(self.main_window.shutdown_accepted)
 
     def test_main_window_does_not_close_when_project_is_loading(self):
         mock_event = Mock()
@@ -264,6 +265,7 @@ class MainWindowTest(unittest.TestCase):
 
         mock_event.ignore.assert_called()
         mock_project.inform_user_not_possible.assert_called()
+        self.assertFalse(self.main_window.shutdown_accepted)
 
     def test_main_window_does_not_close_if_project_not_saved_and_user_cancels_project_save(self):
         mock_event = Mock()
@@ -278,6 +280,7 @@ class MainWindowTest(unittest.TestCase):
 
         mock_project.offer_save.assert_called()
         mock_event.ignore.assert_called()
+        self.assertFalse(self.main_window.shutdown_accepted)
 
     @patch("workbench.app.mainwindow.ConfigService")
     @patch("workbench.app.mainwindow.QApplication")
@@ -314,6 +317,7 @@ class MainWindowTest(unittest.TestCase):
         self.assertTrue(self.main_window.project_recovery.closing_workbench)
         self.main_window.interface_manager.closeHelpWindow.assert_called()
         mock_event.accept.assert_called()
+        self.assertTrue(self.main_window.shutdown_accepted)
 
     def test_read_settings_returns_snapshot_without_writing(self):
         from workbench.app.mainwindow import MainWindowSettings

--- a/qt/applications/workbench/workbench/test/test_workbench_process.py
+++ b/qt/applications/workbench/workbench/test/test_workbench_process.py
@@ -228,7 +228,7 @@ class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
             workbench_process._sync_and_finalize_qsettings_staging(session)
 
         warning.assert_called_once()
-        self.assertIn("mantidproject/mantidworkbench.ini", warning.call_args.args[0])
+        self.assertIn("mantidproject/mantidworkbench.ini", warning.call_args.args[0].replace(chr(92), "/"))
         self.assertIn("/local/cache/session", warning.call_args.args[0])
 
     def test_normal_launch_returns_clean_result_after_accepted_close(self):

--- a/qt/applications/workbench/workbench/test/test_workbench_process.py
+++ b/qt/applications/workbench/workbench/test/test_workbench_process.py
@@ -1,0 +1,130 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+from workbench.app import workbench_process
+
+
+class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
+    def setUp(self):
+        workbench_process._QSETTINGS_STAGING_WARNING_EMITTED = False
+
+    @patch.object(workbench_process, "_prepare_and_activate_qsettings_staging")
+    @patch.object(workbench_process, "_evaluate_qsettings_staging")
+    def test_inactive_local_config_does_not_prepare_or_warn(self, evaluate, prepare):
+        evaluate.return_value = self._eligibility(False, "config_not_nfs")
+
+        with patch.object(workbench_process, "Logger") as logger:
+            self.assertIsNone(workbench_process._prepare_qsettings_staging())
+
+        prepare.assert_not_called()
+        logger.assert_not_called()
+
+    @patch.object(workbench_process, "_evaluate_qsettings_staging")
+    def test_nfs_cache_warns_only_once(self, evaluate):
+        evaluate.return_value = self._eligibility(False, "cache_is_nfs")
+
+        with patch.object(workbench_process, "Logger") as logger:
+            workbench_process._prepare_qsettings_staging()
+            workbench_process._prepare_qsettings_staging()
+
+        logger.return_value.warning.assert_called_once()
+
+    @patch.object(workbench_process, "_prepare_and_activate_qsettings_staging")
+    @patch.object(workbench_process, "_evaluate_qsettings_staging")
+    def test_eligible_storage_returns_activated_session(self, evaluate, prepare):
+        eligibility = self._eligibility(True, "eligible")
+        session = Mock()
+        evaluate.return_value = eligibility
+        prepare.return_value = (session, None)
+
+        self.assertIs(session, workbench_process._prepare_qsettings_staging())
+
+        prepare.assert_called_once_with(eligibility)
+
+    @patch("mantidqt.utils.qt.qsettings_staging_session.QSettingsStagingSessionManager")
+    def test_prepare_and_activate_activates_prepared_session(self, manager):
+        eligibility = self._eligibility(True, "eligible")
+        session = manager.return_value.prepare.return_value
+
+        result, error = workbench_process._prepare_and_activate_qsettings_staging(eligibility)
+
+        self.assertIs(session, result)
+        self.assertIsNone(error)
+        manager.assert_called_once_with(eligibility)
+        session.activate.assert_called_once_with()
+
+    @patch.object(workbench_process, "_prepare_and_activate_qsettings_staging")
+    @patch.object(workbench_process, "_evaluate_qsettings_staging")
+    def test_preparation_failure_warns_and_uses_canonical_path(self, evaluate, prepare):
+        evaluate.return_value = self._eligibility(True, "eligible")
+        prepare.return_value = (None, RuntimeError("cannot acquire coordinator"))
+
+        with patch.object(workbench_process, "Logger") as logger:
+            self.assertIsNone(workbench_process._prepare_qsettings_staging())
+
+        logger.return_value.warning.assert_called_once()
+
+    def test_startup_activates_and_verifies_staging_before_launch(self):
+        events = []
+        session = Mock()
+        app = Mock()
+        options = SimpleNamespace(script=None)
+
+        with (
+            patch.object(workbench_process, "_prepare_qsettings_staging", side_effect=lambda: events.append("stage") or session),
+            patch("workbench.plotting.config.init_mpl_gcf", side_effect=lambda: events.append("matplotlib")),
+            patch.object(workbench_process, "initialize", side_effect=lambda: events.append("initialize") or app),
+            patch.object(workbench_process, "_verify_qsettings_staging", side_effect=lambda _: events.append("verify")),
+            patch.object(workbench_process, "create_and_launch_workbench", side_effect=lambda *_: events.append("launch")) as launch,
+            patch.object(workbench_process.atexit, "register"),
+            patch.object(workbench_process, "setswitchinterval"),
+        ):
+            workbench_process.initialise_qapp_and_launch_workbench(options)
+
+        self.assertEqual(["stage", "matplotlib", "initialize", "verify", "launch"], events)
+        launch.assert_called_once_with(app, options, session)
+
+    def test_inactive_startup_skips_staged_filename_verification(self):
+        app = Mock()
+        options = SimpleNamespace(script=None)
+
+        with (
+            patch.object(workbench_process, "_prepare_qsettings_staging", return_value=None),
+            patch("workbench.plotting.config.init_mpl_gcf"),
+            patch.object(workbench_process, "initialize", return_value=app),
+            patch.object(workbench_process, "_verify_qsettings_staging") as verify,
+            patch.object(workbench_process, "create_and_launch_workbench") as launch,
+            patch.object(workbench_process.atexit, "register"),
+            patch.object(workbench_process, "setswitchinterval"),
+        ):
+            workbench_process.initialise_qapp_and_launch_workbench(options)
+
+        verify.assert_not_called()
+        launch.assert_called_once_with(app, options, None)
+
+    def test_staged_filename_must_match_expected_workbench_settings_file(self):
+        session = SimpleNamespace(staging_root=Path("/local/cache/session"))
+        expected = session.staging_root / "mantidproject" / "mantidworkbench.ini"
+
+        workbench_process._verify_qsettings_filename(session, expected)
+
+        with self.assertRaises(RuntimeError):
+            workbench_process._verify_qsettings_filename(session, Path("/nfs/config/mantidproject/mantidworkbench.ini"))
+
+    @staticmethod
+    def _eligibility(active, reason):
+        return SimpleNamespace(active=active, reason=SimpleNamespace(value=reason))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/applications/workbench/workbench/test/test_workbench_process.py
+++ b/qt/applications/workbench/workbench/test/test_workbench_process.py
@@ -7,13 +7,18 @@
 #  This file is part of the mantid workbench.
 
 from pathlib import Path
+import sys
 from types import SimpleNamespace
 import unittest
 from unittest.mock import Mock, patch
 
+from qtpy.QtCore import QSettings
+
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.app import workbench_process
 
 
+@start_qapplication
 class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
     def setUp(self):
         workbench_process._QSETTINGS_STAGING_WARNING_EMITTED = False
@@ -85,14 +90,24 @@ class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
             patch("workbench.plotting.config.init_mpl_gcf", side_effect=lambda: events.append("matplotlib")),
             patch.object(workbench_process, "initialize", side_effect=lambda: events.append("initialize") or app),
             patch.object(workbench_process, "_verify_qsettings_staging", side_effect=lambda _: events.append("verify")),
-            patch.object(workbench_process, "create_and_launch_workbench", side_effect=lambda *_: events.append("launch")) as launch,
+            patch.object(
+                workbench_process,
+                "create_and_launch_workbench",
+                side_effect=lambda *_: events.append("launch") or workbench_process.WorkbenchLaunchResult(0, True),
+            ) as launch,
+            patch.object(
+                workbench_process, "_sync_and_finalize_qsettings_staging", side_effect=lambda _: events.append("finalize")
+            ) as finalize,
+            patch.object(workbench_process, "ORIGINAL_SYS_EXIT") as exit_process,
             patch.object(workbench_process.atexit, "register"),
             patch.object(workbench_process, "setswitchinterval"),
         ):
             workbench_process.initialise_qapp_and_launch_workbench(options)
 
-        self.assertEqual(["stage", "matplotlib", "initialize", "verify", "launch"], events)
+        self.assertEqual(["stage", "matplotlib", "initialize", "verify", "launch", "finalize"], events)
         launch.assert_called_once_with(app, options, session)
+        finalize.assert_called_once_with(session)
+        exit_process.assert_called_once_with(0)
 
     def test_inactive_startup_skips_staged_filename_verification(self):
         app = Mock()
@@ -103,7 +118,12 @@ class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
             patch("workbench.plotting.config.init_mpl_gcf"),
             patch.object(workbench_process, "initialize", return_value=app),
             patch.object(workbench_process, "_verify_qsettings_staging") as verify,
-            patch.object(workbench_process, "create_and_launch_workbench") as launch,
+            patch.object(
+                workbench_process,
+                "create_and_launch_workbench",
+                return_value=workbench_process.WorkbenchLaunchResult(7, True),
+            ) as launch,
+            patch.object(workbench_process, "ORIGINAL_SYS_EXIT") as exit_process,
             patch.object(workbench_process.atexit, "register"),
             patch.object(workbench_process, "setswitchinterval"),
         ):
@@ -111,6 +131,156 @@ class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
 
         verify.assert_not_called()
         launch.assert_called_once_with(app, options, None)
+        exit_process.assert_called_once_with(7)
+
+    def test_unclean_shutdown_aborts_staging_and_preserves_exit_code(self):
+        session = Mock()
+        app = Mock()
+        options = SimpleNamespace(script=None)
+
+        with (
+            patch.object(workbench_process, "_prepare_qsettings_staging", return_value=session),
+            patch("workbench.plotting.config.init_mpl_gcf"),
+            patch.object(workbench_process, "initialize", return_value=app),
+            patch.object(workbench_process, "_verify_qsettings_staging"),
+            patch.object(
+                workbench_process,
+                "create_and_launch_workbench",
+                return_value=workbench_process.WorkbenchLaunchResult(-1, False),
+            ),
+            patch.object(workbench_process, "_abort_qsettings_staging") as abort,
+            patch.object(workbench_process, "_sync_and_finalize_qsettings_staging") as finalize,
+            patch.object(workbench_process, "ORIGINAL_SYS_EXIT") as exit_process,
+            patch.object(workbench_process.atexit, "register"),
+            patch.object(workbench_process, "setswitchinterval"),
+        ):
+            workbench_process.initialise_qapp_and_launch_workbench(options)
+
+        abort.assert_called_once_with(session, "Workbench did not complete a clean shutdown")
+        finalize.assert_not_called()
+        exit_process.assert_called_once_with(-1)
+
+    def test_startup_failure_aborts_staging_and_propagates(self):
+        session = Mock()
+        options = SimpleNamespace(script=None)
+
+        with (
+            patch.object(workbench_process, "_prepare_qsettings_staging", return_value=session),
+            patch("workbench.plotting.config.init_mpl_gcf", side_effect=RuntimeError("startup failed")),
+            patch.object(workbench_process, "_abort_qsettings_staging") as abort,
+            patch.object(workbench_process, "ORIGINAL_SYS_EXIT") as exit_process,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "startup failed"):
+                workbench_process.initialise_qapp_and_launch_workbench(options)
+
+        abort.assert_called_once_with(session, "Workbench startup failed")
+        exit_process.assert_not_called()
+
+    def test_clean_staging_syncs_and_finalizes(self):
+        session = Mock()
+        session.finalize.return_value = SimpleNamespace(successful=True, files=(), error=None)
+
+        with patch("workbench.config.CONF") as conf:
+            conf.qsettings.status.return_value = QSettings.NoError
+            workbench_process._sync_and_finalize_qsettings_staging(session)
+
+        conf.qsettings.sync.assert_called_once_with()
+        session.finalize.assert_called_once_with()
+        session.abort.assert_not_called()
+
+    def test_failed_staging_sync_aborts_without_finalizing(self):
+        session = Mock(staging_root=Path("/local/cache/session"))
+
+        with (
+            patch("workbench.config.CONF") as conf,
+            patch.object(workbench_process, "_abort_qsettings_staging") as abort,
+        ):
+            conf.qsettings.status.return_value = 1
+            workbench_process._sync_and_finalize_qsettings_staging(session)
+
+        conf.qsettings.sync.assert_called_once_with()
+        abort.assert_called_once()
+        session.finalize.assert_not_called()
+
+    def test_finalization_exception_uses_abort_recovery_path(self):
+        session = Mock(staging_root=Path("/local/cache/session"))
+        session.finalize.side_effect = OSError("copy failed")
+
+        with (
+            patch("workbench.config.CONF") as conf,
+            patch.object(workbench_process, "_abort_qsettings_staging") as abort,
+        ):
+            conf.qsettings.status.return_value = QSettings.NoError
+            workbench_process._sync_and_finalize_qsettings_staging(session)
+
+        abort.assert_called_once_with(session, "copy-back failed: copy failed")
+
+    def test_incomplete_finalization_warns_with_failed_path(self):
+        session = Mock(staging_root=Path("/local/cache/session"))
+        failed_file = SimpleNamespace(relative_path=Path("mantidproject/mantidworkbench.ini"), status=SimpleNamespace(value="conflict"))
+        session.finalize.return_value = SimpleNamespace(successful=False, files=(failed_file,), error=None)
+
+        with (
+            patch("workbench.config.CONF") as conf,
+            patch.object(workbench_process, "_warn_about_qsettings_staging") as warning,
+        ):
+            conf.qsettings.status.return_value = QSettings.NoError
+            workbench_process._sync_and_finalize_qsettings_staging(session)
+
+        warning.assert_called_once()
+        self.assertIn("mantidproject/mantidworkbench.ini", warning.call_args.args[0])
+        self.assertIn("/local/cache/session", warning.call_args.args[0])
+
+    def test_normal_launch_returns_clean_result_after_accepted_close(self):
+        app = Mock()
+        app.exec.return_value = 5
+        main_window = Mock(shutdown_accepted=True, splash=None)
+        main_window.project_recovery.check_for_recover_checkpoint.return_value = False
+        options = SimpleNamespace(script=None, execute=False, quit=False)
+        about = Mock()
+        modules = {
+            "workbench.app.mainwindow": SimpleNamespace(MainWindow=Mock(return_value=main_window)),
+            "workbench.widgets.about.presenter": SimpleNamespace(AboutPresenter=about),
+            "workbench.plugins.exception_handler": SimpleNamespace(exception_logger=Mock()),
+            "workbench.plotting.config": SimpleNamespace(initialize_matplotlib=Mock()),
+        }
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch("workbench.config.set_additional_windows_parent"),
+            patch.object(workbench_process, "FrameworkManagerImpl"),
+        ):
+            about.should_show_on_startup.return_value = False
+            result = workbench_process.create_and_launch_workbench(app, options)
+
+        self.assertEqual(workbench_process.WorkbenchLaunchResult(5, True), result)
+        app.exec.assert_called_once_with()
+
+    def test_script_quit_returns_task_exit_code_and_close_result_without_starting_event_loop(self):
+        app = Mock()
+        task = Mock(exit_code=4)
+        main_window = Mock(shutdown_accepted=False, splash=None)
+        main_window.editor.execute_current_async.return_value = task
+        main_window.close.side_effect = lambda: setattr(main_window, "shutdown_accepted", True)
+        options = SimpleNamespace(script=Path("script.py"), execute=True, quit=True)
+        modules = {
+            "workbench.app.mainwindow": SimpleNamespace(MainWindow=Mock(return_value=main_window)),
+            "workbench.widgets.about.presenter": SimpleNamespace(AboutPresenter=Mock()),
+            "workbench.plugins.exception_handler": SimpleNamespace(exception_logger=Mock()),
+            "workbench.plotting.config": SimpleNamespace(initialize_matplotlib=Mock()),
+        }
+
+        with (
+            patch.dict(sys.modules, modules),
+            patch("workbench.config.set_additional_windows_parent"),
+            patch.object(workbench_process, "FrameworkManagerImpl"),
+        ):
+            result = workbench_process.create_and_launch_workbench(app, options)
+
+        self.assertEqual(workbench_process.WorkbenchLaunchResult(4, True), result)
+        task.join.assert_called_once_with()
+        main_window.close.assert_called_once_with()
+        app.exec.assert_not_called()
 
     def test_staged_filename_must_match_expected_workbench_settings_file(self):
         session = SimpleNamespace(staging_root=Path("/local/cache/session"))

--- a/qt/applications/workbench/workbench/test/test_workbench_process.py
+++ b/qt/applications/workbench/workbench/test/test_workbench_process.py
@@ -228,8 +228,8 @@ class WorkbenchProcessQSettingsStagingTest(unittest.TestCase):
             workbench_process._sync_and_finalize_qsettings_staging(session)
 
         warning.assert_called_once()
-        self.assertIn("mantidproject/mantidworkbench.ini", warning.call_args.args[0].replace(chr(92), "/"))
-        self.assertIn("/local/cache/session", warning.call_args.args[0])
+        self.assertIn(str(Path("mantidproject/mantidworkbench.ini")), warning.call_args.args[0])
+        self.assertIn(str(Path("/local/cache/session")), warning.call_args.args[0])
 
     def test_normal_launch_returns_clean_result_after_accepted_close(self):
         app = Mock()

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PYTHON_TEST_FILES
     mantidqt/utils/qt/test/test_qappthreadcall.py
     mantidqt/utils/qt/test/test_qsettings_change_aware.py
     mantidqt/utils/qt/test/test_qsettings_staging.py
+    mantidqt/utils/qt/test/test_qsettings_staging_activation.py
     mantidqt/utils/qt/test/test_qsettings_staging_session.py
     mantidqt/widgets/test/test_messagedisplay.py
     mantidqt/widgets/test/test_scriptrepository.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -80,6 +80,7 @@ set(PYTHON_TEST_FILES
     mantidqt/utils/qt/test/test_line_edit_double_validator.py
     mantidqt/utils/qt/test/test_qappthreadcall.py
     mantidqt/utils/qt/test/test_qsettings_change_aware.py
+    mantidqt/utils/qt/test/test_qsettings_staging.py
     mantidqt/widgets/test/test_messagedisplay.py
     mantidqt/widgets/test/test_scriptrepository.py
     mantidqt/widgets/test/test_fittingmode.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -82,6 +82,7 @@ set(PYTHON_TEST_FILES
     mantidqt/utils/qt/test/test_qsettings_change_aware.py
     mantidqt/utils/qt/test/test_qsettings_staging.py
     mantidqt/utils/qt/test/test_qsettings_staging_activation.py
+    mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
     mantidqt/utils/qt/test/test_qsettings_staging_session.py
     mantidqt/widgets/test/test_messagedisplay.py
     mantidqt/widgets/test/test_scriptrepository.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PYTHON_TEST_FILES
     mantidqt/utils/qt/test/test_qappthreadcall.py
     mantidqt/utils/qt/test/test_qsettings_change_aware.py
     mantidqt/utils/qt/test/test_qsettings_staging.py
+    mantidqt/utils/qt/test/test_qsettings_staging_session.py
     mantidqt/widgets/test/test_messagedisplay.py
     mantidqt/widgets/test/test_scriptrepository.py
     mantidqt/widgets/test/test_fittingmode.py

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging.py
@@ -8,16 +8,18 @@
 
 """Linux storage discovery for staging user-scope QSettings files."""
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 import os
 from pathlib import Path
 import re
+import sys
 
 
 MOUNTINFO_PATH = Path("/proc/self/mountinfo")
 NFS_FILESYSTEM_TYPES = frozenset(("nfs", "nfs4"))
+QSETTINGS_STAGING_ENV = "MANTID_QSETTINGS_STAGING"
 
 _MOUNTINFO_ESCAPE_PATTERN = re.compile(r"\\(011|012|040|134)")
 _MOUNTINFO_ESCAPES = {
@@ -35,6 +37,27 @@ class MountMatchStatus(Enum):
     NOT_FOUND = "not_found"
     AMBIGUOUS = "ambiguous"
     UNAVAILABLE = "unavailable"
+
+
+class QSettingsStagingReason(Enum):
+    """Stable reason codes returned by the staging eligibility decision."""
+
+    ELIGIBLE = "eligible"
+    DISABLED = "disabled"
+    UNSUPPORTED_PLATFORM = "unsupported_platform"
+    CONFIG_MOUNT_UNAVAILABLE = "config_mount_unavailable"
+    CONFIG_MOUNT_NOT_FOUND = "config_mount_not_found"
+    CONFIG_MOUNT_AMBIGUOUS = "config_mount_ambiguous"
+    CONFIG_NOT_NFS = "config_not_nfs"
+    ROOTS_NOT_DISTINCT = "roots_not_distinct"
+    CACHE_MOUNT_UNAVAILABLE = "cache_mount_unavailable"
+    CACHE_MOUNT_NOT_FOUND = "cache_mount_not_found"
+    CACHE_MOUNT_AMBIGUOUS = "cache_mount_ambiguous"
+    CACHE_IS_NFS = "cache_is_nfs"
+    MOUNTS_NOT_DISTINCT = "mounts_not_distinct"
+    CACHE_NOT_DIRECTORY = "cache_not_directory"
+    CACHE_NOT_OWNED = "cache_not_owned"
+    CACHE_NOT_WRITABLE = "cache_not_writable"
 
 
 @dataclass(frozen=True)
@@ -76,13 +99,37 @@ class QSettingsStorageDiscovery:
     mountinfo_error: str | None = None
 
 
+@dataclass(frozen=True)
+class QSettingsStagingEligibility:
+    """Whether staging may proceed, without performing any storage mutation."""
+
+    active: bool
+    reason: QSettingsStagingReason
+    config_root: Path | None = None
+    cache_root: Path | None = None
+    config_filesystem: str | None = None
+    cache_filesystem: str | None = None
+
+
+def resolve_xdg_config_root(environ: Mapping[str, str] | None = None, home: Path | None = None) -> Path:
+    """Resolve the XDG config root without consulting the cache setting."""
+    environ = os.environ if environ is None else environ
+    home = _resolve_home(home)
+    return _resolve_xdg_root(environ.get("XDG_CONFIG_HOME"), home / ".config")
+
+
+def resolve_xdg_cache_root(environ: Mapping[str, str] | None = None, home: Path | None = None) -> Path:
+    """Resolve the XDG cache root independently of the config setting."""
+    environ = os.environ if environ is None else environ
+    home = _resolve_home(home)
+    return _resolve_xdg_root(environ.get("XDG_CACHE_HOME"), home / ".cache")
+
+
 def resolve_xdg_paths(environ: Mapping[str, str] | None = None, home: Path | None = None) -> XdgPaths:
     """Resolve XDG config/cache roots without creating either directory."""
-    environ = os.environ if environ is None else environ
-    home = (Path.home() if home is None else Path(home)).expanduser().resolve(strict=False)
     return XdgPaths(
-        config_root=_resolve_xdg_root(environ.get("XDG_CONFIG_HOME"), home / ".config"),
-        cache_root=_resolve_xdg_root(environ.get("XDG_CACHE_HOME"), home / ".cache"),
+        config_root=resolve_xdg_config_root(environ=environ, home=home),
+        cache_root=resolve_xdg_cache_root(environ=environ, home=home),
     )
 
 
@@ -144,10 +191,8 @@ def discover_qsettings_storage(
 ) -> QSettingsStorageDiscovery:
     """Resolve XDG roots and classify their mounts without changing storage."""
     paths = resolve_xdg_paths(environ=environ, home=home)
-    try:
-        with Path(mountinfo_path).open(encoding="utf-8") as handle:
-            mounts = parse_mountinfo(handle)
-    except OSError:
+    mounts = _read_mountinfo(mountinfo_path)
+    if mounts is None:
         unavailable = MountMatch(MountMatchStatus.UNAVAILABLE)
         return QSettingsStorageDiscovery(
             paths=paths,
@@ -163,6 +208,117 @@ def discover_qsettings_storage(
     )
 
 
+def evaluate_qsettings_staging(
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    mountinfo_path: Path = MOUNTINFO_PATH,
+    platform_name: str | None = None,
+    effective_uid: int | None = None,
+    access: Callable[[Path, int], bool] | None = None,
+) -> QSettingsStagingEligibility:
+    """Decide whether local staging is eligible without changing any path.
+
+    Config storage is resolved and classified first. A confirmed non-NFS config
+    returns immediately without resolving or inspecting the cache root.
+    """
+    environ = os.environ if environ is None else environ
+    if environ.get(QSETTINGS_STAGING_ENV) != "1":
+        return QSettingsStagingEligibility(False, QSettingsStagingReason.DISABLED)
+
+    platform_name = sys.platform if platform_name is None else platform_name
+    if not platform_name.startswith("linux"):
+        return QSettingsStagingEligibility(False, QSettingsStagingReason.UNSUPPORTED_PLATFORM)
+
+    config_root = resolve_xdg_config_root(environ=environ, home=home)
+    mounts = _read_mountinfo(mountinfo_path)
+    if mounts is None:
+        return QSettingsStagingEligibility(
+            False,
+            QSettingsStagingReason.CONFIG_MOUNT_UNAVAILABLE,
+            config_root=config_root,
+        )
+
+    config_match = find_mount(config_root, mounts)
+    if config_match.status is not MountMatchStatus.FOUND:
+        return QSettingsStagingEligibility(
+            False,
+            _mount_failure_reason(config_match.status, config=True),
+            config_root=config_root,
+        )
+
+    config_mount = config_match.mount
+    if not config_mount.is_nfs:
+        return QSettingsStagingEligibility(
+            False,
+            QSettingsStagingReason.CONFIG_NOT_NFS,
+            config_root=config_root,
+            config_filesystem=config_mount.filesystem_type,
+        )
+
+    cache_root = resolve_xdg_cache_root(environ=environ, home=home)
+    if cache_root == config_root:
+        return _eligibility_with_mounts(
+            False,
+            QSettingsStagingReason.ROOTS_NOT_DISTINCT,
+            config_root,
+            cache_root,
+            config_mount,
+        )
+
+    cache_match = find_mount(cache_root, mounts)
+    if cache_match.status is not MountMatchStatus.FOUND:
+        return _eligibility_with_mounts(
+            False,
+            _mount_failure_reason(cache_match.status, config=False),
+            config_root,
+            cache_root,
+            config_mount,
+        )
+
+    cache_mount = cache_match.mount
+    if cache_mount.is_nfs:
+        return _eligibility_with_mounts(
+            False,
+            QSettingsStagingReason.CACHE_IS_NFS,
+            config_root,
+            cache_root,
+            config_mount,
+            cache_mount,
+        )
+    if cache_mount.mount_id == config_mount.mount_id:
+        return _eligibility_with_mounts(
+            False,
+            QSettingsStagingReason.MOUNTS_NOT_DISTINCT,
+            config_root,
+            cache_root,
+            config_mount,
+            cache_mount,
+        )
+
+    cache_problem = _assess_cache_root(cache_root, effective_uid=effective_uid, access=access)
+    if cache_problem is not None:
+        return _eligibility_with_mounts(
+            False,
+            cache_problem,
+            config_root,
+            cache_root,
+            config_mount,
+            cache_mount,
+        )
+    return _eligibility_with_mounts(
+        True,
+        QSettingsStagingReason.ELIGIBLE,
+        config_root,
+        cache_root,
+        config_mount,
+        cache_mount,
+    )
+
+
+def _resolve_home(home: Path | None) -> Path:
+    return (Path.home() if home is None else Path(home)).expanduser().resolve(strict=False)
+
+
 def _resolve_xdg_root(value: str | None, fallback: Path) -> Path:
     candidate = Path(value) if value else fallback
     if not candidate.is_absolute():
@@ -172,3 +328,70 @@ def _resolve_xdg_root(value: str | None, fallback: Path) -> Path:
 
 def _decode_mountinfo_path(value: str) -> str:
     return _MOUNTINFO_ESCAPE_PATTERN.sub(lambda match: _MOUNTINFO_ESCAPES[match.group(1)], value)
+
+
+def _read_mountinfo(mountinfo_path: Path) -> tuple[MountInfo, ...] | None:
+    try:
+        with Path(mountinfo_path).open(encoding="utf-8") as handle:
+            return parse_mountinfo(handle)
+    except OSError:
+        return None
+
+
+def _mount_failure_reason(status: MountMatchStatus, config: bool) -> QSettingsStagingReason:
+    config_reasons = {
+        MountMatchStatus.NOT_FOUND: QSettingsStagingReason.CONFIG_MOUNT_NOT_FOUND,
+        MountMatchStatus.AMBIGUOUS: QSettingsStagingReason.CONFIG_MOUNT_AMBIGUOUS,
+        MountMatchStatus.UNAVAILABLE: QSettingsStagingReason.CONFIG_MOUNT_UNAVAILABLE,
+    }
+    cache_reasons = {
+        MountMatchStatus.NOT_FOUND: QSettingsStagingReason.CACHE_MOUNT_NOT_FOUND,
+        MountMatchStatus.AMBIGUOUS: QSettingsStagingReason.CACHE_MOUNT_AMBIGUOUS,
+        MountMatchStatus.UNAVAILABLE: QSettingsStagingReason.CACHE_MOUNT_UNAVAILABLE,
+    }
+    return (config_reasons if config else cache_reasons)[status]
+
+
+def _assess_cache_root(
+    cache_root: Path,
+    effective_uid: int | None,
+    access: Callable[[Path, int], bool] | None,
+) -> QSettingsStagingReason | None:
+    access = os.access if access is None else access
+    try:
+        if cache_root.exists():
+            if not cache_root.is_dir():
+                return QSettingsStagingReason.CACHE_NOT_DIRECTORY
+            effective_uid = os.geteuid() if effective_uid is None else effective_uid
+            if cache_root.stat().st_uid != effective_uid:
+                return QSettingsStagingReason.CACHE_NOT_OWNED
+            if not access(cache_root, os.W_OK | os.X_OK):
+                return QSettingsStagingReason.CACHE_NOT_WRITABLE
+            return None
+
+        existing_parent = cache_root.parent
+        while not existing_parent.exists() and existing_parent != existing_parent.parent:
+            existing_parent = existing_parent.parent
+        if not existing_parent.is_dir() or not access(existing_parent, os.W_OK | os.X_OK):
+            return QSettingsStagingReason.CACHE_NOT_WRITABLE
+    except OSError:
+        return QSettingsStagingReason.CACHE_NOT_WRITABLE
+    return None
+
+
+def _eligibility_with_mounts(
+    active: bool,
+    reason: QSettingsStagingReason,
+    config_root: Path,
+    cache_root: Path,
+    config_mount: MountInfo,
+    cache_mount: MountInfo | None = None,
+) -> QSettingsStagingEligibility:
+    return QSettingsStagingEligibility(
+        active=active,
+        reason=reason,
+        config_root=config_root,
+        cache_root=cache_root,
+        config_filesystem=config_mount.filesystem_type,
+        cache_filesystem=cache_mount.filesystem_type if cache_mount is not None else None,
+    )

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging.py
@@ -1,0 +1,174 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+"""Linux storage discovery for staging user-scope QSettings files."""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+import os
+from pathlib import Path
+import re
+
+
+MOUNTINFO_PATH = Path("/proc/self/mountinfo")
+NFS_FILESYSTEM_TYPES = frozenset(("nfs", "nfs4"))
+
+_MOUNTINFO_ESCAPE_PATTERN = re.compile(r"\\(011|012|040|134)")
+_MOUNTINFO_ESCAPES = {
+    "011": "\t",
+    "012": "\n",
+    "040": " ",
+    "134": "\\",
+}
+
+
+class MountMatchStatus(Enum):
+    """Outcome of matching a path to a mount table."""
+
+    FOUND = "found"
+    NOT_FOUND = "not_found"
+    AMBIGUOUS = "ambiguous"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class XdgPaths:
+    """Canonical user roots used by QSettings staging."""
+
+    config_root: Path
+    cache_root: Path
+
+
+@dataclass(frozen=True)
+class MountInfo:
+    """The mount information needed to classify a storage path."""
+
+    mount_id: int
+    mount_point: Path
+    filesystem_type: str
+
+    @property
+    def is_nfs(self) -> bool:
+        return self.filesystem_type.lower() in NFS_FILESYSTEM_TYPES
+
+
+@dataclass(frozen=True)
+class MountMatch:
+    """A conservative mount-table lookup result."""
+
+    status: MountMatchStatus
+    mount: MountInfo | None = None
+
+
+@dataclass(frozen=True)
+class QSettingsStorageDiscovery:
+    """XDG roots and their corresponding Linux mounts."""
+
+    paths: XdgPaths
+    config_mount: MountMatch
+    cache_mount: MountMatch
+    mountinfo_error: str | None = None
+
+
+def resolve_xdg_paths(environ: Mapping[str, str] | None = None, home: Path | None = None) -> XdgPaths:
+    """Resolve XDG config/cache roots without creating either directory."""
+    environ = os.environ if environ is None else environ
+    home = (Path.home() if home is None else Path(home)).expanduser().resolve(strict=False)
+    return XdgPaths(
+        config_root=_resolve_xdg_root(environ.get("XDG_CONFIG_HOME"), home / ".config"),
+        cache_root=_resolve_xdg_root(environ.get("XDG_CACHE_HOME"), home / ".cache"),
+    )
+
+
+def parse_mountinfo(lines: Iterable[str]) -> tuple[MountInfo, ...]:
+    """Parse usable records from Linux mountinfo lines.
+
+    Malformed records are ignored. An empty result is handled conservatively by
+    :func:`find_mount` and never implies a local filesystem.
+    """
+    mounts = []
+    for line in lines:
+        sections = line.rstrip("\n").split(" - ", maxsplit=1)
+        if len(sections) != 2:
+            continue
+        mount_fields = sections[0].split()
+        filesystem_fields = sections[1].split()
+        if len(mount_fields) < 6 or not filesystem_fields:
+            continue
+        try:
+            mount_id = int(mount_fields[0])
+        except ValueError:
+            continue
+        mount_point = Path(_decode_mountinfo_path(mount_fields[4]))
+        if not mount_point.is_absolute():
+            continue
+        mounts.append(
+            MountInfo(
+                mount_id=mount_id,
+                mount_point=mount_point,
+                filesystem_type=filesystem_fields[0],
+            )
+        )
+    return tuple(mounts)
+
+
+def find_mount(path: Path, mounts: Iterable[MountInfo]) -> MountMatch:
+    """Return the longest component-wise mount match for *path*.
+
+    Duplicate records at the most-specific mount point are treated as
+    ambiguous. This is conservative for stacked mounts, where choosing an
+    arbitrary record could incorrectly classify NFS as local storage.
+    """
+    path = Path(path).expanduser().resolve(strict=False)
+    candidates = tuple(mount for mount in mounts if path == mount.mount_point or mount.mount_point in path.parents)
+    if not candidates:
+        return MountMatch(MountMatchStatus.NOT_FOUND)
+
+    longest = max(len(mount.mount_point.parts) for mount in candidates)
+    best_matches = tuple(mount for mount in candidates if len(mount.mount_point.parts) == longest)
+    if len(best_matches) != 1:
+        return MountMatch(MountMatchStatus.AMBIGUOUS)
+    return MountMatch(MountMatchStatus.FOUND, best_matches[0])
+
+
+def discover_qsettings_storage(
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    mountinfo_path: Path = MOUNTINFO_PATH,
+) -> QSettingsStorageDiscovery:
+    """Resolve XDG roots and classify their mounts without changing storage."""
+    paths = resolve_xdg_paths(environ=environ, home=home)
+    try:
+        with Path(mountinfo_path).open(encoding="utf-8") as handle:
+            mounts = parse_mountinfo(handle)
+    except OSError:
+        unavailable = MountMatch(MountMatchStatus.UNAVAILABLE)
+        return QSettingsStorageDiscovery(
+            paths=paths,
+            config_mount=unavailable,
+            cache_mount=unavailable,
+            mountinfo_error="unreadable",
+        )
+
+    return QSettingsStorageDiscovery(
+        paths=paths,
+        config_mount=find_mount(paths.config_root, mounts),
+        cache_mount=find_mount(paths.cache_root, mounts),
+    )
+
+
+def _resolve_xdg_root(value: str | None, fallback: Path) -> Path:
+    candidate = Path(value) if value else fallback
+    if not candidate.is_absolute():
+        candidate = fallback
+    return candidate.resolve(strict=False)
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    return _MOUNTINFO_ESCAPE_PATTERN.sub(lambda match: _MOUNTINFO_ESCAPES[match.group(1)], value)

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -29,7 +29,8 @@ MANAGER_RELATIVE_PATH = Path("mantidproject/qsettings-stage")
 MANIFEST_FILENAME = ".qsettings-staging-manifest.json"
 COMPLETED_FILENAME = ".qsettings-staging-complete"
 COORDINATOR_FILENAME = "coordinator.lock"
-DEFAULT_SETTINGS_PATHS = (Path("mantidproject/mantidworkbench.ini"),)
+QT_PROJECT_SETTINGS_PATH = Path("QtProject.conf")
+DEFAULT_SETTINGS_PATHS = (Path("mantidproject/mantidworkbench.ini"), QT_PROJECT_SETTINGS_PATH)
 ERROR_REPORTER_SETTINGS_PATH = Path("mantidproject/mantid-error-reporter.ini")
 
 _PRIVATE_DIRECTORY_MODE = 0o700
@@ -116,7 +117,7 @@ class PreparedQSettingsSession:
         return self._active
 
     def activate(self) -> None:
-        """Redirect user-scope INI settings to this session exactly once.
+        """Redirect user-scope INI and native settings to this session exactly once.
 
         The caller must invoke this before constructing any QSettings object.
         Existing instances cannot be detected reliably, so startup ordering is
@@ -132,6 +133,7 @@ class PreparedQSettingsSession:
 
             from qtpy.QtCore import QSettings
 
+            QSettings.setPath(QSettings.NativeFormat, QSettings.UserScope, str(self.staging_root))
             QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, str(self.staging_root))
             _QSETTINGS_PATH_ACTIVATED = True
             self._active = True
@@ -225,8 +227,10 @@ def _create_qlockfile(path: Path) -> _Coordinator:
 
 def _validated_settings_path(path: Path) -> Path:
     path = Path(path)
-    if path.is_absolute() or ".." in path.parts or not path.parts or path.parts[0] != "mantidproject":
-        raise ValueError(f"settings path must be relative and below mantidproject: {path}")
+    if path.is_absolute() or ".." in path.parts or not path.parts:
+        raise ValueError(f"settings path must be relative: {path}")
+    if path != QT_PROJECT_SETTINGS_PATH and path.parts[0] != "mantidproject":
+        raise ValueError(f"settings path must be below mantidproject or be {QT_PROJECT_SETTINGS_PATH}: {path}")
     return path
 
 
@@ -318,8 +322,23 @@ def _seed_session(
     for relative_path in expected_settings_paths:
         if _is_excluded_settings_path(relative_path):
             continue
-        entries.setdefault(relative_path, StagedSettingsFile(relative_path, relative_path, None, None))
+        if relative_path not in entries:
+            entries[relative_path] = _seed_expected_file(canonical_root, session_root, relative_path)
     return tuple(entries[path] for path in sorted(entries))
+
+
+def _seed_expected_file(canonical_root: Path, session_root: Path, relative_path: Path) -> StagedSettingsFile:
+    source = canonical_root / relative_path
+    if not source.exists() and not source.is_symlink():
+        return StagedSettingsFile(relative_path, relative_path, None, None)
+
+    source_stat = source.lstat()
+    if stat.S_ISLNK(source_stat.st_mode) or not stat.S_ISREG(source_stat.st_mode):
+        raise StagingPreparationError(f"canonical settings path is not a regular file: {source}")
+    staged = session_root / relative_path
+    staged.parent.mkdir(mode=_PRIVATE_DIRECTORY_MODE, parents=True, exist_ok=True)
+    digest, canonical_mode = _copy_and_hash(source, staged)
+    return StagedSettingsFile(relative_path, relative_path, digest, canonical_mode)
 
 
 def _seed_directory(
@@ -463,11 +482,24 @@ def _finalize_session(
     return QSettingsStagingFinalization(successful, tuple(results), finalization_error)
 
 
+def _is_qt_project_lock_artifact(name: str) -> bool:
+    lock_name = f"{QT_PROJECT_SETTINGS_PATH.name}.lock"
+    return name == lock_name or name.startswith(f"{lock_name}.rmlock")
+
+
 def _discover_staged_settings(staging_root: Path) -> set[Path]:
+    discovered = set()
     for path in staging_root.iterdir():
-        if path.name in {MANIFEST_FILENAME, COMPLETED_FILENAME}:
+        if path.name in {MANIFEST_FILENAME, COMPLETED_FILENAME} or _is_qt_project_lock_artifact(path.name):
             continue
-        if path.name != "mantidproject":
+        if path.name == "mantidproject":
+            continue
+        if path.name == QT_PROJECT_SETTINGS_PATH.name:
+            path_stat = path.lstat()
+            if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+                raise StagingFinalizationError(f"staged settings path is not a regular file: {path}")
+            discovered.add(QT_PROJECT_SETTINGS_PATH)
+        else:
             raise StagingFinalizationError(f"unexpected staged settings path outside mantidproject: {path}")
 
     organization_root = staging_root / "mantidproject"
@@ -475,7 +507,6 @@ def _discover_staged_settings(staging_root: Path) -> set[Path]:
     if stat.S_ISLNK(organization_stat.st_mode) or not stat.S_ISDIR(organization_stat.st_mode):
         raise StagingFinalizationError(f"staged settings root is not a real directory: {organization_root}")
 
-    discovered = set()
     _discover_staged_directory(organization_root, staging_root, discovered)
     return discovered
 

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -16,6 +16,7 @@ import os
 from pathlib import Path
 import shutil
 import stat
+from threading import Lock
 from typing import Protocol
 from uuid import uuid4
 
@@ -30,6 +31,8 @@ DEFAULT_SETTINGS_PATHS = (Path("mantidproject/mantidworkbench.ini"),)
 
 _PRIVATE_DIRECTORY_MODE = 0o700
 _PRIVATE_FILE_MODE = 0o600
+_ACTIVATION_LOCK = Lock()
+_QSETTINGS_PATH_ACTIVATED = False
 
 
 class _Coordinator(Protocol):
@@ -44,6 +47,10 @@ class StagingPreparationError(RuntimeError):
 
 class CoordinatorUnavailable(StagingPreparationError):
     """Raised when another process owns the local staging coordinator."""
+
+
+class StagingActivationError(RuntimeError):
+    """Raised when the process-global QSettings path cannot be activated."""
 
 
 @dataclass(frozen=True)
@@ -66,6 +73,33 @@ class PreparedQSettingsSession:
     retained_session_roots: tuple[Path, ...]
     _coordinator: _Coordinator = field(repr=False)
     _released: bool = field(default=False, init=False, repr=False)
+    _active: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def active(self) -> bool:
+        """Return whether this session installed the process QSettings path."""
+        return self._active
+
+    def activate(self) -> None:
+        """Redirect user-scope INI settings to this session exactly once.
+
+        The caller must invoke this before constructing any QSettings object.
+        Existing instances cannot be detected reliably, so startup ordering is
+        part of this method's contract.
+        """
+        global _QSETTINGS_PATH_ACTIVATED
+
+        with _ACTIVATION_LOCK:
+            if self._released:
+                raise StagingActivationError("cannot activate a released QSettings staging session")
+            if self._active or _QSETTINGS_PATH_ACTIVATED:
+                raise StagingActivationError("the process QSettings staging path has already been activated")
+
+            from qtpy.QtCore import QSettings
+
+            QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, str(self.staging_root))
+            _QSETTINGS_PATH_ACTIVATED = True
+            self._active = True
 
     def abort(self) -> None:
         """Release ownership while retaining this session for recovery."""

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -3,7 +3,7 @@
 # Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-# SPDX - License - Identifier: GPL - 3.0 +
+# SPDX-License-Identifier: GPL-3.0+
 #  This file is part of the mantid workbench.
 
 """Prepare private local sessions for out-of-place QSettings writes."""

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -1,0 +1,333 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+"""Prepare private local sessions for out-of-place QSettings writes."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+from typing import Protocol
+from uuid import uuid4
+
+from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility
+
+
+MANAGER_RELATIVE_PATH = Path("mantidproject/qsettings-stage")
+MANIFEST_FILENAME = ".qsettings-staging-manifest.json"
+COMPLETED_FILENAME = ".qsettings-staging-complete"
+COORDINATOR_FILENAME = "coordinator.lock"
+DEFAULT_SETTINGS_PATHS = (Path("mantidproject/mantidworkbench.ini"),)
+
+_PRIVATE_DIRECTORY_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+
+
+class _Coordinator(Protocol):
+    def tryLock(self, timeout: int = 0) -> bool: ...
+
+    def unlock(self) -> None: ...
+
+
+class StagingPreparationError(RuntimeError):
+    """Raised when a local staging session cannot be prepared safely."""
+
+
+class CoordinatorUnavailable(StagingPreparationError):
+    """Raised when another process owns the local staging coordinator."""
+
+
+@dataclass(frozen=True)
+class StagedSettingsFile:
+    """Startup state required to compare and copy back one settings file."""
+
+    canonical_relative_path: Path
+    staged_relative_path: Path
+    canonical_sha256: str | None
+    canonical_mode: int | None
+
+
+@dataclass
+class PreparedQSettingsSession:
+    """A seeded staging session that retains coordinator ownership."""
+
+    canonical_root: Path
+    staging_root: Path
+    manifest: tuple[StagedSettingsFile, ...]
+    retained_session_roots: tuple[Path, ...]
+    _coordinator: _Coordinator = field(repr=False)
+    _released: bool = field(default=False, init=False, repr=False)
+
+    def abort(self) -> None:
+        """Release ownership while retaining this session for recovery."""
+        if not self._released:
+            self._coordinator.unlock()
+            self._released = True
+
+
+class QSettingsStagingSessionManager:
+    """Create one private, coordinator-owned staging session."""
+
+    def __init__(
+        self,
+        eligibility: QSettingsStagingEligibility,
+        lock_factory: Callable[[Path], _Coordinator] | None = None,
+        expected_settings_paths: Iterable[Path] = DEFAULT_SETTINGS_PATHS,
+        effective_uid: int | None = None,
+    ):
+        if not eligibility.active or eligibility.config_root is None or eligibility.cache_root is None:
+            raise ValueError("an active eligibility result with config and cache roots is required")
+        self._canonical_root = eligibility.config_root
+        self._cache_root = eligibility.cache_root
+        self._lock_factory = _create_qlockfile if lock_factory is None else lock_factory
+        self._expected_settings_paths = tuple(_validated_settings_path(path) for path in expected_settings_paths)
+        self._effective_uid = os.geteuid() if effective_uid is None else effective_uid
+
+    def prepare(self) -> PreparedQSettingsSession:
+        """Acquire ownership, seed a unique session, and record its manifest."""
+        _ensure_directory(self._cache_root, self._effective_uid, private_if_created=True)
+        manager_parent = self._cache_root / MANAGER_RELATIVE_PATH.parent
+        _ensure_directory(manager_parent, self._effective_uid, private_if_created=True)
+        manager_root = manager_parent / MANAGER_RELATIVE_PATH.name
+        _ensure_directory(manager_root, self._effective_uid, private_if_created=True, force_private=True)
+
+        coordinator = self._lock_factory(manager_root / COORDINATOR_FILENAME)
+        if not coordinator.tryLock(0):
+            raise CoordinatorUnavailable(f"QSettings staging coordinator is already held under {manager_root}")
+
+        session_root: Path | None = None
+        try:
+            retained_sessions = _cleanup_completed_sessions(manager_root, self._effective_uid)
+            session_root = manager_root / f"session-{uuid4().hex}"
+            session_root.mkdir(mode=_PRIVATE_DIRECTORY_MODE)
+            manifest = _seed_session(
+                self._canonical_root,
+                session_root,
+                self._expected_settings_paths,
+            )
+            _write_manifest(session_root, manifest)
+            return PreparedQSettingsSession(
+                canonical_root=self._canonical_root,
+                staging_root=session_root,
+                manifest=manifest,
+                retained_session_roots=retained_sessions,
+                _coordinator=coordinator,
+            )
+        except BaseException:
+            try:
+                if session_root is not None:
+                    _remove_owned_session(session_root, manager_root, self._effective_uid)
+            finally:
+                coordinator.unlock()
+            raise
+
+
+def _create_qlockfile(path: Path) -> _Coordinator:
+    # Keep Qt out of discovery and import-only launcher paths. The first actual
+    # preparation is the first point at which QLockFile is needed.
+    from qtpy.QtCore import QLockFile
+
+    return QLockFile(str(path))
+
+
+def _validated_settings_path(path: Path) -> Path:
+    path = Path(path)
+    if path.is_absolute() or ".." in path.parts or not path.parts or path.parts[0] != "mantidproject":
+        raise ValueError(f"settings path must be relative and below mantidproject: {path}")
+    return path
+
+
+def _ensure_directory(path: Path, effective_uid: int, private_if_created: bool, force_private: bool = False) -> None:
+    path = Path(path)
+    created = False
+    try:
+        if not path.exists():
+            path.mkdir(mode=_PRIVATE_DIRECTORY_MODE, parents=True)
+            created = True
+        path_stat = path.lstat()
+    except OSError as error:
+        raise StagingPreparationError(f"cannot prepare staging directory {path}: {error}") from error
+
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISDIR(path_stat.st_mode):
+        raise StagingPreparationError(f"staging path is not a directory: {path}")
+    if path_stat.st_uid != effective_uid:
+        raise StagingPreparationError(f"staging directory is not owned by the current user: {path}")
+    if (created and private_if_created) or force_private:
+        try:
+            path.chmod(_PRIVATE_DIRECTORY_MODE)
+        except OSError as error:
+            raise StagingPreparationError(f"cannot make staging directory private: {path}") from error
+
+
+def _cleanup_completed_sessions(manager_root: Path, effective_uid: int) -> tuple[Path, ...]:
+    retained = []
+    try:
+        children = tuple(manager_root.iterdir())
+    except OSError as error:
+        raise StagingPreparationError(f"cannot inspect staging manager directory: {manager_root}") from error
+
+    for child in children:
+        if not child.name.startswith("session-"):
+            continue
+        try:
+            child_stat = child.lstat()
+        except OSError:
+            retained.append(child)
+            continue
+        if stat.S_ISLNK(child_stat.st_mode) or not stat.S_ISDIR(child_stat.st_mode) or child_stat.st_uid != effective_uid:
+            retained.append(child)
+            continue
+        completion_marker = child / COMPLETED_FILENAME
+        try:
+            marker_stat = completion_marker.lstat()
+        except OSError:
+            retained.append(child)
+            continue
+        if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_uid != effective_uid:
+            retained.append(child)
+            continue
+        _remove_owned_session(child, manager_root, effective_uid)
+    return tuple(retained)
+
+
+def _remove_owned_session(session_root: Path, manager_root: Path, effective_uid: int) -> None:
+    try:
+        root_stat = session_root.lstat()
+    except FileNotFoundError:
+        return
+    if (
+        session_root.parent != manager_root
+        or not session_root.name.startswith("session-")
+        or stat.S_ISLNK(root_stat.st_mode)
+        or not stat.S_ISDIR(root_stat.st_mode)
+        or root_stat.st_uid != effective_uid
+    ):
+        raise StagingPreparationError(f"refusing to remove unvalidated staging path: {session_root}")
+    shutil.rmtree(session_root)
+
+
+def _seed_session(
+    canonical_root: Path,
+    session_root: Path,
+    expected_settings_paths: tuple[Path, ...],
+) -> tuple[StagedSettingsFile, ...]:
+    staged_organization_root = session_root / "mantidproject"
+    staged_organization_root.mkdir(mode=_PRIVATE_DIRECTORY_MODE)
+    source_organization_root = canonical_root / "mantidproject"
+    entries: dict[Path, StagedSettingsFile] = {}
+
+    if source_organization_root.exists() or source_organization_root.is_symlink():
+        source_stat = source_organization_root.lstat()
+        if stat.S_ISLNK(source_stat.st_mode) or not stat.S_ISDIR(source_stat.st_mode):
+            raise StagingPreparationError(f"canonical settings root is not a real directory: {source_organization_root}")
+        _seed_directory(source_organization_root, staged_organization_root, canonical_root, session_root, entries)
+
+    for relative_path in expected_settings_paths:
+        entries.setdefault(relative_path, StagedSettingsFile(relative_path, relative_path, None, None))
+    return tuple(entries[path] for path in sorted(entries))
+
+
+def _seed_directory(
+    source_directory: Path,
+    staged_directory: Path,
+    canonical_root: Path,
+    session_root: Path,
+    entries: dict[Path, StagedSettingsFile],
+) -> None:
+    try:
+        children = tuple(source_directory.iterdir())
+    except OSError as error:
+        raise StagingPreparationError(f"cannot inspect canonical settings directory: {source_directory}") from error
+
+    for source in children:
+        if _is_excluded_artifact(source.name):
+            continue
+        source_stat = source.lstat()
+        if stat.S_ISLNK(source_stat.st_mode):
+            raise StagingPreparationError(f"refusing to follow a canonical settings symlink: {source}")
+        staged = staged_directory / source.name
+        if stat.S_ISDIR(source_stat.st_mode):
+            staged.mkdir(mode=_PRIVATE_DIRECTORY_MODE)
+            _seed_directory(source, staged, canonical_root, session_root, entries)
+        elif stat.S_ISREG(source_stat.st_mode):
+            relative_path = source.relative_to(canonical_root)
+            digest, canonical_mode = _copy_and_hash(source, staged)
+            entries[relative_path] = StagedSettingsFile(
+                canonical_relative_path=relative_path,
+                staged_relative_path=staged.relative_to(session_root),
+                canonical_sha256=digest,
+                canonical_mode=canonical_mode,
+            )
+
+
+def _is_excluded_artifact(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered == MANIFEST_FILENAME
+        or lowered == COMPLETED_FILENAME
+        or lowered == "qsettings-stage"
+        or lowered.startswith(".nfs")
+        or lowered.endswith((".lock", ".rmlock", ".tmp", ".temp", ".swp", "~"))
+        or ".rmlock." in lowered
+    )
+
+
+def _copy_and_hash(source: Path, staged: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    source_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        source_descriptor = os.open(source, source_flags)
+        try:
+            opened_source_stat = os.fstat(source_descriptor)
+            if not stat.S_ISREG(opened_source_stat.st_mode):
+                raise StagingPreparationError(f"canonical settings path changed type while seeding: {source}")
+            destination_descriptor = os.open(staged, destination_flags, _PRIVATE_FILE_MODE)
+            try:
+                while chunk := os.read(source_descriptor, 1024 * 1024):
+                    digest.update(chunk)
+                    _write_all(destination_descriptor, chunk)
+            finally:
+                os.close(destination_descriptor)
+        finally:
+            os.close(source_descriptor)
+    except OSError as error:
+        raise StagingPreparationError(f"cannot seed canonical settings file {source}: {error}") from error
+    return digest.hexdigest(), stat.S_IMODE(opened_source_stat.st_mode)
+
+
+def _write_all(descriptor: int, contents: bytes) -> None:
+    view = memoryview(contents)
+    while view:
+        written = os.write(descriptor, view)
+        if written == 0:
+            raise OSError("short write while preparing staged settings")
+        view = view[written:]
+
+
+def _write_manifest(session_root: Path, manifest: tuple[StagedSettingsFile, ...]) -> None:
+    records = [
+        {
+            "canonical_relative_path": str(entry.canonical_relative_path),
+            "staged_relative_path": str(entry.staged_relative_path),
+            "canonical_sha256": entry.canonical_sha256,
+            "canonical_mode": entry.canonical_mode,
+        }
+        for entry in manifest
+    ]
+    encoded = (json.dumps({"version": 1, "files": records}, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    descriptor = os.open(session_root / MANIFEST_FILENAME, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _PRIVATE_FILE_MODE)
+    try:
+        _write_all(descriptor, encoded)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -101,13 +101,15 @@ class StagedSettingsFile:
 
 @dataclass
 class PreparedQSettingsSession:
-    """A seeded staging session that retains coordinator ownership."""
+    """A seeded staging session with a private local lifetime."""
 
     canonical_root: Path
     staging_root: Path
     manifest: tuple[StagedSettingsFile, ...]
     retained_session_roots: tuple[Path, ...]
-    _coordinator: _Coordinator = field(repr=False)
+    _coordinator_path: Path = field(repr=False)
+    _lock_factory: Callable[[Path], _Coordinator] = field(repr=False)
+    _coordinator: _Coordinator | None = field(default=None, repr=False)
     _released: bool = field(default=False, init=False, repr=False)
     _active: bool = field(default=False, init=False, repr=False)
 
@@ -141,7 +143,6 @@ class PreparedQSettingsSession:
     def abort(self) -> None:
         """Release ownership while retaining this session for recovery."""
         if not self._released:
-            self._coordinator.unlock()
             self._released = True
 
     def finalize(self) -> QSettingsStagingFinalization:
@@ -153,15 +154,18 @@ class PreparedQSettingsSession:
         """
         if self._released:
             raise StagingFinalizationError("cannot finalize a released QSettings staging session")
+        coordinator = self._lock_factory(self._coordinator_path)
+        if not coordinator.tryLock(0):
+            raise StagingFinalizationError("QSettings staging coordinator is busy; staged settings were retained")
         try:
             return _finalize_session(self.canonical_root, self.staging_root, self.manifest)
         finally:
-            self._coordinator.unlock()
+            coordinator.unlock()
             self._released = True
 
 
 class QSettingsStagingSessionManager:
-    """Create one private, coordinator-owned staging session."""
+    """Create one private staging session; coordinate only short preparation and finalization critical sections."""
 
     def __init__(
         self,
@@ -179,7 +183,7 @@ class QSettingsStagingSessionManager:
         self._effective_uid = os.geteuid() if effective_uid is None else effective_uid
 
     def prepare(self) -> PreparedQSettingsSession:
-        """Acquire ownership, seed a unique session, and record its manifest."""
+        """Acquire the coordinator briefly, seed a unique session, release the coordinator, and record its manifest."""
         _ensure_directory(self._cache_root, self._effective_uid, private_if_created=True)
         manager_parent = self._cache_root / MANAGER_RELATIVE_PATH.parent
         _ensure_directory(manager_parent, self._effective_uid, private_if_created=True)
@@ -201,13 +205,16 @@ class QSettingsStagingSessionManager:
                 self._expected_settings_paths,
             )
             _write_manifest(session_root, manifest)
-            return PreparedQSettingsSession(
+            prepared = PreparedQSettingsSession(
                 canonical_root=self._canonical_root,
                 staging_root=session_root,
                 manifest=manifest,
                 retained_session_roots=retained_sessions,
-                _coordinator=coordinator,
+                _coordinator_path=manager_root / COORDINATOR_FILENAME,
+                _lock_factory=self._lock_factory,
             )
+            coordinator.unlock()
+            return prepared
         except BaseException:
             try:
                 if session_root is not None:

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -464,6 +464,12 @@ def _finalize_session(
 
 
 def _discover_staged_settings(staging_root: Path) -> set[Path]:
+    for path in staging_root.iterdir():
+        if path.name in {MANIFEST_FILENAME, COMPLETED_FILENAME}:
+            continue
+        if path.name != "mantidproject":
+            raise StagingFinalizationError(f"unexpected staged settings path outside mantidproject: {path}")
+
     organization_root = staging_root / "mantidproject"
     organization_stat = organization_root.lstat()
     if stat.S_ISLNK(organization_stat.st_mode) or not stat.S_ISDIR(organization_stat.st_mode):

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -180,7 +180,7 @@ class QSettingsStagingSessionManager:
         self._cache_root = eligibility.cache_root
         self._lock_factory = _create_qlockfile if lock_factory is None else lock_factory
         self._expected_settings_paths = tuple(_validated_settings_path(path) for path in expected_settings_paths)
-        self._effective_uid = os.geteuid() if effective_uid is None else effective_uid
+        self._effective_uid = (getattr(os, "geteuid", lambda: 0)()) if effective_uid is None else effective_uid
 
     def prepare(self) -> PreparedQSettingsSession:
         """Acquire the coordinator briefly, seed a unique session, release the coordinator, and record its manifest."""

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -30,6 +30,7 @@ MANIFEST_FILENAME = ".qsettings-staging-manifest.json"
 COMPLETED_FILENAME = ".qsettings-staging-complete"
 COORDINATOR_FILENAME = "coordinator.lock"
 DEFAULT_SETTINGS_PATHS = (Path("mantidproject/mantidworkbench.ini"),)
+ERROR_REPORTER_SETTINGS_PATH = Path("mantidproject/mantid-error-reporter.ini")
 
 _PRIVATE_DIRECTORY_MODE = 0o700
 _PRIVATE_FILE_MODE = 0o600
@@ -315,6 +316,8 @@ def _seed_session(
         _seed_directory(source_organization_root, staged_organization_root, canonical_root, session_root, entries)
 
     for relative_path in expected_settings_paths:
+        if _is_excluded_settings_path(relative_path):
+            continue
         entries.setdefault(relative_path, StagedSettingsFile(relative_path, relative_path, None, None))
     return tuple(entries[path] for path in sorted(entries))
 
@@ -332,7 +335,8 @@ def _seed_directory(
         raise StagingPreparationError(f"cannot inspect canonical settings directory: {source_directory}") from error
 
     for source in children:
-        if _is_excluded_artifact(source.name):
+        relative_path = source.relative_to(canonical_root)
+        if _is_excluded_settings_path(relative_path) or _is_excluded_artifact(source.name):
             continue
         source_stat = source.lstat()
         if stat.S_ISLNK(source_stat.st_mode):
@@ -342,7 +346,6 @@ def _seed_directory(
             staged.mkdir(mode=_PRIVATE_DIRECTORY_MODE)
             _seed_directory(source, staged, canonical_root, session_root, entries)
         elif stat.S_ISREG(source_stat.st_mode):
-            relative_path = source.relative_to(canonical_root)
             digest, canonical_mode = _copy_and_hash(source, staged)
             entries[relative_path] = StagedSettingsFile(
                 canonical_relative_path=relative_path,
@@ -362,6 +365,10 @@ def _is_excluded_artifact(name: str) -> bool:
         or lowered.endswith((".lock", ".rmlock", ".tmp", ".temp", ".swp", "~"))
         or ".rmlock." in lowered
     )
+
+
+def _is_excluded_settings_path(relative_path: Path) -> bool:
+    return relative_path == ERROR_REPORTER_SETTINGS_PATH
 
 
 def _copy_and_hash(source: Path, staged: Path) -> tuple[str, int]:
@@ -421,7 +428,9 @@ def _finalize_session(
     staging_root: Path,
     manifest: tuple[StagedSettingsFile, ...],
 ) -> QSettingsStagingFinalization:
-    manifest_by_path = {entry.canonical_relative_path: entry for entry in manifest}
+    manifest_by_path = {
+        entry.canonical_relative_path: entry for entry in manifest if not _is_excluded_settings_path(entry.canonical_relative_path)
+    }
     try:
         staged_paths = _discover_staged_settings(staging_root)
     except (OSError, StagingFinalizationError) as error:
@@ -467,7 +476,8 @@ def _discover_staged_settings(staging_root: Path) -> set[Path]:
 
 def _discover_staged_directory(directory: Path, staging_root: Path, discovered: set[Path]) -> None:
     for path in directory.iterdir():
-        if _is_excluded_artifact(path.name):
+        relative_path = path.relative_to(staging_root)
+        if _is_excluded_settings_path(relative_path) or _is_excluded_artifact(path.name):
             continue
         path_stat = path.lstat()
         if stat.S_ISLNK(path_stat.st_mode):
@@ -475,7 +485,7 @@ def _discover_staged_directory(directory: Path, staging_root: Path, discovered: 
         if stat.S_ISDIR(path_stat.st_mode):
             _discover_staged_directory(path, staging_root, discovered)
         elif stat.S_ISREG(path_stat.st_mode):
-            discovered.add(path.relative_to(staging_root))
+            discovered.add(relative_path)
         else:
             raise StagingFinalizationError(f"staged settings path is not a regular file: {path}")
 

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -18,6 +18,7 @@ import os
 from pathlib import Path
 import shutil
 import stat
+import tempfile
 from threading import Lock
 from typing import Protocol
 from uuid import uuid4
@@ -582,21 +583,45 @@ def _copy_changed_file(
 
             _ensure_destination_parent(canonical_path.parent, canonical_root)
             destination_existed = canonical_hash is not None
-            flags = os.O_RDWR | no_follow
-            if not destination_existed:
-                flags |= os.O_CREAT | os.O_EXCL
-            with _opened_descriptor(canonical_path, flags, _PRIVATE_FILE_MODE) as canonical_descriptor:
-                current_hash = _hash_descriptor(canonical_descriptor, canonical_path) if destination_existed else None
+            destination_mode = _PRIVATE_FILE_MODE
+            if destination_existed:
+                with _opened_descriptor(canonical_path, os.O_RDONLY | no_follow) as canonical_descriptor:
+                    current_hash = _hash_descriptor(canonical_descriptor, canonical_path)
+                    destination_mode = stat.S_IMODE(os.fstat(canonical_descriptor).st_mode)
+            else:
+                current_hash = _snapshot_file(canonical_path)
+
+            if current_hash == staged_hash:
+                return CopyBackFileResult(relative_path, CopyBackStatus.ALREADY_SYNCHRONIZED)
+            if current_hash != baseline_hash:
+                return CopyBackFileResult(relative_path, CopyBackStatus.CONFLICT)
+
+            temporary_descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{canonical_path.name}.", suffix=".tmp", dir=canonical_path.parent
+            )
+            temporary_path: Path | None = Path(temporary_name)
+            try:
+                with _opened_existing_descriptor(temporary_descriptor):
+                    os.fchmod(temporary_descriptor, destination_mode)
+                    os.lseek(staged_descriptor, 0, os.SEEK_SET)
+                    while contents := os.read(staged_descriptor, 1024 * 1024):
+                        _write_all(temporary_descriptor, contents)
+                    os.fsync(temporary_descriptor)
+
+                current_hash = _snapshot_file(canonical_path)
                 if current_hash == staged_hash:
                     return CopyBackFileResult(relative_path, CopyBackStatus.ALREADY_SYNCHRONIZED)
                 if current_hash != baseline_hash:
                     return CopyBackFileResult(relative_path, CopyBackStatus.CONFLICT)
 
-                os.ftruncate(canonical_descriptor, 0)
-                os.lseek(staged_descriptor, 0, os.SEEK_SET)
-                while contents := os.read(staged_descriptor, 1024 * 1024):
-                    _write_all(canonical_descriptor, contents)
-                os.fsync(canonical_descriptor)
+                directory_flags = os.O_RDONLY | no_follow | getattr(os, "O_DIRECTORY", 0)
+                with _opened_descriptor(canonical_path.parent, directory_flags) as directory_descriptor:
+                    os.replace(temporary_path, canonical_path)
+                    temporary_path = None
+                    os.fsync(directory_descriptor)
+            finally:
+                if temporary_path is not None:
+                    temporary_path.unlink(missing_ok=True)
         return CopyBackFileResult(relative_path, CopyBackStatus.COPIED)
     except (OSError, StagingFinalizationError) as error:
         return _failed_copy(relative_path, error)
@@ -652,6 +677,14 @@ def _validate_real_directory(path: Path) -> None:
 @contextmanager
 def _opened_descriptor(path: Path, flags: int, mode: int | None = None) -> Iterator[int]:
     descriptor = os.open(path, flags) if mode is None else os.open(path, flags, mode)
+    try:
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _opened_existing_descriptor(descriptor: int) -> Iterator[int]:
     try:
         yield descriptor
     finally:

--- a/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qsettings_staging_session.py
@@ -8,8 +8,10 @@
 
 """Prepare private local sessions for out-of-place QSettings writes."""
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from enum import Enum
 import hashlib
 import json
 import os
@@ -51,6 +53,38 @@ class CoordinatorUnavailable(StagingPreparationError):
 
 class StagingActivationError(RuntimeError):
     """Raised when the process-global QSettings path cannot be activated."""
+
+
+class StagingFinalizationError(RuntimeError):
+    """Raised when a staging session cannot enter finalization."""
+
+
+class CopyBackStatus(Enum):
+    """Outcome for one staged settings path."""
+
+    UNCHANGED = "unchanged"
+    ALREADY_SYNCHRONIZED = "already_synchronized"
+    COPIED = "copied"
+    CONFLICT = "conflict"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class CopyBackFileResult:
+    """Copy-back outcome without exposing settings values."""
+
+    relative_path: Path
+    status: CopyBackStatus
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class QSettingsStagingFinalization:
+    """Result of finalizing every file in a staging session."""
+
+    successful: bool
+    files: tuple[CopyBackFileResult, ...]
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -104,6 +138,21 @@ class PreparedQSettingsSession:
     def abort(self) -> None:
         """Release ownership while retaining this session for recovery."""
         if not self._released:
+            self._coordinator.unlock()
+            self._released = True
+
+    def finalize(self) -> QSettingsStagingFinalization:
+        """Copy changed staged files directly to canonical storage.
+
+        This operation is deliberately not crash-atomic: it overwrites each
+        destination through its own descriptor without an adjacent temporary
+        file, rename, unlink, or QSettings operation.
+        """
+        if self._released:
+            raise StagingFinalizationError("cannot finalize a released QSettings staging session")
+        try:
+            return _finalize_session(self.canonical_root, self.staging_root, self.manifest)
+        finally:
             self._coordinator.unlock()
             self._released = True
 
@@ -344,7 +393,7 @@ def _write_all(descriptor: int, contents: bytes) -> None:
     while view:
         written = os.write(descriptor, view)
         if written == 0:
-            raise OSError("short write while preparing staged settings")
+            raise OSError("short write while writing settings file")
         view = view[written:]
 
 
@@ -365,3 +414,201 @@ def _write_manifest(session_root: Path, manifest: tuple[StagedSettingsFile, ...]
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
+
+
+def _finalize_session(
+    canonical_root: Path,
+    staging_root: Path,
+    manifest: tuple[StagedSettingsFile, ...],
+) -> QSettingsStagingFinalization:
+    manifest_by_path = {entry.canonical_relative_path: entry for entry in manifest}
+    try:
+        staged_paths = _discover_staged_settings(staging_root)
+    except (OSError, StagingFinalizationError) as error:
+        return QSettingsStagingFinalization(False, (), str(error))
+
+    relative_paths = sorted(set(manifest_by_path) | staged_paths)
+    results = []
+    for relative_path in relative_paths:
+        entry = manifest_by_path.get(relative_path)
+        staged_relative_path = entry.staged_relative_path if entry is not None else relative_path
+        baseline_hash = entry.canonical_sha256 if entry is not None else None
+        results.append(
+            _finalize_file(
+                canonical_root,
+                staging_root,
+                relative_path,
+                staged_relative_path,
+                baseline_hash,
+            )
+        )
+
+    successful = all(result.status not in (CopyBackStatus.CONFLICT, CopyBackStatus.FAILED) for result in results)
+    finalization_error = None
+    if successful:
+        try:
+            _write_completion_marker(staging_root)
+        except OSError as error:
+            successful = False
+            finalization_error = f"cannot mark staging session complete: {error}"
+    return QSettingsStagingFinalization(successful, tuple(results), finalization_error)
+
+
+def _discover_staged_settings(staging_root: Path) -> set[Path]:
+    organization_root = staging_root / "mantidproject"
+    organization_stat = organization_root.lstat()
+    if stat.S_ISLNK(organization_stat.st_mode) or not stat.S_ISDIR(organization_stat.st_mode):
+        raise StagingFinalizationError(f"staged settings root is not a real directory: {organization_root}")
+
+    discovered = set()
+    _discover_staged_directory(organization_root, staging_root, discovered)
+    return discovered
+
+
+def _discover_staged_directory(directory: Path, staging_root: Path, discovered: set[Path]) -> None:
+    for path in directory.iterdir():
+        if _is_excluded_artifact(path.name):
+            continue
+        path_stat = path.lstat()
+        if stat.S_ISLNK(path_stat.st_mode):
+            raise StagingFinalizationError(f"refusing to follow a staged settings symlink: {path}")
+        if stat.S_ISDIR(path_stat.st_mode):
+            _discover_staged_directory(path, staging_root, discovered)
+        elif stat.S_ISREG(path_stat.st_mode):
+            discovered.add(path.relative_to(staging_root))
+        else:
+            raise StagingFinalizationError(f"staged settings path is not a regular file: {path}")
+
+
+def _finalize_file(
+    canonical_root: Path,
+    staging_root: Path,
+    canonical_relative_path: Path,
+    staged_relative_path: Path,
+    baseline_hash: str | None,
+) -> CopyBackFileResult:
+    staged_path = staging_root / staged_relative_path
+    try:
+        staged_hash = _snapshot_file(staged_path)
+    except (OSError, StagingFinalizationError) as error:
+        return _failed_copy(canonical_relative_path, error)
+
+    if staged_hash is None:
+        if baseline_hash is None:
+            return CopyBackFileResult(canonical_relative_path, CopyBackStatus.UNCHANGED)
+        return _failed_copy(canonical_relative_path, "staged file is missing")
+    if staged_hash == baseline_hash:
+        return CopyBackFileResult(canonical_relative_path, CopyBackStatus.UNCHANGED)
+
+    return _copy_changed_file(
+        canonical_root,
+        canonical_root / canonical_relative_path,
+        staged_path,
+        canonical_relative_path,
+        baseline_hash,
+    )
+
+
+def _copy_changed_file(
+    canonical_root: Path,
+    canonical_path: Path,
+    staged_path: Path,
+    relative_path: Path,
+    baseline_hash: str | None,
+) -> CopyBackFileResult:
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        with _opened_descriptor(staged_path, os.O_RDONLY | no_follow) as staged_descriptor:
+            staged_hash = _hash_descriptor(staged_descriptor, staged_path)
+            canonical_hash = _snapshot_file(canonical_path)
+            if canonical_hash == staged_hash:
+                return CopyBackFileResult(relative_path, CopyBackStatus.ALREADY_SYNCHRONIZED)
+            if canonical_hash != baseline_hash:
+                return CopyBackFileResult(relative_path, CopyBackStatus.CONFLICT)
+
+            _ensure_destination_parent(canonical_path.parent, canonical_root)
+            destination_existed = canonical_hash is not None
+            flags = os.O_RDWR | no_follow
+            if not destination_existed:
+                flags |= os.O_CREAT | os.O_EXCL
+            with _opened_descriptor(canonical_path, flags, _PRIVATE_FILE_MODE) as canonical_descriptor:
+                current_hash = _hash_descriptor(canonical_descriptor, canonical_path) if destination_existed else None
+                if current_hash == staged_hash:
+                    return CopyBackFileResult(relative_path, CopyBackStatus.ALREADY_SYNCHRONIZED)
+                if current_hash != baseline_hash:
+                    return CopyBackFileResult(relative_path, CopyBackStatus.CONFLICT)
+
+                os.ftruncate(canonical_descriptor, 0)
+                os.lseek(staged_descriptor, 0, os.SEEK_SET)
+                while contents := os.read(staged_descriptor, 1024 * 1024):
+                    _write_all(canonical_descriptor, contents)
+                os.fsync(canonical_descriptor)
+        return CopyBackFileResult(relative_path, CopyBackStatus.COPIED)
+    except (OSError, StagingFinalizationError) as error:
+        return _failed_copy(relative_path, error)
+
+
+def _snapshot_file(path: Path) -> str | None:
+    try:
+        with _opened_descriptor(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)) as descriptor:
+            return _hash_descriptor(descriptor, path)
+    except FileNotFoundError:
+        return None
+
+
+def _hash_descriptor(descriptor: int, path: Path) -> str:
+    path_stat = os.fstat(descriptor)
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise StagingFinalizationError(f"settings path is not a regular file: {path}")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    digest = hashlib.sha256()
+    while contents := os.read(descriptor, 1024 * 1024):
+        digest.update(contents)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    return digest.hexdigest()
+
+
+def _ensure_destination_parent(destination_parent: Path, canonical_root: Path) -> None:
+    try:
+        relative_parent = destination_parent.relative_to(canonical_root)
+    except ValueError as error:
+        raise StagingFinalizationError(f"canonical destination escapes its root: {destination_parent}") from error
+
+    try:
+        canonical_root.mkdir(mode=_PRIVATE_DIRECTORY_MODE, parents=True)
+    except FileExistsError:
+        pass
+    _validate_real_directory(canonical_root)
+    current = canonical_root
+    for component in relative_parent.parts:
+        current /= component
+        try:
+            current.mkdir(mode=_PRIVATE_DIRECTORY_MODE)
+        except FileExistsError:
+            pass
+        _validate_real_directory(current)
+
+
+def _validate_real_directory(path: Path) -> None:
+    path_stat = path.lstat()
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISDIR(path_stat.st_mode):
+        raise StagingFinalizationError(f"canonical settings parent is not a real directory: {path}")
+
+
+@contextmanager
+def _opened_descriptor(path: Path, flags: int, mode: int | None = None) -> Iterator[int]:
+    descriptor = os.open(path, flags) if mode is None else os.open(path, flags, mode)
+    try:
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _failed_copy(relative_path: Path, error: object) -> CopyBackFileResult:
+    return CopyBackFileResult(relative_path, CopyBackStatus.FAILED, str(error))
+
+
+def _write_completion_marker(staging_root: Path) -> None:
+    marker = staging_root / COMPLETED_FILENAME
+    with _opened_descriptor(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _PRIVATE_FILE_MODE) as descriptor:
+        os.fsync(descriptor)

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
@@ -9,11 +9,14 @@
 import tempfile
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import (
     MountInfo,
     MountMatchStatus,
+    QSettingsStagingReason,
     discover_qsettings_storage,
+    evaluate_qsettings_staging,
     find_mount,
     parse_mountinfo,
     resolve_xdg_paths,
@@ -186,6 +189,218 @@ class DiscoverQSettingsStorageTest(unittest.TestCase):
 
             self.assertEqual(MountMatchStatus.AMBIGUOUS, discovery.config_mount.status)
             self.assertEqual(MountMatchStatus.AMBIGUOUS, discovery.cache_mount.status)
+
+
+class EvaluateQSettingsStagingTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_home = tempfile.TemporaryDirectory()
+        self.home = Path(self.temporary_home.name)
+        self.remote = self.home / "remote"
+        self.local = self.home / "local"
+        self.remote.mkdir()
+        self.local.mkdir()
+        self.config = self.remote / "config"
+        self.cache = self.local / "cache"
+        self.mountinfo = self.home / "mountinfo"
+        self.environ = {
+            "MANTID_QSETTINGS_STAGING": "1",
+            "XDG_CONFIG_HOME": str(self.config),
+            "XDG_CACHE_HOME": str(self.cache),
+        }
+
+    def tearDown(self):
+        self.temporary_home.cleanup()
+
+    def write_mountinfo(self, config_filesystem="nfs4", cache_filesystem="xfs", cache_mount_id=3):
+        self.mountinfo.write_text(
+            f"1 0 0:1 / / rw - ext4 /dev/root rw\n"
+            f"2 1 0:2 / {self.remote} rw - {config_filesystem} server:/remote rw\n"
+            f"{cache_mount_id} 1 0:3 / {self.local} rw - {cache_filesystem} /dev/local rw\n",
+            encoding="utf-8",
+        )
+
+    def evaluate(self, **kwargs):
+        return evaluate_qsettings_staging(
+            environ=self.environ,
+            home=self.home,
+            mountinfo_path=self.mountinfo,
+            platform_name="linux",
+            **kwargs,
+        )
+
+    def test_requires_explicit_opt_in_before_resolving_config(self):
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging.resolve_xdg_config_root",
+            side_effect=AssertionError("config must not be resolved"),
+        ):
+            result = evaluate_qsettings_staging(environ={}, home=self.home, platform_name="linux")
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.DISABLED, result.reason)
+        self.assertIsNone(result.config_root)
+        self.assertIsNone(result.cache_root)
+
+    def test_rejects_non_linux_before_resolving_config(self):
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging.resolve_xdg_config_root",
+            side_effect=AssertionError("config must not be resolved"),
+        ):
+            result = evaluate_qsettings_staging(environ=self.environ, home=self.home, platform_name="darwin")
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.UNSUPPORTED_PLATFORM, result.reason)
+
+    def test_non_nfs_config_returns_without_any_cache_access(self):
+        self.write_mountinfo(config_filesystem="ext4")
+        with (
+            patch(
+                "mantidqt.utils.qt.qsettings_staging.resolve_xdg_cache_root",
+                side_effect=AssertionError("cache must not be resolved"),
+            ),
+            patch(
+                "mantidqt.utils.qt.qsettings_staging._assess_cache_root",
+                side_effect=AssertionError("cache must not be inspected"),
+            ),
+        ):
+            result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CONFIG_NOT_NFS, result.reason)
+        self.assertEqual("ext4", result.config_filesystem)
+        self.assertIsNone(result.cache_root)
+        self.assertIsNone(result.cache_filesystem)
+
+    def test_unreadable_mountinfo_returns_without_cache_access(self):
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging.resolve_xdg_cache_root",
+            side_effect=AssertionError("cache must not be resolved"),
+        ):
+            result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CONFIG_MOUNT_UNAVAILABLE, result.reason)
+        self.assertIsNone(result.cache_root)
+
+    def test_missing_config_mount_returns_without_cache_access(self):
+        self.mountinfo.write_text("1 0 0:1 / /unrelated rw - ext4 /dev/root rw\n", encoding="utf-8")
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging.resolve_xdg_cache_root",
+            side_effect=AssertionError("cache must not be resolved"),
+        ):
+            result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CONFIG_MOUNT_NOT_FOUND, result.reason)
+
+    def test_ambiguous_config_mount_returns_without_cache_access(self):
+        self.mountinfo.write_text(
+            f"1 0 0:1 / {self.remote} rw - nfs4 server:/remote rw\n2 0 0:2 / {self.remote} rw - ext4 /dev/local rw\n",
+            encoding="utf-8",
+        )
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging.resolve_xdg_cache_root",
+            side_effect=AssertionError("cache must not be resolved"),
+        ):
+            result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CONFIG_MOUNT_AMBIGUOUS, result.reason)
+
+    def test_reports_nfs_cache_with_a_dedicated_reason(self):
+        self.write_mountinfo(cache_filesystem="nfs")
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_IS_NFS, result.reason)
+        self.assertEqual("nfs4", result.config_filesystem)
+        self.assertEqual("nfs", result.cache_filesystem)
+
+    def test_reports_missing_cache_mount(self):
+        self.mountinfo.write_text(f"2 1 0:2 / {self.remote} rw - nfs4 server:/remote rw\n", encoding="utf-8")
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_MOUNT_NOT_FOUND, result.reason)
+
+    def test_reports_ambiguous_cache_mount(self):
+        self.mountinfo.write_text(
+            f"2 1 0:2 / {self.remote} rw - nfs4 server:/remote rw\n"
+            f"3 1 0:3 / {self.local} rw - xfs /dev/local rw\n"
+            f"4 1 0:4 / {self.local} rw - ext4 /dev/other rw\n",
+            encoding="utf-8",
+        )
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_MOUNT_AMBIGUOUS, result.reason)
+
+    def test_reports_identical_roots(self):
+        self.write_mountinfo()
+        self.environ["XDG_CACHE_HOME"] = str(self.config)
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.ROOTS_NOT_DISTINCT, result.reason)
+
+    def test_reports_identical_mount_ids(self):
+        self.write_mountinfo(cache_mount_id=2)
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.MOUNTS_NOT_DISTINCT, result.reason)
+
+    def test_reports_existing_cache_path_that_is_not_a_directory(self):
+        self.write_mountinfo()
+        self.cache.write_text("not a directory", encoding="utf-8")
+
+        result = self.evaluate()
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_NOT_DIRECTORY, result.reason)
+
+    def test_reports_cache_not_owned_by_current_user(self):
+        self.write_mountinfo()
+        self.cache.mkdir()
+
+        result = self.evaluate(effective_uid=self.cache.stat().st_uid + 1)
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_NOT_OWNED, result.reason)
+
+    def test_reports_existing_cache_without_write_access(self):
+        self.write_mountinfo()
+        self.cache.mkdir()
+
+        result = self.evaluate(effective_uid=self.cache.stat().st_uid, access=lambda _path, _mode: False)
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_NOT_WRITABLE, result.reason)
+
+    def test_reports_missing_cache_with_unwritable_existing_parent(self):
+        self.write_mountinfo()
+
+        result = self.evaluate(access=lambda _path, _mode: False)
+
+        self.assertFalse(result.active)
+        self.assertEqual(QSettingsStagingReason.CACHE_NOT_WRITABLE, result.reason)
+
+    def test_is_eligible_for_nfs_config_and_writable_local_cache_parent(self):
+        self.write_mountinfo()
+
+        result = self.evaluate(access=lambda path, _mode: path == self.local)
+
+        self.assertTrue(result.active)
+        self.assertEqual(QSettingsStagingReason.ELIGIBLE, result.reason)
+        self.assertEqual(self.config, result.config_root)
+        self.assertEqual(self.cache, result.cache_root)
+        self.assertEqual("nfs4", result.config_filesystem)
+        self.assertEqual("xfs", result.cache_filesystem)
+        self.assertFalse(self.cache.exists())
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
@@ -8,7 +8,11 @@
 
 import tempfile
 from pathlib import Path
+import sys
 import unittest
+
+if not sys.platform.startswith("linux"):
+    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import (

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
@@ -11,8 +11,6 @@ from pathlib import Path
 import sys
 import unittest
 
-if not sys.platform.startswith("linux"):
-    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import (
@@ -27,6 +25,7 @@ from mantidqt.utils.qt.qsettings_staging import (
 )
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class ResolveXdgPathsTest(unittest.TestCase):
     def test_uses_defaults_when_environment_is_empty(self):
         with tempfile.TemporaryDirectory() as temporary_home:
@@ -80,6 +79,7 @@ class ResolveXdgPathsTest(unittest.TestCase):
             self.assertFalse(cache.exists())
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class ParseMountInfoTest(unittest.TestCase):
     def test_parses_mount_id_point_and_filesystem(self):
         mounts = parse_mountinfo(["36 25 0:32 / /home rw,relatime - nfs4 server:/home rw\n"])
@@ -104,6 +104,7 @@ class ParseMountInfoTest(unittest.TestCase):
         self.assertEqual((), mounts)
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class FindMountTest(unittest.TestCase):
     def test_selects_longest_component_wise_mount(self):
         mounts = (
@@ -142,6 +143,7 @@ class FindMountTest(unittest.TestCase):
         self.assertIsNone(match.mount)
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class DiscoverQSettingsStorageTest(unittest.TestCase):
     def test_discovers_config_and_cache_mounts(self):
         with tempfile.TemporaryDirectory() as temporary_home:
@@ -195,6 +197,7 @@ class DiscoverQSettingsStorageTest(unittest.TestCase):
             self.assertEqual(MountMatchStatus.AMBIGUOUS, discovery.cache_mount.status)
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class EvaluateQSettingsStagingTest(unittest.TestCase):
     def setUp(self):
         self.temporary_home = tempfile.TemporaryDirectory()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging.py
@@ -1,0 +1,192 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+import tempfile
+from pathlib import Path
+import unittest
+
+from mantidqt.utils.qt.qsettings_staging import (
+    MountInfo,
+    MountMatchStatus,
+    discover_qsettings_storage,
+    find_mount,
+    parse_mountinfo,
+    resolve_xdg_paths,
+)
+
+
+class ResolveXdgPathsTest(unittest.TestCase):
+    def test_uses_defaults_when_environment_is_empty(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+
+            paths = resolve_xdg_paths(environ={}, home=home)
+
+            self.assertEqual(home / ".config", paths.config_root)
+            self.assertEqual(home / ".cache", paths.cache_root)
+
+    def test_uses_absolute_environment_overrides(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+            config = home / "config override"
+            cache = home / "cache override"
+
+            paths = resolve_xdg_paths(
+                environ={"XDG_CONFIG_HOME": str(config), "XDG_CACHE_HOME": str(cache)},
+                home=home,
+            )
+
+            self.assertEqual(config, paths.config_root)
+            self.assertEqual(cache, paths.cache_root)
+
+    def test_ignores_relative_environment_overrides(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+
+            paths = resolve_xdg_paths(
+                environ={"XDG_CONFIG_HOME": "relative-config", "XDG_CACHE_HOME": "relative-cache"},
+                home=home,
+            )
+
+            self.assertEqual(home / ".config", paths.config_root)
+            self.assertEqual(home / ".cache", paths.cache_root)
+
+    def test_resolves_roots_that_do_not_exist(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+            config = home / "missing" / "config"
+            cache = home / "missing" / "cache"
+
+            paths = resolve_xdg_paths(
+                environ={"XDG_CONFIG_HOME": str(config), "XDG_CACHE_HOME": str(cache)},
+                home=home,
+            )
+
+            self.assertEqual(config, paths.config_root)
+            self.assertEqual(cache, paths.cache_root)
+            self.assertFalse(config.exists())
+            self.assertFalse(cache.exists())
+
+
+class ParseMountInfoTest(unittest.TestCase):
+    def test_parses_mount_id_point_and_filesystem(self):
+        mounts = parse_mountinfo(["36 25 0:32 / /home rw,relatime - nfs4 server:/home rw\n"])
+
+        self.assertEqual((MountInfo(36, Path("/home"), "nfs4"),), mounts)
+        self.assertTrue(mounts[0].is_nfs)
+
+    def test_decodes_mountinfo_path_escapes(self):
+        mounts = parse_mountinfo([r"42 25 0:40 / /path\040with\011tab\134slash rw - ext4 /dev/sda rw" + "\n"])
+
+        self.assertEqual("/path with\ttab\\slash", str(mounts[0].mount_point))
+
+    def test_ignores_malformed_records(self):
+        mounts = parse_mountinfo(
+            [
+                "not a mountinfo record\n",
+                "not-an-id 25 0:32 / /home rw - nfs4 server:/home rw\n",
+                "36 25 0:32 / relative rw - nfs4 server:/home rw\n",
+            ]
+        )
+
+        self.assertEqual((), mounts)
+
+
+class FindMountTest(unittest.TestCase):
+    def test_selects_longest_component_wise_mount(self):
+        mounts = (
+            MountInfo(1, Path("/"), "ext4"),
+            MountInfo(2, Path("/home"), "nfs4"),
+            MountInfo(3, Path("/home/user/.cache"), "xfs"),
+        )
+
+        config_match = find_mount(Path("/home/user/.config/mantidproject"), mounts)
+        cache_match = find_mount(Path("/home/user/.cache/mantidproject"), mounts)
+
+        self.assertEqual(MountMatchStatus.FOUND, config_match.status)
+        self.assertEqual(Path("/home"), config_match.mount.mount_point)
+        self.assertTrue(config_match.mount.is_nfs)
+        self.assertEqual(MountMatchStatus.FOUND, cache_match.status)
+        self.assertEqual(Path("/home/user/.cache"), cache_match.mount.mount_point)
+        self.assertFalse(cache_match.mount.is_nfs)
+
+    def test_does_not_use_a_partial_path_component_match(self):
+        mounts = (MountInfo(1, Path("/home/user"), "nfs4"),)
+
+        match = find_mount(Path("/home/username/.config"), mounts)
+
+        self.assertEqual(MountMatchStatus.NOT_FOUND, match.status)
+        self.assertIsNone(match.mount)
+
+    def test_reports_duplicate_most_specific_mounts_as_ambiguous(self):
+        mounts = (
+            MountInfo(1, Path("/home"), "nfs4"),
+            MountInfo(2, Path("/home"), "ext4"),
+        )
+
+        match = find_mount(Path("/home/user/.config"), mounts)
+
+        self.assertEqual(MountMatchStatus.AMBIGUOUS, match.status)
+        self.assertIsNone(match.mount)
+
+
+class DiscoverQSettingsStorageTest(unittest.TestCase):
+    def test_discovers_config_and_cache_mounts(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+            config = home / "remote" / "config"
+            cache = home / "local" / "cache"
+            mountinfo = home / "mountinfo"
+            mountinfo.write_text(
+                f"1 0 0:1 / / rw - ext4 /dev/root rw\n"
+                f"2 1 0:2 / {home / 'remote'} rw - nfs4 server:/remote rw\n"
+                f"3 1 0:3 / {home / 'local'} rw - xfs /dev/local rw\n",
+                encoding="utf-8",
+            )
+
+            discovery = discover_qsettings_storage(
+                environ={"XDG_CONFIG_HOME": str(config), "XDG_CACHE_HOME": str(cache)},
+                home=home,
+                mountinfo_path=mountinfo,
+            )
+
+            self.assertEqual(config, discovery.paths.config_root)
+            self.assertEqual(cache, discovery.paths.cache_root)
+            self.assertEqual("nfs4", discovery.config_mount.mount.filesystem_type)
+            self.assertTrue(discovery.config_mount.mount.is_nfs)
+            self.assertEqual("xfs", discovery.cache_mount.mount.filesystem_type)
+            self.assertFalse(discovery.cache_mount.mount.is_nfs)
+            self.assertIsNone(discovery.mountinfo_error)
+
+    def test_reports_unreadable_mountinfo_as_unavailable(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+
+            discovery = discover_qsettings_storage(environ={}, home=home, mountinfo_path=home / "missing-mountinfo")
+
+            self.assertEqual(MountMatchStatus.UNAVAILABLE, discovery.config_mount.status)
+            self.assertEqual(MountMatchStatus.UNAVAILABLE, discovery.cache_mount.status)
+            self.assertEqual("unreadable", discovery.mountinfo_error)
+
+    def test_preserves_an_ambiguous_match(self):
+        with tempfile.TemporaryDirectory() as temporary_home:
+            home = Path(temporary_home)
+            mountinfo = home / "mountinfo"
+            mountinfo.write_text(
+                f"1 0 0:1 / {home} rw - nfs4 server:/home rw\n2 0 0:2 / {home} rw - ext4 /dev/local rw\n",
+                encoding="utf-8",
+            )
+
+            discovery = discover_qsettings_storage(environ={}, home=home, mountinfo_path=mountinfo)
+
+            self.assertEqual(MountMatchStatus.AMBIGUOUS, discovery.config_mount.status)
+            self.assertEqual(MountMatchStatus.AMBIGUOUS, discovery.cache_mount.status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
@@ -1,0 +1,198 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+_SETUP = """
+from pathlib import Path
+import tempfile
+
+from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
+from mantidqt.utils.qt.qsettings_staging_session import QSettingsStagingSessionManager, StagingActivationError
+
+temporary_directory = tempfile.TemporaryDirectory()
+root = Path(temporary_directory.name)
+config_root = root / "config"
+cache_root = root / "cache"
+config_root.mkdir()
+cache_root.mkdir()
+eligibility = QSettingsStagingEligibility(
+    True,
+    QSettingsStagingReason.ELIGIBLE,
+    config_root=config_root,
+    cache_root=cache_root,
+    config_filesystem="nfs4",
+    cache_filesystem="ext4",
+)
+"""
+
+
+class QSettingsStagingActivationTest(unittest.TestCase):
+    def run_in_subprocess(self, body: str) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(_SETUP + body)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(0, result.returncode, msg=result.stderr)
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
+    def test_explicit_and_default_writes_and_lock_are_redirected(self):
+        self.run_in_subprocess(
+            """
+import ctypes
+import os
+import struct
+
+from qtpy.QtCore import QCoreApplication, QSettings
+
+canonical_directory = config_root / "mantidproject"
+canonical_directory.mkdir()
+canonical_file = canonical_directory / "mantidworkbench.ini"
+canonical_contents = b"[General]\\nseeded=canonical\\n"
+canonical_file.write_bytes(canonical_contents)
+
+session = QSettingsStagingSessionManager(eligibility).prepare()
+assert not session.active
+session.activate()
+assert session.active
+
+QSettings.setDefaultFormat(QSettings.IniFormat)
+QCoreApplication.setOrganizationName("mantidproject")
+QCoreApplication.setApplicationName("mantidworkbench")
+expected_file = session.staging_root / "mantidproject/mantidworkbench.ini"
+
+explicit_settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "mantidproject", "mantidworkbench")
+assert Path(explicit_settings.fileName()) == expected_file
+assert explicit_settings.value("seeded") == "canonical"
+
+libc = ctypes.CDLL(None, use_errno=True)
+inotify_descriptor = libc.inotify_init1(os.O_NONBLOCK | os.O_CLOEXEC)
+assert inotify_descriptor >= 0
+IN_ALL_EVENTS = 0x00000FFF
+staged_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(expected_file.parent), IN_ALL_EVENTS)
+canonical_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(canonical_directory), IN_ALL_EVENTS)
+assert staged_watch >= 0
+assert canonical_watch >= 0
+
+explicit_settings.setValue("explicit", "staged")
+explicit_settings.sync()
+assert explicit_settings.status() == QSettings.NoError
+
+default_settings = QSettings()
+assert Path(default_settings.fileName()) == expected_file
+default_settings.setValue("default", "staged")
+default_settings.sync()
+assert default_settings.status() == QSettings.NoError
+
+events = os.read(inotify_descriptor, 65536)
+os.close(inotify_descriptor)
+event_header = struct.Struct("iIII")
+names_by_watch = {}
+offset = 0
+while offset < len(events):
+    watch, _mask, _cookie, name_length = event_header.unpack_from(events, offset)
+    offset += event_header.size
+    name = events[offset : offset + name_length].split(b"\\0", 1)[0].decode()
+    offset += name_length
+    names_by_watch.setdefault(watch, []).append(name)
+
+assert "mantidworkbench.ini.lock" in names_by_watch.get(staged_watch, []), names_by_watch
+assert names_by_watch.get(canonical_watch, []) == [], names_by_watch
+assert canonical_file.read_bytes() == canonical_contents
+assert sorted(path.name for path in canonical_directory.iterdir()) == ["mantidworkbench.ini"]
+assert explicit_settings.value("explicit") == "staged"
+assert explicit_settings.value("default") == "staged"
+session.abort()
+"""
+        )
+
+    def test_process_guard_rejects_repeated_activation(self):
+        self.run_in_subprocess(
+            """
+first_session = QSettingsStagingSessionManager(eligibility).prepare()
+first_session.activate()
+try:
+    first_session.activate()
+except StagingActivationError:
+    pass
+else:
+    raise AssertionError("the same session activated twice")
+
+first_session.abort()
+second_session = QSettingsStagingSessionManager(eligibility).prepare()
+try:
+    second_session.activate()
+except StagingActivationError:
+    pass
+else:
+    raise AssertionError("a second session replaced the process path")
+second_session.abort()
+"""
+        )
+
+    def test_released_session_is_rejected_without_consuming_guard(self):
+        self.run_in_subprocess(
+            """
+released_session = QSettingsStagingSessionManager(eligibility).prepare()
+released_session.abort()
+try:
+    released_session.activate()
+except StagingActivationError:
+    pass
+else:
+    raise AssertionError("a released session activated")
+
+active_session = QSettingsStagingSessionManager(eligibility).prepare()
+active_session.activate()
+assert active_session.active
+active_session.abort()
+"""
+        )
+
+    def test_failed_qt_call_does_not_activate_session_or_consume_guard(self):
+        self.run_in_subprocess(
+            """
+from qtpy import QtCore
+
+real_qsettings = QtCore.QSettings
+
+class FailingQSettings:
+    IniFormat = real_qsettings.IniFormat
+    UserScope = real_qsettings.UserScope
+
+    @staticmethod
+    def setPath(_format, _scope, _path):
+        raise RuntimeError("injected setPath failure")
+
+session = QSettingsStagingSessionManager(eligibility).prepare()
+QtCore.QSettings = FailingQSettings
+try:
+    session.activate()
+except RuntimeError as error:
+    assert str(error) == "injected setPath failure"
+else:
+    raise AssertionError("the injected setPath failure was ignored")
+assert not session.active
+
+QtCore.QSettings = real_qsettings
+session.activate()
+assert session.active
+session.abort()
+"""
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
@@ -87,16 +87,14 @@ assert native_settings.value("seeded") == "canonical-native"
 
 libc = ctypes.CDLL(None, use_errno=True)
 inotify_descriptor = libc.inotify_init1(os.O_NONBLOCK | os.O_CLOEXEC)
-assert inotify_descriptor >= 0
 IN_ALL_EVENTS = 0x00000FFF
-staged_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(expected_file.parent), IN_ALL_EVENTS)
-staged_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(session.staging_root), IN_ALL_EVENTS)
-canonical_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(canonical_directory), IN_ALL_EVENTS)
-canonical_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(config_root), IN_ALL_EVENTS)
-assert staged_watch >= 0
-assert staged_root_watch >= 0
-assert canonical_watch >= 0
-assert canonical_root_watch >= 0
+watching = inotify_descriptor >= 0
+if watching:
+    staged_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(expected_file.parent), IN_ALL_EVENTS)
+    staged_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(session.staging_root), IN_ALL_EVENTS)
+    canonical_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(canonical_directory), IN_ALL_EVENTS)
+    canonical_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(config_root), IN_ALL_EVENTS)
+    watching = min(staged_watch, staged_root_watch, canonical_watch, canonical_root_watch) >= 0
 
 explicit_settings.setValue("explicit", "staged")
 explicit_settings.sync()
@@ -112,22 +110,22 @@ native_settings.setValue("native", "staged")
 native_settings.sync()
 assert native_settings.status() == QSettings.NoError
 
-events = os.read(inotify_descriptor, 65536)
-os.close(inotify_descriptor)
-event_header = struct.Struct("iIII")
-names_by_watch = {}
-offset = 0
-while offset < len(events):
-    watch, _mask, _cookie, name_length = event_header.unpack_from(events, offset)
-    offset += event_header.size
-    name = events[offset : offset + name_length].split(b"\\0", 1)[0].decode()
-    offset += name_length
-    names_by_watch.setdefault(watch, []).append(name)
+if watching:
+    events = os.read(inotify_descriptor, 65536)
+    event_header = struct.Struct("iIII")
+    names_by_watch = {}
+    offset = 0
+    while offset < len(events):
+        watch, _mask, _cookie, name_length = event_header.unpack_from(events, offset)
+        offset += event_header.size
+        name = events[offset : offset + name_length].split(b"\\0", 1)[0].decode()
+        offset += name_length
+        names_by_watch.setdefault(watch, []).append(name)
 
-assert "mantidworkbench.ini.lock" in names_by_watch.get(staged_watch, []), names_by_watch
-assert "QtProject.conf.lock" in names_by_watch.get(staged_root_watch, []), names_by_watch
-assert names_by_watch.get(canonical_watch, []) == [], names_by_watch
-assert names_by_watch.get(canonical_root_watch, []) == [], names_by_watch
+    assert "mantidworkbench.ini.lock" in names_by_watch.get(staged_watch, []), names_by_watch
+    assert "QtProject.conf.lock" in names_by_watch.get(staged_root_watch, []), names_by_watch
+    assert names_by_watch.get(canonical_watch, []) == [], names_by_watch
+    assert names_by_watch.get(canonical_root_watch, []) == [], names_by_watch
 assert canonical_file.read_bytes() == canonical_contents
 assert canonical_native_file.read_bytes() == canonical_native_contents
 assert sorted(path.name for path in canonical_directory.iterdir()) == ["mantidworkbench.ini"]

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
@@ -62,6 +62,9 @@ canonical_directory.mkdir()
 canonical_file = canonical_directory / "mantidworkbench.ini"
 canonical_contents = b"[General]\\nseeded=canonical\\n"
 canonical_file.write_bytes(canonical_contents)
+canonical_native_file = config_root / "QtProject.conf"
+canonical_native_contents = b"[General]\\nseeded=canonical-native\\n"
+canonical_native_file.write_bytes(canonical_native_contents)
 
 session = QSettingsStagingSessionManager(eligibility).prepare()
 assert not session.active
@@ -72,19 +75,28 @@ QSettings.setDefaultFormat(QSettings.IniFormat)
 QCoreApplication.setOrganizationName("mantidproject")
 QCoreApplication.setApplicationName("mantidworkbench")
 expected_file = session.staging_root / "mantidproject/mantidworkbench.ini"
+expected_native_file = session.staging_root / "QtProject.conf"
 
 explicit_settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "mantidproject", "mantidworkbench")
 assert Path(explicit_settings.fileName()) == expected_file
 assert explicit_settings.value("seeded") == "canonical"
+
+native_settings = QSettings(QSettings.NativeFormat, QSettings.UserScope, "QtProject", "")
+assert Path(native_settings.fileName()) == expected_native_file
+assert native_settings.value("seeded") == "canonical-native"
 
 libc = ctypes.CDLL(None, use_errno=True)
 inotify_descriptor = libc.inotify_init1(os.O_NONBLOCK | os.O_CLOEXEC)
 assert inotify_descriptor >= 0
 IN_ALL_EVENTS = 0x00000FFF
 staged_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(expected_file.parent), IN_ALL_EVENTS)
+staged_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(session.staging_root), IN_ALL_EVENTS)
 canonical_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(canonical_directory), IN_ALL_EVENTS)
+canonical_root_watch = libc.inotify_add_watch(inotify_descriptor, os.fsencode(config_root), IN_ALL_EVENTS)
 assert staged_watch >= 0
+assert staged_root_watch >= 0
 assert canonical_watch >= 0
+assert canonical_root_watch >= 0
 
 explicit_settings.setValue("explicit", "staged")
 explicit_settings.sync()
@@ -95,6 +107,10 @@ assert Path(default_settings.fileName()) == expected_file
 default_settings.setValue("default", "staged")
 default_settings.sync()
 assert default_settings.status() == QSettings.NoError
+
+native_settings.setValue("native", "staged")
+native_settings.sync()
+assert native_settings.status() == QSettings.NoError
 
 events = os.read(inotify_descriptor, 65536)
 os.close(inotify_descriptor)
@@ -109,8 +125,11 @@ while offset < len(events):
     names_by_watch.setdefault(watch, []).append(name)
 
 assert "mantidworkbench.ini.lock" in names_by_watch.get(staged_watch, []), names_by_watch
+assert "QtProject.conf.lock" in names_by_watch.get(staged_root_watch, []), names_by_watch
 assert names_by_watch.get(canonical_watch, []) == [], names_by_watch
+assert names_by_watch.get(canonical_root_watch, []) == [], names_by_watch
 assert canonical_file.read_bytes() == canonical_contents
+assert canonical_native_file.read_bytes() == canonical_native_contents
 assert sorted(path.name for path in canonical_directory.iterdir()) == ["mantidworkbench.ini"]
 assert explicit_settings.value("explicit") == "staged"
 assert explicit_settings.value("default") == "staged"
@@ -170,6 +189,7 @@ real_qsettings = QtCore.QSettings
 
 class FailingQSettings:
     IniFormat = real_qsettings.IniFormat
+    NativeFormat = real_qsettings.NativeFormat
     UserScope = real_qsettings.UserScope
 
     @staticmethod

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_activation.py
@@ -3,7 +3,7 @@
 # Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-# SPDX - License - Identifier: GPL - 3.0 +
+# SPDX-License-Identifier: GPL-3.0+
 #  This file is part of the mantid workbench.
 
 import subprocess

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -120,6 +120,28 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertEqual(b"native changed", native_file.read_bytes())
         self.assertFalse((self.config_root / "QtProject.conf.lock").exists())
 
+    def test_concurrent_sessions_conflict_for_workbench_and_qt_project_files(self):
+        native_file = self.config_root / "QtProject.conf"
+        native_file.write_bytes(b"native original")
+        first = self.prepare()
+        second = QSettingsStagingSessionManager(self.eligibility, lock_factory=self.lock_factory).prepare()
+
+        (first.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"first workbench")
+        (first.staging_root / "QtProject.conf").write_bytes(b"first native")
+        (second.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"second workbench")
+        (second.staging_root / "QtProject.conf").write_bytes(b"second native")
+
+        first_finalization = first.finalize()
+        second_finalization = second.finalize()
+
+        self.assertTrue(first_finalization.successful)
+        self.assertEqual(b"first workbench", self.canonical_file.read_bytes())
+        self.assertEqual(b"first native", native_file.read_bytes())
+        self.assertFalse(second_finalization.successful)
+        self.assertEqual(CopyBackStatus.CONFLICT, self.result_for(second_finalization).status)
+        self.assertEqual(CopyBackStatus.CONFLICT, self.result_for(second_finalization, "QtProject.conf").status)
+        self.assertFalse((second.staging_root / COMPLETED_FILENAME).exists())
+
     def test_currently_identical_files_are_not_opened_for_update(self):
         session = self.prepare()
         staged_file = session.staging_root / "mantidproject/mantidworkbench.ini"

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -148,6 +148,20 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertEqual(b"reduction settings", copied.read_bytes())
         self.assertEqual(0o600, copied.stat().st_mode & 0o777)
 
+    def test_unexpected_settings_organization_fails_finalization_and_retains_session(self):
+        session = self.prepare()
+        unexpected = session.staging_root / "Other Organization/settings.ini"
+        unexpected.parent.mkdir()
+        unexpected.write_text("[General]\nvalue=unexpected\n")
+
+        finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertIn("outside mantidproject", finalization.error)
+        self.assertTrue(unexpected.exists())
+        self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+        self.assertTrue(self.coordinators[0].unlocked)
+
     def test_error_reporter_settings_are_never_seeded_or_copied_back(self):
         self.canonical_directory.mkdir()
         reporter_file = self.canonical_directory / "mantid-error-reporter.ini"

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -148,6 +148,23 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertEqual(b"reduction settings", copied.read_bytes())
         self.assertEqual(0o600, copied.stat().st_mode & 0o777)
 
+    def test_error_reporter_settings_are_never_seeded_or_copied_back(self):
+        self.canonical_directory.mkdir()
+        reporter_file = self.canonical_directory / "mantid-error-reporter.ini"
+        reporter_file.write_bytes(b"canonical reporter settings")
+        session = self.prepare()
+        staged_reporter_file = session.staging_root / "mantidproject/mantid-error-reporter.ini"
+        self.assertFalse(staged_reporter_file.exists())
+
+        staged_reporter_file.write_bytes(b"transient staged reporter settings")
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed workbench settings")
+        finalization = session.finalize()
+
+        self.assertTrue(finalization.successful)
+        self.assertEqual(b"canonical reporter settings", reporter_file.read_bytes())
+        self.assertEqual(b"changed workbench settings", self.canonical_file.read_bytes())
+        self.assertNotIn(Path("mantidproject/mantid-error-reporter.ini"), {result.relative_path for result in finalization.files})
+
     def test_missing_seeded_file_fails_without_deleting_canonical_file(self):
         session = self.prepare()
         (session.staging_root / "mantidproject/mantidworkbench.ini").unlink()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -106,6 +106,20 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertEqual(["mantidworkbench.ini"], sorted(path.name for path in self.canonical_directory.iterdir()))
         self.assertTrue(self.coordinators[0].unlocked)
 
+    def test_changed_qt_project_native_settings_are_copied_back(self):
+        native_file = self.config_root / "QtProject.conf"
+        native_file.write_bytes(b"native original")
+        session = self.prepare()
+        (session.staging_root / "QtProject.conf").write_bytes(b"native changed")
+        (session.staging_root / "QtProject.conf.lock").write_bytes(b"local lock artifact")
+
+        finalization = session.finalize()
+
+        self.assertTrue(finalization.successful)
+        self.assertEqual(CopyBackStatus.COPIED, self.result_for(finalization, "QtProject.conf").status)
+        self.assertEqual(b"native changed", native_file.read_bytes())
+        self.assertFalse((self.config_root / "QtProject.conf.lock").exists())
+
     def test_currently_identical_files_are_not_opened_for_update(self):
         session = self.prepare()
         staged_file = session.staging_root / "mantidproject/mantidworkbench.ini"

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -92,7 +92,7 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertTrue((session.staging_root / COMPLETED_FILENAME).is_file())
         self.assertTrue(self.coordinators[0].unlocked)
 
-    def test_changed_file_is_overwritten_directly_and_preserves_mode_and_inode(self):
+    def test_changed_file_is_atomically_replaced_and_preserves_mode(self):
         session = self.prepare()
         self.canonical_file.chmod(0o640)
         original_inode = self.canonical_file.stat().st_ino
@@ -104,7 +104,7 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertTrue(finalization.successful)
         self.assertEqual(CopyBackStatus.COPIED, self.result_for(finalization).status)
         self.assertEqual(b"changed", self.canonical_file.read_bytes())
-        self.assertEqual(original_inode, self.canonical_file.stat().st_ino)
+        self.assertNotEqual(original_inode, self.canonical_file.stat().st_ino)
         self.assertEqual(0o640, self.canonical_file.stat().st_mode & 0o777)
         self.assertEqual(["mantidworkbench.ini"], sorted(path.name for path in self.canonical_directory.iterdir()))
         self.assertTrue(self.coordinators[0].unlocked)
@@ -325,24 +325,38 @@ class QSettingsStagingCopyBackTest(unittest.TestCase):
         self.assertIn("fsync failed", self.result_for(finalization).error)
         self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
 
-    def test_close_error_is_reported_and_retains_session(self):
+    def test_replace_error_is_reported_and_removes_temporary_file(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+
+        with patch.object(os, "replace", side_effect=OSError("replace failed")):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertIn("replace failed", self.result_for(finalization).error)
+        self.assertEqual(b"original", self.canonical_file.read_bytes())
+        self.assertEqual(["mantidworkbench.ini"], sorted(path.name for path in self.canonical_directory.iterdir()))
+
+    def test_temporary_file_close_error_is_reported_and_retains_session(self):
         session = self.prepare()
         (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
         real_close = os.close
 
-        def fail_canonical_close(descriptor):
+        def fail_temporary_close(descriptor):
             descriptor_path = Path(f"/proc/self/fd/{descriptor}").resolve()
             real_close(descriptor)
-            if descriptor_path == self.canonical_file:
+            if descriptor_path.parent == self.canonical_directory and descriptor_path.name.startswith(f".{self.canonical_file.name}."):
                 raise OSError("close failed")
 
-        with patch.object(os, "close", side_effect=fail_canonical_close):
+        with patch.object(os, "close", side_effect=fail_temporary_close):
             finalization = session.finalize()
 
         self.assertFalse(finalization.successful)
         self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
         self.assertIn("close failed", self.result_for(finalization).error)
         self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+        self.assertEqual(["mantidworkbench.ini"], sorted(path.name for path in self.canonical_directory.iterdir()))
 
     def test_canonical_parent_symlink_is_rejected(self):
         session = self.prepare(canonical_contents=None)

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -1,0 +1,302 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+import errno
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
+from mantidqt.utils.qt.qsettings_staging_session import (
+    COMPLETED_FILENAME,
+    CopyBackFileResult,
+    CopyBackStatus,
+    QSettingsStagingSessionManager,
+    StagingFinalizationError,
+)
+import mantidqt.utils.qt.qsettings_staging_session as staging_module
+
+
+class FakeCoordinator:
+    def __init__(self, _path: Path):
+        self.unlocked = False
+
+    def tryLock(self, _timeout: int = 0) -> bool:
+        return True
+
+    def unlock(self) -> None:
+        self.unlocked = True
+
+
+class QSettingsStagingCopyBackTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.config_root = self.root / "config"
+        self.cache_root = self.root / "cache"
+        self.config_root.mkdir()
+        self.cache_root.mkdir()
+        self.canonical_directory = self.config_root / "mantidproject"
+        self.canonical_file = self.canonical_directory / "mantidworkbench.ini"
+        self.eligibility = QSettingsStagingEligibility(
+            True,
+            QSettingsStagingReason.ELIGIBLE,
+            config_root=self.config_root,
+            cache_root=self.cache_root,
+            config_filesystem="nfs4",
+            cache_filesystem="ext4",
+        )
+        self.coordinators = []
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def lock_factory(self, path: Path) -> FakeCoordinator:
+        coordinator = FakeCoordinator(path)
+        self.coordinators.append(coordinator)
+        return coordinator
+
+    def prepare(self, canonical_contents: bytes | None = b"original"):
+        if canonical_contents is not None:
+            self.canonical_directory.mkdir(exist_ok=True)
+            self.canonical_file.write_bytes(canonical_contents)
+        return QSettingsStagingSessionManager(self.eligibility, lock_factory=self.lock_factory).prepare()
+
+    def result_for(self, finalization, relative_path="mantidproject/mantidworkbench.ini"):
+        return next(result for result in finalization.files if result.relative_path == Path(relative_path))
+
+    def test_unchanged_file_is_not_opened_for_update(self):
+        session = self.prepare()
+        original_stat = self.canonical_file.stat()
+
+        with patch(
+            "mantidqt.utils.qt.qsettings_staging_session._copy_changed_file",
+            side_effect=AssertionError("unchanged file must not be copied"),
+        ):
+            finalization = session.finalize()
+
+        self.assertTrue(finalization.successful)
+        self.assertEqual(CopyBackStatus.UNCHANGED, self.result_for(finalization).status)
+        self.assertEqual(original_stat.st_ino, self.canonical_file.stat().st_ino)
+        self.assertEqual(original_stat.st_mtime_ns, self.canonical_file.stat().st_mtime_ns)
+        self.assertTrue((session.staging_root / COMPLETED_FILENAME).is_file())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_changed_file_is_overwritten_directly_and_preserves_mode_and_inode(self):
+        session = self.prepare()
+        self.canonical_file.chmod(0o640)
+        original_inode = self.canonical_file.stat().st_ino
+        staged_file = session.staging_root / "mantidproject/mantidworkbench.ini"
+        staged_file.write_bytes(b"changed")
+
+        finalization = session.finalize()
+
+        self.assertTrue(finalization.successful)
+        self.assertEqual(CopyBackStatus.COPIED, self.result_for(finalization).status)
+        self.assertEqual(b"changed", self.canonical_file.read_bytes())
+        self.assertEqual(original_inode, self.canonical_file.stat().st_ino)
+        self.assertEqual(0o640, self.canonical_file.stat().st_mode & 0o777)
+        self.assertEqual(["mantidworkbench.ini"], sorted(path.name for path in self.canonical_directory.iterdir()))
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_currently_identical_files_are_not_opened_for_update(self):
+        session = self.prepare()
+        staged_file = session.staging_root / "mantidproject/mantidworkbench.ini"
+        staged_file.write_bytes(b"converged")
+        self.canonical_file.write_bytes(b"converged")
+        converged_stat = self.canonical_file.stat()
+
+        with patch.object(os, "ftruncate", side_effect=AssertionError("identical file must not be truncated")):
+            finalization = session.finalize()
+
+        self.assertTrue(finalization.successful)
+        self.assertEqual(CopyBackStatus.ALREADY_SYNCHRONIZED, self.result_for(finalization).status)
+        self.assertEqual(converged_stat.st_ino, self.canonical_file.stat().st_ino)
+        self.assertEqual(converged_stat.st_mtime_ns, self.canonical_file.stat().st_mtime_ns)
+
+    def test_external_change_is_a_conflict(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"staged change")
+        self.canonical_file.write_bytes(b"external change")
+
+        finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.CONFLICT, self.result_for(finalization).status)
+        self.assertEqual(b"external change", self.canonical_file.read_bytes())
+        self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_new_nested_settings_file_is_created_privately(self):
+        session = self.prepare(canonical_contents=None)
+        staged_file = session.staging_root / "mantidproject/nested/Mantid Reduction.ini"
+        staged_file.parent.mkdir()
+        staged_file.write_bytes(b"reduction settings")
+
+        finalization = session.finalize()
+
+        copied = self.config_root / "mantidproject/nested/Mantid Reduction.ini"
+        self.assertTrue(finalization.successful)
+        self.assertEqual(CopyBackStatus.COPIED, self.result_for(finalization, "mantidproject/nested/Mantid Reduction.ini").status)
+        self.assertEqual(b"reduction settings", copied.read_bytes())
+        self.assertEqual(0o600, copied.stat().st_mode & 0o777)
+
+    def test_missing_seeded_file_fails_without_deleting_canonical_file(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").unlink()
+
+        finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertEqual(b"original", self.canonical_file.read_bytes())
+
+    def test_staged_symlink_fails_without_following_it(self):
+        session = self.prepare()
+        outside = self.root / "outside"
+        outside.write_bytes(b"outside")
+        (session.staging_root / "mantidproject/linked.ini").symlink_to(outside)
+
+        finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertIn("symlink", finalization.error)
+        self.assertEqual(b"outside", outside.read_bytes())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_short_write_is_reported_and_retains_session(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+        real_write = os.write
+        writes = 0
+
+        def short_write(descriptor, contents):
+            nonlocal writes
+            writes += 1
+            if writes == 1:
+                return real_write(descriptor, contents[:1])
+            return 0
+
+        with patch.object(os, "write", side_effect=short_write):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertTrue((session.staging_root / "mantidproject/mantidworkbench.ini").exists())
+        self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_full_disk_write_error_is_reported(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+
+        with patch.object(os, "write", side_effect=OSError(errno.ENOSPC, "disk full")):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertIn("disk full", self.result_for(finalization).error)
+
+    def test_partial_multi_file_finalization_reports_each_outcome(self):
+        self.canonical_directory.mkdir()
+        first_canonical = self.canonical_directory / "first.ini"
+        second_canonical = self.canonical_directory / "second.ini"
+        first_canonical.write_bytes(b"first original")
+        second_canonical.write_bytes(b"second original")
+        session = self.prepare(canonical_contents=None)
+        (session.staging_root / "mantidproject/first.ini").write_bytes(b"first changed")
+        (session.staging_root / "mantidproject/second.ini").write_bytes(b"second changed")
+        real_copy = staging_module._copy_changed_file
+
+        def fail_second(canonical_root, canonical_path, staged_path, relative_path, baseline_hash):
+            if relative_path.name == "second.ini":
+                return CopyBackFileResult(relative_path, CopyBackStatus.FAILED, "injected failure")
+            return real_copy(canonical_root, canonical_path, staged_path, relative_path, baseline_hash)
+
+        with patch.object(staging_module, "_copy_changed_file", side_effect=fail_second):
+            finalization = session.finalize()
+
+        statuses = {result.relative_path.name: result.status for result in finalization.files}
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.COPIED, statuses["first.ini"])
+        self.assertEqual(CopyBackStatus.FAILED, statuses["second.ini"])
+        self.assertEqual(b"first changed", first_canonical.read_bytes())
+        self.assertEqual(b"second original", second_canonical.read_bytes())
+
+    def test_completion_marker_failure_retains_successfully_copied_session(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+
+        with patch.object(staging_module, "_write_completion_marker", side_effect=OSError("marker failure")):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual("cannot mark staging session complete: marker failure", finalization.error)
+        self.assertEqual(CopyBackStatus.COPIED, self.result_for(finalization).status)
+        self.assertTrue(session.staging_root.exists())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_fsync_error_is_reported_and_retains_session(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+
+        with patch.object(os, "fsync", side_effect=OSError("fsync failed")):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertIn("fsync failed", self.result_for(finalization).error)
+        self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+
+    def test_close_error_is_reported_and_retains_session(self):
+        session = self.prepare()
+        (session.staging_root / "mantidproject/mantidworkbench.ini").write_bytes(b"changed")
+        real_close = os.close
+
+        def fail_canonical_close(descriptor):
+            descriptor_path = Path(f"/proc/self/fd/{descriptor}").resolve()
+            real_close(descriptor)
+            if descriptor_path == self.canonical_file:
+                raise OSError("close failed")
+
+        with patch.object(os, "close", side_effect=fail_canonical_close):
+            finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization).status)
+        self.assertIn("close failed", self.result_for(finalization).error)
+        self.assertFalse((session.staging_root / COMPLETED_FILENAME).exists())
+
+    def test_canonical_parent_symlink_is_rejected(self):
+        session = self.prepare(canonical_contents=None)
+        staged_file = session.staging_root / "mantidproject/nested/new.ini"
+        staged_file.parent.mkdir()
+        staged_file.write_bytes(b"new settings")
+        outside = self.root / "outside-directory"
+        outside.mkdir()
+        self.canonical_directory.mkdir()
+        (self.canonical_directory / "nested").symlink_to(outside, target_is_directory=True)
+
+        finalization = session.finalize()
+
+        self.assertFalse(finalization.successful)
+        self.assertEqual(CopyBackStatus.FAILED, self.result_for(finalization, "mantidproject/nested/new.ini").status)
+        self.assertEqual([], list(outside.iterdir()))
+
+    def test_released_session_cannot_be_finalized(self):
+        session = self.prepare()
+        session.abort()
+
+        with self.assertRaises(StagingFinalizationError):
+            session.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -3,7 +3,7 @@
 # Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-# SPDX - License - Identifier: GPL - 3.0 +
+# SPDX-License-Identifier: GPL-3.0+
 #  This file is part of the mantid workbench.
 
 import errno

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -13,8 +13,6 @@ import tempfile
 import sys
 import unittest
 
-if not sys.platform.startswith("linux"):
-    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
@@ -39,6 +37,7 @@ class FakeCoordinator:
         self.unlocked = True
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class QSettingsStagingCopyBackTest(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = tempfile.TemporaryDirectory()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_copyback.py
@@ -10,7 +10,11 @@ import errno
 import os
 from pathlib import Path
 import tempfile
+import sys
 import unittest
+
+if not sys.platform.startswith("linux"):
+    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -95,6 +95,8 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         reporter_settings.write_bytes(b"[ContactInfo]\nName=Reporter\n")
         secondary = nested_root / "Mantid Reduction.ini"
         secondary.write_bytes(b"[Reduction]\nfacility=SNS\n")
+        native_settings = self.config_root / "QtProject.conf"
+        native_settings.write_bytes(b"[General]\nstyle=system\n")
         for artifact in ("mantidworkbench.ini.lock", "old.rmlock", "write.tmp", ".nfs123"):
             (organization_root / artifact).write_text("ignored", encoding="utf-8")
 
@@ -104,6 +106,7 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         staged_secondary = session.staging_root / "mantidproject/nested/Mantid Reduction.ini"
         self.assertEqual(settings.read_bytes(), staged_settings.read_bytes())
         self.assertEqual(secondary.read_bytes(), staged_secondary.read_bytes())
+        self.assertEqual(native_settings.read_bytes(), (session.staging_root / "QtProject.conf").read_bytes())
         self.assertEqual(0o600, staged_settings.stat().st_mode & 0o777)
         self.assertFalse((session.staging_root / "mantidproject/mantidworkbench.ini.lock").exists())
         self.assertFalse((session.staging_root / "mantidproject/mantid-error-reporter.ini").exists())
@@ -116,7 +119,7 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         self.assertEqual(entry.canonical_relative_path, entry.staged_relative_path)
         manifest = json.loads((session.staging_root / MANIFEST_FILENAME).read_text(encoding="utf-8"))
         self.assertNotIn("value=unchanged", json.dumps(manifest))
-        self.assertEqual(2, len(manifest["files"]))
+        self.assertEqual(3, len(manifest["files"]))
         session.abort()
 
     def test_does_not_record_error_reporter_when_supplied_as_an_expected_path(self):
@@ -128,7 +131,7 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
     def test_records_expected_file_as_absent_without_creating_it(self):
         session = self.manager().prepare()
 
-        entry = session.manifest[0]
+        entry = next(entry for entry in session.manifest if entry.canonical_relative_path == Path("mantidproject/mantidworkbench.ini"))
         self.assertEqual(Path("mantidproject/mantidworkbench.ini"), entry.canonical_relative_path)
         self.assertIsNone(entry.canonical_sha256)
         self.assertIsNone(entry.canonical_mode)

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -70,13 +70,13 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
             **kwargs,
         )
 
-    def test_prepares_private_unique_session_and_holds_coordinator(self):
+    def test_prepares_private_unique_session_and_releases_coordinator(self):
         session = self.manager().prepare()
 
         self.assertEqual(0o700, session.staging_root.stat().st_mode & 0o777)
         self.assertEqual(0o700, (self.cache_root / MANAGER_RELATIVE_PATH).stat().st_mode & 0o777)
         self.assertEqual(self.cache_root / MANAGER_RELATIVE_PATH / "coordinator.lock", self.coordinators[0].path)
-        self.assertFalse(self.coordinators[0].unlocked)
+        self.assertTrue(self.coordinators[0].unlocked)
         self.assertTrue((session.staging_root / "mantidproject").is_dir())
 
         other_session = self.manager().prepare()
@@ -148,15 +148,13 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         self.assertEqual([], list(manager_root.glob("session-*")))
         self.assertFalse(self.coordinators[0].unlocked)
 
-    def test_real_qlockfile_coordinator_prevents_a_second_owner(self):
+    def test_real_qlockfile_coordinator_allows_concurrent_sessions(self):
         first_session = QSettingsStagingSessionManager(self.eligibility).prepare()
+        second_session = QSettingsStagingSessionManager(self.eligibility).prepare()
 
-        with self.assertRaises(CoordinatorUnavailable):
-            QSettingsStagingSessionManager(self.eligibility).prepare()
-
+        self.assertNotEqual(first_session.staging_root, second_session.staging_root)
         first_session.abort()
-        next_session = QSettingsStagingSessionManager(self.eligibility).prepare()
-        next_session.abort()
+        second_session.abort()
 
     def test_completed_session_is_cleaned_but_incomplete_and_unrelated_paths_are_retained(self):
         manager_root = self.cache_root / MANAGER_RELATIVE_PATH

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -3,7 +3,7 @@
 # Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
-# SPDX - License - Identifier: GPL - 3.0 +
+# SPDX-License-Identifier: GPL-3.0+
 #  This file is part of the mantid workbench.
 
 import hashlib

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -10,7 +10,11 @@ import hashlib
 import json
 from pathlib import Path
 import tempfile
+import sys
 import unittest
+
+if not sys.platform.startswith("linux"):
+    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -91,6 +91,8 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         settings = organization_root / "mantidworkbench.ini"
         settings.write_bytes(b"[General]\nvalue=unchanged\n")
         settings.chmod(0o640)
+        reporter_settings = organization_root / "mantid-error-reporter.ini"
+        reporter_settings.write_bytes(b"[ContactInfo]\nName=Reporter\n")
         secondary = nested_root / "Mantid Reduction.ini"
         secondary.write_bytes(b"[Reduction]\nfacility=SNS\n")
         for artifact in ("mantidworkbench.ini.lock", "old.rmlock", "write.tmp", ".nfs123"):
@@ -104,8 +106,10 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         self.assertEqual(secondary.read_bytes(), staged_secondary.read_bytes())
         self.assertEqual(0o600, staged_settings.stat().st_mode & 0o777)
         self.assertFalse((session.staging_root / "mantidproject/mantidworkbench.ini.lock").exists())
+        self.assertFalse((session.staging_root / "mantidproject/mantid-error-reporter.ini").exists())
 
         entries = {entry.canonical_relative_path: entry for entry in session.manifest}
+        self.assertNotIn(Path("mantidproject/mantid-error-reporter.ini"), entries)
         entry = entries[Path("mantidproject/mantidworkbench.ini")]
         self.assertEqual(hashlib.sha256(settings.read_bytes()).hexdigest(), entry.canonical_sha256)
         self.assertEqual(0o640, entry.canonical_mode)
@@ -113,6 +117,12 @@ class QSettingsStagingSessionManagerTest(unittest.TestCase):
         manifest = json.loads((session.staging_root / MANIFEST_FILENAME).read_text(encoding="utf-8"))
         self.assertNotIn("value=unchanged", json.dumps(manifest))
         self.assertEqual(2, len(manifest["files"]))
+        session.abort()
+
+    def test_does_not_record_error_reporter_when_supplied_as_an_expected_path(self):
+        session = self.manager(expected_settings_paths=(Path("mantidproject/mantid-error-reporter.ini"),)).prepare()
+
+        self.assertEqual((), session.manifest)
         session.abort()
 
     def test_records_expected_file_as_absent_without_creating_it(self):

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -1,0 +1,272 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
+from mantidqt.utils.qt.qsettings_staging_session import (
+    COMPLETED_FILENAME,
+    MANAGER_RELATIVE_PATH,
+    MANIFEST_FILENAME,
+    CoordinatorUnavailable,
+    QSettingsStagingSessionManager,
+    StagingPreparationError,
+)
+
+
+class FakeCoordinator:
+    def __init__(self, path: Path, acquired: bool = True):
+        self.path = path
+        self.acquired = acquired
+        self.unlocked = False
+
+    def tryLock(self, timeout: int = 0) -> bool:
+        return self.acquired
+
+    def unlock(self) -> None:
+        self.unlocked = True
+
+
+class QSettingsStagingSessionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.config_root = self.root / "config"
+        self.cache_root = self.root / "cache"
+        self.config_root.mkdir()
+        self.cache_root.mkdir()
+        self.eligibility = QSettingsStagingEligibility(
+            True,
+            QSettingsStagingReason.ELIGIBLE,
+            config_root=self.config_root,
+            cache_root=self.cache_root,
+            config_filesystem="nfs4",
+            cache_filesystem="ext4",
+        )
+        self.coordinators = []
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def make_coordinator(self, path: Path, acquired: bool = True) -> FakeCoordinator:
+        coordinator = FakeCoordinator(path, acquired)
+        self.coordinators.append(coordinator)
+        return coordinator
+
+    def manager(self, **kwargs) -> QSettingsStagingSessionManager:
+        return QSettingsStagingSessionManager(
+            self.eligibility,
+            lock_factory=kwargs.pop("lock_factory", self.make_coordinator),
+            **kwargs,
+        )
+
+    def test_prepares_private_unique_session_and_holds_coordinator(self):
+        session = self.manager().prepare()
+
+        self.assertEqual(0o700, session.staging_root.stat().st_mode & 0o777)
+        self.assertEqual(0o700, (self.cache_root / MANAGER_RELATIVE_PATH).stat().st_mode & 0o777)
+        self.assertEqual(self.cache_root / MANAGER_RELATIVE_PATH / "coordinator.lock", self.coordinators[0].path)
+        self.assertFalse(self.coordinators[0].unlocked)
+        self.assertTrue((session.staging_root / "mantidproject").is_dir())
+
+        other_session = self.manager().prepare()
+        self.assertNotEqual(session.staging_root, other_session.staging_root)
+        session.abort()
+        other_session.abort()
+
+    def test_seeds_subtree_excludes_artifacts_and_records_hash_and_mode(self):
+        organization_root = self.config_root / "mantidproject"
+        nested_root = organization_root / "nested"
+        nested_root.mkdir(parents=True)
+        settings = organization_root / "mantidworkbench.ini"
+        settings.write_bytes(b"[General]\nvalue=unchanged\n")
+        settings.chmod(0o640)
+        secondary = nested_root / "Mantid Reduction.ini"
+        secondary.write_bytes(b"[Reduction]\nfacility=SNS\n")
+        for artifact in ("mantidworkbench.ini.lock", "old.rmlock", "write.tmp", ".nfs123"):
+            (organization_root / artifact).write_text("ignored", encoding="utf-8")
+
+        session = self.manager().prepare()
+
+        staged_settings = session.staging_root / "mantidproject/mantidworkbench.ini"
+        staged_secondary = session.staging_root / "mantidproject/nested/Mantid Reduction.ini"
+        self.assertEqual(settings.read_bytes(), staged_settings.read_bytes())
+        self.assertEqual(secondary.read_bytes(), staged_secondary.read_bytes())
+        self.assertEqual(0o600, staged_settings.stat().st_mode & 0o777)
+        self.assertFalse((session.staging_root / "mantidproject/mantidworkbench.ini.lock").exists())
+
+        entries = {entry.canonical_relative_path: entry for entry in session.manifest}
+        entry = entries[Path("mantidproject/mantidworkbench.ini")]
+        self.assertEqual(hashlib.sha256(settings.read_bytes()).hexdigest(), entry.canonical_sha256)
+        self.assertEqual(0o640, entry.canonical_mode)
+        self.assertEqual(entry.canonical_relative_path, entry.staged_relative_path)
+        manifest = json.loads((session.staging_root / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+        self.assertNotIn("value=unchanged", json.dumps(manifest))
+        self.assertEqual(2, len(manifest["files"]))
+        session.abort()
+
+    def test_records_expected_file_as_absent_without_creating_it(self):
+        session = self.manager().prepare()
+
+        entry = session.manifest[0]
+        self.assertEqual(Path("mantidproject/mantidworkbench.ini"), entry.canonical_relative_path)
+        self.assertIsNone(entry.canonical_sha256)
+        self.assertIsNone(entry.canonical_mode)
+        self.assertFalse((session.staging_root / entry.staged_relative_path).exists())
+        session.abort()
+
+    def test_coordinator_contention_creates_no_session(self):
+        manager = self.manager(lock_factory=lambda path: self.make_coordinator(path, acquired=False))
+
+        with self.assertRaises(CoordinatorUnavailable):
+            manager.prepare()
+
+        manager_root = self.cache_root / MANAGER_RELATIVE_PATH
+        self.assertEqual([], list(manager_root.glob("session-*")))
+        self.assertFalse(self.coordinators[0].unlocked)
+
+    def test_real_qlockfile_coordinator_prevents_a_second_owner(self):
+        first_session = QSettingsStagingSessionManager(self.eligibility).prepare()
+
+        with self.assertRaises(CoordinatorUnavailable):
+            QSettingsStagingSessionManager(self.eligibility).prepare()
+
+        first_session.abort()
+        next_session = QSettingsStagingSessionManager(self.eligibility).prepare()
+        next_session.abort()
+
+    def test_completed_session_is_cleaned_but_incomplete_and_unrelated_paths_are_retained(self):
+        manager_root = self.cache_root / MANAGER_RELATIVE_PATH
+        completed = manager_root / "session-completed"
+        incomplete = manager_root / "session-incomplete"
+        unrelated = manager_root / "unrelated"
+        completed.mkdir(parents=True)
+        incomplete.mkdir()
+        unrelated.mkdir()
+        (completed / COMPLETED_FILENAME).touch()
+        (completed / "old.ini").touch()
+
+        session = self.manager().prepare()
+
+        self.assertFalse(completed.exists())
+        self.assertTrue(incomplete.exists())
+        self.assertTrue(unrelated.exists())
+        self.assertEqual((incomplete,), session.retained_session_roots)
+        session.abort()
+
+    def test_cleanup_does_not_follow_session_symlink(self):
+        manager_root = self.cache_root / MANAGER_RELATIVE_PATH
+        outside = self.root / "outside"
+        outside.mkdir()
+        marker = outside / COMPLETED_FILENAME
+        marker.touch()
+        manager_root.mkdir(parents=True)
+        symlink = manager_root / "session-symlink"
+        symlink.symlink_to(outside, target_is_directory=True)
+
+        session = self.manager().prepare()
+
+        self.assertTrue(symlink.is_symlink())
+        self.assertTrue(marker.exists())
+        self.assertEqual((symlink,), session.retained_session_roots)
+        session.abort()
+
+    def test_canonical_symlink_aborts_without_reading_target(self):
+        organization_root = self.config_root / "mantidproject"
+        organization_root.mkdir()
+        outside = self.root / "secret"
+        outside.write_text("do not copy", encoding="utf-8")
+        (organization_root / "linked.ini").symlink_to(outside)
+
+        with self.assertRaises(StagingPreparationError):
+            self.manager().prepare()
+
+        self.assertTrue(self.coordinators[0].unlocked)
+        self.assertEqual([], list((self.cache_root / MANAGER_RELATIVE_PATH).glob("session-*")))
+
+    def test_failure_partway_through_preparation_removes_only_new_session_and_unlocks(self):
+        old_session = self.cache_root / MANAGER_RELATIVE_PATH / "session-old"
+        old_session.mkdir(parents=True)
+        organization_root = self.config_root / "mantidproject"
+        organization_root.mkdir()
+        (organization_root / "first.ini").write_text("first", encoding="utf-8")
+        (organization_root / "second.ini").write_text("second", encoding="utf-8")
+
+        with (
+            patch(
+                "mantidqt.utils.qt.qsettings_staging_session._copy_and_hash",
+                side_effect=[("first-hash", 0o600), StagingPreparationError("injected failure")],
+            ),
+            self.assertRaisesRegex(StagingPreparationError, "injected failure"),
+        ):
+            self.manager().prepare()
+
+        self.assertTrue(old_session.exists())
+        self.assertEqual([old_session], list((self.cache_root / MANAGER_RELATIVE_PATH).glob("session-*")))
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_cleanup_failure_still_releases_coordinator(self):
+        organization_root = self.config_root / "mantidproject"
+        organization_root.mkdir()
+        (organization_root / "linked.ini").symlink_to(self.root / "missing")
+
+        with (
+            patch(
+                "mantidqt.utils.qt.qsettings_staging_session._remove_owned_session",
+                side_effect=StagingPreparationError("cleanup failed"),
+            ),
+            self.assertRaisesRegex(StagingPreparationError, "cleanup failed"),
+        ):
+            self.manager().prepare()
+
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_abort_is_idempotent_and_retains_recovery_session(self):
+        session = self.manager().prepare()
+
+        session.abort()
+        session.abort()
+
+        self.assertTrue(session.staging_root.exists())
+        self.assertTrue(self.coordinators[0].unlocked)
+
+    def test_rejects_paths_outside_mantidproject(self):
+        with self.assertRaises(ValueError):
+            self.manager(expected_settings_paths=(Path("../outside.ini"),))
+
+    def test_existing_manager_symlink_is_rejected(self):
+        manager_root = self.cache_root / MANAGER_RELATIVE_PATH
+        outside = self.root / "outside-manager"
+        outside.mkdir()
+        manager_root.parent.mkdir()
+        manager_root.symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(StagingPreparationError):
+            self.manager().prepare()
+
+        self.assertEqual([], self.coordinators)
+
+    def test_existing_manager_parent_symlink_is_rejected(self):
+        manager_parent = self.cache_root / MANAGER_RELATIVE_PATH.parent
+        outside = self.root / "outside-parent"
+        outside.mkdir()
+        manager_parent.symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(StagingPreparationError):
+            self.manager().prepare()
+
+        self.assertEqual([], self.coordinators)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qsettings_staging_session.py
@@ -13,8 +13,6 @@ import tempfile
 import sys
 import unittest
 
-if not sys.platform.startswith("linux"):
-    raise unittest.SkipTest("QSettings staging is Linux-only")
 from unittest.mock import patch
 
 from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
@@ -41,6 +39,7 @@ class FakeCoordinator:
         self.unlocked = True
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
 class QSettingsStagingSessionManagerTest(unittest.TestCase):
     def setUp(self):
         self.temporary_directory = tempfile.TemporaryDirectory()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -11,6 +11,7 @@ Main window for reduction UIs
 
 import sys
 import os
+from pathlib import Path
 import traceback
 
 from mantidqt.gui_helper import get_qapplication
@@ -19,7 +20,7 @@ from mantidqt.utils.qt.qsettings_change_aware import QSettingsChangeAware
 from mantidqtinterfaces.reduction_gui.instruments.instrument_factory import instrument_factory, INSTRUMENT_DICT
 from mantidqtinterfaces.reduction_gui.settings.application_settings import GeneralSettings
 
-from qtpy.QtWidgets import QAction, QDialog, QFileDialog, QMainWindow, QMessageBox
+from qtpy.QtWidgets import QAction, QApplication, QDialog, QFileDialog, QMainWindow, QMessageBox
 from qtpy.QtCore import QCoreApplication, QFile, QFileInfo, QSettings
 
 
@@ -27,13 +28,17 @@ from qtpy.QtCore import QCoreApplication, QFile, QFileInfo, QSettings
 CAN_REDUCE = False
 try:
     CAN_REDUCE = True
-    from mantid.kernel import ConfigService
+    from mantid.kernel import ConfigService, Logger
 except ImportError:
     pass
 
 unicode = str
 
 STARTUP_WARNING = ""
+REDUCTION_ORGANIZATION = "mantidproject"
+REDUCTION_APPLICATION = "Mantid Reduction"
+REDUCTION_SETTINGS_PATH = Path(REDUCTION_ORGANIZATION, f"{REDUCTION_APPLICATION}.ini")
+_QSETTINGS_STAGING_WARNING_EMITTED = False
 
 if CAN_REDUCE:
     try:
@@ -51,8 +56,19 @@ if CAN_REDUCE:
         STARTUP_WARNING += unicode(traceback.format_exc())
 
 
+def _create_application_settings(explicit_ini=False):
+    if explicit_ini:
+        return QSettings(
+            QSettings.IniFormat,
+            QSettings.UserScope,
+            QCoreApplication.organizationName(),
+            QCoreApplication.applicationName(),
+        )
+    return QSettings(QCoreApplication.organizationName(), QCoreApplication.applicationName())
+
+
 class ReductionGUI(QMainWindow):
-    def __init__(self, parent=None, window_flags=None, instrument=None, instrument_list=None):
+    def __init__(self, parent=None, window_flags=None, instrument=None, instrument_list=None, application_settings=None):
         QMainWindow.__init__(self, parent)
         if window_flags:
             self.setWindowFlags(window_flags)
@@ -64,7 +80,9 @@ class ReductionGUI(QMainWindow):
             QMessageBox.warning(self, "WARNING", message)
 
         # Application settings
-        settings = QSettings(QCoreApplication.organizationName(), QCoreApplication.applicationName())
+        settings = _create_application_settings() if application_settings is None else application_settings
+        self._settings = settings
+        self._shutdown_accepted = False
 
         # Name handle for the instrument
         if instrument is None:
@@ -110,6 +128,14 @@ class ReductionGUI(QMainWindow):
         self.interface_chk.setChecked(self.general_settings.advanced)
 
         self.general_settings.progress.connect(self._progress_updated)
+
+    @property
+    def application_settings(self):
+        return self._settings
+
+    @property
+    def shutdown_accepted(self):
+        return self._shutdown_accepted
 
     def _set_window_title(self):
         """
@@ -343,14 +369,16 @@ class ReductionGUI(QMainWindow):
         # Save application settings
         if self._clear_and_restart:
             self._clear_and_restart = False
-            QSettings().clear()
+            self._settings.clear()
         else:
-            settings = QSettingsChangeAware()
+            settings = QSettingsChangeAware(self._settings)
             settings.setValue("instrument_name", self._instrument)
             settings.setValue("last_file", self._filename)
             settings.setValue("recent_files", self._recent_files)
             settings.setValue("last_directory", str(self._last_directory))
             settings.setValue("last_export_directory", str(self._last_export_directory))
+        self._shutdown_accepted = True
+        event.accept()
 
     def reduce_clicked(self):
         """
@@ -532,15 +560,131 @@ class ReductionGUI(QMainWindow):
 # --------------------------------------------------------------------------------------------------------
 
 
-def start():
-    app, within_mantid = get_qapplication()
+def _warn_about_qsettings_staging(message):
+    global _QSETTINGS_STAGING_WARNING_EMITTED
+    if _QSETTINGS_STAGING_WARNING_EMITTED:
+        return
 
-    app.setApplicationName("Mantid Reduction")
-    reducer = ReductionGUI()
-    reducer.setup_layout(load_last=True)
-    reducer.show()
-    if not within_mantid:
-        sys.exit(app.exec())
+    if CAN_REDUCE:
+        Logger("Mantid Reduction").warning(message)
+    else:
+        print(message, file=sys.stderr)
+    _QSETTINGS_STAGING_WARNING_EMITTED = True
+
+
+def _prepare_qsettings_staging():
+    from mantidqt.utils.qt.qsettings_staging import evaluate_qsettings_staging
+
+    eligibility = evaluate_qsettings_staging()
+    if not eligibility.active:
+        reason = eligibility.reason.value
+        if reason == "cache_is_nfs":
+            _warn_about_qsettings_staging(
+                "QSettings staging was requested, but the XDG cache directory is also on NFS. "
+                "Mantid Reduction will use the canonical configuration directory. Use a user-owned local "
+                "XDG_CACHE_HOME or unset MANTID_QSETTINGS_STAGING."
+            )
+        elif reason not in {"disabled", "unsupported_platform", "config_not_nfs"}:
+            _warn_about_qsettings_staging(
+                f"QSettings staging was requested but is unavailable ({reason}). "
+                "Mantid Reduction will use the canonical configuration directory."
+            )
+        return None
+
+    from mantidqt.utils.qt.qsettings_staging_session import QSettingsStagingSessionManager, StagingPreparationError
+
+    try:
+        session = QSettingsStagingSessionManager(eligibility, expected_settings_paths=(REDUCTION_SETTINGS_PATH,)).prepare()
+    except StagingPreparationError as error:
+        _warn_about_qsettings_staging(
+            f"QSettings staging preparation failed ({error}). Mantid Reduction will use the canonical configuration directory."
+        )
+        return None
+
+    session.activate()
+    return session
+
+
+def _abort_qsettings_staging(session, reason):
+    try:
+        session.abort()
+    except Exception as error:
+        reason = f"{reason}; coordinator release also failed: {error}"
+    _warn_about_qsettings_staging(
+        f"QSettings staging was not copied back ({reason}). Recoverable files remain under {session.staging_root}."
+    )
+
+
+def _sync_and_finalize_qsettings_staging(session, settings):
+    try:
+        settings.sync()
+        status = settings.status()
+        if status != QSettings.NoError:
+            _abort_qsettings_staging(session, f"QSettings sync failed with status {status}")
+            return
+    except Exception as error:
+        _abort_qsettings_staging(session, f"QSettings sync failed: {error}")
+        return
+
+    try:
+        finalization = session.finalize()
+    except Exception as error:
+        _abort_qsettings_staging(session, f"copy-back failed: {error}")
+        return
+
+    if not finalization.successful:
+        failed_paths = ", ".join(
+            str(result.relative_path) for result in finalization.files if result.status.value in {"conflict", "failed"}
+        )
+        detail = finalization.error or failed_paths or "unknown finalization error"
+        _warn_about_qsettings_staging(
+            f"QSettings staging copy-back was incomplete ({detail}). Recoverable files remain under {session.staging_root}."
+        )
+
+
+def _verify_qsettings_staging(session, settings):
+    expected = (session.staging_root / REDUCTION_SETTINGS_PATH).resolve(strict=False)
+    actual = QFileInfo(settings.fileName()).absoluteFilePath()
+    if os.path.realpath(actual) != str(expected):
+        raise RuntimeError(f"QSettings staging activation selected {actual}, expected {expected}")
+
+
+def start():
+    # A hosted interface inherits Workbench's identity and staging lifecycle.
+    # Only a process creating its own QApplication may own a second session.
+    qsettings_staging_session = _prepare_qsettings_staging() if QApplication.instance() is None else None
+
+    try:
+        app, within_mantid = get_qapplication()
+
+        if not within_mantid:
+            app.setApplicationName(REDUCTION_APPLICATION)
+
+        staged_settings = None
+        if qsettings_staging_session is not None:
+            QSettings.setDefaultFormat(QSettings.IniFormat)
+            app.setOrganizationName(REDUCTION_ORGANIZATION)
+            staged_settings = _create_application_settings(explicit_ini=True)
+
+        reducer = ReductionGUI(application_settings=staged_settings)
+        if qsettings_staging_session is not None:
+            _verify_qsettings_staging(qsettings_staging_session, reducer.application_settings)
+        reducer.setup_layout(load_last=True)
+        reducer.show()
+        if within_mantid:
+            return
+        exit_code = app.exec()
+    except BaseException:
+        if qsettings_staging_session is not None:
+            _abort_qsettings_staging(qsettings_staging_session, "Mantid Reduction startup failed")
+        raise
+
+    if qsettings_staging_session is not None:
+        if reducer.shutdown_accepted:
+            _sync_and_finalize_qsettings_staging(qsettings_staging_session, reducer.application_settings)
+        else:
+            _abort_qsettings_staging(qsettings_staging_session, "Mantid Reduction did not complete a clean shutdown")
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -640,7 +640,9 @@ def _sync_and_finalize_qsettings_staging(session, settings):
 
     if not finalization.successful:
         failed_paths = ", ".join(
-            str(result.relative_path) for result in finalization.files if result.status.value in {"conflict", "failed"}
+            f"{result.relative_path} ({result.status.value})"
+            for result in finalization.files
+            if result.status.value in {"conflict", "failed"}
         )
         detail = finalization.error or failed_paths or "unknown finalization error"
         _warn_about_qsettings_staging(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -594,6 +594,7 @@ def _prepare_qsettings_staging():
     from mantidqt.utils.qt.qsettings_staging_session import (
         QT_PROJECT_SETTINGS_PATH,
         QSettingsStagingSessionManager,
+        StagingActivationError,
         StagingPreparationError,
     )
 
@@ -607,7 +608,11 @@ def _prepare_qsettings_staging():
         )
         return None
 
-    session.activate()
+    try:
+        session.activate()
+    except StagingActivationError as error:
+        _abort_qsettings_staging(session, f"QSettings staging activation failed: {error}")
+        return None
     return session
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -591,10 +591,16 @@ def _prepare_qsettings_staging():
             )
         return None
 
-    from mantidqt.utils.qt.qsettings_staging_session import QSettingsStagingSessionManager, StagingPreparationError
+    from mantidqt.utils.qt.qsettings_staging_session import (
+        QT_PROJECT_SETTINGS_PATH,
+        QSettingsStagingSessionManager,
+        StagingPreparationError,
+    )
 
     try:
-        session = QSettingsStagingSessionManager(eligibility, expected_settings_paths=(REDUCTION_SETTINGS_PATH,)).prepare()
+        session = QSettingsStagingSessionManager(
+            eligibility, expected_settings_paths=(REDUCTION_SETTINGS_PATH, QT_PROJECT_SETTINGS_PATH)
+        ).prepare()
     except StagingPreparationError as error:
         _warn_about_qsettings_staging(
             f"QSettings staging preparation failed ({error}). Mantid Reduction will use the canonical configuration directory."

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/settings/application_settings.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/settings/application_settings.py
@@ -10,8 +10,8 @@ Notes:
 From the command line:
 $ cd ~/git/mantid/Code/Mantid/scripts/Interface
 $ python reduction_application.py
-It uses:
-.config/Mantid/Mantid Reduction.conf
+With QSettings staging enabled it uses:
+.config/mantidproject/Mantid Reduction.ini
 From mantidplot:
 .config/Mantid/MantidPlot.conf
 """

--- a/qt/python/mantidqtinterfaces/test/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(TEST_PY_FILES PyChopInstrumentTest.py)
+set(TEST_PY_FILES PyChopInstrumentTest.py reduction_application_test.py)
 
 if(ENABLE_WORKBENCH)
   set(PYUNITTEST_QT_API pyqt${MANTID_QT_VERSION}) # force to use the configured Qt version

--- a/qt/python/mantidqtinterfaces/test/reduction_application_test.py
+++ b/qt/python/mantidqtinterfaces/test/reduction_application_test.py
@@ -172,6 +172,25 @@ class ReductionApplicationQSettingsStagingTest(unittest.TestCase):
         session.activate.assert_called_once_with()
         self.assertIs(session, result)
 
+    def test_staging_activation_failure_aborts_session_and_returns_none(self):
+        from mantidqt.utils.qt.qsettings_staging_session import StagingActivationError
+
+        eligibility = SimpleNamespace(active=True)
+        session = Mock()
+        session.activate.side_effect = StagingActivationError("activation failed")
+        manager = Mock()
+        manager.prepare.return_value = session
+
+        with (
+            patch("mantidqt.utils.qt.qsettings_staging.evaluate_qsettings_staging", return_value=eligibility),
+            patch("mantidqt.utils.qt.qsettings_staging_session.QSettingsStagingSessionManager", return_value=manager),
+            patch.object(reduction_application, "_abort_qsettings_staging") as abort,
+        ):
+            result = reduction_application._prepare_qsettings_staging()
+
+        abort.assert_called_once_with(session, "QSettings staging activation failed: activation failed")
+        self.assertIsNone(result)
+
     @unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
     def test_real_reduction_settings_round_trip(self):
         result = subprocess.run(

--- a/qt/python/mantidqtinterfaces/test/reduction_application_test.py
+++ b/qt/python/mantidqtinterfaces/test/reduction_application_test.py
@@ -1,0 +1,249 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+from qtpy.QtCore import QSettings
+
+from mantidqtinterfaces import reduction_application
+
+
+class ReductionApplicationQSettingsStagingTest(unittest.TestCase):
+    def setUp(self):
+        reduction_application._QSETTINGS_STAGING_WARNING_EMITTED = False
+
+    def test_reduction_settings_use_explicit_ini_user_scope(self):
+        with (
+            patch.object(reduction_application, "QSettings") as qsettings,
+            patch.object(reduction_application.QCoreApplication, "organizationName", return_value="mantidproject"),
+            patch.object(reduction_application.QCoreApplication, "applicationName", return_value="Mantid Reduction"),
+        ):
+            qsettings.IniFormat = QSettings.IniFormat
+            qsettings.UserScope = QSettings.UserScope
+            reduction_application._create_application_settings(explicit_ini=True)
+
+        qsettings.assert_called_once_with(QSettings.IniFormat, QSettings.UserScope, "mantidproject", "Mantid Reduction")
+
+    def test_default_reduction_settings_preserve_platform_format(self):
+        with (
+            patch.object(reduction_application, "QSettings") as qsettings,
+            patch.object(reduction_application.QCoreApplication, "organizationName", return_value="legacy-organization"),
+            patch.object(reduction_application.QCoreApplication, "applicationName", return_value="Mantid Reduction"),
+        ):
+            reduction_application._create_application_settings()
+
+        qsettings.assert_called_once_with("legacy-organization", "Mantid Reduction")
+
+    def test_close_saves_through_retained_settings_and_marks_shutdown_clean(self):
+        settings = Mock()
+        gui = SimpleNamespace(
+            _clear_and_restart=False,
+            _settings=settings,
+            _shutdown_accepted=False,
+            _instrument="EQSANS",
+            _filename="reduction.xml",
+            _recent_files=["reduction.xml"],
+            _last_directory=Path("/data"),
+            _last_export_directory=Path("/exports"),
+        )
+        event = Mock()
+
+        with patch.object(reduction_application, "QSettingsChangeAware") as writer_type:
+            reduction_application.ReductionGUI.closeEvent(gui, event)
+
+        writer_type.assert_called_once_with(settings)
+        self.assertTrue(gui._shutdown_accepted)
+        event.accept.assert_called_once_with()
+
+    def test_standalone_start_finalizes_after_clean_close(self):
+        events = []
+        app = Mock()
+        app.exec.return_value = 6
+        session = Mock(staging_root=Path("/local/cache/session"))
+        settings = Mock()
+        reducer = Mock(shutdown_accepted=True, application_settings=settings)
+
+        with (
+            patch.object(reduction_application.QApplication, "instance", return_value=None),
+            patch.object(reduction_application, "_prepare_qsettings_staging", side_effect=lambda: events.append("stage") or session),
+            patch.object(reduction_application, "get_qapplication", side_effect=lambda: events.append("app") or (app, False)),
+            patch.object(
+                reduction_application,
+                "_create_application_settings",
+                side_effect=lambda **_: events.append("settings") or settings,
+            ) as create_settings,
+            patch.object(reduction_application, "ReductionGUI", side_effect=lambda **_: events.append("gui") or reducer) as gui_type,
+            patch.object(reduction_application, "_verify_qsettings_staging", side_effect=lambda *_: events.append("verify")),
+            patch.object(
+                reduction_application,
+                "_sync_and_finalize_qsettings_staging",
+                side_effect=lambda *_: events.append("finalize"),
+            ) as finalize,
+            patch.object(reduction_application.sys, "exit") as exit_process,
+        ):
+            reduction_application.start()
+
+        self.assertEqual(["stage", "app", "settings", "gui", "verify", "finalize"], events)
+        app.setOrganizationName.assert_called_once_with("mantidproject")
+        app.setApplicationName.assert_called_once_with("Mantid Reduction")
+        create_settings.assert_called_once_with(explicit_ini=True)
+        gui_type.assert_called_once_with(application_settings=settings)
+        finalize.assert_called_once_with(session, reducer.application_settings)
+        exit_process.assert_called_once_with(6)
+
+    def test_standalone_unclean_shutdown_aborts(self):
+        app = Mock()
+        app.exec.return_value = -1
+        session = Mock()
+        reducer = Mock(shutdown_accepted=False)
+
+        with (
+            patch.object(reduction_application.QApplication, "instance", return_value=None),
+            patch.object(reduction_application, "_prepare_qsettings_staging", return_value=session),
+            patch.object(reduction_application, "get_qapplication", return_value=(app, False)),
+            patch.object(reduction_application, "_create_application_settings", return_value=Mock()),
+            patch.object(reduction_application, "ReductionGUI", return_value=reducer),
+            patch.object(reduction_application, "_verify_qsettings_staging"),
+            patch.object(reduction_application, "_abort_qsettings_staging") as abort,
+            patch.object(reduction_application.sys, "exit"),
+        ):
+            reduction_application.start()
+
+        abort.assert_called_once_with(session, "Mantid Reduction did not complete a clean shutdown")
+
+    def test_hosted_start_inherits_workbench_staging_and_does_not_own_session(self):
+        app = Mock()
+        reducer = Mock()
+
+        with (
+            patch.object(reduction_application.QApplication, "instance", return_value=app),
+            patch.object(reduction_application, "_prepare_qsettings_staging") as prepare,
+            patch.object(reduction_application, "get_qapplication", return_value=(app, True)),
+            patch.object(reduction_application, "ReductionGUI", return_value=reducer) as gui_type,
+            patch.object(reduction_application.sys, "exit") as exit_process,
+        ):
+            reduction_application.start()
+
+        prepare.assert_not_called()
+        app.setOrganizationName.assert_not_called()
+        app.setApplicationName.assert_not_called()
+        gui_type.assert_called_once_with(application_settings=None)
+        exit_process.assert_not_called()
+
+    def test_failed_sync_aborts_without_finalizing(self):
+        session = Mock(staging_root=Path("/local/cache/session"))
+        settings = Mock()
+        settings.status.return_value = QSettings.AccessError
+
+        with patch.object(reduction_application, "_abort_qsettings_staging") as abort:
+            reduction_application._sync_and_finalize_qsettings_staging(session, settings)
+
+        settings.sync.assert_called_once_with()
+        abort.assert_called_once()
+        session.finalize.assert_not_called()
+
+    def test_staging_preparation_uses_reduction_settings_path(self):
+        eligibility = SimpleNamespace(active=True)
+        session = Mock()
+        manager = Mock()
+        manager.prepare.return_value = session
+
+        with (
+            patch("mantidqt.utils.qt.qsettings_staging.evaluate_qsettings_staging", return_value=eligibility),
+            patch("mantidqt.utils.qt.qsettings_staging_session.QSettingsStagingSessionManager", return_value=manager) as manager_type,
+        ):
+            result = reduction_application._prepare_qsettings_staging()
+
+        manager_type.assert_called_once_with(eligibility, expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH,))
+        session.activate.assert_called_once_with()
+        self.assertIs(session, result)
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "QSettings staging is Linux-only")
+    def test_real_reduction_settings_round_trip(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                textwrap.dedent(
+                    """
+                    from pathlib import Path
+                    import tempfile
+
+                    from qtpy.QtCore import QCoreApplication, QSettings
+
+                    from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
+                    from mantidqt.utils.qt.qsettings_staging_session import (
+                        COMPLETED_FILENAME,
+                        QSettingsStagingSessionManager,
+                    )
+                    from mantidqtinterfaces import reduction_application
+
+                    with tempfile.TemporaryDirectory() as temporary_directory:
+                        root = Path(temporary_directory)
+                        config_root = root / "config"
+                        cache_root = root / "cache"
+                        canonical_directory = config_root / "mantidproject"
+                        canonical_directory.mkdir(parents=True)
+                        cache_root.mkdir()
+                        canonical_file = canonical_directory / "Mantid Reduction.ini"
+                        canonical_contents = b"[General]\\ninstrument_name=EQSANS\\nunchanged=canonical\\n"
+                        canonical_file.write_bytes(canonical_contents)
+
+                        eligibility = QSettingsStagingEligibility(
+                            True,
+                            QSettingsStagingReason.ELIGIBLE,
+                            config_root=config_root,
+                            cache_root=cache_root,
+                            config_filesystem="nfs4",
+                            cache_filesystem="ext4",
+                        )
+                        session = QSettingsStagingSessionManager(
+                            eligibility,
+                            expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH,),
+                        ).prepare()
+                        session.activate()
+
+                        QSettings.setDefaultFormat(QSettings.IniFormat)
+                        QCoreApplication.setOrganizationName(reduction_application.REDUCTION_ORGANIZATION)
+                        QCoreApplication.setApplicationName(reduction_application.REDUCTION_APPLICATION)
+                        settings = reduction_application._create_application_settings(explicit_ini=True)
+                        expected_staged_file = session.staging_root / reduction_application.REDUCTION_SETTINGS_PATH
+
+                        assert Path(settings.fileName()) == expected_staged_file
+                        assert settings.value("instrument_name") == "EQSANS"
+                        assert settings.value("unchanged") == "canonical"
+                        assert canonical_file.read_bytes() == canonical_contents
+
+                        settings.setValue("instrument_name", "GPSANS")
+                        settings.setValue("recent_files", ["one.xml", "two.xml"])
+                        reduction_application._sync_and_finalize_qsettings_staging(session, settings)
+
+                        canonical_settings = QSettings(str(canonical_file), QSettings.IniFormat)
+                        assert canonical_settings.value("instrument_name") == "GPSANS"
+                        assert canonical_settings.value("recent_files", type=list) == ["one.xml", "two.xml"]
+                        assert canonical_settings.value("unchanged") == "canonical"
+                        assert (session.staging_root / COMPLETED_FILENAME).exists()
+                        assert sorted(path.name for path in canonical_directory.iterdir()) == ["Mantid Reduction.ini"]
+                    """
+                ),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(0, result.returncode, msg=result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/test/reduction_application_test.py
+++ b/qt/python/mantidqtinterfaces/test/reduction_application_test.py
@@ -164,7 +164,11 @@ class ReductionApplicationQSettingsStagingTest(unittest.TestCase):
         ):
             result = reduction_application._prepare_qsettings_staging()
 
-        manager_type.assert_called_once_with(eligibility, expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH,))
+        from mantidqt.utils.qt.qsettings_staging_session import QT_PROJECT_SETTINGS_PATH
+
+        manager_type.assert_called_once_with(
+            eligibility, expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH, QT_PROJECT_SETTINGS_PATH)
+        )
         session.activate.assert_called_once_with()
         self.assertIs(session, result)
 
@@ -184,6 +188,7 @@ class ReductionApplicationQSettingsStagingTest(unittest.TestCase):
                     from mantidqt.utils.qt.qsettings_staging import QSettingsStagingEligibility, QSettingsStagingReason
                     from mantidqt.utils.qt.qsettings_staging_session import (
                         COMPLETED_FILENAME,
+                        QT_PROJECT_SETTINGS_PATH,
                         QSettingsStagingSessionManager,
                     )
                     from mantidqtinterfaces import reduction_application
@@ -209,7 +214,7 @@ class ReductionApplicationQSettingsStagingTest(unittest.TestCase):
                         )
                         session = QSettingsStagingSessionManager(
                             eligibility,
-                            expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH,),
+                            expected_settings_paths=(reduction_application.REDUCTION_SETTINGS_PATH, QT_PROJECT_SETTINGS_PATH),
                         ).prepare()
                         session.activate()
 


### PR DESCRIPTION
On Linux systems with an NFS-backed configuration directory and a local XDG cache, this change stages Workbench and standalone Mantid Reduction QSettings in private local sessions, safely copies modified settings back after a clean shutdown, and retains conflicting sessions for recovery, avoiding recursive Qt lock-file failures when multiple instances are running.

This can be reverted once the fix for [QTBUG-148845](https://qt-project.atlassian.net/browse/QTBUG-148845) gets into either v6.11.3 ([release schedule](https://wiki.qt.io/Qt_6.11_Release)) or v6.12.0 ([release schedule](https://wiki.qt.io/Qt_6.12_Release)) conda packages. v6.11.3 is the preferred one to move to since it should have less changes.

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

Refs #41904

### To test:

On a Linux system where `findmnt -T "${XDG_CONFIG_HOME:-$HOME/.config}" -no FSTYPE` reports nfs or nfs4 and the equivalent command for `${XDG_CACHE_HOME:-$HOME/.cache}` reports a local filesystem, launch two Workbench instances, change a preference in each, and close them sequentially; confirm the first instance exits cleanly and updates `mantidproject/mantidworkbench.ini`, the second reports a copy-back conflict without recursive .lock/.rmlock errors, and its recoverable session remains under `${XDG_CACHE_HOME:-$HOME/.cache}/mantidproject/qsettings-stage`.

Finally, restart Workbench and confirm the successfully copied settings persist.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
