### PR TITLE
Enable support for workspace groups in ISIS Reflectometry GUI

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -1119,7 +1119,6 @@ std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const Workspa
   const std::string hide_prefix = getProperty("HideSummedWorkspaces") ? "__" : "";
   if (std::dynamic_pointer_cast<WorkspaceGroup>(workspace))
     return hide_prefix + ws_prefix + SUMMED_WORKSPACE_SUFFIX;
-
   return hide_prefix + ws_prefix + getRunNumber(*std::dynamic_pointer_cast<MatrixWorkspace>(workspace)) +
          SUMMED_WORKSPACE_SUFFIX;
 }

--- a/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
@@ -877,6 +877,8 @@ Typical usage of the tool is as follows:
 - Enter a **run** number and **angle**.
 
   - The run is loaded, and a plot of the workspace is displayed, with pre-processing (e.g. calibration) applied.
+  - If the run contains a workspace group, use **Group Member** to choose which member is displayed in the detector
+    image and TOF plot.
   - For **2D detectors**, a **detector image** is displayed
   - For **linear** detectors, a **Spectrum vs TOF** plot is displayed
 
@@ -889,6 +891,11 @@ Typical usage of the tool is as follows:
   - A full **reduction** is run using the selected regions, and a plot of the final **reflectivity curve** is displayed.
 
 - **Adjust** the regions of interest until you are happy with the reflectivity curve.
+
+  - When previewing a workspace group, detector and TOF region bounds are retained when changing group member.
+    Masks drawn on the TOF plot are retained separately for each member.
+  - Select **Plot reduction preview for all group members** to compare the reduced reflectivity curves on the same
+    plot.
 
 - Click the **Apply** button to save the regions of interest into the batch settings.
 

--- a/docs/source/release/v7.0.0/Reflectometry/New_features/42042.rst
+++ b/docs/source/release/v7.0.0/Reflectometry/New_features/42042.rst
@@ -1,0 +1,3 @@
+- The ISIS Reflectometry Preview tab now supports workspace groups. Individual group members can be inspected while
+  retaining detector and time-of-flight regions, masks are retained separately for each member, and the reduced
+  reflectivity curves can be overplotted for comparison.

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewPresenter.py
@@ -107,7 +107,7 @@ class ReflectometryInstrumentViewPresenter:
             return
 
         plotter = self.view.main_plotter
-        plotter.clear()
+        plotter.clear_actors()
 
         self._detector_mesh = self._renderer.build_detector_mesh(self._model.detector_positions, self._model.flip_beam, self._model)
         self._renderer.set_detector_scalars(self._detector_mesh, self._model.detector_counts, self._COUNTS_LABEL)

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_presenter.py
@@ -70,6 +70,20 @@ class TestReflectometryInstrumentViewPresenter(unittest.TestCase):
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.ShapeRenderer")
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.FullInstrumentViewModel")
+    def test_update_workspace_preserves_shape_overlay(self, mock_model_cls, mock_renderer_cls, _mock_styles_cls):
+        mock_ws = MagicMock()
+        mock_model_cls.return_value.detector_positions = np.zeros((10, 3))
+        mock_model_cls.return_value.detector_counts = np.zeros(10)
+        mock_renderer_cls.return_value.build_detector_mesh.return_value = MagicMock(bounds=(0, 1, 0, 1, 0, 1))
+
+        self._presenter.update_workspace(mock_ws)
+
+        self._mock_view.main_plotter.clear_actors.assert_called_once_with()
+        self._mock_view.main_plotter.clear.assert_not_called()
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.InteractorStyles")
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.ShapeRenderer")
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewPresenter.FullInstrumentViewModel")
     def test_update_workspace_sets_model(self, mock_model_cls, mock_renderer_cls, _mock_styles_cls):
         mock_ws = MagicMock()
         mock_model_cls.return_value.detector_positions = np.zeros((10, 3))

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -58,6 +58,9 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         super().__init__(ws, self.view.data_view)
         self._selectors: list[Selector] = []
         self._drawing_region = False
+        self._group_member_name = None
+        self._group_member_maskings = {}
+        self._masking_inverted = False
 
         self._toggle_masking_options(False)
 
@@ -116,13 +119,21 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         pass
 
     def clear_workspace(self):
+        if self._data_view.masking:
+            self._data_view.masking.clear_and_disconnect()
+        self._clear_group_member_maskings()
+        self._data_view.masking = None
+        self._group_member_name = None
         self._selectors = []
         self.model.ws = None
         self.view.clear_figure()
 
-    def update_workspace(self, workspace) -> None:
+    def update_workspace(self, workspace, group_member_name=None) -> None:
         if WorkspaceInfo.get_ws_type(workspace) != WS_TYPE.MATRIX:
             raise NotImplementedError("Only Matrix Workspaces are currently supported by the region selector.")
+
+        if group_member_name != self._group_member_name:
+            self._switch_group_member_masking(group_member_name)
 
         if not self.model.ws:
             self._initialise_dimensions(workspace)
@@ -267,9 +278,46 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         self._data_view.deactivate_and_disable_tool(ToolItemText.ZOOM)
         self._data_view.deactivate_and_disable_tool(ToolItemText.PAN)
         self._data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
-        self._data_view.masking = Masking(self._data_view, self.model.ws.name(), auto_update_mask_file=True)
-        self._data_view.masking.new_selector(ToolItemText.RECT_MASKING)  # default to rect masking
+        masking = self._group_member_maskings.pop(self._group_member_name, None)
+        if masking:
+            masking.set_visible(True)
+            self._data_view.canvas.draw_idle()
+        else:
+            masking = self._create_masking()
+        self._data_view.masking = masking
         self._data_view.activate_tool(ToolItemText.RECT_MASKING, True)
+
+    def _create_masking(self):
+        workspace_name = self._group_member_name or self.model.ws.name()
+        masking = Masking(self._data_view, workspace_name, auto_update_mask_file=True)
+        masking.new_selector(ToolItemText.RECT_MASKING)
+        if self._masking_inverted:
+            masking.invert_masking_clicked(True)
+        return masking
+
+    def _switch_group_member_masking(self, group_member_name):
+        masking_active = self._data_view.masking is not None
+        if masking_active:
+            self._data_view.masking.set_visible(False)
+            if self._group_member_name:
+                self._group_member_maskings[self._group_member_name] = self._data_view.masking
+
+        self._data_view.masking = None
+        self._group_member_name = group_member_name
+
+        if masking_active:
+            masking = self._group_member_maskings.pop(group_member_name, None) or self._create_masking()
+            masking.set_visible(True)
+            self._data_view.masking = masking
+
+    def _clean_up_masking(self):
+        super()._clean_up_masking()
+        self._clear_group_member_maskings()
+
+    def _clear_group_member_maskings(self):
+        for masking in self._group_member_maskings.values():
+            masking.clear_and_disconnect()
+        self._group_member_maskings = {}
 
     def masking(self, active) -> None:
         super().masking(active)
@@ -295,7 +343,10 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         pass
 
     def invert_masking_clicked(self, active) -> None:
+        self._masking_inverted = active
         self.view.data_view.masking.invert_masking_clicked(active)
+        for masking in self._group_member_maskings.values():
+            masking.invert_masking_clicked(active)
 
     @property
     def _is_masking_disabled(self):

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -91,6 +91,69 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertEqual(region_selector._selectors, [selector])
         self.assertEqual(selector.extents, (1000.0, 5000.0, 10.0, 20.0))
 
+    @patch("mantidqt.widgets.regionselector.presenter.Masking")
+    def test_update_workspace_switches_to_group_member_specific_masking(self, mock_masking_cls):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector.show_all_data_clicked = Mock()
+        first_masking = MagicMock()
+        second_masking = MagicMock()
+        mock_masking_cls.return_value = second_masking
+        region_selector._group_member_name = "POLREF_1"
+        region_selector._data_view.masking = first_masking
+
+        region_selector.update_workspace(Mock(spec=MatrixWorkspace), "POLREF_2")
+
+        first_masking.set_visible.assert_called_once_with(False)
+        mock_masking_cls.assert_called_once_with(region_selector._data_view, "POLREF_2", auto_update_mask_file=True)
+        second_masking.new_selector.assert_called_once_with(ToolItemText.RECT_MASKING)
+        second_masking.set_visible.assert_called_once_with(True)
+        self.assertEqual(region_selector._data_view.masking, second_masking)
+
+    @patch("mantidqt.widgets.regionselector.presenter.Masking")
+    def test_update_workspace_restores_cached_group_member_masking(self, mock_masking_cls):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector.show_all_data_clicked = Mock()
+        first_masking = MagicMock()
+        second_masking = MagicMock()
+        region_selector._group_member_name = "POLREF_2"
+        region_selector._group_member_maskings = {"POLREF_1": first_masking}
+        region_selector._data_view.masking = second_masking
+
+        region_selector.update_workspace(Mock(spec=MatrixWorkspace), "POLREF_1")
+
+        second_masking.set_visible.assert_called_once_with(False)
+        first_masking.set_visible.assert_called_once_with(True)
+        mock_masking_cls.assert_not_called()
+        self.assertEqual(region_selector._data_view.masking, first_masking)
+
+    @patch("mantidqt.widgets.regionselector.presenter.Masking")
+    def test_update_workspace_applies_inverted_masking_to_a_new_group_member(self, mock_masking_cls):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector.show_all_data_clicked = Mock()
+        first_masking = MagicMock()
+        second_masking = MagicMock()
+        mock_masking_cls.return_value = second_masking
+        region_selector._group_member_name = "POLREF_1"
+        region_selector._data_view.masking = first_masking
+
+        region_selector.invert_masking_clicked(True)
+        region_selector.update_workspace(Mock(spec=MatrixWorkspace), "POLREF_2")
+
+        second_masking.invert_masking_clicked.assert_called_once_with(True)
+
+    def test_update_workspace_keeps_cached_group_member_masking_hidden_when_masking_is_inactive(self):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector.show_all_data_clicked = Mock()
+        first_masking = MagicMock()
+        region_selector._group_member_name = "POLREF_2"
+        region_selector._group_member_maskings = {"POLREF_1": first_masking}
+        region_selector._data_view.masking = None
+
+        region_selector.update_workspace(Mock(spec=MatrixWorkspace), "POLREF_1")
+
+        first_masking.set_visible.assert_not_called()
+        self.assertIsNone(region_selector._data_view.masking)
+
     def test_add_rectangular_region_creates_selector(self):
         region_selector = RegionSelector(ws=Mock(spec=MatrixWorkspace), view=self.mock_view)
 
@@ -137,6 +200,22 @@ class RegionSelectorTest(unittest.TestCase):
         region_selector.clear_workspace()
 
         mock_view.clear_figure.assert_called_once_with()
+
+    def test_clear_workspace_discards_group_member_maskings(self):
+        region_selector = RegionSelector(view=self.mock_view)
+        current_masking = MagicMock()
+        cached_masking = MagicMock()
+        region_selector._data_view.masking = current_masking
+        region_selector._group_member_maskings = {"POLREF_1": cached_masking}
+        region_selector._group_member_name = "POLREF_2"
+
+        region_selector.clear_workspace()
+
+        current_masking.clear_and_disconnect.assert_called_once_with()
+        cached_masking.clear_and_disconnect.assert_called_once_with()
+        self.assertIsNone(region_selector._data_view.masking)
+        self.assertEqual(region_selector._group_member_maskings, {})
+        self.assertIsNone(region_selector._group_member_name)
 
     def test_get_region_with_two_signal_regions(self):
         region_selector, selector_one, selector_two = self._mock_selectors()
@@ -340,17 +419,28 @@ class RegionSelectorTest(unittest.TestCase):
 
     def test_invert_masking_clicked(self):
         mock_masking = MagicMock()
+        cached_maskings = [MagicMock(), MagicMock()]
         mock_data_view = MagicMock()
         mock_data_view.masking = mock_masking
         self.mock_view.data_view = mock_data_view
 
         region_selector = RegionSelector(view=self.mock_view)
+        region_selector._group_member_maskings = {"POLREF_1": cached_maskings[0], "POLREF_2": cached_maskings[1]}
 
         region_selector.invert_masking_clicked(True)
+        self.assertTrue(region_selector._masking_inverted)
         mock_masking.invert_masking_clicked.assert_called_once_with(True)
+        for masking in cached_maskings:
+            masking.invert_masking_clicked.assert_called_once_with(True)
         mock_masking.reset_mock()
+        for masking in cached_maskings:
+            masking.reset_mock()
+
         region_selector.invert_masking_clicked(False)
+        self.assertFalse(region_selector._masking_inverted)
         mock_masking.invert_masking_clicked.assert_called_once_with(False)
+        for masking in cached_maskings:
+            masking.invert_masking_clicked.assert_called_once_with(False)
 
     def test_rect_masking_clicked(self):
         mock_masking = MagicMock()
@@ -416,6 +506,21 @@ class RegionSelectorTest(unittest.TestCase):
             ]
         )
 
+    def test_toggling_masking_off_discards_current_and_cached_group_member_maskings(self):
+        region_selector = RegionSelector(view=self.mock_view)
+        current_masking = MagicMock()
+        cached_maskings = [MagicMock(), MagicMock()]
+        region_selector._data_view.masking = current_masking
+        region_selector._group_member_maskings = {"POLREF_1": cached_maskings[0], "POLREF_2": cached_maskings[1]}
+
+        region_selector.masking(False)
+
+        current_masking.clear_and_disconnect.assert_called_once_with()
+        for masking in cached_maskings:
+            masking.clear_and_disconnect.assert_called_once_with()
+        self.assertIsNone(region_selector._data_view.masking)
+        self.assertEqual(region_selector._group_member_maskings, {})
+
     @patch("mantidqt.widgets.regionselector.presenter.Masking")
     def test_activate_masking(self, mock_masking_cls):
         region_selector = RegionSelector(view=self.mock_view)
@@ -444,6 +549,21 @@ class RegionSelectorTest(unittest.TestCase):
             ToolItemText.RECT_MASKING,
             True,
         )
+
+    @patch("mantidqt.widgets.regionselector.presenter.Masking")
+    def test_activate_masking_restores_cached_group_member_masking(self, mock_masking_cls):
+        region_selector = RegionSelector(view=self.mock_view)
+        region_selector._data_view = MagicMock()
+        cached_masking = MagicMock()
+        region_selector._group_member_name = "POLREF_1"
+        region_selector._group_member_maskings = {"POLREF_1": cached_masking}
+
+        region_selector._activate_masking()
+
+        cached_masking.set_visible.assert_called_once_with(True)
+        region_selector._data_view.canvas.draw_idle.assert_called_once_with()
+        mock_masking_cls.assert_not_called()
+        self.assertEqual(region_selector._data_view.masking, cached_masking)
 
     def test_display_rectangular_region_y1_out_of_bounds_does_not_add_selector(self):
         y_limits = (200, 500)

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -79,6 +79,18 @@ class RegionSelectorTest(unittest.TestCase):
         mock_view.set_workspace.assert_called_once_with(mock_ws)
         region_selector.show_all_data_clicked.assert_called_once()
 
+    def test_update_workspace_preserves_selector_extents(self):
+        region_selector = RegionSelector(view=Mock())
+        region_selector.show_all_data_clicked = Mock()
+        selector = Mock()
+        selector.extents = (1000.0, 5000.0, 10.0, 20.0)
+        region_selector._selectors = [selector]
+
+        region_selector.update_workspace(Mock(spec=MatrixWorkspace))
+
+        self.assertEqual(region_selector._selectors, [selector])
+        self.assertEqual(selector.extents, (1000.0, 5000.0, 10.0, 20.0))
+
     def test_add_rectangular_region_creates_selector(self):
         region_selector = RegionSelector(ws=Mock(spec=MatrixWorkspace), view=self.mock_view)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/masking.py
@@ -459,7 +459,9 @@ class MaskingModel:
 
     def invert_masking_clicked(self, active):
         self._apply_inverted_mask = active
-        if self._auto_update_mask_file and self._active_mask:
-            self._masks.append(self._active_mask)
+        if self._auto_update_mask_file and (self._active_mask or self._masks):
+            if self._active_mask:
+                self._masks.append(self._active_mask)
             self.export_selectors()
-            self._masks.remove(self._active_mask)
+            if self._active_mask:
+                self._masks.pop()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/masking.py
@@ -29,6 +29,10 @@ class SelectionMaskingBase(ABC):
     def set_active(self, state):
         self._selector.set_active(state)
 
+    def set_visible(self, visible):
+        for artist in self._selector.artists:
+            artist.set_visible(visible)
+
     def clear(self):
         if self._clear:
             return
@@ -231,6 +235,13 @@ class Masking:
     def clear_model(self):
         self._model.clear_active_mask()
         self._model.clear_stored_masks()
+
+    def set_visible(self, visible):
+        for selector in self._selectors:
+            selector.set_visible(visible)
+        if self._active_selector:
+            self._active_selector.set_visible(visible)
+            self._active_selector.set_active(visible)
 
     def invert_masking_clicked(self, active):
         self._model.invert_masking_clicked(active)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingmodel.py
@@ -140,6 +140,16 @@ class SliceViewerMaskingModelTest(unittest.TestCase):
         self.assertFalse(self.model._apply_inverted_mask)
         self.model.export_selectors.assert_called_once()
 
