### PR TITLE
Add a msvc problem matcher

### DIFF
--- a/.github/matchers/msvc.json
+++ b/.github/matchers/msvc.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "msvc-problem-matcher",
+      "pattern": [
+        {
+          "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "code": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/matchers/msvc.json
+++ b/.github/matchers/msvc.json
@@ -4,13 +4,14 @@
       "owner": "msvc-problem-matcher",
       "pattern": [
         {
-          "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
-          "file": 1,
-          "line": 2,
-          "column": 3,
-          "severity": 4,
-          "code": 5,
-          "message": 6
+          "regexp": "^(?:\\s+\\d+\\>)?(.*[\\\\/]mantid[\\\\/])(.+?)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+          "fromPath": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "severity": 5,
+          "code": 6,
+          "message": 7
         }
       ]
     }

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: Remove MSVC Problem Matchers
         if: ${{ matrix.os == 'Windows' }}
-        run: echo "::remove-matcher msvc-problem-matcher::"
+        run: echo "::remove-matcher owner=msvc-problem-matcher::"
 
       - name: Run unit tests
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -201,14 +201,30 @@ jobs:
         # telling jenkins scripts this is a PR build
         run: echo "JOB_NAME=pull_requests" >> $GITHUB_ENV
 
+      - name: Register GCC Problem Matchers
+        if: ${{ matrix.os == 'Linux' }}
+        run: echo "::add-matcher::.github/matchers/gcc.json"
+
+      - name: Register MSVC Problem Matchers
+        if: ${{ matrix.os == 'Windows' }}
+        run: echo "::add-matcher::.github/matchers/msvc.json"
+
       - name: Build code
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
         run: |
+          set -o pipefail
           echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
           cd ${GITHUB_WORKSPACE}
-          echo "::add-matcher::.github/matchers/gcc.json"
-          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS
-          echo "::remove-matcher owner=gcc-problem-matcher::"
+          pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS 2>&1 \
+              | tee ${GITHUB_WORKSPACE}/build/test_logs/build_${{ matrix.os }}.log
+
+      - name: Remove GCC Problem Matchers
+        if: ${{ matrix.os == 'Linux' }}
+        run: echo "::remove-matcher owner=gcc-problem-matcher::"
+
+      - name: Remove MSVC Problem Matchers
+        if: ${{ matrix.os == 'Windows' }}
+        run: echo "::remove-matcher msvc-problem-matcher::"
 
       - name: Run unit tests
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -215,6 +215,7 @@ jobs:
           set -o pipefail
           echo "For Jenkins scripts JOB_NAME=${JOB_NAME}"
           cd ${GITHUB_WORKSPACE}
+          mkdir -p ${GITHUB_WORKSPACE}/build/test_logs/
           pixi run --frozen bash -ex ${GITHUB_WORKSPACE}/buildconfig/Jenkins/Conda/build ${GITHUB_WORKSPACE} $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_DOC_TESTS $EXTRA_CMAKE_FLAGS 2>&1 \
               | tee ${GITHUB_WORKSPACE}/build/test_logs/build_${{ matrix.os }}.log
 


### PR DESCRIPTION
The builds will now get annotations of msvc compiler warnings too. The builds are also saved to a log file for processing in future PRs.

This is a trimmed-down version of what was originally put in #41934. Getting the annotations on the code is very useful on its own.

There is no associated issue.

### To test:

Look at the windows build and see that it has annotations from compiler warnings.

*This does not require release notes* because it is a change to CI

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
