### PR TITLE
Fail Linux builds with GCC compiler warnings

### DIFF
--- a/.github/actions/check-build-warnings/action.yml
+++ b/.github/actions/check-build-warnings/action.yml
@@ -4,6 +4,13 @@ inputs:
   log-file:
     description: 'Path to the captured build log, relative to the workspace'
     required: true
+  allowed-warnings-count:
+    description: |
+      If warnings slip through to main this can be used to set a non-zero allowed count while those
+      warnings are dealt with. This avoids breaking all builds for all developers. It should always
+      be zero otherwise.
+    required: false
+    default: '0'
 runs:
   using: "composite"
   steps:
@@ -12,5 +19,7 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         BUILD_LOG: ${{ inputs.log-file }}
+        ALLOWED_WARNINGS_COUNT: ${{ inputs.allowed-warnings-count }}
       run: |
-        pixi run --frozen python ${GITHUB_WORKSPACE}/.github/actions/check-build-warnings/count_warnings.py "${GITHUB_WORKSPACE}/${BUILD_LOG}"
+        pixi run --frozen python ${GITHUB_WORKSPACE}/.github/actions/check-build-warnings/count_warnings.py \
+          "${GITHUB_WORKSPACE}/${BUILD_LOG}" --allowed-warnings "${ALLOWED_WARNINGS_COUNT}"

--- a/.github/actions/check-build-warnings/action.yml
+++ b/.github/actions/check-build-warnings/action.yml
@@ -1,0 +1,16 @@
+name: 'Check Build Warnings'
+description: 'Fails the job if the C++ compiler emitted warnings, after the whole build has completed'
+inputs:
+  log-file:
+    description: 'Path to the captured build log, relative to the workspace'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Check for compiler warnings
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        BUILD_LOG: ${{ inputs.log-file }}
+      run: |
+        pixi run --frozen python ${GITHUB_WORKSPACE}/.github/actions/check-build-warnings/count_warnings.py "${GITHUB_WORKSPACE}/${BUILD_LOG}"