+    def test_invert_masking_clicked_exports_stored_masks_without_an_active_mask(self):
+        self.model._auto_update_mask_file = True
+        self.model._masks = ["stored_mask"]
+        self.model.export_selectors = MagicMock()
+
+        self.model.invert_masking_clicked(True)
+
+        self.assertTrue(self.model._apply_inverted_mask)
+        self.model.export_selectors.assert_called_once_with()
+
     def test_export_selectors(self):
         with (
             patch("mantidqt.widgets.sliceviewer.models.masking.AnalysisDataService") as ads_mock,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_maskingpresenter.py
@@ -132,6 +132,19 @@ class SliceViewerMaskingPresenterTest(unittest.TestCase):
         mock_model.clear_active_mask.assert_called_once()
         mock_model.clear_stored_masks.assert_called_once()
 
+    def test_set_visible_updates_stored_and_active_selectors(self):
+        active_selector = Mock()
+        presenter, _ = self._setup_presenter_test(active_selector=active_selector)
+        stored_selectors = [Mock(), Mock()]
+        presenter._selectors = stored_selectors
+
+        presenter.set_visible(False)
+
+        for selector in stored_selectors:
+            selector.set_visible.assert_called_once_with(False)
+        active_selector.set_visible.assert_called_once_with(False)
+        active_selector.set_active.assert_called_once_with(False)
+
 
 class SliceViewerSelectionMaskingTest(unittest.TestCase):
     Click = namedtuple("Click", ["xdata", "ydata"])
@@ -161,6 +174,17 @@ class SliceViewerSelectionMaskingTest(unittest.TestCase):
 
             selector.add_cursor_info("test_click", "test_release")
             mocks["model"].add_elli_cursor_info.assert_called_once_with(click="test_click", release="test_release", transpose=False)
+
+    def test_set_visible_updates_all_selector_artists(self):
+        with patch("mantidqt.widgets.sliceviewer.presenters.masking.make_selector_class") as selector_fn_mock:
+            artists = [Mock(), Mock()]
+            selector_fn_mock.return_value.return_value.artists = artists
+            selector, _ = self._set_up_selector_test(ToolItemText.RECT_MASKING)
+
+            selector.set_visible(False)
+
+            for artist in artists:
+                artist.set_visible.assert_called_once_with(False)
 
     def _test_inactive_color_rect_base(self, text):
         with patch("mantidqt.widgets.sliceviewer.presenters.masking.make_selector_class") as selector_fn_mock:

--- a/qt/scientific_interfaces/ISISReflectometry/Common/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/CMakeLists.txt
@@ -1,5 +1,11 @@
-set(COMMON_SRC_FILES Detector.cpp Parse.cpp GetInstrumentParameter.cpp InstrumentParameters.cpp OptionDefaults.cpp
-                     Clipboard.cpp
+set(COMMON_SRC_FILES
+    Detector.cpp
+    Parse.cpp
+    GetInstrumentParameter.cpp
+    GroupHelper.cpp
+    InstrumentParameters.cpp
+    OptionDefaults.cpp
+    Clipboard.cpp
 )
 
 # Include files aren't required, but this makes them appear in Visual Studio IMPORTANT: Include files are required in
@@ -10,6 +16,7 @@ set(COMMON_INC_FILES
     DllConfig.h
     First.h
     GetInstrumentParameter.h
+    GroupHelper.h
     IndexOf.h
     InstrumentParameters.h
     Map.h

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.cpp
@@ -9,6 +9,15 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
+namespace {
+
+void throwUnsupportedWsError() {
+  throw std::runtime_error(
+      "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of MatrixWorkspaces");
+}
+
+} // namespace
+
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 /**
@@ -19,20 +28,28 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
  * @param ws A MatrixWorkspace or WorkspaceGroup of MatrixWorkspaces.
  * @return a vector containing the MatrixWorkspaces present in the input.
  */
-std::vector<Mantid::API::MatrixWorkspace_sptr> getMembers(Mantid::API::Workspace_sptr const &ws) {
+std::vector<Mantid::API::MatrixWorkspace_sptr> getMembers(Mantid::API::Workspace_sptr const &ws, bool validate) {
   auto matrix_ws = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
   if (matrix_ws) {
     return {matrix_ws};
   }
   auto ws_group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws);
-  if (!ws_group) {
+  if (!ws_group || ws_group->isEmpty()) {
+    if (validate) {
+      throwUnsupportedWsError();
+    }
     return {};
   }
   std::vector<Mantid::API::MatrixWorkspace_sptr> members;
   members.reserve(ws_group->size());
   auto const &allItems = ws_group->getAllItems();
-  std::transform(allItems.cbegin(), allItems.cend(), std::back_inserter(members),
-                 [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); });
+  std::transform(allItems.cbegin(), allItems.cend(), std::back_inserter(members), [validate](auto const &member) {
+    auto maybe_matrix = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member);
+    if (validate && !maybe_matrix) {
+      throwUnsupportedWsError();
+    }
+    return maybe_matrix;
+  });
   return members;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.cpp
@@ -1,0 +1,39 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "GroupHelper.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+
+/**
+ * Extract a vector of MatrixWorkspaces from a Workspace pointer.
+ * Returns a length 1 list if the input is a MatrixWorkspace already.
+ * Otherwise extracts the MatrixWorkspaces from the group.
+ *
+ * @param ws A MatrixWorkspace or WorkspaceGroup of MatrixWorkspaces.
+ * @return a vector containing the MatrixWorkspaces present in the input.
+ */
+std::vector<Mantid::API::MatrixWorkspace_sptr> getMembers(Mantid::API::Workspace_sptr const &ws) {
+  auto matrix_ws = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+  if (matrix_ws) {
+    return {matrix_ws};
+  }
+  auto ws_group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws);
+  if (!ws_group) {
+    return {};
+  }
+  std::vector<Mantid::API::MatrixWorkspace_sptr> members;
+  members.reserve(ws_group->size());
+  auto const &allItems = ws_group->getAllItems();
+  std::transform(allItems.cbegin(), allItems.cend(), std::back_inserter(members),
+                 [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); });
+  return members;
+}
+
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.h
@@ -18,7 +18,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 MANTIDQT_ISISREFLECTOMETRY_DLL std::vector<Mantid::API::MatrixWorkspace_sptr>
-getMembers(Mantid::API::Workspace_sptr const &workspace);
+getMembers(Mantid::API::Workspace_sptr const &workspace, bool validate = false);
 
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GroupHelper.h
@@ -1,0 +1,25 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+#include "DllConfig.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace.h"
+
+#include <vector>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace ISISReflectometry {
+
+MANTIDQT_ISISREFLECTOMETRY_DLL std::vector<Mantid::API::MatrixWorkspace_sptr>
+getMembers(Mantid::API::Workspace_sptr const &workspace);
+
+} // namespace ISISReflectometry
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
@@ -13,7 +13,7 @@
 #include "MantidAPI/AlgorithmProperties.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/IAlgorithm.h"
-#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "Reduction/Item.h"
 #include "Reduction/PreviewRow.h"
@@ -69,10 +69,8 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
 void updateRowOnAlgorithmComplete(const Mantid::API::IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
   Mantid::API::Workspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
-  auto matrixWs = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(outputWs);
-  if (!matrixWs)
-    throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace");
-  row.setLoadedWs(matrixWs);
+  validatePreviewWorkspace(outputWs);
+  row.setLoadedWs(outputWs);
   // TODO reset the rest of the workspaces associated with the workflow
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -239,15 +239,6 @@ std::optional<double> getDouble(const IAlgorithm_sptr &algorithm, std::string co
   return result;
 }
 
-MatrixWorkspace_sptr getMatrixWorkspaceOutput(const IAlgorithm_sptr &algorithm, std::string const &property) {
-  Workspace_sptr outputWs = algorithm->getProperty(property);
-  auto matrixOutputWs = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(outputWs);
-  if (!matrixOutputWs) {
-    throw std::runtime_error("Expected output property " + property + " to be a MatrixWorkspace.");
-  }
-  return matrixOutputWs;
-}
-
 void updateRowFromOutputProperties(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<Row &>(item);
 
@@ -366,7 +357,7 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
 
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
-  auto outputWs = getMatrixWorkspaceOutput(algorithm, "OutputWorkspaceBinned");
+  Workspace_sptr outputWs = algorithm->getProperty("OutputWorkspaceBinned");
   row.setReducedWs(outputWs);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/Logger.h"
 
 using namespace MantidQt::CustomInterfaces::ISISReflectometry;
@@ -352,6 +353,9 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
   updateProcessingInstructionsProperties(*properties, previewRow);
 
   properties->setProperty("HideInputWorkspaces", true);
+  if (std::dynamic_pointer_cast<WorkspaceGroup>(previewRow.getLoadedWs())) {
+    properties->setProperty("GroupTOFWorkspaces", false);
+  }
   return properties;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
@@ -11,7 +11,7 @@
 #include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/IAlgorithmRuntimeProps.h"
-#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "Reduction/IBatch.h"
 #include "Reduction/Item.h"
@@ -26,7 +26,7 @@ using MantidQt::API::IConfiguredAlgorithm;
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 
 namespace {
-void updateInputProperties(Mantid::API::IAlgorithmRuntimeProps &properties, MatrixWorkspace_sptr const &workspace,
+void updateInputProperties(Mantid::API::IAlgorithmRuntimeProps &properties, Workspace_sptr const &workspace,
                            std::optional<ProcessingInstructions> const &detIDsStr) {
   Workspace_sptr inputWorkspace = workspace;
   properties.setProperty("InputWorkspace", inputWorkspace);
@@ -75,6 +75,6 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
   Workspace_sptr outputWorkspace = algorithm->getProperty("OutputWorkspace");
-  row.setSummedWs(std::dynamic_pointer_cast<MatrixWorkspace>(outputWorkspace));
+  row.setSummedWs(outputWorkspace);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -47,6 +47,7 @@ public:
 
   // Instrument display
   virtual void updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
+  virtual void updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
   virtual void resetInstView() = 0;
   virtual void plotInstView() = 0;
   //  Instrument viewer toolbar

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -38,6 +38,7 @@ public:
   virtual void notifyEditROIModeRequested() = 0;
   virtual void notifyRectangularROIModeRequested() = 0;
   virtual void notifySetYAxisSymlogChanged() = 0;
+  virtual void notifyPlotAllGroupMembersChanged() = 0;
 };
 
 class IPreviewDockedWidgets {
@@ -67,6 +68,8 @@ public:
   virtual std::string getRegionType() const = 0;
   virtual double getLinthresh() const = 0;
   virtual bool getSymlogEnabled() const = 0;
+  virtual bool getPlotAllGroupMembers() const = 0;
+  virtual void setPlotAllGroupMembersCheckboxVisible(bool visible) = 0;
 
   virtual QLayout *getRegionSelectorLayout() const = 0;
   virtual MantidQt::MantidWidgets::IPlotView *getLinePlotView() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewInstrumentDisplay.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewInstrumentDisplay.h
@@ -20,6 +20,7 @@ public:
   virtual ~IPreviewInstrumentDisplay() = default;
 
   virtual void updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
+  virtual void updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
   virtual void resetInstView() = 0;
   virtual void plotInstView() = 0;
   virtual void setInstViewZoomMode() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include "ROIType.h"
 #include "Reduction/PreviewRow.h"
@@ -30,16 +31,23 @@ public:
   virtual void sumBanksAsync(IJobManager &jobManager) = 0;
   virtual void reduceAsync(IJobManager &jobManager) = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
+  virtual Mantid::API::Workspace_sptr getLoadedWs() const = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr getSelectedLoadedWs() const = 0;
   virtual std::optional<ProcessingInstructions> getSelectedBanks() const = 0;
-  virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
-  virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
+  virtual Mantid::API::Workspace_sptr getSummedWs() const = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr getSelectedSummedWs() const = 0;
+  virtual Mantid::API::Workspace_sptr getReducedWs() const = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const = 0;
+  virtual bool isWorkspaceGroup() const = 0;
+  virtual size_t getNumberOfGroupMembers() const = 0;
+  virtual size_t getSelectedGroupMember() const = 0;
+  virtual void setSelectedGroupMember(size_t index) = 0;
   virtual std::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const = 0;
   virtual std::optional<double> getDefaultTheta() const = 0;
   virtual PreviewRow const &getPreviewRow() const = 0;
   virtual std::optional<Selection> const getSelectedRegion(ROIType regionType) = 0;
 
-  virtual void setSummedWs(Mantid::API::MatrixWorkspace_sptr workspace) = 0;
+  virtual void setSummedWs(Mantid::API::Workspace_sptr workspace) = 0;
 
   virtual void setTheta(double theta) = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -38,6 +38,7 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr getSelectedSummedWs() const = 0;
   virtual Mantid::API::Workspace_sptr getReducedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const = 0;
+  virtual std::vector<Mantid::API::MatrixWorkspace_sptr> getReducedWorkspaceMembers() const = 0;
   virtual bool isWorkspaceGroup() const = 0;
   virtual std::vector<std::string> getGroupMemberDisplayNames() const = 0;
   virtual size_t getNumberOfGroupMembers() const = 0;
@@ -49,6 +50,7 @@ public:
   virtual std::optional<Selection> const getSelectedRegion(ROIType regionType) = 0;
 
   virtual void setSummedWs(Mantid::API::Workspace_sptr workspace) = 0;
+  virtual void clearReducedWorkspace() = 0;
 
   virtual void setTheta(double theta) = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -39,6 +39,7 @@ public:
   virtual Mantid::API::Workspace_sptr getReducedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const = 0;
   virtual bool isWorkspaceGroup() const = 0;
+  virtual std::vector<std::string> getGroupMemberDisplayNames() const = 0;
   virtual size_t getNumberOfGroupMembers() const = 0;
   virtual size_t getSelectedGroupMember() const = 0;
   virtual void setSelectedGroupMember(size_t index) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -11,8 +11,10 @@
 #include "MantidQtWidgets/InstrumentView/RotationSurface.h"
 
 #include <QLayout>
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace MantidQt::MantidWidgets {
 class IPlotView;
@@ -28,6 +30,7 @@ public:
   virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
 
   virtual void notifyLoadWorkspaceRequested() = 0;
+  virtual void notifyGroupMemberSelectionChanged() = 0;
   virtual void notifyUpdateAngle() = 0;
   virtual void notifyApplyRequested() = 0;
 };
@@ -42,9 +45,11 @@ public:
   virtual void disableMainWidget() = 0;
 
   virtual std::string getWorkspaceName() const = 0;
+  virtual size_t getSelectedGroupMember() const = 0;
   virtual double getAngle() const = 0;
   virtual void setAngle(double angle) = 0;
   virtual void setUpdateAngleButtonEnabled(bool enabled) = 0;
   virtual void setTitle(const std::string &title) = 0;
+  virtual void setGroupMembers(std::vector<std::string> const &workspaceNames) = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -249,6 +249,16 @@
                         </layout>
                     </widget>
                 </item>
+                <item>
+                    <widget class="QCheckBox" name="plot_all_group_members_checkbox">
+                        <property name="visible">
+                            <bool>false</bool>
+                        </property>
+                        <property name="text">
+                            <string>Plot reduction preview for all group members</string>
+                        </property>
+                    </widget>
+                </item>
             </layout>
         </item>
       </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -22,7 +22,9 @@
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
+#include <algorithm>
 #include <filesystem>
+#include <iterator>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -101,8 +103,9 @@ std::vector<MatrixWorkspace_sptr> PreviewModel::getReducedWorkspaceMembers() con
   auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getReducedWs());
   std::vector<MatrixWorkspace_sptr> members;
   members.reserve(group->size());
-  for (auto const &member : group->getAllItems())
-    members.emplace_back(std::dynamic_pointer_cast<MatrixWorkspace>(member));
+  auto const &allItems = group->getAllItems();
+  std::transform(allItems.cbegin(), allItems.cend(), std::back_inserter(members),
+                 [](auto const &member) { return std::dynamic_pointer_cast<MatrixWorkspace>(member); });
   return members;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/Logger.h"
@@ -22,6 +23,7 @@
 #include <boost/utility/in_place_factory.hpp>
 
 #include <optional>
+#include <stdexcept>
 #include <string>
 
 using namespace Mantid::API;
@@ -29,7 +31,7 @@ using namespace Mantid::Kernel;
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Preview Model");
-}
+} // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -49,10 +51,8 @@ bool PreviewModel::loadWorkspaceFromAds(std::string const &workspaceName) {
   if (!adsInstance.doesExist(workspaceName)) {
     return false;
   }
-  auto ws = adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
-  if (!ws) {
-    throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace");
-  }
+  auto ws = adsInstance.retrieve(workspaceName);
+  validatePreviewWorkspace(ws);
 
   createRunDetails(workspaceName);
   m_runDetails->setLoadedWs(ws);
@@ -80,9 +80,38 @@ void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumB
 
 void PreviewModel::reduceAsync(IJobManager &jobManager) { jobManager.startReduction(*m_runDetails); }
 
-MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
-MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
-MatrixWorkspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->getReducedWs(); }
+Workspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
+MatrixWorkspace_sptr PreviewModel::getSelectedLoadedWs() const {
+  return getWorkspaceGroupMember(m_runDetails->getLoadedWs());
+}
+Workspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
+MatrixWorkspace_sptr PreviewModel::getSelectedSummedWs() const {
+  return getWorkspaceGroupMember(m_runDetails->getSummedWs());
+}
+Workspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->getReducedWs(); }
+MatrixWorkspace_sptr PreviewModel::getSelectedReducedWs() const {
+  return getWorkspaceGroupMember(m_runDetails->getReducedWs());
+}
+
+bool PreviewModel::isWorkspaceGroup() const {
+  return static_cast<bool>(std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getLoadedWs()));
+}
+
+size_t PreviewModel::getNumberOfGroupMembers() const {
+  auto const workspace = m_runDetails->getLoadedWs();
+  if (!workspace)
+    return 0;
+  auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(workspace);
+  return group ? group->size() : 1;
+}
+
+size_t PreviewModel::getSelectedGroupMember() const { return m_selectedGroupMember; }
+
+void PreviewModel::setSelectedGroupMember(size_t index) {
+  if (index >= getNumberOfGroupMembers())
+    throw std::out_of_range("Workspace group member index is out of range");
+  m_selectedGroupMember = index;
+}
 
 std::optional<double> PreviewModel::getDefaultTheta() const {
   auto theta = getThetaFromLogs("Theta");
@@ -98,9 +127,9 @@ std::optional<ProcessingInstructions> PreviewModel::getSelectedBanks() const {
   return m_runDetails->getSelectedBanks();
 }
 
-void PreviewModel::setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace) { m_runDetails->setLoadedWs(workspace); }
+void PreviewModel::setLoadedWs(Mantid::API::Workspace_sptr workspace) { m_runDetails->setLoadedWs(workspace); }
 
