### PR TITLE
Fixed a crash when finding peaks in HRP training course data

### DIFF
--- a/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMDMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMDMinimizer.cpp
@@ -151,6 +151,9 @@ bool LevenbergMarquardtMDMinimizer::iterate(size_t /*iteration*/) {
   } catch (std::runtime_error &error) {
     m_errorString = error.what();
     return false;
+  } catch (std::invalid_argument &error) {
+    m_errorString = error.what();
+    return false;
   }
 
   if (verbose) {

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/41702.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/41702.rst
@@ -1,1 +1,1 @@
-- This Fixes a crash occuring when trying to find peaks from HRP training course data via fit property browser. The crash was due to an unhandled exception raised from the :ref:`Levenberg-MarquardtMD minimizer <LevenbergMarquardtMD>` whenever the paramter matrix is singular.
+- Fixed a crash in Fit Property Browser ocurring when trying to find peaks for HRP data due to an unhandled exception raised from the :ref:`Levenberg-MarquardtMD minimizer <LevenbergMarquardtMD>`.

--- a/docs/source/release/v7.0.0/Workbench/Bugfixes/41702.rst
+++ b/docs/source/release/v7.0.0/Workbench/Bugfixes/41702.rst
@@ -1,0 +1,1 @@
+- This Fixes a crash occuring when trying to find peaks from HRP training course data via fit property browser. The crash was due to an unhandled exception raised from the :ref:`Levenberg-MarquardtMD minimizer <LevenbergMarquardtMD>` whenever the paramter matrix is singular.

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -57,7 +57,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
     def _connect_signals(self):
         self.xRangeChanged.connect(self.move_x_range)
         self.algorithmFinished.connect(self.fitting_done_slot)
-        self.changedParameterOf.connect(self.peak_changed_slot)
+        self.changedParameterOf.connect(self.peak_changed_slot, Qt.QueuedConnection)
         self.removeFitCurves.connect(self.clear_fit_result_lines_slot, Qt.QueuedConnection)
         self.functionChanged.connect(self.function_changed_slot, Qt.QueuedConnection)
         # Update whether data needs to be normalised when a button on the Fit menu is clicked

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -123,7 +123,7 @@ public:
   /// save function
   void saveFunction(const QString &fnName);
   /// Create a new function
-  PropertyHandler *addFunction(const std::string &fnName, bool notify = false);
+  PropertyHandler *addFunction(const std::string &fnName, bool notify = true);
 
   /// Removes the function held by the property handler
   virtual void removeFunction(PropertyHandler *handler);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -123,7 +123,7 @@ public:
   /// save function
   void saveFunction(const QString &fnName);
   /// Create a new function
-  PropertyHandler *addFunction(const std::string &fnName);
+  PropertyHandler *addFunction(const std::string &fnName, bool notify = false);
 
   /// Removes the function held by the property handler
   virtual void removeFunction(PropertyHandler *handler);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -221,6 +221,9 @@ private:
   // mutable FunctionCurve* m_curve;//< the curve to plot the handled function
   mutable bool m_hasPlot;
 
+  /// QtProperties to PropertyHandler map for faster lookup
+  QMap<QtProperty *, PropertyHandler *> m_paramToPropertyHandlerMap;
+
   /// Sync function parameter value with the manager
   void updateParameter(QtProperty *prop);
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -709,7 +709,7 @@ PropertyHandler *FitPropertyBrowser::getHandler() const {
   return dynamic_cast<PropertyHandler *>(m_compositeFunction->getHandler());
 }
 
-PropertyHandler *FitPropertyBrowser::addFunction(const std::string &fnName, bool notify /*= false*/) {
+PropertyHandler *FitPropertyBrowser::addFunction(const std::string &fnName, bool notify /*= true*/) {
   PropertyHandler *h = getHandler()->addFunction(fnName);
   if (notify) {
     emit functionChanged();
@@ -786,7 +786,7 @@ void FitPropertyBrowser::createCompositeFunction(const Mantid::API::IFunction_sp
 
   auto h = std::make_unique<PropertyHandler>(m_compositeFunction, Mantid::API::CompositeFunction_sptr(), this);
   m_compositeFunction->setHandler(std::move(h));
-  setCurrentFunction(dynamic_cast<PropertyHandler *>(m_compositeFunction->getHandler()));
+  setCurrentFunction(static_cast<PropertyHandler *>(m_compositeFunction->getHandler()));
 
   if (m_auto_back) {
     addAutoBackground();
@@ -3319,7 +3319,7 @@ bool FitPropertyBrowser::createAndAddFunction(const Mantid::API::MatrixWorkspace
     f->setCentre(findPeakStrategy->getPeakCentre(peakIndex));
     f->setFwhm(findPeakStrategy->getPeakWidth(peakIndex));
     f->setHeight(findPeakStrategy->getPeakHeight(peakIndex));
-    addFunction(f->asString());
+    addFunction(f->asString(), false);
   }
   return validFn;
 }

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -706,7 +706,7 @@ FitPropertyBrowser::~FitPropertyBrowser() {
 
 /// Get handler to the root composite function
 PropertyHandler *FitPropertyBrowser::getHandler() const {
-  return dynamic_cast<PropertyHandler *>(m_compositeFunction->getHandler());
+  return static_cast<PropertyHandler *>(m_compositeFunction->getHandler());
 }
 
 PropertyHandler *FitPropertyBrowser::addFunction(const std::string &fnName, bool notify /*= true*/) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -706,12 +706,14 @@ FitPropertyBrowser::~FitPropertyBrowser() {
 
 /// Get handler to the root composite function
 PropertyHandler *FitPropertyBrowser::getHandler() const {
-  return static_cast<PropertyHandler *>(m_compositeFunction->getHandler());
+  return dynamic_cast<PropertyHandler *>(m_compositeFunction->getHandler());
 }
 
-PropertyHandler *FitPropertyBrowser::addFunction(const std::string &fnName) {
+PropertyHandler *FitPropertyBrowser::addFunction(const std::string &fnName, bool notify /*= false*/) {
   PropertyHandler *h = getHandler()->addFunction(fnName);
-  emit functionChanged();
+  if (notify) {
+    emit functionChanged();
+  }
   return h;
 }
 
@@ -784,7 +786,7 @@ void FitPropertyBrowser::createCompositeFunction(const Mantid::API::IFunction_sp
 
   auto h = std::make_unique<PropertyHandler>(m_compositeFunction, Mantid::API::CompositeFunction_sptr(), this);
   m_compositeFunction->setHandler(std::move(h));
-  setCurrentFunction(static_cast<PropertyHandler *>(m_compositeFunction->getHandler()));
+  setCurrentFunction(dynamic_cast<PropertyHandler *>(m_compositeFunction->getHandler()));
 
   if (m_auto_back) {
     addAutoBackground();
@@ -2763,6 +2765,7 @@ void FitPropertyBrowser::findPeaks(const std::unique_ptr<FindPeakStrategyGeneric
   try {
     findPeakStrategy->execute();
     clear();
+    m_browser->setUpdatesEnabled(false);
     for (size_t i = 0; i < findPeakStrategy->peakNumber(); ++i) {
       if (findPeakStrategy->getPeakCentre(i) < startX() || findPeakStrategy->getPeakCentre(i) > endX()) {
         continue;
@@ -2771,7 +2774,10 @@ void FitPropertyBrowser::findPeaks(const std::unique_ptr<FindPeakStrategyGeneric
         break;
       }
     }
+    m_browser->setUpdatesEnabled(true);
+    emit functionChanged();
   } catch (...) {
+    m_browser->setUpdatesEnabled(true);
     QApplication::restoreOverrideCursor();
     throw;
   }

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -245,6 +245,8 @@ void PropertyHandler::initParameters() {
     m_item->property()->removeSubProperty(parameter);
   }
   m_parameters.clear();
+  m_paramToPropertyHandlerMap.clear();
+
   for (size_t i = 0; i < function()->nParams(); i++) {
     QString parName = QString::fromStdString(function()->parameterName(i));
     if (parName.contains('.'))
@@ -295,6 +297,13 @@ void PropertyHandler::initParameters() {
         prop->addSubProperty(upProp);
       }
       m_constraints.insert(parName, std::pair<QtProperty *, QtProperty *>(loProp, upProp));
+    }
+  }
+
+  PropertyHandler *pHandler = this->parentHandler();
+  if (pHandler) {
+    for (auto it = m_parameters.cbegin(); it != m_parameters.cend(); ++it) {
+      pHandler->m_paramToPropertyHandlerMap[*it] = this;
     }
   }
 }
@@ -360,9 +369,8 @@ PropertyHandler *PropertyHandler::addFunction(const std::string &fnName) {
     f = Mantid::API::FunctionFactory::Instance().createInitialized(fnName);
   }
 
-  // turn of the change slots (doubleChanged() etc) to avoid infinite loop
+  // turn off the change slots (doubleChanged() etc) to avoid infinite loop
   m_browser->m_changeSlotsEnabled = false;
-
   // Check if it's a peak and set its width
   std::shared_ptr<Mantid::API::IPeakFunction> pf = std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(f);
   if (pf) {
@@ -415,20 +423,21 @@ PropertyHandler *PropertyHandler::addFunction(const std::string &fnName) {
 
   size_t nFunctions = m_cf->nFunctions() + 1;
   m_cf->addFunction(f);
+
   m_browser->compositeFunction()->checkFunction();
 
   if (m_cf->nFunctions() != nFunctions) { // this may happen
     m_browser->reset();
+    m_browser->m_changeSlotsEnabled = true;
     return nullptr;
   }
 
   f->setHandler(std::make_unique<PropertyHandler>(f, m_cf, m_browser));
+
   auto h = static_cast<PropertyHandler *>(f->getHandler());
   h->setAttribute("StartX", m_browser->startX());
   h->setAttribute("EndX", m_browser->endX());
 
-  // enable the change slots
-  m_browser->m_changeSlotsEnabled = true;
   m_browser->setFitEnabled(true);
   if (pf) {
     m_browser->setDefaultPeakType(f->name());
@@ -438,7 +447,8 @@ PropertyHandler *PropertyHandler::addFunction(const std::string &fnName) {
   m_browser->setFocus();
   auto return_ptr = static_cast<PropertyHandler *>(f->getHandler());
   m_browser->setCurrentFunction(return_ptr);
-
+  // enable the change slots
+  m_browser->m_changeSlotsEnabled = true;
   return return_ptr;
 }
 
@@ -663,7 +673,6 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
     std::string parName = prop->propertyName().toStdString();
     double parValue = m_browser->m_parameterManager->value(prop);
     m_fun->setParameter(parName, parValue);
-
     // If the parameter is fixed, re-fix to update the subproperty.
     if (m_fun->isFixed(m_fun->parameterIndex(parName))) {
       const auto subProps = prop->subProperties();
@@ -678,8 +687,9 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
     return true;
   }
   if (m_cf) {
-    for (size_t i = 0; i < m_cf->nFunctions(); i++) {
-      bool res = getHandler(i)->setParameter(prop);
+    auto pit = m_paramToPropertyHandlerMap.find(prop);
+    if (pit != m_paramToPropertyHandlerMap.end()) {
+      bool res = pit.value()->setParameter(prop);
       if (res) {
         m_cf->applyTies();
         updateParameters();


### PR DESCRIPTION
### Description of work

This PR fixes a crash occuring when trying to find peaks from HRP training course data via fit property browser. The crash was due to an unhandled exception raised from the LevenbergMarquardtMDMinimizer whenever the paramter matrix is singular(i.e determinant of the matrix = 0).

However, due to the inherent complexity of the fitproperty browser, the time to update the fit property browser with the identified peaks, increases exponentially with the number of peaks despite some optimizations have already done via this PR. A larger overhaul of the fit property browser may be required to optimize the number of signals transmitted through sip bindings across python and c++ as the browser is updated.

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41702. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

1. Load HRP39182 from training course data
2. run CropWorkspace to reduce the number of bins in X axis: ex: xmin=20000, xmax=27000 (this is to get the results in a reasonable amount of time)
3. Plot spectrum number 1 from the cropped workspace
4. Open the fit browser
5. Click Setup->Peak Finding Algorithms->Find Peaks (Please note that, when the number of peaks is high it will take some time for the fit property browser to be responsive)
6. No crashes and the peaks should appear in the plot and fit property browser.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
