### PR TITLE
Add list of installed versions to grype job

### DIFF
--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -74,6 +74,14 @@ jobs:
         shell: bash
         run: pixi install --manifest-path "${{ steps.pixi-project.outputs.project_dir }}/pixi.toml"
 
+      - name: List versions installed
+        shell: bash
+        run: |
+          echo "Top level dependencies"
+          pixi list --explicit --manifest-path "${{ steps.pixi-project.outputs.project_dir }}/pixi.toml"
+          echo "::group::All dependencies"
+          pixi list --manifest-path "${{ steps.pixi-project.outputs.project_dir }}/pixi.toml"
+          echo "::endgroup::"
       - name: Scan with Grype
         id: scan
         uses: anchore/scan-action@v7

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Archive unit test output (Linux)
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.os == 'Linux' && failure() && steps.testunit.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Linux' && !cancelled() && github.event_name == 'pull_request' && steps.testunit.conclusion != 'skipped' }}
         with:
           name: junit-unit-Linux
           if-no-files-found: ignore
@@ -231,7 +231,7 @@ jobs:
 
       - name: Archive unit test output (Windows)
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.os == 'Windows' && failure() && steps.testunit.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Windows' && !cancelled() && github.event_name == 'pull_request' && steps.testunit.conclusion != 'skipped' }}
         with:
           name: junit-unit-Windows
           if-no-files-found: ignore
@@ -258,7 +258,7 @@ jobs:
 
       - name: Archive system test output
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.os == 'Linux' && failure() && steps.testsystem.conclusion == 'failure' }}
+        if: ${{ matrix.os == 'Linux' && !cancelled() && github.event_name == 'pull_request' && steps.testsystem.conclusion != 'skipped' }}
         with:
           name: junit-system
           if-no-files-found: ignore
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload event payload
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.os == 'Linux' && failure() && github.event_name == 'pull_request' }}
+        if: ${{ matrix.os == 'Linux' && !cancelled() && github.event_name == 'pull_request' }}
         with:
           name: event-file
           path: ${{ github.event_path }}
@@ -343,7 +343,7 @@ jobs:
 
       - name: Upload doctest results
         uses: actions/upload-artifact@v7
-        if: ${{ failure() && steps.testdocs.conclusion == 'failure' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.testdocs.conclusion != 'skipped' }}
         with:
           name: junit-doctest
           if-no-files-found: ignore
@@ -351,7 +351,7 @@ jobs:
 
       - name: Upload event payload
         uses: actions/upload-artifact@v7
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         with:
           name: event-file-doctest
           path: ${{ github.event_path }}

--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' && (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled')
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
While trying to figure out what was installed in the environment, I discovered there is no real way to find it in the logs. This remedies the issue.

Discovered that there was a hole in the logic for parsing test results. Resubmitting a job with a flakey test (same sha) where the job now passed doesn't clear the state for the parsing job.

There is no associated issue

### To test:

Go to the [grype -> scan-package job](https://github.com/mantidproject/mantid/actions/runs/31818432172/job/94825599197?pr=42044) and look at the text of the "List versions installed" step.

*This does not require release notes* because it is modifying CI jobs.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