-void PreviewModel::setSummedWs(Mantid::API::MatrixWorkspace_sptr workspace) { m_runDetails->setSummedWs(workspace); }
+void PreviewModel::setSummedWs(Mantid::API::Workspace_sptr workspace) { m_runDetails->setSummedWs(workspace); }
 
 void PreviewModel::setTheta(double theta) { m_runDetails->setTheta(theta); }
 void PreviewModel::setSelectedBanks(std::optional<ProcessingInstructions> selectedBanks) {
@@ -165,6 +194,13 @@ std::optional<IPreviewModel::Selection> const PreviewModel::getSelectedRegion(RO
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {
   m_runDetails = std::make_optional<PreviewRow>(std::vector<std::string>{workspaceName});
+  m_selectedGroupMember = 0;
+}
+
+MatrixWorkspace_sptr PreviewModel::getWorkspaceGroupMember(Workspace_sptr const &workspace) const {
+  if (auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(workspace))
+    return std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(m_selectedGroupMember));
+  return std::dynamic_pointer_cast<MatrixWorkspace>(workspace);
 }
 
 void PreviewModel::exportSummedWsToAds() const {
@@ -185,7 +221,7 @@ void PreviewModel::exportReducedWsToAds() const {
 }
 
 std::optional<double> PreviewModel::getThetaFromLogs(const std::string &logName) const {
-  const Mantid::API::Run &run = getLoadedWs()->run();
+  const Mantid::API::Run &run = getSelectedLoadedWs()->run();
   if (!run.hasProperty(logName)) {
     return std::nullopt;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "PreviewModel.h"
+#include "Common/GroupHelper.h"
 #include "GUI/Common/IJobManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -100,13 +101,7 @@ MatrixWorkspace_sptr PreviewModel::getSelectedReducedWs() const {
 }
 
 std::vector<MatrixWorkspace_sptr> PreviewModel::getReducedWorkspaceMembers() const {
-  auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getReducedWs());
-  std::vector<MatrixWorkspace_sptr> members;
-  members.reserve(group->size());
-  auto const &allItems = group->getAllItems();
-  std::transform(allItems.cbegin(), allItems.cend(), std::back_inserter(members),
-                 [](auto const &member) { return std::dynamic_pointer_cast<MatrixWorkspace>(member); });
-  return members;
+  return getMembers(m_runDetails->getReducedWs());
 }
 
 bool PreviewModel::isWorkspaceGroup() const {
@@ -126,13 +121,7 @@ std::vector<std::string> PreviewModel::getGroupMemberDisplayNames() const {
   return names;
 }
 
-size_t PreviewModel::getNumberOfGroupMembers() const {
-  auto const workspace = m_runDetails->getLoadedWs();
-  if (!workspace)
-    return 0;
-  auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(workspace);
-  return group ? group->size() : 1;
-}
+size_t PreviewModel::getNumberOfGroupMembers() const { return getMembers(m_runDetails->getLoadedWs()).size(); }
 
 size_t PreviewModel::getSelectedGroupMember() const { return m_selectedGroupMember; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -22,6 +22,7 @@
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
+#include <filesystem>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -95,6 +96,19 @@ MatrixWorkspace_sptr PreviewModel::getSelectedReducedWs() const {
 
 bool PreviewModel::isWorkspaceGroup() const {
   return static_cast<bool>(std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getLoadedWs()));
+}
+
+std::vector<std::string> PreviewModel::getGroupMemberDisplayNames() const {
+  auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getLoadedWs());
+  if (!group)
+    return {};
+
+  auto names = group->getNames();
+  auto const prefix = std::filesystem::path(m_runDetails->runNumbers().front()).stem().string();
+  for (size_t i = 0; i < names.size(); ++i)
+    if (names[i].empty())
+      names[i] = prefix + "_" + std::to_string(i + 1);
+  return names;
 }
 
 size_t PreviewModel::getNumberOfGroupMembers() const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -90,8 +90,20 @@ MatrixWorkspace_sptr PreviewModel::getSelectedSummedWs() const {
   return getWorkspaceGroupMember(m_runDetails->getSummedWs());
 }
 Workspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->getReducedWs(); }
+
+void PreviewModel::clearReducedWorkspace() { m_runDetails->setReducedWs(nullptr); }
+
 MatrixWorkspace_sptr PreviewModel::getSelectedReducedWs() const {
   return getWorkspaceGroupMember(m_runDetails->getReducedWs());
+}
+
+std::vector<MatrixWorkspace_sptr> PreviewModel::getReducedWorkspaceMembers() const {
+  auto const group = std::dynamic_pointer_cast<WorkspaceGroup>(m_runDetails->getReducedWs());
+  std::vector<MatrixWorkspace_sptr> members;
+  members.reserve(group->size());
+  for (auto const &member : group->getAllItems())
+    members.emplace_back(std::dynamic_pointer_cast<MatrixWorkspace>(member));
+  return members;
 }
 
 bool PreviewModel::isWorkspaceGroup() const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -43,6 +43,7 @@ public:
   Mantid::API::Workspace_sptr getReducedWs() const override;
   Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const override;
   bool isWorkspaceGroup() const override;
+  std::vector<std::string> getGroupMemberDisplayNames() const override;
   size_t getNumberOfGroupMembers() const override;
   size_t getSelectedGroupMember() const override;
   void setSelectedGroupMember(size_t index) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -42,6 +42,7 @@ public:
   std::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const override;
   Mantid::API::Workspace_sptr getReducedWs() const override;
   Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const override;
+  std::vector<Mantid::API::MatrixWorkspace_sptr> getReducedWorkspaceMembers() const override;
   bool isWorkspaceGroup() const override;
   std::vector<std::string> getGroupMemberDisplayNames() const override;
   size_t getNumberOfGroupMembers() const override;
@@ -53,6 +54,7 @@ public:
 
   void setLoadedWs(Mantid::API::Workspace_sptr workspace);
   void setSummedWs(Mantid::API::Workspace_sptr workspace) override;
+  void clearReducedWorkspace() override;
   void setTheta(double theta) override;
   void setSelectedBanks(std::optional<ProcessingInstructions> selectedBanks) override;
   void setSelectedRegion(ROIType regionType, Selection const &selection) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -10,6 +10,7 @@
 #include "Common/DllConfig.h"
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include "ROIType.h"
 #include "Reduction/PreviewRow.h"
@@ -33,17 +34,24 @@ public:
   void sumBanksAsync(IJobManager &jobManager) override;
   void reduceAsync(IJobManager &jobManager) override;
 
-  Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
+  Mantid::API::Workspace_sptr getLoadedWs() const override;
+  Mantid::API::MatrixWorkspace_sptr getSelectedLoadedWs() const override;
   std::optional<ProcessingInstructions> getSelectedBanks() const override;
-  Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
+  Mantid::API::Workspace_sptr getSummedWs() const override;
+  Mantid::API::MatrixWorkspace_sptr getSelectedSummedWs() const override;
   std::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const override;
-  Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
+  Mantid::API::Workspace_sptr getReducedWs() const override;
+  Mantid::API::MatrixWorkspace_sptr getSelectedReducedWs() const override;
+  bool isWorkspaceGroup() const override;
+  size_t getNumberOfGroupMembers() const override;
+  size_t getSelectedGroupMember() const override;
+  void setSelectedGroupMember(size_t index) override;
   std::optional<double> getDefaultTheta() const override;
   PreviewRow const &getPreviewRow() const override;
   std::optional<Selection> const getSelectedRegion(ROIType regionType) override;
 
-  void setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace);
-  void setSummedWs(Mantid::API::MatrixWorkspace_sptr workspace) override;
+  void setLoadedWs(Mantid::API::Workspace_sptr workspace);
+  void setSummedWs(Mantid::API::Workspace_sptr workspace) override;
   void setTheta(double theta) override;
   void setSelectedBanks(std::optional<ProcessingInstructions> selectedBanks) override;
   void setSelectedRegion(ROIType regionType, Selection const &selection) override;
@@ -53,8 +61,10 @@ public:
 
 private:
   std::optional<PreviewRow> m_runDetails;
+  size_t m_selectedGroupMember{0};
 
   void createRunDetails(std::string const &workspaceName);
+  Mantid::API::MatrixWorkspace_sptr getWorkspaceGroupMember(Mantid::API::Workspace_sptr const &workspace) const;
 
   std::optional<double> getThetaFromLogs(std::string const &logName) const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -32,6 +32,11 @@ class QLayout;
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Preview Presenter");
+
+void warnIfUnexpectedSpectrumCount(MatrixWorkspace_sptr const &workspace) {
+  if (workspace->getNumberHistograms() != 1)
+    g_log.warning("Reduced workspace has " + std::to_string(workspace->getNumberHistograms()) + " spectra; expected 1");
+}
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -88,6 +93,11 @@ void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState();
 
 void PreviewPresenter::notifySetYAxisSymlogChanged() { updatePlotAxes(); }
 