--- a/.github/actions/check-build-warnings/count_warnings.py
+++ b/.github/actions/check-build-warnings/count_warnings.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+"""Fail a CI job when the C++ compiler emitted warnings during the build.
+
+The build itself is allowed to run to completion; its merged stdout/stderr is
+captured to a log file which this script scans afterwards. Only warnings that a
+developer can act on are counted, i.e. those attributed to a source file that is
+tracked in the repository. Warnings from third-party or generated code, and
+warnings without a source location, are reported but do not fail the job.
+"""
+
+import os
+import pathlib
+import re
+import sys
+from collections import Counter
+
+# Colour codes are disabled in CI via COLORED_COMPILER_OUTPUT=OFF, but strip them
+# anyway so the script also works on a log captured from a developer build.
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# gcc/clang diagnostics of the form "path:line[:column]: warning: message"
+LOCATED_WARNING_RE = re.compile(r"^(?P<file>.+?):(?P<line>\d+):(?:(?P<column>\d+):)?\s+warning:\s+(?P<message>.*)$")
+
+# Warnings carrying no source location, e.g. "cc1plus: warning: ..." or "ld: warning: ..."
+UNLOCATED_WARNING_RE = re.compile(r"^(?P<tool>[^\s:]+):\s+warning:\s+(?P<message>.*)$")
+
+# Trailing warning flag, e.g. the "-Wconversion" in "... [-Wconversion]"
+WARNING_FLAG_RE = re.compile(r"\[(-W[^\]]+)\]\s*$")
+
+# The C/C++ extensions listed in .github/filters.yaml, plus those the build can emit
+SOURCE_SUFFIXES = frozenset((".c", ".cc", ".cpp", ".cu", ".cxx", ".h", ".hpp", ".hxx", ".tcc"))
+
+# Workspace subdirectories holding generated, vendored or third-party sources
+EXCLUDED_TOP_LEVEL_DIRS = frozenset(("build", "_deps", ".pixi"))
+
+
+def _source_path(raw_path: str, build_dir: pathlib.Path, workspace: pathlib.Path) -> pathlib.Path | None:
+    """Return the workspace-relative path of a warning that should be counted, else None.
+
+    Relative paths are resolved against the build directory as that is the working
+    directory of the build tool that emitted them.
+    """
+    candidate = pathlib.Path(raw_path)
+    if candidate.suffix.lower() not in SOURCE_SUFFIXES:
+        return None
+
+    if not candidate.is_absolute():
+        candidate = build_dir / candidate
+
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(workspace):
+        return None
+
+    relative = resolved.relative_to(workspace)
+    if relative.parts[0] in EXCLUDED_TOP_LEVEL_DIRS:
+        return None
+
+    return relative
+
+
+def _scan(log_path: pathlib.Path, build_dir: pathlib.Path, workspace: pathlib.Path) -> tuple[list, list, int]:
+    """Return the deduplicated counted warnings, the uncounted warning lines and the number of lines read."""
+    counted = {}
+    uncounted = []
+    lines_read = 0
+
+    with log_path.open(errors="replace") as handle:
+        for raw_line in handle:
+            lines_read += 1
+            line = ANSI_RE.sub("", raw_line.rstrip("\r\n"))
+            match = LOCATED_WARNING_RE.match(line)
+            if match:
+                relative = _source_path(match["file"], build_dir, workspace)
+                if relative is None:
+                    uncounted.append(line)
+                else:
+                    # A warning in a header is re-emitted once per translation unit
+                    # that includes it, so key on the location and message.
+                    key = (relative.as_posix(), int(match["line"]), int(match["column"] or 0), match["message"])
+                    counted.setdefault(key, None)
+            elif UNLOCATED_WARNING_RE.match(line):
+                uncounted.append(line)
+
+    return sorted(counted), uncounted, lines_read
+
+
+def _format(warning: tuple) -> str:
+    file_path, line, column, message = warning
+    location = f"{file_path}:{line}:{column}" if column else f"{file_path}:{line}"
+
+    return f"{location}: warning: {message}"
+
+
+def _warning_flag(message: str) -> str:
+    match = WARNING_FLAG_RE.search(message)
+
+    return match.group(1) if match else "unflagged"
+
+
+def _write_step_summary(warnings: list) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    lines = [f"## {len(warnings)} compiler warning(s)", "", "```"]
+    lines.extend(_format(warning) for warning in warnings)
+    lines.extend(("```", ""))
+    with open(summary_path, "a") as handle:
+        handle.write("\n".join(lines))
+
+
+def main() -> int:
+    log_path = pathlib.Path(sys.argv[1])
+    workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
+    build_dir = pathlib.Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else workspace / "build"
+
+    if not log_path.exists():
+        print(f"::error::Build log {log_path} does not exist, cannot check for compiler warnings")
+        return 1
+
+    counted, uncounted, lines_read = _scan(log_path, build_dir, workspace)
+
+    # An empty log means the build output was not captured, which must not pass silently
+    if lines_read == 0:
+        print(f"::error::Build log {log_path} is empty, cannot check for compiler warnings")
+        return 1
+
+    if uncounted:
+        print("::group::Warnings not counted (third-party, generated code, or no source location)")
+        for line in uncounted:
+            print(line)
+        print("::endgroup::")
+
+    if not counted:
+        print("No compiler warnings found")
+        return 0
+
+    print(f"::group::{len(counted)} compiler warning(s)")
+    for warning in counted:
+        print(_format(warning))
+    print("::endgroup::")
+
+    flags = Counter(_warning_flag(message) for _, _, _, message in counted)
+    print("Warnings by flag:")
+    for flag, count in flags.most_common():
+        print(f"  {count:5d}  {flag}")
+
+    _write_step_summary(counted)
+    print(f"::error::Build produced {len(counted)} compiler warning(s). See the build log artifact for full context.")
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/check-build-warnings/count_warnings.py
+++ b/.github/actions/check-build-warnings/count_warnings.py
@@ -9,6 +9,7 @@ tracked in the repository. Warnings from third-party or generated code, and
 warnings without a source location, are reported but do not fail the job.
 """
 
+import argparse
 import os
 import pathlib
 import re
@@ -110,10 +111,35 @@ def _write_step_summary(warnings: list) -> None:
         handle.write("\n".join(lines))
 
 
+def _parse_args(argv: list) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fail a CI job when the C++ compiler emitted warnings.")
+    parser.add_argument("log_file", type=pathlib.Path, help="Build log to scan")
+    parser.add_argument(
+        "--build-dir",
+        type=pathlib.Path,
+        help="Directory the build tool ran in, used to resolve relative paths (default: <workspace>/build)",
+    )
+    parser.add_argument(
+        "--allowed-warnings",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Number of warnings tolerated before the job fails. Should always be 0; a non-zero value is a "
+        "temporary measure so that a known backlog does not break every build while it is dealt with.",
+    )
+
+    return parser.parse_args(argv)
+
+
 def main() -> int:
-    log_path = pathlib.Path(sys.argv[1])
+    args = _parse_args(sys.argv[1:])
+    log_path = args.log_file
     workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
-    build_dir = pathlib.Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else workspace / "build"
+    build_dir = args.build_dir.resolve() if args.build_dir else workspace / "build"
+
+    if args.allowed_warnings < 0:
+        print(f"::error::--allowed-warnings must not be negative, got {args.allowed_warnings}")
+        return 1
 
     if not log_path.exists():
         print(f"::error::Build log {log_path} does not exist, cannot check for compiler warnings")
@@ -147,7 +173,16 @@ def main() -> int:
         print(f"  {count:5d}  {flag}")
 
     _write_step_summary(counted)
-    print(f"::error::Build produced {len(counted)} compiler warning(s). See the build log artifact for full context.")
+
+    if len(counted) <= args.allowed_warnings:
+        print(
+            f"::warning::Build produced {len(counted)} compiler warning(s), within the allowance of "
+            f"{args.allowed_warnings}. Fix these and lower the allowance."
+        )
+        return 0
+
+    allowance = f" Only {args.allowed_warnings} are allowed." if args.allowed_warnings else ""
+    print(f"::error::Build produced {len(counted)} compiler warning(s).{allowance} See the build log artifact for full context.")
 
     return 1
 

--- a/.github/actions/check-build-warnings/test_count_warnings.py
+++ b/.github/actions/check-build-warnings/test_count_warnings.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+"""Unit tests for count_warnings.
+
+These cover the log parsing and the exit conditions, which is everything that can
+regress without a compiler or a GitHub Actions runner. Run them with:
+
+    python -m unittest discover -s .github/actions/check-build-warnings
+
+It deliberately omits a module-level test runner entry point, as it is not one of the
+CMake-registered pytest suites. The check_build_warnings_tests.yml workflow runs it.
+
+Each test is laid out as three blocks: write the build log, scan it, assert on the result.
+"""
+
+import contextlib
+import io
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+import count_warnings
+
+WARNING = "conversion from 'int' to 'char' may change value [-Wconversion]"
+
+
+class CountWarningsTestCase(unittest.TestCase):
+    def setUp(self):
+        self._workspace_dir = tempfile.TemporaryDirectory()
+        # Resolve so comparisons match count_warnings, which resolves both sides
+        self.workspace = pathlib.Path(self._workspace_dir.name).resolve()
+        self.build_dir = self.workspace / "build"
+        self.addCleanup(self._workspace_dir.cleanup)
+
+    def _write_log(self, *lines) -> pathlib.Path:
+        """Write the given lines to a build log and return its path."""
+        log_path = self.workspace / "build.log"
+        log_path.write_text("\n".join(lines) + "\n")
+
+        return log_path
+
+    def _scan(self, log_path: pathlib.Path):
+        """Scan a build log, returning (counted, uncounted, lines read)."""
+        return count_warnings._scan(log_path, self.build_dir, self.workspace)
+
+    def _run_main(self, argv, env=None):
+        """Return (exit code, stdout) for a main() call, keeping the test output clean."""
+        environment = {"GITHUB_WORKSPACE": str(self.workspace)}
+        environment.update(env or {})
+        stdout = io.StringIO()
+        with mock.patch.object(count_warnings.sys, "argv", ["count_warnings.py", *argv]):
+            with mock.patch.dict(os.environ, environment, clear=False):
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = count_warnings.main()
+
+        return exit_code, stdout.getvalue()
+
+
+class TestScan(CountWarningsTestCase):
+    def test_counts_warning_for_workspace_source_file(self):
+        log_path = self._write_log(f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 12, 5, WARNING)])
+        self.assertEqual(uncounted, [])
+
+    def test_resolves_relative_paths_against_the_build_directory(self):
+        # ninja emits paths relative to the build directory it runs in
+        log_path = self._write_log(f"../Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual([warning[0] for warning in counted], ["Framework/Kernel/src/Foo.cpp"])
+
+    def test_counts_warning_that_has_no_column(self):
+        log_path = self._write_log(f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12: warning: {WARNING}")
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 12, 0, WARNING)])
+
+    def test_deduplicates_the_same_warning_reported_by_several_translation_units(self):
+        header_warning = f"{self.workspace}/Framework/Kernel/inc/MantidKernel/Foo.h:8:3: warning: {WARNING}"
+        log_path = self._write_log(header_warning, "[2/9] Building CXX object Bar.cpp.o", header_warning)
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(len(counted), 1)
+
+    def test_counts_warnings_that_differ_only_by_line(self):
+        log_path = self._write_log(
+            f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}",
+            f"{self.workspace}/Framework/Kernel/src/Foo.cpp:13:5: warning: {WARNING}",
+        )
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(len(counted), 2)
+
+    def test_excludes_generated_and_third_party_paths(self):
+        generated_and_third_party = (
+            f"{self.build_dir}/_deps/googletest-src/gtest.h:10:1: warning: {WARNING}",
+            f"{self.build_dir}/qt/generated/moc_Foo.cpp:10:1: warning: {WARNING}",
+            f"{self.workspace}/_deps/eigen-src/Eigen/Core.h:44:9: warning: {WARNING}",
+            f"{self.workspace}/.pixi/envs/default/include/thing.hpp:99:1: warning: {WARNING}",
+        )
+        log_path = self._write_log(*generated_and_third_party)
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), len(generated_and_third_party))
+
+    def test_excludes_paths_outside_the_workspace(self):
+        log_path = self._write_log(f"/opt/conda/envs/mantid/include/boost/thing.hpp:99:1: warning: {WARNING}")
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 1)
+
+    def test_excludes_files_that_are_not_c_or_cpp(self):
+        log_path = self._write_log(f"{self.workspace}/docs/source/algorithms/Foo.py:1:1: warning: {WARNING}")
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 1)
+
+    def test_records_warnings_without_a_source_location_as_uncounted(self):
+        log_path = self._write_log(
+            "cc1plus: warning: command-line option '-Wfoo' is valid for C but not for C++",
+            "/usr/bin/ld: warning: libfoo.so, needed by libbar.so, not found",
+        )
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 2)
+
+    def test_ignores_lines_that_are_not_warnings(self):
+        log_path = self._write_log(
+            "[1/9] Building CXX object Framework/Kernel/CMakeFiles/Kernel.dir/src/Foo.cpp.o",
+            f"{self.workspace}/Framework/Kernel/src/Foo.cpp: In function 'char narrow(int)':",
+            f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12:5: note: in expansion of macro 'FOO'",
+            "CMake Warning at CMakeLists.txt:1 (message):",
+            f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12:5: error: something broke",
+        )
+
+        counted, uncounted, lines_read = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(uncounted, [])
+        self.assertEqual(lines_read, 5)
+
+    def test_strips_ansi_escape_sequences(self):
+        coloured_warning = (
+            f"\x1b[01m\x1b[K{self.workspace}/Framework/Kernel/src/Foo.cpp:7:3:\x1b[m\x1b[K "
+            "\x1b[01;35m\x1b[Kwarning: \x1b[m\x1b[Kunused variable 'x' [\x1b[01;35m\x1b[K-Wunused-variable\x1b[m\x1b[K]"
+        )
+        log_path = self._write_log(coloured_warning)
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 7, 3, "unused variable 'x' [-Wunused-variable]")])
+
+    def test_counts_lines_read(self):
+        log_path = self._write_log("one", "two", "three")
+
+        _, _, lines_read = self._scan(log_path)
+
+        self.assertEqual(lines_read, 3)
+
+
+class TestWarningFlag(unittest.TestCase):
+    def test_extracts_the_trailing_warning_flag(self):
+        message = WARNING
+
+        flag = count_warnings._warning_flag(message)
+
+        self.assertEqual(flag, "-Wconversion")
+
+    def test_reports_a_warning_with_no_flag_as_unflagged(self):
+        message = "something happened"
+
+        flag = count_warnings._warning_flag(message)
+
+        self.assertEqual(flag, "unflagged")
+
+
+class TestMain(CountWarningsTestCase):
+    def test_fails_when_the_log_is_missing(self):
+        missing_log = self.workspace / "absent.log"
+
+        exit_code, output = self._run_main([str(missing_log)])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("does not exist", output)
+
+    def test_fails_when_the_log_is_empty(self):
+        empty_log = self.workspace / "empty.log"
+        empty_log.touch()
+
+        exit_code, output = self._run_main([str(empty_log)])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("is empty", output)
+
+    def test_passes_when_there_are_no_countable_warnings(self):
+        log_path = self._write_log(
+            "[1/1] Building CXX object Foo.cpp.o",
+            "cc1plus: warning: some toolchain noise",
+        )
+
+        exit_code, output = self._run_main([str(log_path), str(self.build_dir)])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("No compiler warnings found", output)
+
+    def test_fails_when_there_are_countable_warnings(self):
+        log_path = self._write_log(f"../Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
+
+        exit_code, output = self._run_main([str(log_path), str(self.build_dir)])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("::error::Build produced 1 compiler warning(s)", output)
+        self.assertIn("Framework/Kernel/src/Foo.cpp:12:5", output)
+        self.assertIn("-Wconversion", output)
+
+    def test_writes_the_warnings_to_the_step_summary(self):
+        log_path = self._write_log(f"../Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
+        summary_path = self.workspace / "summary.md"
+
+        self._run_main([str(log_path), str(self.build_dir)], env={"GITHUB_STEP_SUMMARY": str(summary_path)})
+
+        summary = summary_path.read_text()
+        self.assertIn("1 compiler warning(s)", summary)
+        self.assertIn("Framework/Kernel/src/Foo.cpp:12:5", summary)

--- a/.github/actions/check-build-warnings/test_count_warnings.py
+++ b/.github/actions/check-build-warnings/test_count_warnings.py
@@ -57,6 +57,10 @@ class CountWarningsTestCase(unittest.TestCase):
 
         return exit_code, stdout.getvalue()
 
+    def _build_dir_args(self) -> list:
+        """The flags every main() call needs so relative log paths resolve like they do in CI."""
+        return ["--build-dir", str(self.build_dir)]
+
 
 class TestScan(CountWarningsTestCase):
     def test_counts_warning_for_workspace_source_file(self):
@@ -215,7 +219,7 @@ class TestMain(CountWarningsTestCase):
             "cc1plus: warning: some toolchain noise",
         )
 
-        exit_code, output = self._run_main([str(log_path), str(self.build_dir)])
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args()])
 
         self.assertEqual(exit_code, 0)
         self.assertIn("No compiler warnings found", output)
@@ -223,7 +227,7 @@ class TestMain(CountWarningsTestCase):
     def test_fails_when_there_are_countable_warnings(self):
         log_path = self._write_log(f"../Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
 
-        exit_code, output = self._run_main([str(log_path), str(self.build_dir)])
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args()])
 
         self.assertEqual(exit_code, 1)
         self.assertIn("::error::Build produced 1 compiler warning(s)", output)
@@ -234,8 +238,63 @@ class TestMain(CountWarningsTestCase):
         log_path = self._write_log(f"../Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}")
         summary_path = self.workspace / "summary.md"
 
-        self._run_main([str(log_path), str(self.build_dir)], env={"GITHUB_STEP_SUMMARY": str(summary_path)})
+        self._run_main([str(log_path), *self._build_dir_args()], env={"GITHUB_STEP_SUMMARY": str(summary_path)})
 
         summary = summary_path.read_text()
         self.assertIn("1 compiler warning(s)", summary)
         self.assertIn("Framework/Kernel/src/Foo.cpp:12:5", summary)
+
+
+class TestAllowedWarnings(CountWarningsTestCase):
+    def _log_with_warnings(self, count: int) -> pathlib.Path:
+        lines = [f"../Framework/Kernel/src/Foo.cpp:{line}:5: warning: {WARNING}" for line in range(1, count + 1)]
+
+        return self._write_log(*lines)
+
+    def test_defaults_to_allowing_no_warnings(self):
+        log_path = self._log_with_warnings(1)
+
+        exit_code, _ = self._run_main([str(log_path), *self._build_dir_args()])
+
+        self.assertEqual(exit_code, 1)
+
+    def test_passes_when_the_count_is_within_the_allowance(self):
+        log_path = self._log_with_warnings(3)
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args(), "--allowed-warnings", "3"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("::warning::Build produced 3 compiler warning(s), within the allowance of 3", output)
+
+    def test_passes_when_the_count_is_below_the_allowance(self):
+        log_path = self._log_with_warnings(1)
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args(), "--allowed-warnings", "5"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("within the allowance of 5", output)
+
+    def test_fails_when_the_count_exceeds_the_allowance(self):
+        log_path = self._log_with_warnings(4)
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args(), "--allowed-warnings", "3"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("::error::Build produced 4 compiler warning(s). Only 3 are allowed.", output)
+
+    def test_reports_no_warnings_rather_than_an_allowance_when_the_build_is_clean(self):
+        log_path = self._write_log("[1/1] Building CXX object Foo.cpp.o")
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args(), "--allowed-warnings", "3"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("No compiler warnings found", output)
+        self.assertNotIn("allowance", output)
+
+    def test_rejects_a_negative_allowance(self):
+        log_path = self._log_with_warnings(1)
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args(), "--allowed-warnings", "-1"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("must not be negative", output)

--- a/.github/workflows/check_build_warnings_tests.yml
+++ b/.github/workflows/check_build_warnings_tests.yml
@@ -1,0 +1,36 @@
+name: Build Warning Parser Tests
+
+# The compiler warning gate in pr_build_and_test.yml is what stops a build with warnings
+# from reaching the tests. Its parser is ordinary Python, so it is unit tested here rather
+# than in the build. Only runs when the action itself changes.
+on:
+  pull_request:
+    paths:
+      - .github/workflows/check_build_warnings_tests.yml
+      - .github/actions/check-build-warnings/**
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-warning-parser:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout workflow dependencies
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/workflows/check_build_warnings_tests.yml
+            .github/actions/check-build-warnings/
+          sparse-checkout-cone-mode: false
+
+      # The tests use only the standard library, so no pixi environment is needed
+      - name: Run the warning parser unit tests
+        run: python3 -m unittest discover --start-directory .github/actions/check-build-warnings --verbose

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -215,6 +215,8 @@ jobs:
           set -o pipefail
           echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
           cd ${GITHUB_WORKSPACE}
+          # 2>&1 is required as compiler diagnostics are written to stderr, and the
+          # warning check in the next step reads them back out of this log
           mkdir -p ${GITHUB_WORKSPACE}/build/test_logs/
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS 2>&1 \
               | tee ${GITHUB_WORKSPACE}/build/test_logs/build_${{ matrix.os }}.log
@@ -226,6 +228,14 @@ jobs:
       - name: Remove MSVC Problem Matchers
         if: ${{ matrix.os == 'Windows' }}
         run: echo "::remove-matcher owner=msvc-problem-matcher::"
+
+      # Runs after the whole build has completed so that every warning is reported at once,
+      # and before the tests so that a warning stops the job from proceeding any further.
+      - uses: ./.github/actions/check-build-warnings
+        name: Check for compiler warnings
+        if: ${{ matrix.os == 'Linux' && needs.check-filters.outputs.code_changes == 'true' }}
+        with:
+          log-file: build/test_logs/build_${{ matrix.os }}.log
 
       - name: Run unit tests
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
@@ -72,15 +72,6 @@ public:
   virtual void updateSelectedSpectra() override {}
 };
 
-// Exposes the protected setNumericQAxis method so that the axis/unit
-// conversion logic behind the "Add Numeric Workspace" button can be tested
-// directly, without needing to drive the real Qt dialog widgets.
-class TestableFitDataPresenter : public FitDataPresenter {
-public:
-  using FitDataPresenter::FitDataPresenter;
-  using FitDataPresenter::setNumericQAxis;
-};
-
 } // namespace
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
@@ -299,6 +290,15 @@ private:
   }
 
   std::string getTableItem(int row, int column) const { return m_table->item(row, column)->text().toStdString(); }
+
+  // Exposes the protected setNumericQAxis method so that the axis/unit
+  // conversion logic behind the "Add Numeric Workspace" button can be tested
+  // directly, without needing to drive the real Qt dialog widgets.
+  class TestableFitDataPresenter : public FitDataPresenter {
+  public:
+    using FitDataPresenter::FitDataPresenter;
+    using FitDataPresenter::setNumericQAxis;
+  };
 
   std::unique_ptr<QTableWidget> m_table;
 


### PR DESCRIPTION
### Description of work

Adds a new step to the Linux build.  During the build, any compiler warnings are logged.  At the **end** of the build, the log is checked for warnings.

This happens after the build so that all build warnings are surfaced, but before any tests are run, so that devs can respond more timely.

Because of the incremental nature of builds, warnings might show up unexpectedly in later PRs.

### To test:

[In this build](https://github.com/mantidproject/mantid/actions/runs/31818110209), you can see it failed due to a compiler warnings, proving positive signal.

There is a unit test suite of the new action, which will only run when the action itself is changed.
You can check that they ran [here](https://github.com/mantidproject/mantid/actions/runs/31828477385)

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