+void PreviewPresenter::notifyPlotAllGroupMembersChanged() {
+  if (m_model->getReducedWs())
+    plotLinePlot();
+}
+
 void PreviewPresenter::updateWidgetEnabledState() {
   if (mainPresenter().isProcessing() || mainPresenter().isAutoreducing()) {
     m_view->disableMainWidget();
@@ -114,6 +124,7 @@ void PreviewPresenter::updatePlotAxes() {
  */
 void PreviewPresenter::notifyLoadWorkspaceRequested() {
   m_view->disableMainWidget();
+  m_dockedWidgets->setPlotAllGroupMembersCheckboxVisible(false);
   auto const name = m_view->getWorkspaceName();
   try {
     if (m_model->loadWorkspaceFromAds(name)) {
@@ -137,6 +148,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   assert(ws);
 
   m_view->setGroupMembers(m_model->getGroupMemberDisplayNames());
+  m_dockedWidgets->setPlotAllGroupMembersCheckboxVisible(m_model->isWorkspaceGroup());
 
   // Set the angle so that it has a non-zero value when the reduction is run
   if (auto const theta = m_model->getDefaultTheta()) {
@@ -340,13 +352,17 @@ void PreviewPresenter::plotRegionSelector() {
 }
 
 void PreviewPresenter::plotLinePlot() {
-  auto ws = m_model->getSelectedReducedWs();
-  assert(ws);
-  auto const numSpec = ws->getNumberHistograms();
-  if (numSpec != 1) {
-    g_log.warning("Reduced workspace has " + std::to_string(numSpec) + " spectra; expected 1");
+  if (m_dockedWidgets->getPlotAllGroupMembers()) {
+    auto const workspaces = m_model->getReducedWorkspaceMembers();
+    for (auto const &workspace : workspaces)
+      warnIfUnexpectedSpectrumCount(workspace);
+    m_plotPresenter->setSpectra(workspaces, 0);
+  } else {
+    auto const workspace = m_model->getSelectedReducedWs();
+    assert(workspace);
+    warnIfUnexpectedSpectrumCount(workspace);
+    m_plotPresenter->setSpectrum(workspace, 0);
   }
-  m_plotPresenter->setSpectrum(ws, 0);
   m_plotPresenter->plot();
 }
 
@@ -394,6 +410,7 @@ void PreviewPresenter::runReduction() {
   // Ensure the selected regions are up to date. Required when Loading new data because an empty run details is created.
   updateSelectedRegionInModelFromView();
   // Perform the reduction
+  m_model->clearReducedWorkspace();
   m_model->reduceAsync(*m_jobManager);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -133,7 +133,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   // The model has already been updated by another callback to contain the loaded workspace. If loading fails
   // then it should bail out early and this method should never be called, so the workspace should
   // always be valid at this point.
-  auto ws = m_model->getLoadedWs();
+  auto ws = m_model->getSelectedLoadedWs();
   assert(ws);
 
   // Set the angle so that it has a non-zero value when the reduction is run
@@ -321,7 +321,7 @@ void PreviewPresenter::plotRegionSelector() {
 }
 
 void PreviewPresenter::plotLinePlot() {
-  auto ws = m_model->getReducedWs();
+  auto ws = m_model->getSelectedReducedWs();
   assert(ws);
   auto const numSpec = ws->getNumberHistograms();
   if (numSpec != 1) {
@@ -334,7 +334,7 @@ void PreviewPresenter::plotLinePlot() {
 void PreviewPresenter::runSumBanks(bool const addExistingROIsToPlot) {
   m_plotExistingROIs = addExistingROIsToPlot;
 
-  if (!m_model->getLoadedWs()) {
+  if (!m_model->getSelectedLoadedWs()) {
     g_log.error("Unable to perform sum banks step because there is no run loaded");
     return;
   }
@@ -364,7 +364,7 @@ void PreviewPresenter::runSumBanks(bool const addExistingROIsToPlot) {
 }
 
 void PreviewPresenter::runReduction() {
-  if (!m_model->getLoadedWs()) {
+  if (!m_model->getSelectedLoadedWs()) {
     g_log.error("Unable to perform preview reduction because there is no run loaded");
     return;
   }
@@ -397,6 +397,8 @@ void PreviewPresenter::updateSelectedRegionInModelFromView() {
                              m_regionSelector->getRegion(roiTypeToString(ROIType::Transmission)));
 }
 
-void PreviewPresenter::updateRegionSelectorWorkspace() { m_regionSelector->updateWorkspace(m_model->getSummedWs()); }
+void PreviewPresenter::updateRegionSelectorWorkspace() {
+  m_regionSelector->updateWorkspace(m_model->getSelectedSummedWs());
+}
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -136,6 +136,8 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   auto ws = m_model->getSelectedLoadedWs();
   assert(ws);
 
+  m_view->setGroupMembers(m_model->getGroupMemberDisplayNames());
+
   // Set the angle so that it has a non-zero value when the reduction is run
   if (auto const theta = m_model->getDefaultTheta()) {
     m_view->setAngle(*theta);
@@ -154,6 +156,23 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   m_dockedWidgets->setInstViewToolbarEnabled(true);
   notifyInstViewZoomRequested();
   runSumBanks(true);
+}
+
+void PreviewPresenter::notifyGroupMemberSelectionChanged() {
+  m_model->setSelectedGroupMember(m_view->getSelectedGroupMember());
+  updateSelectedGroupMemberDisplay();
+}
+
+void PreviewPresenter::updateSelectedGroupMemberDisplay() {
+  auto loadedWs = m_model->getSelectedLoadedWs();
+  assert(loadedWs);
+  m_view->setTitle(loadedWs->getTitle());
+  m_dockedWidgets->updateWorkspacePreservingSelection(loadedWs);
+
+  if (m_model->getSelectedSummedWs())
+    updateRegionSelectorWorkspace();
+  if (m_model->getSelectedReducedWs())
+    plotLinePlot();
 }
 
 void PreviewPresenter::notifyUpdateAngle() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -417,7 +417,13 @@ void PreviewPresenter::updateSelectedRegionInModelFromView() {
 }
 
 void PreviewPresenter::updateRegionSelectorWorkspace() {
-  m_regionSelector->updateWorkspace(m_model->getSelectedSummedWs());
+  auto const groupMemberNames = m_model->getGroupMemberDisplayNames();
+  if (groupMemberNames.empty()) {
+    m_regionSelector->updateWorkspace(m_model->getSelectedSummedWs());
+  } else {
+    m_regionSelector->updateWorkspaceForGroupMember(m_model->getSelectedSummedWs(),
+                                                    groupMemberNames[m_model->getSelectedGroupMember()]);
+  }
 }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -124,6 +124,7 @@ void PreviewPresenter::updatePlotAxes() {
  */
 void PreviewPresenter::notifyLoadWorkspaceRequested() {
   m_view->disableMainWidget();
+  m_view->setGroupMembers({});
   m_dockedWidgets->setPlotAllGroupMembersCheckboxVisible(false);
   auto const name = m_view->getWorkspaceName();
   try {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -80,6 +80,7 @@ public:
   void notifyEditROIModeRequested() override;
   void notifyRectangularROIModeRequested() override;
   void notifySetYAxisSymlogChanged() override;
+  void notifyPlotAllGroupMembersChanged() override;
 
   void notifyApplyRequested() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -66,6 +66,7 @@ public:
 
   // PreviewViewSubscriber overrides
   void notifyLoadWorkspaceRequested() override;
+  void notifyGroupMemberSelectionChanged() override;
   void notifyUpdateAngle() override;
 
   void notifyInstViewZoomRequested() override;
@@ -124,5 +125,6 @@ private:
   bool isRegionSelectionChanged();
   bool isRegionChanged(ROIType type);
   void updatePlotAxes();
+  void updateSelectedGroupMemberDisplay();
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPythonInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPythonInstrumentView.cpp
@@ -106,6 +106,10 @@ void PreviewPythonInstrumentView::updateWorkspace(MatrixWorkspace_sptr &workspac
   }
 }
 
+void PreviewPythonInstrumentView::updateWorkspacePreservingSelection(MatrixWorkspace_sptr &workspace) {
+  updateWorkspace(workspace);
+}
+
 void PreviewPythonInstrumentView::resetInstView() {
   try {
     GlobalInterpreterLock lock;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPythonInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPythonInstrumentView.h
@@ -30,6 +30,7 @@ public:
   void setShapeChangedCallback(std::function<void()> callback);
 
   void updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) override;
+  void updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) override;
   void resetInstView() override;
   void plotInstView() override;
   void setInstViewZoomMode() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -119,6 +119,40 @@
        </property>
       </widget>
      </item>
+   </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="group_member_layout">
+     <item>
+      <widget class="QLabel" name="group_member_label">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Group member</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="group_member_combo_box">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="group_member_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
     </layout>
    </item>
    <item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -131,6 +131,10 @@ void QtPreviewDockedWidgets::updateWorkspace(Mantid::API::MatrixWorkspace_sptr &
   m_instDisplay->updateWorkspace(workspace);
 }
 
+void QtPreviewDockedWidgets::updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) {
+  m_instDisplay->updateWorkspacePreservingSelection(workspace);
+}
+
 void QtPreviewDockedWidgets::resetInstView() { m_instDisplay->resetInstView(); }
 
 void QtPreviewDockedWidgets::plotInstView() { m_instDisplay->plotInstView(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -16,6 +16,7 @@
 #include <QAction>
 #include <QMainWindow>
 #include <QMenu>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 
 using namespace Mantid::Kernel;
@@ -93,6 +94,7 @@ void QtPreviewDockedWidgets::connectSignals() const {
   // Line plot toolbar
   connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
   connect(m_ui.set_yaxis_symlog_checkbox, SIGNAL(toggled(bool)), this, SLOT(onYAxisSymlogToggled(bool)));
+  connect(m_ui.plot_all_group_members_checkbox, SIGNAL(toggled(bool)), this, SLOT(onPlotAllGroupMembersToggled()));
   connect(m_ui.linthresh_line_edit, SIGNAL(textChanged(QString)), this, SLOT(onLineEditUpdated()));
   connect(m_ui.apply_button, SIGNAL(clicked()), this, SLOT(onApplyButtonClicked()));
 }
@@ -113,6 +115,8 @@ void QtPreviewDockedWidgets::onYAxisSymlogToggled(bool checked) const {
   onLineEditUpdated();
   m_notifyee->notifySetYAxisSymlogChanged();
 }
+
+void QtPreviewDockedWidgets::onPlotAllGroupMembersToggled() const { m_notifyee->notifyPlotAllGroupMembersChanged(); }
 
 void QtPreviewDockedWidgets::onLineEditUpdated() const {
   m_ui.apply_button->setEnabled(!m_ui.linthresh_line_edit->text().isEmpty());
@@ -163,6 +167,18 @@ void QtPreviewDockedWidgets::setInstViewToolbarEnabled(bool enable) {
 }
 
 bool QtPreviewDockedWidgets::getSymlogEnabled() const { return m_ui.set_yaxis_symlog_checkbox->isChecked(); }
+
+bool QtPreviewDockedWidgets::getPlotAllGroupMembers() const {
+  return m_ui.plot_all_group_members_checkbox->isChecked();
+}
+
+void QtPreviewDockedWidgets::setPlotAllGroupMembersCheckboxVisible(bool visible) {
+  m_ui.plot_all_group_members_checkbox->setVisible(visible);
+  if (!visible) {
+    QSignalBlocker const blocker(m_ui.plot_all_group_members_checkbox);
+    m_ui.plot_all_group_members_checkbox->setChecked(false);
+  }
+}
 
 double QtPreviewDockedWidgets::getLinthresh() const {
   bool ok = false;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -58,6 +58,8 @@ public:
   std::string getRegionType() const override;
   double getLinthresh() const override;
   bool getSymlogEnabled() const override;
+  bool getPlotAllGroupMembers() const override;
+  void setPlotAllGroupMembersCheckboxVisible(bool visible) override;
 
   QLayout *getRegionSelectorLayout() const override;
   MantidQt::MantidWidgets::IPlotView *getLinePlotView() const override;
@@ -81,6 +83,7 @@ private slots:
   void onEditROIClicked() const;
   void onAddRectangularROIClicked(QAction *regionType) const;
   void onYAxisSymlogToggled(bool checked) const;
+  void onPlotAllGroupMembersToggled() const;
   void onLineEditUpdated() const;
   void onApplyButtonClicked() const;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -38,6 +38,7 @@ public:
 
   // Instrument display
   void updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) override;
+  void updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) override;
   void resetInstView() override;
   void plotInstView() override;
   // Instrument viewer toolbar

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewInstrumentDisplay.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewInstrumentDisplay.cpp
@@ -27,6 +27,14 @@ void QtPreviewInstrumentDisplay::updateWorkspace(Mantid::API::MatrixWorkspace_sp
   m_instViewModel->updateWorkspace(workspace);
 }
 
+void QtPreviewInstrumentDisplay::updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) {
+  m_instViewModel->updateWorkspace(workspace);
+  if (auto const surface = getSurface()) {
+    surface->resetInstrumentActor(m_instViewModel->getInstrumentViewActor());
+    surface->updateDetectors();
+  }
+}
+
 void QtPreviewInstrumentDisplay::resetInstView() {
   disconnectSurfaceSignals();
   m_instDisplay = std::make_unique<MantidWidgets::InstrumentDisplay>(m_placeholder);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewInstrumentDisplay.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewInstrumentDisplay.h
@@ -28,6 +28,7 @@ public:
   ~QtPreviewInstrumentDisplay() override;
 
   void updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) override;
+  void updateWorkspacePreservingSelection(Mantid::API::MatrixWorkspace_sptr &workspace) override;
   void resetInstView() override;
   void plotInstView() override;
   void setInstViewZoomMode() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -42,6 +42,7 @@ void QtPreviewView::disableMainWidget() { this->setEnabled(false); }
 void QtPreviewView::connectSignals() const {
   // Loading section
   connect(m_ui.load_button, SIGNAL(clicked()), this, SLOT(onLoadWorkspaceRequested()));
+  connect(m_ui.group_member_combo_box, SIGNAL(currentIndexChanged(int)), this, SLOT(onGroupMemberSelectionChanged()));
   connect(m_ui.update_button, SIGNAL(clicked()), this, SLOT(onUpdateClicked()));
   connect(m_ui.angle_spin_box, SIGNAL(valueChanged(double)), this, SLOT(onAngleEdited()));
   // Apply button
@@ -49,6 +50,7 @@ void QtPreviewView::connectSignals() const {
 }
 
 void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWorkspaceRequested(); }
+void QtPreviewView::onGroupMemberSelectionChanged() const { m_notifyee->notifyGroupMemberSelectionChanged(); }
 void QtPreviewView::onUpdateClicked() const { m_notifyee->notifyUpdateAngle(); }
 
 void QtPreviewView::onAngleEdited() { m_ui.update_button->setEnabled(true); }
@@ -56,6 +58,10 @@ void QtPreviewView::onAngleEdited() { m_ui.update_button->setEnabled(true); }
 void QtPreviewView::onApplyClicked() const { m_notifyee->notifyApplyRequested(); }
 
 std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line_edit->text().toStdString(); }
+
+size_t QtPreviewView::getSelectedGroupMember() const {
+  return static_cast<size_t>(m_ui.group_member_combo_box->currentIndex());
+}
 
 double QtPreviewView::getAngle() const { return m_ui.angle_spin_box->value(); }
 
@@ -69,5 +75,16 @@ void QtPreviewView::setUpdateAngleButtonEnabled(bool enabled) { m_ui.update_butt
 
 void QtPreviewView::setTitle(const std::string &title) {
   m_ui.title_display_label->setText(QString::fromStdString(title));
+}
+
+void QtPreviewView::setGroupMembers(std::vector<std::string> const &workspaceNames) {
+  auto const isGroup = !workspaceNames.empty();
+  m_ui.group_member_label->setVisible(isGroup);
+  m_ui.group_member_combo_box->setVisible(isGroup);
+  m_ui.group_member_combo_box->blockSignals(true);
+  m_ui.group_member_combo_box->clear();
+  for (auto const &name : workspaceNames)
+    m_ui.group_member_combo_box->addItem(QString::fromStdString(name));
+  m_ui.group_member_combo_box->blockSignals(false);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -44,10 +44,12 @@ public:
   void disableMainWidget() override;
 
   std::string getWorkspaceName() const override;
+  size_t getSelectedGroupMember() const override;
   double getAngle() const override;
   void setAngle(double angle) override;
   void setUpdateAngleButtonEnabled(bool enable) override;
   void setTitle(const std::string &title) override;
+  void setGroupMembers(std::vector<std::string> const &workspaceNames) override;
 
 private:
   Ui::PreviewWidget m_ui;
@@ -59,6 +61,7 @@ private:
 
 private slots:
   void onLoadWorkspaceRequested() const;
+  void onGroupMemberSelectionChanged() const;
   void onUpdateClicked() const;
   void onAngleEdited();
   void onApplyClicked() const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -8,6 +8,7 @@
 #include "LookupTable.h"
 #include "IGroup.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "ParseReflectometryStrings.h"
 #include "PreviewRow.h"
 #include "Row.h"
@@ -24,6 +25,13 @@ bool equalWithinTolerance(double val1, double val2, double tolerance) {
 }
 
 static const std::string EMPTY_SEARCH_TITLE = "";
+
+std::string getPreviewTitle(MantidQt::CustomInterfaces::ISISReflectometry::PreviewRow const &previewRow) {
+  auto workspace = previewRow.getLoadedWs();
+  if (auto const group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace))
+    workspace = group->getItem(0);
+  return workspace ? workspace->getTitle() : EMPTY_SEARCH_TITLE;
+}
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -42,7 +50,7 @@ std::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double toler
 }
 
 std::optional<LookupRow> LookupTable::findLookupRow(PreviewRow const &previewRow, double tolerance) const {
-  auto const title = !previewRow.getLoadedWs() ? EMPTY_SEARCH_TITLE : previewRow.getLoadedWs()->getTitle();
+  auto const title = getPreviewTitle(previewRow);
   auto titleAndTheta = parseTitleAndThetaFromRunTitle(title);
 
   if (titleAndTheta.has_value()) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "LookupTable.h"
+#include "Common/GroupHelper.h"
 #include "IGroup.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -13,6 +14,7 @@
 #include "PreviewRow.h"
 #include "Row.h"
 #include "RowExceptions.h"
+
 #include <boost/regex.hpp>
 #include <cmath>
 #include <vector>
@@ -26,12 +28,6 @@ bool equalWithinTolerance(double val1, double val2, double tolerance) {
 
 static const std::string EMPTY_SEARCH_TITLE = "";
 
-std::string getPreviewTitle(MantidQt::CustomInterfaces::ISISReflectometry::PreviewRow const &previewRow) {
-  auto workspace = previewRow.getLoadedWs();
-  if (auto const group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace))
-    workspace = group->getItem(0);
-  return workspace ? workspace->getTitle() : EMPTY_SEARCH_TITLE;
-}
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -148,6 +144,15 @@ std::vector<LookupRow::ValueArray> LookupTable::toValueArray() const {
   std::transform(m_lookupRows.cbegin(), m_lookupRows.cend(), std::back_inserter(result),
                  [](auto const &lookupRow) { return lookupRowToArray(lookupRow); });
   return result;
+}
+
+std::string
+LookupTable::getPreviewTitle(MantidQt::CustomInterfaces::ISISReflectometry::PreviewRow const &previewRow) const {
+  auto const &members = getMembers(previewRow.getLoadedWs());
+  if (members.empty()) {
+    return EMPTY_SEARCH_TITLE;
+  }
+  return members[0]->getTitle();
 }
 
 bool operator==(LookupTable const &lhs, LookupTable const &rhs) { return lhs.m_lookupRows == rhs.m_lookupRows; }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -42,6 +42,7 @@ private:
                                          double) const;
   std::vector<LookupRow> findMatchingRegexes(std::string const &title) const;
   std::vector<LookupRow> findEmptyRegexes() const;
+  std::string getPreviewTitle(MantidQt::CustomInterfaces::ISISReflectometry::PreviewRow const &previewRow) const;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "PreviewRow.h"
+#include "Common/GroupHelper.h"
 #include "GUI/Preview/ROIType.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Workspace.h"
@@ -18,19 +19,15 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 void validatePreviewWorkspace(Mantid::API::Workspace_sptr const &workspace) {
-  if (std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(workspace))
-    return;
-
-  auto const group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace);
-  if (group && group->size() > 0) {
-    auto const members = group->getAllItems();
-    if (std::all_of(members.cbegin(), members.cend(),
-                    [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); }))
-      return;
+  auto const &members = getMembers(workspace);
+  if (members.empty()) {
+    throw std::runtime_error(
+        "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of MatrixWorkspaces");
   }
-
-  throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
-                           "MatrixWorkspaces");
+  if (std::all_of(members.cbegin(), members.cend(),
+                  [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); })) {
+    return;
+  }
 }
 
 PreviewRow::PreviewRow(const std::vector<std::string> &runNumbers)

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -18,17 +18,7 @@
 #include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
-void validatePreviewWorkspace(Mantid::API::Workspace_sptr const &workspace) {
-  auto const &members = getMembers(workspace);
-  if (members.empty()) {
-    throw std::runtime_error(
-        "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of MatrixWorkspaces");
-  }
-  if (std::all_of(members.cbegin(), members.cend(),
-                  [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); })) {
-    return;
-  }
-}
+void validatePreviewWorkspace(Mantid::API::Workspace_sptr const &workspace) { getMembers(workspace, true); }
 
 PreviewRow::PreviewRow(const std::vector<std::string> &runNumbers)
     : Item(), m_runNumbers(std::move(runNumbers)), m_theta{0.0} {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -7,12 +7,32 @@
 #include "PreviewRow.h"
 #include "GUI/Preview/ROIType.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/IDTypes.h"
 
+#include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+void validatePreviewWorkspace(Mantid::API::Workspace_sptr const &workspace) {
+  if (std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(workspace))
+    return;
+
+  auto const group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace);
+  if (group && group->size() > 0) {
+    auto const members = group->getAllItems();
+    if (std::all_of(members.cbegin(), members.cend(),
+                    [](auto const &member) { return std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(member); }))
+      return;
+  }
+
+  throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                           "MatrixWorkspaces");
+}
+
 PreviewRow::PreviewRow(const std::vector<std::string> &runNumbers)
     : Item(), m_runNumbers(std::move(runNumbers)), m_theta{0.0} {
   std::sort(m_runNumbers.begin(), m_runNumbers.end());
@@ -32,13 +52,13 @@ int PreviewRow::totalItems() const { return 1; }
 
 int PreviewRow::completedItems() const { return 1; }
 
-Mantid::API::MatrixWorkspace_sptr PreviewRow::getLoadedWs() const noexcept { return m_loadedWs; }
-Mantid::API::MatrixWorkspace_sptr PreviewRow::getSummedWs() const noexcept { return m_summedWs; }
-Mantid::API::MatrixWorkspace_sptr PreviewRow::getReducedWs() const noexcept { return m_reducedWs; }
+Mantid::API::Workspace_sptr PreviewRow::getLoadedWs() const noexcept { return m_loadedWs; }
+Mantid::API::Workspace_sptr PreviewRow::getSummedWs() const noexcept { return m_summedWs; }
+Mantid::API::Workspace_sptr PreviewRow::getReducedWs() const noexcept { return m_reducedWs; }
 
-void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_loadedWs = std::move(ws); }
-void PreviewRow::setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
-void PreviewRow::setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_reducedWs = std::move(ws); }
+void PreviewRow::setLoadedWs(Mantid::API::Workspace_sptr ws) noexcept { m_loadedWs = std::move(ws); }
+void PreviewRow::setSummedWs(Mantid::API::Workspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
+void PreviewRow::setReducedWs(Mantid::API::Workspace_sptr ws) noexcept { m_reducedWs = std::move(ws); }
 
 std::optional<ProcessingInstructions> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -8,7 +8,7 @@
 #include "Common/DllConfig.h"
 #include "GUI/Preview/ROIType.h"
 #include "Item.h"
-#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include "Reduction/ProcessingInstructions.h"
 
@@ -17,6 +17,8 @@
 #include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+MANTIDQT_ISISREFLECTOMETRY_DLL void validatePreviewWorkspace(Mantid::API::Workspace_sptr const &workspace);
+
 class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewRow : public Item {
 public:
   explicit PreviewRow(const std::vector<std::string> &runNumbers);
@@ -42,15 +44,15 @@ public:
   void renameOutputWorkspace(std::string const &, std::string const &) override {}
   void setOutputNames(std::vector<std::string> const &) override {}
 
-  Mantid::API::MatrixWorkspace_sptr getLoadedWs() const noexcept;
-  Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
-  Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
+  Mantid::API::Workspace_sptr getLoadedWs() const noexcept;
+  Mantid::API::Workspace_sptr getSummedWs() const noexcept;
+  Mantid::API::Workspace_sptr getReducedWs() const noexcept;
   std::optional<ProcessingInstructions> getSelectedBanks() const noexcept;
   std::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const;
 
-  void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
-  void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
-  void setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
+  void setLoadedWs(Mantid::API::Workspace_sptr ws) noexcept;
+  void setSummedWs(Mantid::API::Workspace_sptr ws) noexcept;
+  void setReducedWs(Mantid::API::Workspace_sptr ws) noexcept;
   void setSelectedBanks(std::optional<ProcessingInstructions> selectedBanks) noexcept;
   void setProcessingInstructions(ROIType regionType, std::optional<ProcessingInstructions> processingInstructions);
 
@@ -67,9 +69,9 @@ private:
   std::optional<ProcessingInstructions> m_processingInstructions{std::nullopt};
   std::optional<ProcessingInstructions> m_backgroundProcessingInstructions{std::nullopt};
   std::optional<ProcessingInstructions> m_transmissionProcessingInstructions{std::nullopt};
-  Mantid::API::MatrixWorkspace_sptr m_loadedWs;
-  Mantid::API::MatrixWorkspace_sptr m_summedWs;
-  Mantid::API::MatrixWorkspace_sptr m_reducedWs;
+  Mantid::API::Workspace_sptr m_loadedWs;
+  Mantid::API::Workspace_sptr m_summedWs;
+  Mantid::API::Workspace_sptr m_reducedWs;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -12,6 +12,8 @@
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MockBatch.h"
@@ -103,5 +105,57 @@ public:
     updateRowOnAlgorithmComplete(mockAlg, row);
 
     TS_ASSERT_EQUALS(row.getLoadedWs(), mockWs);
+  }
+
+  void test_row_is_updated_with_workspace_group_on_algorithm_complete() {
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    Mantid::API::Workspace_sptr output = group;
+    mockAlg->addOutputWorkspace(output);
+    auto row = PreviewRow({});
+
+    updateRowOnAlgorithmComplete(mockAlg, row);
+
+    TS_ASSERT_EQUALS(row.getLoadedWs(), group);
+  }
+
+  void test_empty_workspace_group_output_is_rejected() {
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+    Mantid::API::Workspace_sptr output = std::make_shared<Mantid::API::WorkspaceGroup>();
+    mockAlg->addOutputWorkspace(output);
+    auto row = PreviewRow({});
+
+    TS_ASSERT_THROWS_EQUALS(updateRowOnAlgorithmComplete(mockAlg, row), std::runtime_error const &e,
+                            std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
+  }
+
+  void test_workspace_group_with_non_matrix_member_is_rejected() {
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    group->addWorkspace(Mantid::API::WorkspaceFactory::Instance().createTable());
+    Mantid::API::Workspace_sptr output = group;
+    mockAlg->addOutputWorkspace(output);
+    auto row = PreviewRow({});
+
+    TS_ASSERT_THROWS_EQUALS(updateRowOnAlgorithmComplete(mockAlg, row), std::runtime_error const &e,
+                            std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
+  }
+
+  void test_non_matrix_workspace_output_is_rejected() {
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+    Mantid::API::Workspace_sptr output = Mantid::API::WorkspaceFactory::Instance().createTable();
+    mockAlg->addOutputWorkspace(output);
+    auto row = PreviewRow({});
+
+    TS_ASSERT_THROWS_EQUALS(updateRowOnAlgorithmComplete(mockAlg, row), std::runtime_error const &e,
+                            std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -11,6 +11,7 @@
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
 #include <cxxtest/TestSuite.h>
@@ -73,6 +74,15 @@ public:
     TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "6-7");
     TS_ASSERT_EQUALS(result->getPropertyValue("ROIDetectorIDs"), "10-50");
     assertProperty(*result, "ThetaIn", theta);
+  }
+
+  void testWorkspaceGroupNameIsForwardedAsPreviewInputRunList() {
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    auto previewRow = PreviewRow({"polarized_group"});
+
+    auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
+
+    TS_ASSERT_EQUALS(result->getPropertyValue("InputRunList"), "polarized_group");
   }
 
   void testLookupRowWithAngleLookup() {
@@ -288,7 +298,8 @@ public:
     auto mockAlg = std::make_shared<StubbedReduction>();
     const bool isHistogram = true;
     Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
-    mockAlg->addOutputWorkspace(mockWs);
+    Mantid::API::Workspace_sptr output = mockWs;
+    mockAlg->addOutputWorkspace(output);
 
     auto runNumbers = std::vector<std::string>{};
     auto row = PreviewRow(runNumbers);
@@ -296,6 +307,19 @@ public:
     Reduction::updateRowOnAlgorithmComplete(mockAlg, row);
 
     TS_ASSERT_EQUALS(row.getReducedWs(), mockWs);
+  }
+
+  void test_preview_row_is_updated_with_workspace_group_on_reduction_algorithm_complete() {
+    auto mockAlg = std::make_shared<StubbedReduction>();
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    Mantid::API::Workspace_sptr output = group;
+    mockAlg->addOutputWorkspace(output);
+    auto row = PreviewRow({});
+
+    Reduction::updateRowOnAlgorithmComplete(mockAlg, row);
+
+    TS_ASSERT_EQUALS(row.getReducedWs(), group);
   }
 
 private:
@@ -315,7 +339,7 @@ private:
       declareProperty(std::move(prop));
     }
 
-    void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
+    void addOutputWorkspace(Mantid::API::Workspace_sptr &ws) {
       this->getPointerToProperty("OutputWorkspaceBinned")->createTemporaryValue();
       setProperty(m_propName, ws);
     }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -85,6 +85,38 @@ public:
     TS_ASSERT_EQUALS(result->getPropertyValue("InputRunList"), "polarized_group");
   }
 
+  void testPreviewWorkspaceGroupIsNotFlattenedIntoHiddenTOFGroup() {
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    auto previewRow = PreviewRow({"polarized_group"});
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    previewRow.setLoadedWs(group);
+
+    auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
+
+    TS_ASSERT(result->existsProperty("GroupTOFWorkspaces"));
+    TS_ASSERT(!static_cast<bool>(result->getProperty("GroupTOFWorkspaces")));
+  }
+
+  void testPreviewMatrixWorkspaceRetainsDefaultTOFGrouping() {
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    auto previewRow = PreviewRow({"12345"});
+    previewRow.setLoadedWs(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+
+    auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
+
+    TS_ASSERT(!result->existsProperty("GroupTOFWorkspaces"));
+  }
+
+  void testRunsTabReductionRetainsDefaultTOFGrouping() {
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    auto row = makeRow("12345");
+
+    auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);
+
+    TS_ASSERT(!result->existsProperty("GroupTOFWorkspaces"));
+  }
+
   void testLookupRowWithAngleLookup() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     // angle within tolerance of 2.3

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
@@ -11,6 +11,7 @@
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MockBatch.h"
@@ -38,7 +39,7 @@ class SumBanksAlgorithmTest : public CxxTest::TestSuite {
           m_propName, "", Mantid::Kernel::Direction::Output));
     }
 
-    void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
+    void addOutputWorkspace(Mantid::API::Workspace_sptr &ws) {
       this->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
       setProperty(m_propName, ws);
     }
@@ -103,7 +104,8 @@ public:
     auto mockAlg = std::make_shared<StubbedPreProcess>();
     const bool isHistogram = true;
     Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
-    mockAlg->addOutputWorkspace(mockWs);
+    Mantid::API::Workspace_sptr output = mockWs;
+    mockAlg->addOutputWorkspace(output);
 
     auto runNumbers = std::vector<std::string>{};
     auto row = PreviewRow(runNumbers);
@@ -111,5 +113,27 @@ public:
     updateRowOnAlgorithmComplete(mockAlg, row);
 
     TS_ASSERT_EQUALS(row.getSummedWs(), mockWs);
+  }
+
+  void test_workspace_group_input_and_output_are_forwarded() {
+    auto batch = MockBatch();
+    auto inputGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
+    inputGroup->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    auto outputGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
+    outputGroup->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    auto row = PreviewRow({});
+    row.setLoadedWs(inputGroup);
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+
+    auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
+    Mantid::API::Workspace_sptr input = configuredAlg->getAlgorithmRuntimeProps().getProperty("InputWorkspace");
+    TS_ASSERT_EQUALS(input, inputGroup);
+    TS_ASSERT_THROWS_NOTHING(mockAlg->updatePropertyValues(configuredAlg->getAlgorithmRuntimeProps()));
+    Mantid::API::Workspace_sptr output = outputGroup;
+    mockAlg->addOutputWorkspace(output);
+
+    updateRowOnAlgorithmComplete(mockAlg, row);
+
+    TS_ASSERT_EQUALS(row.getSummedWs(), outputGroup);
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_FILES
     Preview/PreviewJobManagerTest.h
     Preview/PreviewModelTest.h
     Preview/PreviewPresenterTest.h
+    Preview/QtPreviewDockedWidgetsTest.h
     Preview/QtPreviewViewTest.h
     Preview/PreviewSettingsTest.h
 )

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TEST_FILES
     Preview/PreviewJobManagerTest.h
     Preview/PreviewModelTest.h
     Preview/PreviewPresenterTest.h
+    Preview/QtPreviewViewTest.h
     Preview/PreviewSettingsTest.h
 )
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_FILES
     Common/DetectorTest.h
     Common/EncoderTest.h
     Common/PlotOptionsProviderTest.h
+    Common/GroupHelperTest.h
     Common/PlotterTest.h
     Experiment/ExperimentPresenterTest.h
     Experiment/LookupTableValidatorTest.h

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/GroupHelperTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/GroupHelperTest.h
@@ -1,0 +1,41 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "../../../ISISReflectometry/Common/GroupHelper.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+#include <gtest/gtest.h>
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using ::testing::_;
+using ::testing::Invoke;
+
+class GroupHelperTest : public CxxTest::TestSuite {
+public:
+  static GroupHelperTest *createSuite() { return new GroupHelperTest(); }
+  static void destroySuite(GroupHelperTest *suite) { delete suite; }
+
+  void test_getMembers() {
+    // Given
+    auto ws1 = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    auto ws2 = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(ws1);
+    group->addWorkspace(ws2);
+
+    // When
+    auto const &groupMembers = getMembers(group);
+
+    // Then
+    TS_ASSERT_EQUALS(groupMembers.size(), 2);
+    TS_ASSERT_EQUALS(groupMembers[0], ws1);
+    TS_ASSERT_EQUALS(groupMembers[1], ws2)
+  }
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/GroupHelperTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/GroupHelperTest.h
@@ -38,4 +38,27 @@ public:
     TS_ASSERT_EQUALS(groupMembers[0], ws1);
     TS_ASSERT_EQUALS(groupMembers[1], ws2)
   }
+
+  void test_validation_throws_empty_group() {
+    // Given
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+
+    // When & Then
+    TS_ASSERT_THROWS_EQUALS(getMembers(group, true), std::runtime_error const &e, std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
+  }
+
+  void test_validation_throws_non_matrix_members() {
+    // Given
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(WorkspaceCreationHelper::create2DWorkspace(1, 1));
+    group->addWorkspace(Mantid::API::WorkspaceFactory::Instance().createTable());
+    Mantid::API::Workspace_sptr output = group;
+
+    // When & Then
+    TS_ASSERT_THROWS_EQUALS(getMembers(group, true), std::runtime_error const &e, std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
+  }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPlotPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPlotPresenter.h
@@ -18,6 +18,7 @@ public:
 
   MOCK_METHOD(void, clearModel, (), (override));
   MOCK_METHOD(void, setSpectrum, (const Mantid::API::MatrixWorkspace_sptr &, const size_t), (override));
+  MOCK_METHOD(void, setSpectra, (const std::vector<Mantid::API::MatrixWorkspace_sptr> &, const size_t), (override));
   MOCK_METHOD(void, setScaleLinear, (const AxisID), (override));
   MOCK_METHOD(void, setScaleLog, (const AxisID), (override));
   MOCK_METHOD(void, setScaleSymLog, (const AxisID, const double), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -37,6 +37,8 @@ public:
   MOCK_METHOD(std::string, getRegionType, (), (const, override));
   MOCK_METHOD(double, getLinthresh, (), (const, override));
   MOCK_METHOD(bool, getSymlogEnabled, (), (const, override));
+  MOCK_METHOD(bool, getPlotAllGroupMembers, (), (const, override));
+  MOCK_METHOD(void, setPlotAllGroupMembersCheckboxVisible, (bool), (override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
   MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -20,6 +20,7 @@ class MockPreviewDockedWidgets : public IPreviewDockedWidgets {
 public:
   MOCK_METHOD(void, subscribe, (PreviewDockedWidgetsSubscriber *), (noexcept, override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::MatrixWorkspace_sptr &), (override));
+  MOCK_METHOD(void, updateWorkspacePreservingSelection, (Mantid::API::MatrixWorkspace_sptr &), (override));
   MOCK_METHOD(void, resetInstView, (), (override));
   MOCK_METHOD(void, plotInstView, (), (override));
   MOCK_METHOD(void, setInstViewZoomState, (bool), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewInstrumentDisplay.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewInstrumentDisplay.h
@@ -20,6 +20,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class MockPreviewInstrumentDisplay : public IPreviewInstrumentDisplay {
 public:
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::MatrixWorkspace_sptr &), (override));
+  MOCK_METHOD(void, updateWorkspacePreservingSelection, (Mantid::API::MatrixWorkspace_sptr &), (override));
   MOCK_METHOD(void, resetInstView, (), (override));
   MOCK_METHOD(void, plotInstView, (), (override));
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -9,6 +9,7 @@
 #include "GUI/Common/IJobManager.h"
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include "ROIType.h"
 #include "Reduction/PreviewRow.h"
@@ -19,6 +20,7 @@
 #include <string>
 
 using Mantid::API::MatrixWorkspace_sptr;
+using Mantid::API::Workspace_sptr;
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -26,16 +28,23 @@ class MockPreviewModel : public IPreviewModel {
 public:
   MOCK_METHOD(bool, loadWorkspaceFromAds, (std::string const &workspaceName), (override));
   MOCK_METHOD(void, loadAndPreprocessWorkspaceAsync, (std::string const &, IJobManager &), (override));
-  MOCK_METHOD(MatrixWorkspace_sptr, getLoadedWs, (), (const, override));
-  MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
-  MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
+  MOCK_METHOD(Workspace_sptr, getLoadedWs, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, getSelectedLoadedWs, (), (const, override));
+  MOCK_METHOD(Workspace_sptr, getSummedWs, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, getSelectedSummedWs, (), (const, override));
+  MOCK_METHOD(Workspace_sptr, getReducedWs, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, getSelectedReducedWs, (), (const, override));
+  MOCK_METHOD(bool, isWorkspaceGroup, (), (const, override));
+  MOCK_METHOD(size_t, getNumberOfGroupMembers, (), (const, override));
+  MOCK_METHOD(size_t, getSelectedGroupMember, (), (const, override));
+  MOCK_METHOD(void, setSelectedGroupMember, (size_t), (override));
   MOCK_METHOD(std::optional<ProcessingInstructions>, getSelectedBanks, (), (const, override));
   MOCK_METHOD(std::optional<ProcessingInstructions>, getProcessingInstructions, (ROIType), (const, override));
   MOCK_METHOD(std::optional<double>, getDefaultTheta, (), (const, override));
   MOCK_METHOD(PreviewRow const &, getPreviewRow, (), (const, override));
   MOCK_METHOD(std::optional<Selection> const, getSelectedRegion, (ROIType), (override));
 
-  MOCK_METHOD(void, setSummedWs, (MatrixWorkspace_sptr), (override));
+  MOCK_METHOD(void, setSummedWs, (Workspace_sptr), (override));
   MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::optional<ProcessingInstructions>), (override));
   MOCK_METHOD(void, setSelectedRegion, (ROIType, Selection const &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -34,6 +34,7 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getSelectedSummedWs, (), (const, override));
   MOCK_METHOD(Workspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getSelectedReducedWs, (), (const, override));
+  MOCK_METHOD(std::vector<MatrixWorkspace_sptr>, getReducedWorkspaceMembers, (), (const, override));
   MOCK_METHOD(bool, isWorkspaceGroup, (), (const, override));
   MOCK_METHOD(std::vector<std::string>, getGroupMemberDisplayNames, (), (const, override));
   MOCK_METHOD(size_t, getNumberOfGroupMembers, (), (const, override));
@@ -46,6 +47,7 @@ public:
   MOCK_METHOD(std::optional<Selection> const, getSelectedRegion, (ROIType), (override));
 
   MOCK_METHOD(void, setSummedWs, (Workspace_sptr), (override));
+  MOCK_METHOD(void, clearReducedWorkspace, (), (override));
   MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::optional<ProcessingInstructions>), (override));
   MOCK_METHOD(void, setSelectedRegion, (ROIType, Selection const &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -35,6 +35,7 @@ public:
   MOCK_METHOD(Workspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getSelectedReducedWs, (), (const, override));
   MOCK_METHOD(bool, isWorkspaceGroup, (), (const, override));
+  MOCK_METHOD(std::vector<std::string>, getGroupMemberDisplayNames, (), (const, override));
   MOCK_METHOD(size_t, getNumberOfGroupMembers, (), (const, override));
   MOCK_METHOD(size_t, getSelectedGroupMember, (), (const, override));
   MOCK_METHOD(void, setSelectedGroupMember, (size_t), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -24,9 +24,11 @@ public:
   MOCK_METHOD(void, enableMainWidget, (), (override));
   MOCK_METHOD(void, disableMainWidget, (), (override));
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));
+  MOCK_METHOD(size_t, getSelectedGroupMember, (), (const, override));
   MOCK_METHOD(double, getAngle, (), (const, override));
   MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(void, setUpdateAngleButtonEnabled, (bool), (override));
   MOCK_METHOD(void, setTitle, (const std::string &), (override));
+  MOCK_METHOD(void, setGroupMembers, (std::vector<std::string> const &), (override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -246,6 +246,12 @@ public:
 
     TS_ASSERT_EQUALS(model.getReducedWs(), expectedGroup);
     TS_ASSERT_EQUALS(model.getSelectedReducedWs(), secondOutput);
+    TS_ASSERT_EQUALS(model.getReducedWorkspaceMembers(),
+                     std::vector<MatrixWorkspace_sptr>({firstOutput, secondOutput}));
+
+    model.clearReducedWorkspace();
+
+    TS_ASSERT(!model.getReducedWs());
   }
 
   void test_export_summed_ws_to_ads() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -31,6 +31,7 @@ public:
     PreviewModel model;
     // This will throw if the underlying RunDetails is null
     TS_ASSERT_THROWS_NOTHING(model.getSelectedBanks())
+    TS_ASSERT_EQUALS(model.getNumberOfGroupMembers(), 0)
   }
 
   void test_load_workspace_from_ads() {
@@ -42,21 +43,51 @@ public:
     AnalysisDataService::Instance().addOrReplace(workspaceName, createWorkspace());
 
     TS_ASSERT(model.loadWorkspaceFromAds(workspaceName));
-    auto workspace = model.getLoadedWs();
+    auto workspace = model.getSelectedLoadedWs();
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace->getName(), workspaceName);
   }
 
-  void test_load_workspace_from_ads_throws_if_wrong_type() {
-    auto mockJobManager = MockJobManager();
-    EXPECT_CALL(mockJobManager, startPreprocessing(_)).Times(0);
+  void test_load_workspace_group_from_ads() {
+    PreviewModel model;
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    auto const group = createWorkspaceGroup({first, second});
+    auto const workspaceName = std::string("test group");
+    AnalysisDataService::Instance().addOrReplace(workspaceName, group);
 
+    TS_ASSERT(model.loadWorkspaceFromAds(workspaceName));
+    TS_ASSERT(model.isWorkspaceGroup());
+    TS_ASSERT_EQUALS(model.getNumberOfGroupMembers(), 2);
+    TS_ASSERT_EQUALS(model.getSelectedGroupMember(), 0);
+    TS_ASSERT_EQUALS(model.getLoadedWs(), group);
+    TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), first);
+
+    model.setSelectedGroupMember(1);
+
+    TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), second);
+  }
+
+  void test_load_workspace_from_ads_throws_if_group_is_empty() {
     PreviewModel model;
     auto workspaceName = std::string("test workspace");
-    // We don't currently support workspace groups so it should throw with this type
     AnalysisDataService::Instance().addOrReplace(workspaceName, std::make_shared<WorkspaceGroup>());
 
-    TS_ASSERT_THROWS(model.loadWorkspaceFromAds(workspaceName), std::runtime_error const &);
+    TS_ASSERT_THROWS_EQUALS(model.loadWorkspaceFromAds(workspaceName), std::runtime_error const &e,
+                            std::string(e.what()),
+                            "Unsupported workspace type; expected MatrixWorkspace or WorkspaceGroup of "
+                            "MatrixWorkspaces");
+  }
+
+  void test_setting_group_member_outside_loaded_group_is_rejected() {
+    PreviewModel model;
+    auto const group = createWorkspaceGroup({createWorkspace(), createWorkspace()});
+    AnalysisDataService::Instance().addOrReplace("group", group);
+    model.loadWorkspaceFromAds("group");
+
+    TS_ASSERT_THROWS_EQUALS(model.setSelectedGroupMember(2), std::out_of_range const &e, std::string(e.what()),
+                            "Workspace group member index is out of range");
+    TS_ASSERT_EQUALS(model.getSelectedGroupMember(), 0);
   }
 
   void test_load_workspace_from_file() {
@@ -71,9 +102,25 @@ public:
     auto workspaceName = std::string("not there");
 
     model.loadAndPreprocessWorkspaceAsync(workspaceName, mockJobManager);
-    auto workspace = model.getLoadedWs();
+    auto workspace = model.getSelectedLoadedWs();
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace, expectedWs);
+  }
+
+  void test_load_workspace_group_from_file() {
+    auto mockJobManager = MockJobManager();
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    auto const expectedGroup = createWorkspaceGroup({first, second});
+    auto wsLoadEffect = [&expectedGroup](PreviewRow &row) { row.setLoadedWs(expectedGroup); };
+    EXPECT_CALL(mockJobManager, startPreprocessing(_)).Times(1).WillOnce(Invoke(wsLoadEffect));
+
+    PreviewModel model;
+    model.loadAndPreprocessWorkspaceAsync("group", mockJobManager);
+
+    TS_ASSERT(model.isWorkspaceGroup());
+    TS_ASSERT_EQUALS(model.getLoadedWs(), expectedGroup);
+    TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), first);
   }
 
   void test_set_and_get_selected_banks() {
@@ -116,9 +163,26 @@ public:
     PreviewModel model;
     model.sumBanksAsync(mockJobManager);
 
-    auto workspace = model.getSummedWs();
+    auto workspace = model.getSelectedSummedWs();
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace, expectedWs);
+  }
+
+  void test_sum_banks_stores_group_and_exposes_selected_member() {
+    auto mockJobManager = MockJobManager();
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    auto const expectedGroup = createWorkspaceGroup({first, second});
+    auto wsSumBanksEffect = [&expectedGroup](PreviewRow &row) { row.setSummedWs(expectedGroup); };
+    EXPECT_CALL(mockJobManager, startSumBanks(_)).Times(1).WillOnce(Invoke(wsSumBanksEffect));
+
+    PreviewModel model;
+    model.setLoadedWs(expectedGroup);
+    model.sumBanksAsync(mockJobManager);
+    model.setSelectedGroupMember(1);
+
+    TS_ASSERT_EQUALS(model.getSummedWs(), expectedGroup);
+    TS_ASSERT_EQUALS(model.getSelectedSummedWs(), second);
   }
 
   void test_reduce() {
@@ -130,9 +194,34 @@ public:
     PreviewModel model;
     model.reduceAsync(mockJobManager);
 
-    auto workspace = model.getReducedWs();
+    auto workspace = model.getSelectedReducedWs();
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace, expectedWs);
+  }
+
+  void test_reduce_stores_group_and_exposes_selected_member() {
+    auto mockJobManager = MockJobManager();
+    auto const inputGroup = createWorkspaceGroup({createWorkspace(), createWorkspace()});
+    auto const firstOutput = createWorkspace();
+    auto const secondOutput = createWorkspace();
+    auto const expectedGroup = createWorkspaceGroup({firstOutput, secondOutput});
+    auto const groupName = std::string("input_group");
+    AnalysisDataService::Instance().addOrReplace(groupName, inputGroup);
+    auto wsReductionEffect = [&expectedGroup, &inputGroup, &groupName](PreviewRow &row) {
+      TS_ASSERT_EQUALS(row.getLoadedWs(), inputGroup);
+      TS_ASSERT_EQUALS(row.runNumbers().size(), 1);
+      TS_ASSERT_EQUALS(row.runNumbers()[0], groupName);
+      row.setReducedWs(expectedGroup);
+    };
+    EXPECT_CALL(mockJobManager, startReduction(_)).Times(1).WillOnce(Invoke(wsReductionEffect));
+
+    PreviewModel model;
+    model.loadWorkspaceFromAds(groupName);
+    model.reduceAsync(mockJobManager);
+    model.setSelectedGroupMember(1);
+
+    TS_ASSERT_EQUALS(model.getReducedWs(), expectedGroup);
+    TS_ASSERT_EQUALS(model.getSelectedReducedWs(), secondOutput);
   }
 
   void test_export_summed_ws_to_ads() {
@@ -147,6 +236,21 @@ public:
     TS_ASSERT(ads.doesExist(expectedName));
     TS_ASSERT_EQUALS(ws, ads.retrieveWS<MatrixWorkspace>(expectedName));
     ads.remove(expectedName);
+  }
+
+  void test_export_summed_workspace_group_to_ads() {
+    PreviewModel model;
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    auto const group = createWorkspaceGroup({first, second});
+    model.setSummedWs(group);
+
+    model.exportSummedWsToAds();
+
+    auto const exported = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("preview_summed_ws");
+    TS_ASSERT_EQUALS(exported, group);
+    TS_ASSERT_EQUALS(exported->getItem(0), first);
+    TS_ASSERT_EQUALS(exported->getItem(1), second);
   }
 
   void test_export_summed_ws_with_no_ws_set_does_not_throw() {
@@ -169,6 +273,24 @@ public:
     ads.remove(expectedName);
   }
 
+  void test_export_reduced_workspace_group_to_ads() {
+    PreviewModel model;
+    auto mockJobManager = MockJobManager();
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    auto const group = createWorkspaceGroup({first, second});
+    auto wsReductionEffect = [&group](PreviewRow &row) { row.setReducedWs(group); };
+    EXPECT_CALL(mockJobManager, startReduction(_)).WillOnce(Invoke(wsReductionEffect));
+    model.reduceAsync(mockJobManager);
+
+    model.exportReducedWsToAds();
+
+    auto const exported = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("preview_reduced_ws");
+    TS_ASSERT_EQUALS(exported, group);
+    TS_ASSERT_EQUALS(exported->getItem(0), first);
+    TS_ASSERT_EQUALS(exported->getItem(1), second);
+  }
+
   void test_export_reduced_ws_with_no_ws_set_does_not_throw() {
     PreviewModel model;
     // This should emit an error, but we cannot observe this from our test
@@ -180,7 +302,22 @@ public:
     auto ws = createWorkspace();
     model.setLoadedWs(ws);
 
-    TS_ASSERT_EQUALS(model.getLoadedWs(), ws);
+    TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), ws);
+  }
+
+  void test_loading_new_workspace_resets_selected_group_member() {
+    PreviewModel model;
+    auto const firstGroup = createWorkspaceGroup({createWorkspace(), createWorkspace()});
+    AnalysisDataService::Instance().addOrReplace("first", firstGroup);
+    AnalysisDataService::Instance().addOrReplace("second", createWorkspace());
+    model.loadWorkspaceFromAds("first");
+    model.setSelectedGroupMember(1);
+
+    model.loadWorkspaceFromAds("second");
+
+    TS_ASSERT_EQUALS(model.getSelectedGroupMember(), 0);
+    TS_ASSERT(!model.isWorkspaceGroup());
+    TS_ASSERT_EQUALS(model.getNumberOfGroupMembers(), 1);
   }
 
   void test_get_theta_from_workspace() {
@@ -241,4 +378,11 @@ private:
   }
 
   MatrixWorkspace_sptr createWorkspace() { return WorkspaceCreationHelper::create2DWorkspace(1, 1); }
+
+  WorkspaceGroup_sptr createWorkspaceGroup(std::initializer_list<MatrixWorkspace_sptr> members) {
+    auto group = std::make_shared<WorkspaceGroup>();
+    for (auto const &member : members)
+      group->addWorkspace(member);
+    return group;
+  }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -68,6 +68,28 @@ public:
     TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), second);
   }
 
+  void test_group_member_names_are_returned_in_group_order() {
+    PreviewModel model;
+    auto const first = createWorkspace();
+    auto const second = createWorkspace();
+    AnalysisDataService::Instance().addOrReplace("first", first);
+    AnalysisDataService::Instance().addOrReplace("second", second);
+    auto const group = createWorkspaceGroup({first, second});
+    AnalysisDataService::Instance().addOrReplace("group", group);
+
+    model.loadWorkspaceFromAds("group");
+
+    TS_ASSERT_EQUALS(model.getGroupMemberDisplayNames(), std::vector<std::string>({"first", "second"}));
+  }
+
+  void test_group_member_names_are_empty_for_matrix_workspace() {
+    PreviewModel model;
+    AnalysisDataService::Instance().addOrReplace("workspace", createWorkspace());
+    model.loadWorkspaceFromAds("workspace");
+
+    TS_ASSERT(model.getGroupMemberDisplayNames().empty());
+  }
+
   void test_load_workspace_from_ads_throws_if_group_is_empty() {
     PreviewModel model;
     auto workspaceName = std::string("test workspace");
@@ -116,11 +138,13 @@ public:
     EXPECT_CALL(mockJobManager, startPreprocessing(_)).Times(1).WillOnce(Invoke(wsLoadEffect));
 
     PreviewModel model;
-    model.loadAndPreprocessWorkspaceAsync("group", mockJobManager);
+    model.loadAndPreprocessWorkspaceAsync("/data/POLREF00004699.nxs", mockJobManager);
 
     TS_ASSERT(model.isWorkspaceGroup());
     TS_ASSERT_EQUALS(model.getLoadedWs(), expectedGroup);
     TS_ASSERT_EQUALS(model.getSelectedLoadedWs(), first);
+    TS_ASSERT_EQUALS(model.getGroupMemberDisplayNames(),
+                     std::vector<std::string>({"POLREF00004699_1", "POLREF00004699_2"}));
   }
 
   void test_set_and_get_selected_banks() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -659,7 +659,7 @@ public:
     auto lineLabel = std::string("line_label");
     auto ws = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
 
-    EXPECT_CALL(*mockModel, getReducedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(*mockModel, getSelectedReducedWs()).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(*mockLinePlot, setSpectrum(ws, 0)).Times(1);
     EXPECT_CALL(*mockLinePlot, plot()).Times(1);
 
@@ -871,7 +871,7 @@ private:
                                                      MockPreviewDockedWidgets &mockDockedWidgets) {
     auto ws = createLinearDetectorWorkspace();
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1);
     EXPECT_CALL(mockDockedWidgets, updateWorkspace(ws)).Times(1);
     EXPECT_CALL(mockDockedWidgets, setInstViewToolbarEnabled(true)).Times(1);
@@ -889,7 +889,7 @@ private:
     auto ws = createRectangularDetectorWorkspace();
     auto angle = 2.3;
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1).WillOnce(Return(angle));
     EXPECT_CALL(mockView, setAngle(angle)).Times(1);
   }
@@ -897,14 +897,14 @@ private:
   void expectLoadWorkspaceCompletedSetsRunTitle(MockPreviewView &mockView, MockPreviewModel &mockModel) {
     auto ws = createRectangularDetectorWorkspace();
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockView, setTitle(ws->getTitle())).Times(1);
   }
 
   void expectInstViewModelUpdatedWithLoadedWorkspace(MockPreviewModel &mockModel,
                                                      MockPreviewDockedWidgets &mockDockedWidgets) {
     auto ws = createRectangularDetectorWorkspace();
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockDockedWidgets, updateWorkspace(Eq(ws))).Times(1);
   }
 
@@ -916,7 +916,7 @@ private:
     auto theta = 0.3;
     auto detIDsStr = std::optional<ProcessingInstructions>{"2-4"};
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(AtLeast(2)).WillOnce(Return(ws)).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(AtLeast(2)).WillOnce(Return(ws)).WillOnce(Return(ws));
     EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(theta));
     EXPECT_CALL(mockModel, setTheta(theta)).Times(1);
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(detIDsStr));
@@ -928,7 +928,8 @@ private:
                                                    MockBatchPresenter &mockMainPresenter) {
     auto ws = createRectangularDetectorWorkspace();
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(4).WillRepeatedly(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(3).WillRepeatedly(Return(ws));
+    EXPECT_CALL(mockModel, getLoadedWs()).WillOnce(Return(ws));
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(std::nullopt));
     EXPECT_CALL(mockModel, getSelectedBanks()).WillOnce(Return(std::nullopt));
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(0);
@@ -940,7 +941,7 @@ private:
     auto previousDetIDsStr = std::optional<ProcessingInstructions>{};
     auto detIDsStr = std::optional<ProcessingInstructions>{"2-4"};
     auto ws = createRectangularDetectorWorkspace();
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(AtLeast(1)).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillOnce(Return(ws));
     expectInstViewShapeChanged(mockDockedWidgets, mockModel, detIDs, previousDetIDsStr, detIDsStr);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
@@ -954,7 +955,8 @@ private:
 
     expectInstViewShapeChanged(mockDockedWidgets, mockModel, detIDs, previousDetIDsStr, detIDsStr);
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(std::nullopt));
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(3).WillOnce(Return(ws)).WillOnce(Return(ws)).WillOnce(Return(nullptr));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillOnce(Return(ws)).WillOnce(Return(nullptr));
+    EXPECT_CALL(mockModel, getLoadedWs()).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, setSummedWs(Eq(ws))).Times(1);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(0);
   }
@@ -969,7 +971,7 @@ private:
     auto detIDsStr = std::nullopt;
 
     expectInstViewShapeChanged(mockDockedWidgets, mockModel, detIDs, previousDetIDsStr, detIDsStr);
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(previousDetIDsStr));
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
@@ -990,7 +992,7 @@ private:
   }
 
   void expectRunSumBanksNoLoadedWs(MockPreviewModel &mockModel, MockJobManager &mockJobManager) {
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(0);
   }
 
@@ -1017,7 +1019,7 @@ private:
     auto const detIDs =
         hasSelectedDetectors ? std::vector<Mantid::detid_t>{44, 45, 46} : std::vector<Mantid::detid_t>{};
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(AtLeast(1)).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillOnce(Return(ws));
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(detIDsStr));
     EXPECT_CALL(mockDockedWidgets, getSelectedDetectorIDs()).WillOnce(Return(detIDs));
     if (hasSelectedDetectors) {
@@ -1036,7 +1038,7 @@ private:
     auto const detIDsStr = std::optional<ProcessingInstructions>{"2-4"};
     auto const detIDs = std::vector<Mantid::detid_t>{};
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillRepeatedly(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(2).WillRepeatedly(Return(ws));
     EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(theta));
     EXPECT_CALL(mockModel, setTheta(theta)).Times(1);
     EXPECT_CALL(mockMainPresenter, getMatchingROIDetectorIDsForPreviewRow()).WillOnce(Return(detIDsStr));
@@ -1162,7 +1164,7 @@ private:
                           MockRegionSelector &mockRegionSelector, bool checkTheta = true) {
     auto ws = createLinearDetectorWorkspace();
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(AtLeast(1)).WillRepeatedly(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillRepeatedly(Return(ws));
     EXPECT_CALL(mockView, disableMainWidget()).Times(1);
     EXPECT_CALL(mockView, setUpdateAngleButtonEnabled(false)).Times(1);
     if (checkTheta) {
@@ -1188,7 +1190,7 @@ private:
   }
 
   void expectRunReductionNoLoadedWs(MockPreviewModel &mockModel, MockJobManager &mockJobManager) {
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(mockModel, getSelectedLoadedWs()).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(mockModel, reduceAsync(Ref(mockJobManager))).Times(0);
   }
 
@@ -1221,7 +1223,7 @@ private:
 
   void expectUpdateRegionSelectorWorkspace(MockPreviewModel &mockModel, MockRegionSelector &mockRegionSelector) {
     auto ws = createRectangularDetectorWorkspace();
-    EXPECT_CALL(mockModel, getSummedWs).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getSelectedSummedWs).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(mockRegionSelector, updateWorkspace(Eq(ws))).Times(1);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -265,6 +265,53 @@ public:
     presenter.notifyLoadWorkspaceCompleted();
   }
 
+  void test_group_members_are_set_when_workspace_loaded() {
+    auto mockModel = makeModel();
+    auto mockView = std::make_unique<MockPreviewView>();
+    auto mainPresenter = MockBatchPresenter();
+    auto const members = std::vector<std::string>{"IvsQ_12345_1", "IvsQ_12345_2"};
+    MatrixWorkspace_sptr const workspace = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+
+    EXPECT_CALL(*mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillRepeatedly(Return(workspace));
+    EXPECT_CALL(*mockModel, getGroupMemberDisplayNames()).WillOnce(Return(members));
+    EXPECT_CALL(*mockView, setGroupMembers(members));
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+    presenter.acceptMainPresenter(&mainPresenter);
+    presenter.notifyLoadWorkspaceCompleted();
+  }
+
+  void test_group_member_selection_updates_each_preview_without_clearing_regions() {
+    auto mockModel = makeModel();
+    auto mockView = std::make_unique<MockPreviewView>();
+    auto mockDockedWidgets = std::make_unique<MockPreviewDockedWidgets>();
+    auto mockRegionSelector = makeRegionSelector();
+    auto mockLinePlot = std::make_unique<MockPlotPresenter>();
+    MatrixWorkspace_sptr loaded = WorkspaceCreationHelper::create2DWorkspace(2, 1);
+    MatrixWorkspace_sptr const summed = WorkspaceCreationHelper::create2DWorkspace(2, 1);
+    MatrixWorkspace_sptr const reduced = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    Workspace_sptr const summedWorkspace = summed;
+    loaded->setTitle("selected member");
+
+    EXPECT_CALL(*mockView, getSelectedGroupMember()).WillOnce(Return(1));
+    EXPECT_CALL(*mockModel, setSelectedGroupMember(1));
+    EXPECT_CALL(*mockModel, getSelectedLoadedWs()).WillOnce(Return(loaded));
+    EXPECT_CALL(*mockView, setTitle("selected member"));
+    EXPECT_CALL(*mockDockedWidgets, updateWorkspacePreservingSelection(loaded));
+    EXPECT_CALL(*mockDockedWidgets, plotInstView()).Times(0);
+    EXPECT_CALL(*mockModel, getSelectedSummedWs()).Times(2).WillRepeatedly(Return(summed));
+    EXPECT_CALL(*mockRegionSelector, updateWorkspace(summedWorkspace));
+    EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(0);
+    EXPECT_CALL(*mockModel, getSelectedReducedWs()).Times(2).WillRepeatedly(Return(reduced));
+    EXPECT_CALL(*mockLinePlot, setSpectrum(reduced, 0));
+    EXPECT_CALL(*mockLinePlot, plot());
+
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), std::move(mockDockedWidgets),
+                                  std::move(mockRegionSelector), std::move(mockLinePlot)));
+    presenter.notifyGroupMemberSelectionChanged();
+  }
+
   void test_notify_load_workspace_error_reenables_load_widgets() {
     auto mockModel = makeModel();
     auto mockView = std::make_unique<MockPreviewView>();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -273,7 +273,7 @@ public:
     MatrixWorkspace_sptr const workspace = WorkspaceCreationHelper::create2DWorkspace(1, 1);
 
     EXPECT_CALL(*mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillRepeatedly(Return(workspace));
-    EXPECT_CALL(*mockModel, getGroupMemberDisplayNames()).WillOnce(Return(members));
+    EXPECT_CALL(*mockModel, getGroupMemberDisplayNames()).Times(2).WillRepeatedly(Return(members));
     EXPECT_CALL(*mockView, setGroupMembers(members));
 
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
@@ -291,6 +291,7 @@ public:
     MatrixWorkspace_sptr const summed = WorkspaceCreationHelper::create2DWorkspace(2, 1);
     MatrixWorkspace_sptr const reduced = WorkspaceCreationHelper::create2DWorkspace(1, 1);
     Workspace_sptr const summedWorkspace = summed;
+    auto const groupMemberNames = std::vector<std::string>{"POLREF_1", "POLREF_2"};
     loaded->setTitle("selected member");
 
     EXPECT_CALL(*mockView, getSelectedGroupMember()).WillOnce(Return(1));
@@ -300,7 +301,10 @@ public:
     EXPECT_CALL(*mockDockedWidgets, updateWorkspacePreservingSelection(loaded));
     EXPECT_CALL(*mockDockedWidgets, plotInstView()).Times(0);
     EXPECT_CALL(*mockModel, getSelectedSummedWs()).Times(2).WillRepeatedly(Return(summed));
-    EXPECT_CALL(*mockRegionSelector, updateWorkspace(summedWorkspace));
+    EXPECT_CALL(*mockModel, getGroupMemberDisplayNames()).WillOnce(Return(groupMemberNames));
+    EXPECT_CALL(*mockModel, getSelectedGroupMember()).WillOnce(Return(1));
+    EXPECT_CALL(*mockRegionSelector, updateWorkspaceForGroupMember(summedWorkspace, "POLREF_2"));
+    EXPECT_CALL(*mockRegionSelector, updateWorkspace(summedWorkspace)).Times(0);
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(0);
     EXPECT_CALL(*mockModel, getSelectedReducedWs()).Times(2).WillRepeatedly(Return(reduced));
     EXPECT_CALL(*mockLinePlot, setSpectrum(reduced, 0));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -60,15 +60,18 @@ public:
   void test_notify_load_workspace_requested_loads_from_file_if_not_in_ads() {
     auto mockModel = makeModel();
     auto mockView = makeView();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockJobManager = makeJobManager();
     auto const workspaceName = std::string("test workspace");
 
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockView, disableMainWidget()).Times(1);
+    EXPECT_CALL(*mockDockedWidgets, setPlotAllGroupMembersCheckboxVisible(false));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(Eq(workspaceName), Ref(*mockJobManager))).Times(1);
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager)));
+    auto presenter = PreviewPresenter(
+        packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockDockedWidgets)));
     presenter.notifyLoadWorkspaceRequested();
   }
 
@@ -145,6 +148,8 @@ public:
     expectLoadWorkspaceCompletedForLinearDetector(*mockModel, *mockDockedWidgets);
 
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(1);
+    EXPECT_CALL(*mockModel, isWorkspaceGroup()).WillOnce(Return(false));
+    EXPECT_CALL(*mockDockedWidgets, setPlotAllGroupMembersCheckboxVisible(false));
 
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockDockedWidgets),
                          std::move(mockRegionSelector));
@@ -268,20 +273,24 @@ public:
   void test_group_members_are_set_when_workspace_loaded() {
     auto mockModel = makeModel();
     auto mockView = std::make_unique<MockPreviewView>();
+    auto mockDockedWidgets = std::make_unique<MockPreviewDockedWidgets>();
     auto mainPresenter = MockBatchPresenter();
     auto const members = std::vector<std::string>{"IvsQ_12345_1", "IvsQ_12345_2"};
     MatrixWorkspace_sptr const workspace = WorkspaceCreationHelper::create2DWorkspace(1, 1);
 
     EXPECT_CALL(*mockModel, getSelectedLoadedWs()).Times(AtLeast(1)).WillRepeatedly(Return(workspace));
     EXPECT_CALL(*mockModel, getGroupMemberDisplayNames()).Times(2).WillRepeatedly(Return(members));
+    EXPECT_CALL(*mockModel, isWorkspaceGroup()).WillOnce(Return(true));
     EXPECT_CALL(*mockView, setGroupMembers(members));
+    EXPECT_CALL(*mockDockedWidgets, setPlotAllGroupMembersCheckboxVisible(true));
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+    auto presenter = PreviewPresenter(
+        packDeps(mockView.get(), std::move(mockModel), makeJobManager(), std::move(mockDockedWidgets)));
     presenter.acceptMainPresenter(&mainPresenter);
     presenter.notifyLoadWorkspaceCompleted();
   }
 
-  void test_group_member_selection_updates_each_preview_without_clearing_regions() {
+  void test_group_member_selection_updates_each_preview_and_keeps_all_members_overplotted() {
     auto mockModel = makeModel();
     auto mockView = std::make_unique<MockPreviewView>();
     auto mockDockedWidgets = std::make_unique<MockPreviewDockedWidgets>();
@@ -290,6 +299,8 @@ public:
     MatrixWorkspace_sptr loaded = WorkspaceCreationHelper::create2DWorkspace(2, 1);
     MatrixWorkspace_sptr const summed = WorkspaceCreationHelper::create2DWorkspace(2, 1);
     MatrixWorkspace_sptr const reduced = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    MatrixWorkspace_sptr const otherReduced = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    auto const reducedWorkspaces = std::vector<MatrixWorkspace_sptr>{reduced, otherReduced};
     Workspace_sptr const summedWorkspace = summed;
     auto const groupMemberNames = std::vector<std::string>{"POLREF_1", "POLREF_2"};
     loaded->setTitle("selected member");
@@ -306,8 +317,11 @@ public:
     EXPECT_CALL(*mockRegionSelector, updateWorkspaceForGroupMember(summedWorkspace, "POLREF_2"));
     EXPECT_CALL(*mockRegionSelector, updateWorkspace(summedWorkspace)).Times(0);
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(0);
-    EXPECT_CALL(*mockModel, getSelectedReducedWs()).Times(2).WillRepeatedly(Return(reduced));
-    EXPECT_CALL(*mockLinePlot, setSpectrum(reduced, 0));
+    EXPECT_CALL(*mockModel, getSelectedReducedWs()).WillOnce(Return(reduced));
+    EXPECT_CALL(*mockDockedWidgets, getPlotAllGroupMembers()).WillOnce(Return(true));
+    EXPECT_CALL(*mockModel, getReducedWorkspaceMembers()).WillOnce(Return(reducedWorkspaces));
+    EXPECT_CALL(*mockLinePlot, setSpectra(reducedWorkspaces, 0));
+    EXPECT_CALL(*mockLinePlot, setSpectrum(_, _)).Times(0);
     EXPECT_CALL(*mockLinePlot, plot());
 
     auto presenter =
@@ -721,6 +735,86 @@ public:
     presenter.notifyReductionCompleted();
   }
 
+  void test_all_group_member_line_plots_are_displayed_when_reduction_completed() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    auto mockLinePlot = std::make_unique<MockPlotPresenter>();
+    auto const first = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+    auto const second = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+    auto const workspaces = std::vector<MatrixWorkspace_sptr>{first, second};
+
+    EXPECT_CALL(*mockDockedWidgets, getPlotAllGroupMembers()).WillOnce(Return(true));
+    EXPECT_CALL(*mockModel, getReducedWorkspaceMembers()).WillOnce(Return(workspaces));
+    EXPECT_CALL(*mockLinePlot, setSpectra(workspaces, 0));
+    EXPECT_CALL(*mockLinePlot, plot());
+
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), std::move(mockDockedWidgets),
+                                  makeRegionSelector(), std::move(mockLinePlot)));
+
+    presenter.notifyReductionCompleted();
+  }
+
+  void test_plot_all_group_members_change_overplots_all_reduced_workspaces() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    auto mockLinePlot = std::make_unique<MockPlotPresenter>();
+    auto const first = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+    auto const second = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+    auto const workspaces = std::vector<MatrixWorkspace_sptr>{first, second};
+
+    EXPECT_CALL(*mockModel, getReducedWs()).WillOnce(Return(first));
+    EXPECT_CALL(*mockDockedWidgets, getPlotAllGroupMembers()).WillOnce(Return(true));
+    EXPECT_CALL(*mockModel, getReducedWorkspaceMembers()).WillOnce(Return(workspaces));
+    EXPECT_CALL(*mockModel, getSelectedReducedWs()).Times(0);
+    EXPECT_CALL(*mockLinePlot, setSpectra(workspaces, 0));
+    EXPECT_CALL(*mockLinePlot, setSpectrum(_, _)).Times(0);
+    EXPECT_CALL(*mockLinePlot, plot());
+
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), std::move(mockDockedWidgets),
+                                  makeRegionSelector(), std::move(mockLinePlot)));
+
+    presenter.notifyPlotAllGroupMembersChanged();
+  }
+
+  void test_plot_all_group_members_change_does_not_plot_before_reduction() {
+    auto mockModel = makeModel();
+    auto mockLinePlot = std::make_unique<MockPlotPresenter>();
+
+    EXPECT_CALL(*mockModel, getReducedWs()).WillOnce(Return(nullptr));
+    EXPECT_CALL(*mockLinePlot, plot()).Times(0);
+
+    auto presenter =
+        PreviewPresenter(packDeps(makeView().get(), std::move(mockModel), makeJobManager(), makePreviewDockedWidgets(),
+                                  makeRegionSelector(), std::move(mockLinePlot)));
+
+    presenter.notifyPlotAllGroupMembersChanged();
+  }
+
+  void test_plot_all_group_members_change_plots_selected_member_when_unchecked() {
+    auto mockModel = makeModel();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    auto mockLinePlot = std::make_unique<MockPlotPresenter>();
+    auto const workspace = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+    EXPECT_CALL(*mockModel, getReducedWs()).WillOnce(Return(workspace));
+    EXPECT_CALL(*mockDockedWidgets, getPlotAllGroupMembers()).WillOnce(Return(false));
+    EXPECT_CALL(*mockModel, getSelectedReducedWs()).WillOnce(Return(workspace));
+    EXPECT_CALL(*mockModel, getReducedWorkspaceMembers()).Times(0);
+    EXPECT_CALL(*mockLinePlot, setSpectrum(workspace, 0));
+    EXPECT_CALL(*mockLinePlot, setSpectra(_, _)).Times(0);
+    EXPECT_CALL(*mockLinePlot, plot());
+
+    auto presenter =
+        PreviewPresenter(packDeps(makeView().get(), std::move(mockModel), makeJobManager(),
+                                  std::move(mockDockedWidgets), makeRegionSelector(), std::move(mockLinePlot)));
+
+    presenter.notifyPlotAllGroupMembersChanged();
+  }
+
   void test_notify_reduction_resumed_disables_view() {
     auto mockView = makeView();
     auto mainPresenter = MockBatchPresenter();
@@ -870,6 +964,39 @@ public:
     expectReductionPlotCleared(rawMockPlotPresenter);
 
     presenter.notifyReductionAlgorithmError();
+  }
+
+  void test_failed_reduction_cannot_replot_the_previous_reduction() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+    auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    auto mockRegionSelector = makeRegionSelector();
+    auto mockPlotPresenter = std::make_unique<MockPlotPresenter>();
+    Workspace_sptr reducedWorkspace = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    auto const summedWorkspace = createRectangularDetectorWorkspace();
+    Workspace_sptr const genericSummedWorkspace = summedWorkspace;
+    auto const loadedWorkspace = createLinearDetectorWorkspace();
+
+    EXPECT_CALL(*mockModel, getSelectedSummedWs()).WillOnce(Return(summedWorkspace));
+    EXPECT_CALL(*mockRegionSelector, updateWorkspace(genericSummedWorkspace));
+    EXPECT_CALL(*mockModel, getSelectedLoadedWs()).WillOnce(Return(loadedWorkspace));
+    EXPECT_CALL(*mockModel, clearReducedWorkspace()).WillOnce(::testing::Invoke([&reducedWorkspace] {
+      reducedWorkspace.reset();
+    }));
+    EXPECT_CALL(*mockModel, reduceAsync(Ref(*mockJobManager)));
+    expectReductionPlotCleared(mockPlotPresenter.get());
+    EXPECT_CALL(*mockModel, getReducedWs()).WillOnce(::testing::Invoke([&reducedWorkspace] {
+      return reducedWorkspace;
+    }));
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
+                                               std::move(mockDockedWidgets), std::move(mockRegionSelector),
+                                               std::move(mockPlotPresenter)));
+
+    presenter.notifySumBanksCompleted();
+    presenter.notifyReductionAlgorithmError();
+    presenter.notifyPlotAllGroupMembersChanged();
   }
 
 private:
@@ -1237,6 +1364,7 @@ private:
     EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Background, roi)).Times(1);
     EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Transmission, roi)).Times(1);
     // Check reduction is executed
+    EXPECT_CALL(mockModel, clearReducedWorkspace()).Times(1);
     EXPECT_CALL(mockModel, reduceAsync(Ref(mockJobManager))).Times(1);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -66,6 +66,7 @@ public:
 
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockView, disableMainWidget()).Times(1);
+    EXPECT_CALL(*mockView, setGroupMembers(std::vector<std::string>{}));
     EXPECT_CALL(*mockDockedWidgets, setPlotAllGroupMembersCheckboxVisible(false));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(Eq(workspaceName), Ref(*mockJobManager))).Times(1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/QtPreviewDockedWidgetsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/QtPreviewDockedWidgetsTest.h
@@ -1,0 +1,65 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "QtPreviewDockedWidgets.h"
+
+#include <QCheckBox>
+#include <cxxtest/TestSuite.h>
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+
+class QtPreviewDockedWidgetsTest : public CxxTest::TestSuite {
+public:
+  void test_plot_all_group_members_checkbox_is_shown_and_notifies_subscriber() {
+    QtPreviewDockedWidgets view;
+    Subscriber subscriber;
+    view.subscribe(&subscriber);
+    auto *checkbox = view.findChild<QCheckBox *>("plot_all_group_members_checkbox");
+
+    view.setPlotAllGroupMembersCheckboxVisible(true);
+    checkbox->setChecked(true);
+
+    TS_ASSERT(!checkbox->isHidden());
+    TS_ASSERT_EQUALS(checkbox->text().toStdString(), "Plot reduction preview for all group members");
+    TS_ASSERT(view.getPlotAllGroupMembers());
+    TS_ASSERT_EQUALS(subscriber.plotAllGroupMembersChangedCount, 1);
+  }
+
+  void test_hiding_plot_all_group_members_checkbox_resets_it_without_notifying_subscriber() {
+    QtPreviewDockedWidgets view;
+    Subscriber subscriber;
+    view.subscribe(&subscriber);
+    auto *checkbox = view.findChild<QCheckBox *>("plot_all_group_members_checkbox");
+    view.setPlotAllGroupMembersCheckboxVisible(true);
+    checkbox->setChecked(true);
+
+    view.setPlotAllGroupMembersCheckboxVisible(false);
+
+    TS_ASSERT(checkbox->isHidden());
+    TS_ASSERT(!view.getPlotAllGroupMembers());
+    TS_ASSERT_EQUALS(subscriber.plotAllGroupMembersChangedCount, 1);
+  }
+
+private:
+  class Subscriber final : public PreviewDockedWidgetsSubscriber {
+  public:
+    void acceptMainPresenter(IBatchPresenter *) override {}
+    void notifyInstViewZoomRequested() override {}
+    void notifyInstViewEditRequested() override {}
+    void notifyInstViewSelectRectRequested() override {}
+    void notifyInstViewShapeChanged() override {}
+    void notifyRegionSelectorExportAdsRequested() override {}
+    void notifyLinePlotExportAdsRequested() override {}
+    void notifyEditROIModeRequested() override {}
+    void notifyRectangularROIModeRequested() override {}
+    void notifySetYAxisSymlogChanged() override {}
+    void notifyPlotAllGroupMembersChanged() override { ++plotAllGroupMembersChangedCount; }
+
+    size_t plotAllGroupMembersChangedCount{0};
+  };
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/QtPreviewViewTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/QtPreviewViewTest.h
@@ -1,0 +1,70 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "QtPreviewView.h"
+
+#include <QComboBox>
+#include <QLabel>
+#include <cxxtest/TestSuite.h>
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+
+class QtPreviewViewTest : public CxxTest::TestSuite {
+public:
+  void test_group_member_selector_is_populated_and_shown_for_group() {
+    QtPreviewView view;
+    auto *selector = view.findChild<QComboBox *>("group_member_combo_box");
+    auto *label = view.findChild<QLabel *>("group_member_label");
+
+    view.setGroupMembers({"member_1", "member_2"});
+
+    TS_ASSERT(!selector->isHidden());
+    TS_ASSERT(!label->isHidden());
+    TS_ASSERT_EQUALS(selector->count(), 2);
+    TS_ASSERT_EQUALS(selector->itemText(0).toStdString(), "member_1");
+    TS_ASSERT_EQUALS(selector->itemText(1).toStdString(), "member_2");
+  }
+
+  void test_group_member_selector_is_cleared_and_hidden_for_matrix_workspace() {
+    QtPreviewView view;
+    auto *selector = view.findChild<QComboBox *>("group_member_combo_box");
+    auto *label = view.findChild<QLabel *>("group_member_label");
+    view.setGroupMembers({"member_1", "member_2"});
+
+    view.setGroupMembers({});
+
+    TS_ASSERT(selector->isHidden());
+    TS_ASSERT(label->isHidden());
+    TS_ASSERT_EQUALS(selector->count(), 0);
+  }
+
+  void test_changing_group_member_notifies_subscriber_and_updates_selection() {
+    QtPreviewView view;
+    Subscriber subscriber;
+    view.subscribe(&subscriber);
+    view.setGroupMembers({"member_1", "member_2"});
+    auto *selector = view.findChild<QComboBox *>("group_member_combo_box");
+
+    selector->setCurrentIndex(1);
+
+    TS_ASSERT_EQUALS(subscriber.selectionChangedCount, 1);
+    TS_ASSERT_EQUALS(view.getSelectedGroupMember(), 1);
+  }
+
+private:
+  class Subscriber final : public PreviewViewSubscriber {
+  public:
+    void acceptMainPresenter(IBatchPresenter *) override {}
+    void notifyLoadWorkspaceRequested() override {}
+    void notifyGroupMemberSelectionChanged() override { ++selectionChangedCount; }
+    void notifyUpdateAngle() override {}
+    void notifyApplyRequested() override {}
+
+    size_t selectionChangedCount{0};
+  };
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -10,6 +10,8 @@
 #include "../../../ISISReflectometry/Reduction/LookupTable.h"
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/Reduction/RowExceptions.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "TestHelpers/ModelCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
@@ -142,6 +144,28 @@ public:
     auto title = "El Em En Oh"s;
     auto row = ModelCreationHelper::makePreviewRow(angle, title);
     const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    if (foundLookupRow)
+      TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)
+  }
+
+  void test_searching_by_theta_and_title_for_preview_group_uses_first_member_title() {
+    auto constexpr angle = 2.3;
+    auto expectedLookupRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("El"));
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")), expectedLookupRow};
+    auto first = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    first->setTitle("El Em En Oh");
+    auto second = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    second->setTitle("Ay Bee Sea");
+    auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
+    group->addWorkspace(first);
+    group->addWorkspace(second);
+    auto row = PreviewRow({});
+    row.setTheta(angle);
+    row.setLoadedWs(group);
+
+    auto const foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+
     TS_ASSERT(foundLookupRow)
     if (foundLookupRow)
       TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotModel.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotModel.h
@@ -22,6 +22,7 @@ public:
   virtual void clear() noexcept;
 
   virtual void setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex);
+  virtual void setSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces, const size_t wsIndex);
 
   virtual bool getPlotErrorBars() const { return m_plotErrorBars; }
   virtual void setPlotErrorBars(const bool plotErrorBars) { m_plotErrorBars = plotErrorBars; }

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h
@@ -21,6 +21,7 @@ public:
   virtual void clearModel();
 
   virtual void setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex);
+  virtual void setSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces, const size_t wsIndex);
 
   virtual void setScaleLinear(const AxisID axisID);
   virtual void setScaleLog(const AxisID axisID);

--- a/qt/widgets/plotting/src/PlotWidget/PlotModel.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/PlotModel.cpp
@@ -26,4 +26,9 @@ void PlotModel::setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const s
   m_workspaces = std::vector<MatrixWorkspace_sptr>{ws};
   m_workspaceIndices = std::vector<int>{static_cast<int>(wsIndex)};
 }
+
+void PlotModel::setSpectra(const std::vector<MatrixWorkspace_sptr> &workspaces, const size_t wsIndex) {
+  m_workspaces = workspaces;
+  m_workspaceIndices = std::vector<int>{static_cast<int>(wsIndex)};
+}
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
@@ -23,6 +23,10 @@ void PlotPresenter::setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, con
   m_model->setSpectrum(ws, wsIndex);
 }
 
+void PlotPresenter::setSpectra(const std::vector<MatrixWorkspace_sptr> &workspaces, const size_t wsIndex) {
+  m_model->setSpectra(workspaces, wsIndex);
+}
+
 void PlotPresenter::setScaleLinear(const AxisID axisID) { m_view->setScaleLinear(axisID); }
 
 void PlotPresenter::setScaleLog(const AxisID axisID) { m_view->setScaleLog(axisID); }

--- a/qt/widgets/plotting/test/PlotWidget/MockPlotModel.h
+++ b/qt/widgets/plotting/test/PlotWidget/MockPlotModel.h
@@ -19,6 +19,7 @@ public:
   MOCK_METHOD(std::vector<Mantid::API::MatrixWorkspace_sptr>, getWorkspaces, (), (const, override));
   MOCK_METHOD(std::vector<int>, getWorkspaceIndices, (), (const, override));
   MOCK_METHOD(void, setSpectrum, (const Mantid::API::MatrixWorkspace_sptr &, const size_t), (override));
+  MOCK_METHOD(void, setSpectra, (const std::vector<Mantid::API::MatrixWorkspace_sptr> &, const size_t), (override));
   MOCK_METHOD(void, setPlotErrorBars, (const bool), (override));
   MOCK_METHOD(bool, getPlotErrorBars, (), (const, override));
 };

--- a/qt/widgets/plotting/test/PlotWidget/PlotModelTest.h
+++ b/qt/widgets/plotting/test/PlotWidget/PlotModelTest.h
@@ -43,6 +43,16 @@ public:
     TS_ASSERT_EQUALS(model.getWorkspaces(), expectedWorkspaces);
   }
 
+  void test_set_spectra() {
+    auto model = PlotModel();
+    auto const workspaces = std::vector<MatrixWorkspace_sptr>{createMatrixWorkspace(2), createMatrixWorkspace(2)};
+
+    model.setSpectra(workspaces, 1);
+
+    TS_ASSERT_EQUALS(model.getWorkspaceIndices(), std::vector<int>({1}));
+    TS_ASSERT_EQUALS(model.getWorkspaces(), workspaces);
+  }
+
   void test_clear_will_clear_the_model() {
     auto model = PlotModel();
     auto ws = createMatrixWorkspace(3);

--- a/qt/widgets/plotting/test/PlotWidget/PlotPresenterTest.h
+++ b/qt/widgets/plotting/test/PlotWidget/PlotPresenterTest.h
@@ -45,6 +45,18 @@ public:
     presenter.setSpectrum(ws, wsIndex);
   }
 
+  void test_set_spectra() {
+    auto view = MockPlotView();
+    auto model = std::make_unique<MockPlotModel>();
+    auto const workspaces = std::vector<MatrixWorkspace_sptr>{createMatrixWorkspace(1), createMatrixWorkspace(1)};
+
+    EXPECT_CALL(*model, setSpectra(workspaces, 0)).Times(1);
+
+    auto presenter = PlotPresenter(&view, std::move(model));
+
+    presenter.setSpectra(workspaces, 0);
+  }
+
   void test_plot() {
     auto view = MockPlotView();
     auto model = makeModel();

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -22,6 +22,8 @@ public:
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
   virtual void clearWorkspace() = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
+  virtual void updateWorkspaceForGroupMember(Mantid::API::Workspace_sptr const &workspace,
+                                             std::string const &groupMemberName) = 0;
   virtual void addRectangularRegion(const std::string &regionType, const std::string &color,
                                     const std::string &hatch) = 0;
   virtual void deselectAllSelectors() = 0;

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -28,6 +28,8 @@ public:
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
   void clearWorkspace() override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
+  void updateWorkspaceForGroupMember(Mantid::API::Workspace_sptr const &workspace,
+                                     std::string const &groupMemberName) override;
   void addRectangularRegion(const std::string &regionType, const std::string &color, const std::string &hatch) override;
   void deselectAllSelectors() override;
   Selection getRegion(const std::string &regionType) override;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -94,6 +94,15 @@ void RegionSelector::updateWorkspace(Workspace_sptr const &workspace) {
   pyobj().attr("update_workspace")(*boost::python::tuple(), **kwargs);
 }
 
+void RegionSelector::updateWorkspaceForGroupMember(Workspace_sptr const &workspace,
+                                                   std::string const &groupMemberName) {
+  GlobalInterpreterLock lock;
+  boost::python::dict kwargs;
+  kwargs["workspace"] = workspace;
+  kwargs["group_member_name"] = groupMemberName;
+  pyobj().attr("update_workspace")(*boost::python::tuple(), **kwargs);
+}
+
 void RegionSelector::addRectangularRegion(const std::string &regionType, const std::string &color,
                                           const std::string &hatch) {
   GlobalInterpreterLock lock;

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -15,6 +15,8 @@ public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
   MOCK_METHOD(void, clearWorkspace, (), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
+  MOCK_METHOD(void, updateWorkspaceForGroupMember,
+              (Mantid::API::Workspace_sptr const &workspace, std::string const &groupMemberName), (override));
   MOCK_METHOD(void, addRectangularRegion,
               (std::string const &regionType, std::string const &color, std::string const &hatch), (override));
   MOCK_METHOD(void, deselectAllSelectors, (), (override));


### PR DESCRIPTION
### Description of work

This PR does the following:

- Enables users to specify a workspace group in the preview tab of the ISISReflectometry GUI. In this instance, a drop-down menu is provided that allows the user to select specific workspace group members to be represented on the instrument view, sliceviewer and preview plot.
- Regions drawn remain consistent across the different group members (this is a requirement for PNR workflows).
- Any masks drawn on sliceviewer however are cached, and are specific to the workspace group member. These masks are not yet integrated with the PNR workflow (this is not within scope).
- An option to plot all the reduction preview outputs on the same graph has been provided.

- The sum banks algorithm has been updated to work with workspace groups. It however turned out this was pretty pointless, as it’s only relevant for 2D detectors. Only INTER has one of these, and its not clear why a INTER would ever use a group workspace. Ah well, we’re future proofed for if POLREF get a 2D detector…


Closes #42005

### To test:

1) Ensure data archive access, or access to a PNR dataset
2) On the ISIS Reflectometry GUI, Set the instrument on the `Runs` tab to `POLREF`, then go to the `Reduction Preview` tab
3) In the `Run` box, type in a PNR dataset (I used `47041`)
4) Observe the `Group member` dropdown appears, containing the two group members
5) Switch between the group members, observe the instrument view, sliceviewer and preview plot change for each group member.
6) On the sliceviewer plot, select a signal region over the specular region (Note: if you draw a region on the instrument view you will see an error, as you're trying to sum over a 1D detector, will likely disable this in a separate PR).
7) Once again, switch between the group members. Observe that the selected region is consistent.
8) Using the sliceviewer masking feature, enable then draw a masking shape on the sliceviewer (you may have to click the `>>` depending on window size.
9) Again, switch between the group members. See that the mask is workspace member specific, and is cached on the relevant group member. You will not see the impact of the mask on the reduction, as this integration is not yet provided.
10) Below the preview plot, select the `Plot reduction preview for all group members` button. See the preview reduction outputs for each member are now over plotted.

To test the sum banks change, run the following script. This effectively enables the use of `ReflectometryISISLoadAndProcess` whilst supplying a `ROIDetectorIDs` argument.
```
from mantid.simpleapi import *

# Need to use data on Babylon, there is some preprocessing: /Volumes/babylon5/Public/miallewis/refl/preproccessed_inter_data
INTER_DATA=['INTER00084884', 'INTER00084885', 'INTER00084886']

for data in INTER_DATA:
    INTER_DATA_PATH=f'/Users/mial.lewis/data/{data}.nxs'
    Load(Filename=INTER_DATA_PATH, OutputWorkspace=data, LoadMonitors=True, MonitorsLoadOnly="Histogram", PreserveEvents=False)
GroupWorkspaces(InputWorkspaces=f'{",".join(INTER_DATA)}', OutputWorkspace='inter_group')

ReflectometryISISLoadAndProcess(
    InputRunList='inter_group', ThetaIn=0.80000000000000004, ROIDetectorIDs='6037-6121,7037-7121',
    AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='64-90', WavelengthMin=1.5,
    WavelengthMax=17, I0MonitorIndex=2, MonitorBackgroundWavelengthMin=17,
    MonitorBackgroundWavelengthMax=18, MonitorIntegrationWavelengthMin=4,
    MonitorIntegrationWavelengthMax=10, BackgroundProcessingInstructions='166-242',
    StartOverlap=10, EndOverlap=12, ScaleRHSWorkspace=False, MomentumTransferMin=0.010321400099096547,
    MomentumTransferStep=0.055396421622090297, MomentumTransferMax=0.11695694927687957,
    OutputWorkspaceBinned='inter_group_out_binned', OutputWorkspace='inter_group_out', OutputWorkspaceWavelength='inter_group_out_lam')
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
