### PR TITLE
Move flood corr out of core reduction - ISIS Reflectometry

### DIFF
--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -145,7 +145,7 @@ private:
   double getPropertyOrDefault(const std::string &propertyName, const double defaultValue, bool &isDefault);
   WorkspaceNames getOutputNamesForGroupMember(const std::string &inputNames, const std::string &runNumber,
                                               const size_t wsGroupNumber);
-  void validateTransmissionRun(std::map<std::string, std::string> &results, const std::string &transmissionRun);
+  void validateTransmissionRun(std::map<std::string, std::string> &results, const Property &transmissionRun);
   void setOutputGroupedWorkspaces(std::vector<WorkspaceNames> const &outputNames,
                                   WorkspaceNames const &outputGroupNames, const bool outputIvsLam, bool outputTrans,
                                   bool outputTrans1, bool outputTrans2);

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -87,6 +87,20 @@ private:
     std::string polynomial;
   };
 
+  class CacheHandler {
+    ReflectometryReductionOneAuto3 &m_parent;
+
+  public:
+    CacheHandler(ReflectometryReductionOneAuto3 &parent) : m_parent(parent) {};
+    ~CacheHandler();
+
+    // deleted methods
+    CacheHandler(const CacheHandler &) = delete;
+    CacheHandler &operator=(const CacheHandler &) = delete;
+    CacheHandler(CacheHandler &&) = delete;
+    CacheHandler &operator=(CacheHandler &&) = delete;
+  };
+
   // A class member to cache properties associated with the algorithmic correction to be applied
   CorrectionProperties m_correctionProperties;
   // cache flood workspace
@@ -152,7 +166,7 @@ private:
   WorkspaceGroup_sptr applyFloodCorrection(const WorkspaceGroup_sptr &ws);
   MatrixWorkspace_sptr applyFloodCorrection(const MatrixWorkspace_sptr &ws);
   void applyFloodCorrectionToTransmissionRuns();
-  void clearCachedWorkspaces();
+  void clearCaches();
   std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> getTransmissionRuns();
 };
 } // namespace Reflectometry

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -89,6 +89,11 @@ private:
 
   // A class member to cache properties associated with the algorithmic correction to be applied
   CorrectionProperties m_correctionProperties;
+  // cache flood workspace
+  MatrixWorkspace_sptr m_floodWorkspace;
+  // cache transmission workspaces
+  MatrixWorkspace_sptr m_firstTransmissionRun;
+  MatrixWorkspace_sptr m_secondTransmissionRun;
 
   void init() override;
   void exec() override;
@@ -137,14 +142,16 @@ private:
                                                 const bool reduced = false);
   WorkspaceGroup_sptr groupWorkspaces(const std::vector<std::string> &workspaceNames,
                                       std::string const &outputName = "");
-  RROOutputs performCoreReduction(MatrixWorkspace_sptr inputWS, const std::vector<std::string> &taskOrder = {},
-                                  const bool applyFloodCorrections = true);
+  RROOutputs performCoreReduction(MatrixWorkspace_sptr inputWS, const std::vector<std::string> &taskOrder = {});
   MatrixWorkspace_sptr postReductionProcessing(const RROOutputs &out, const RebinParams &params);
   void postReductionProcessingGroups(std::vector<RROOutputs> &outputs, std::vector<WorkspaceNames> const &outputNames,
                                      const WorkspaceNames &groupedOutputNames, const bool outputIvsLam);
   void setOutputWorkspaces(const RROOutputs &out, const MatrixWorkspace_sptr &binnedWS);
   void updatePropertiesAfterReduction(RROOutputs &out, const RebinParams &params);
   std::vector<std::string> getTaskExecutionOrder(const bool reduced, const bool summingInQ) const;
+  WorkspaceGroup_sptr applyFloodCorrection(const WorkspaceGroup_sptr &ws);
+  MatrixWorkspace_sptr applyFloodCorrection(const MatrixWorkspace_sptr &ws);
+  std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> getTransmissionRuns();
 };
 } // namespace Reflectometry
 } // namespace Mantid

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -151,6 +151,8 @@ private:
   std::vector<std::string> getTaskExecutionOrder(const bool reduced, const bool summingInQ) const;
   WorkspaceGroup_sptr applyFloodCorrection(const WorkspaceGroup_sptr &ws);
   MatrixWorkspace_sptr applyFloodCorrection(const MatrixWorkspace_sptr &ws);
+  void applyFloodCorrectionToTransmissionRuns();
+  void clearCachedWorkspaces();
   std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> getTransmissionRuns();
 };
 } // namespace Reflectometry

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
@@ -144,6 +144,12 @@ protected:
   /// Populate transmission properties
   bool populateTransmissionProperties(const Mantid::API::IAlgorithm_sptr &alg,
                                       const MatrixWorkspace_sptr &flood = nullptr);
+  void setTransmissionProperties(const IAlgorithm_sptr &alg, const MatrixWorkspace_sptr &firstWS,
+                                 const MatrixWorkspace_sptr &secondWS) const;
+  std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr>
+  applyFloodCorrectionToTransmission(const MatrixWorkspace_sptr &flood, const MatrixWorkspace_sptr &firstWS,
+                                     const MatrixWorkspace_sptr &secondWS);
+
   MatrixWorkspace_sptr runFloodCorrectionAlg(const MatrixWorkspace_sptr &flood, const MatrixWorkspace_sptr &ws);
   /// Given a algorithm workspace property name return the workspace, or if a group workspace, the first member.
   MatrixWorkspace_sptr getWorkspaceFromProperty(const std::string &propName) const;

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
@@ -144,7 +144,7 @@ protected:
   /// Populate transmission properties
   bool populateTransmissionProperties(const Mantid::API::IAlgorithm_sptr &alg,
                                       const MatrixWorkspace_sptr &flood = nullptr);
-  void setTransmissionProperties(const IAlgorithm_sptr &alg, const MatrixWorkspace_sptr &firstWS,
+  bool setTransmissionProperties(const IAlgorithm_sptr &alg, const MatrixWorkspace_sptr &firstWS,
                                  const MatrixWorkspace_sptr &secondWS) const;
   std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr>
   applyFloodCorrectionToTransmission(const MatrixWorkspace_sptr &flood, const MatrixWorkspace_sptr &firstWS,

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -97,7 +97,8 @@ std::map<std::string, std::string> ReflectometryReductionOneAuto3::validateInput
   const std::string firstTrans = getPropertyValue("FirstTransmissionRun");
   const std::string secondTrans = getPropertyValue("SecondTransmissionRun");
   if (!secondTrans.empty() && firstTrans.empty()) {
-    results[secondTrans] = "If a second transmission run is provided, a first transmission run must also be provided.";
+    results["SecondTransmissionRun"] =
+        "If a second transmission run is provided, a first transmission run must also be provided.";
   }
 
   // Validate transmission runs only if our input workspace is a group
@@ -946,6 +947,12 @@ std::vector<std::string> ReflectometryReductionOneAuto3::getTaskExecutionOrder(c
  */
 bool ReflectometryReductionOneAuto3::processGroups() {
   // this algorithm effectively behaves as MultiPeriodGroupAlgorithm
+  // Validate inputs as this is not run for group workspace inputs not called via alg dialog
+  const auto &results = validateInputs();
+  for (const auto &result : results) {
+    throw std::runtime_error(result.first + " property: " + result.second);
+  }
+
   m_usingBaseProcessGroups = true;
   enableHistoryRecordingForProcessGroups(true);
 

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -75,9 +75,8 @@ const std::string ReflectometryReductionOneAuto3::summary() const {
  */
 void ReflectometryReductionOneAuto3::validateTransmissionRun(std::map<std::string, std::string> &results,
                                                              const std::string &transmissionRun) {
-  const std::string str = getPropertyValue(transmissionRun);
-  if (!str.empty()) {
-    auto transmissionGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(str);
+  if (!transmissionRun.empty()) {
+    auto transmissionGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(transmissionRun);
     // If it is not a group, we don't need to validate its size
     if (!transmissionGroup)
       return;
@@ -95,6 +94,12 @@ void ReflectometryReductionOneAuto3::validateTransmissionRun(std::map<std::strin
 std::map<std::string, std::string> ReflectometryReductionOneAuto3::validateInputs() {
   std::map<std::string, std::string> results;
 
+  const std::string firstTrans = getPropertyValue("FirstTransmissionRun");
+  const std::string secondTrans = getPropertyValue("SecondTransmissionRun");
+  if (!secondTrans.empty() && firstTrans.empty()) {
+    results[secondTrans] = "If a second transmission run is provided, a first transmission run must also be provided.";
+  }
+
   // Validate transmission runs only if our input workspace is a group
   if (!checkGroups())
     return results;
@@ -104,9 +109,8 @@ std::map<std::string, std::string> ReflectometryReductionOneAuto3::validateInput
     return results;
 
   // First and second transmission runs
-  validateTransmissionRun(results, "FirstTransmissionRun");
-  validateTransmissionRun(results, "SecondTransmissionRun");
-
+  validateTransmissionRun(results, firstTrans);
+  validateTransmissionRun(results, secondTrans);
   return results;
 }
 
@@ -376,8 +380,8 @@ ReflectometryReductionOneAuto3::performCoreReduction(MatrixWorkspace_sptr inputW
   alg->setPropertyValue("NormalizeByIntegratedMonitors", getPropertyValue("NormalizeByIntegratedMonitors"));
 
   const auto &[firstTransRun, secondTransRun] = getTransmissionRuns();
-  setTransmissionProperties(alg, firstTransRun, secondTransRun);
-  if (!firstTransRun && !secondTransRun)
+  const bool transPropsSet = setTransmissionProperties(alg, firstTransRun, secondTransRun);
+  if (!transPropsSet)
     populateAlgorithmicCorrectionProperties(alg);
 
   alg->setPropertyValue("SubtractBackground", getPropertyValue("SubtractBackground"));

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -320,14 +320,9 @@ void ReflectometryReductionOneAuto3::init() {
 }
 
 // Performs the reduction using ReflectometryReductionOne
-ReflectometryReductionOneAuto3::RROOutputs ReflectometryReductionOneAuto3::performCoreReduction(
-    MatrixWorkspace_sptr inputWS, const std::vector<std::string> &taskOrder, const bool applyFloodCorrections) {
-  auto instrument = inputWS->getInstrument();
-  MatrixWorkspace_sptr flood = (applyFloodCorrections) ? getFloodWorkspace(instrument) : MatrixWorkspace_sptr{};
-  if (flood) {
-    inputWS = runFloodCorrectionAlg(flood, inputWS);
-  }
-
+ReflectometryReductionOneAuto3::RROOutputs
+ReflectometryReductionOneAuto3::performCoreReduction(MatrixWorkspace_sptr inputWS,
+                                                     const std::vector<std::string> &taskOrder) {
   bool const isDebug = getProperty("Debug");
 
   Algorithm_sptr alg = createChildAlgorithm("ReflectometryReductionOne");
@@ -342,6 +337,8 @@ ReflectometryReductionOneAuto3::RROOutputs ReflectometryReductionOneAuto3::perfo
   alg->setProperty("IncludePartialBins", getPropertyValue("IncludePartialBins"));
   alg->setProperty("Diagnostics", getPropertyValue("Diagnostics"));
   alg->setProperty("Debug", isDebug);
+
+  const auto instrument = inputWS->getInstrument();
   double wavMin = checkForMandatoryInstrumentDefault<double>(this, "WavelengthMin", instrument, "LambdaMin");
   alg->setProperty("WavelengthMin", wavMin);
   double wavMax = checkForMandatoryInstrumentDefault<double>(this, "WavelengthMax", instrument, "LambdaMax");
@@ -378,8 +375,9 @@ ReflectometryReductionOneAuto3::RROOutputs ReflectometryReductionOneAuto3::perfo
   populateMonitorProperties(alg, instrument);
   alg->setPropertyValue("NormalizeByIntegratedMonitors", getPropertyValue("NormalizeByIntegratedMonitors"));
 
-  bool transRunsFound = populateTransmissionProperties(alg, flood);
-  if (!transRunsFound)
+  const auto &[firstTransRun, secondTransRun] = getTransmissionRuns();
+  setTransmissionProperties(alg, firstTransRun, secondTransRun);
+  if (!firstTransRun && !secondTransRun)
     populateAlgorithmicCorrectionProperties(alg);
 
   alg->setPropertyValue("SubtractBackground", getPropertyValue("SubtractBackground"));
@@ -402,6 +400,14 @@ ReflectometryReductionOneAuto3::RROOutputs ReflectometryReductionOneAuto3::perfo
           .trans2 = alg->getProperty("OutputWorkspaceSecondTransmission"),
           .out = alg->getProperty("OutputWorkspace"),
           .theta = theta};
+}
+
+std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> ReflectometryReductionOneAuto3::getTransmissionRuns() {
+  if (!m_firstTransmissionRun) {
+    m_firstTransmissionRun = getWorkspaceFromProperty("FirstTransmissionRun");
+    m_secondTransmissionRun = getWorkspaceFromProperty("SecondTransmissionRun");
+  }
+  return {m_firstTransmissionRun, m_secondTransmissionRun};
 }
 
 void ReflectometryReductionOneAuto3::postReductionProcessingGroups(std::vector<RROOutputs> &outputs,
@@ -478,9 +484,13 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::postReductionProcessing(con
 void ReflectometryReductionOneAuto3::exec() {
   Workspace_sptr inputWorkspace = getWorkspaceFromProperty("InputWorkspace");
   sumBanks(inputWorkspace);
-  setDefaultOutputWorkspaceNames();
 
   auto inputWS = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace);
+  inputWS = applyFloodCorrection(inputWS);
+  m_firstTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("FirstTransmissionRun"));
+  m_secondTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("SecondTransmissionRun"));
+
+  setDefaultOutputWorkspaceNames();
   determineCorrectionAlgorithm(inputWS->getInstrument());
   RROOutputs out = performCoreReduction(inputWS);
   const auto params = getRebinParams(out.IvsQ, out.theta);
@@ -899,7 +909,7 @@ ReflectometryReductionOneAuto3::processGroupMembersOutput ReflectometryReduction
     if (reduced) {
       const auto &origProcessingInstructions = getPropertyValue("ProcessingInstructions");
       setPropertyValue("ProcessingInstructions", convertToSpectrumNumber("0", matrixWs));
-      allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder, false));
+      allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder));
       setPropertyValue("ProcessingInstructions", origProcessingInstructions);
     } else {
       allRROOutputs.push_back(performCoreReduction(std::move(matrixWs), taskOrder));
@@ -938,11 +948,14 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   Workspace_sptr inputWorkspace =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getPropertyValue("InputWorkspace"));
   const bool banksSummed = sumBanks(inputWorkspace);
-  const auto inputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWorkspace);
+  WorkspaceGroup_sptr inputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWorkspace);
   const auto groupName = inputGroup->getName();
   const auto groupMembers = inputGroup->getAllItems();
   std::string const runNumber = getRunNumberForWorkspaceGroup(groupName);
   determineCorrectionAlgorithm(std::dynamic_pointer_cast<MatrixWorkspace>(groupMembers[0])->getInstrument());
+  inputGroup = applyFloodCorrection(inputGroup);
+  m_firstTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("FirstTransmissionRun"));
+  m_secondTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("SecondTransmissionRun"));
 
   const bool polarizationAnalysisOn = getProperty("PolarizationAnalysis");
   std::vector<std::string> taskOrder;
@@ -1035,6 +1048,8 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::getFloodWorkspace(const Ins
   }
   if (method == "Workspace" && !isDefault("FloodWorkspace")) {
     return getProperty("FloodWorkspace");
+  } else if (m_floodWorkspace) {
+    return m_floodWorkspace;
   } else if (method == "ParameterFile") {
     if (!isDefault("FloodWorkspace")) {
       g_log.warning() << "Flood correction is performed using data in the "
@@ -1070,6 +1085,7 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::getFloodWorkspace(const Ins
       }
       alg->execute();
       MatrixWorkspace_sptr out = alg->getProperty("OutputWorkspace");
+      m_floodWorkspace = out; // cache so this function does not repeat
       return out;
     }
   }
@@ -1157,6 +1173,27 @@ bool ReflectometryReductionOneAuto3::sumBanks(Workspace_sptr &inputWorkspace) {
     }
   }
   return true;
+}
+
+MatrixWorkspace_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const MatrixWorkspace_sptr &ws) {
+  const auto &flood = getFloodWorkspace(ws->getInstrument());
+  if (!flood || !ws)
+    return ws;
+  return runFloodCorrectionAlg(flood, ws);
+}
+
+WorkspaceGroup_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const WorkspaceGroup_sptr &group) {
+  const auto &instrument = std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(0))->getInstrument();
+  const auto &flood = getFloodWorkspace(instrument);
+  if (!flood)
+    return group;
+
+  WorkspaceGroup_sptr outGroup = std::make_shared<WorkspaceGroup>();
+  for (const auto &ws : group->getAllItems()) {
+    const auto &correctedWs = runFloodCorrectionAlg(flood, std::dynamic_pointer_cast<MatrixWorkspace>(ws));
+    outGroup->addWorkspace(correctedWs); // Generic output ws will be IvsLam at this point due specified task order
+  }
+  return outGroup;
 }
 
 } // namespace Mantid::Reflectometry

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -487,6 +487,7 @@ MatrixWorkspace_sptr ReflectometryReductionOneAuto3::postReductionProcessing(con
 /** Execute the algorithm.
  */
 void ReflectometryReductionOneAuto3::exec() {
+  CacheHandler cacheHandler(*this);
   Workspace_sptr inputWorkspace = getWorkspaceFromProperty("InputWorkspace");
   sumBanks(inputWorkspace);
 
@@ -501,7 +502,6 @@ void ReflectometryReductionOneAuto3::exec() {
   const auto binnedWS = postReductionProcessing(out, params);
   setOutputWorkspaces(out, binnedWS);
   updatePropertiesAfterReduction(out, params);
-  clearCachedWorkspaces();
 }
 
 /** Returns the detectors of interest, specified via processing instructions.
@@ -946,6 +946,8 @@ std::vector<std::string> ReflectometryReductionOneAuto3::getTaskExecutionOrder(c
  * runs and polarization analysis.
  */
 bool ReflectometryReductionOneAuto3::processGroups() {
+  CacheHandler cacheHandler(*this);
+
   // this algorithm effectively behaves as MultiPeriodGroupAlgorithm
   // Validate inputs as this is not run for group workspace inputs not called via alg dialog
   const auto &results = validateInputs();
@@ -988,7 +990,6 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   }
   postReductionProcessingGroups(processGroupsOutput.rroOutputs, processGroupsOutput.outputNames, groupedOutputNames,
                                 !polarizationAnalysisOn);
-  clearCachedWorkspaces();
   return true;
 }
 
@@ -1203,10 +1204,11 @@ void ReflectometryReductionOneAuto3::applyFloodCorrectionToTransmissionRuns() {
     m_secondTransmissionRun = applyFloodCorrection(m_secondTransmissionRun);
 }
 
-void ReflectometryReductionOneAuto3::clearCachedWorkspaces() {
+void ReflectometryReductionOneAuto3::clearCaches() {
   m_floodWorkspace.reset();
   m_firstTransmissionRun.reset();
   m_secondTransmissionRun.reset();
+  m_correctionProperties = {};
 }
 
 WorkspaceGroup_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const WorkspaceGroup_sptr &group) {
@@ -1222,5 +1224,7 @@ WorkspaceGroup_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const W
   }
   return outGroup;
 }
+
+ReflectometryReductionOneAuto3::CacheHandler::~CacheHandler() { m_parent.clearCaches(); }
 
 } // namespace Mantid::Reflectometry

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -487,8 +487,7 @@ void ReflectometryReductionOneAuto3::exec() {
 
   auto inputWS = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace);
   inputWS = applyFloodCorrection(inputWS);
-  m_firstTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("FirstTransmissionRun"));
-  m_secondTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("SecondTransmissionRun"));
+  applyFloodCorrectionToTransmissionRuns();
 
   setDefaultOutputWorkspaceNames();
   determineCorrectionAlgorithm(inputWS->getInstrument());
@@ -497,6 +496,7 @@ void ReflectometryReductionOneAuto3::exec() {
   const auto binnedWS = postReductionProcessing(out, params);
   setOutputWorkspaces(out, binnedWS);
   updatePropertiesAfterReduction(out, params);
+  clearCachedWorkspaces();
 }
 
 /** Returns the detectors of interest, specified via processing instructions.
@@ -950,12 +950,11 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   const bool banksSummed = sumBanks(inputWorkspace);
   WorkspaceGroup_sptr inputGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWorkspace);
   const auto groupName = inputGroup->getName();
-  const auto groupMembers = inputGroup->getAllItems();
   std::string const runNumber = getRunNumberForWorkspaceGroup(groupName);
-  determineCorrectionAlgorithm(std::dynamic_pointer_cast<MatrixWorkspace>(groupMembers[0])->getInstrument());
   inputGroup = applyFloodCorrection(inputGroup);
-  m_firstTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("FirstTransmissionRun"));
-  m_secondTransmissionRun = applyFloodCorrection(getWorkspaceFromProperty("SecondTransmissionRun"));
+  const auto groupMembers = inputGroup->getAllItems();
+  determineCorrectionAlgorithm(std::dynamic_pointer_cast<MatrixWorkspace>(groupMembers[0])->getInstrument());
+  applyFloodCorrectionToTransmissionRuns();
 
   const bool polarizationAnalysisOn = getProperty("PolarizationAnalysis");
   std::vector<std::string> taskOrder;
@@ -978,6 +977,7 @@ bool ReflectometryReductionOneAuto3::processGroups() {
   }
   postReductionProcessingGroups(processGroupsOutput.rroOutputs, processGroupsOutput.outputNames, groupedOutputNames,
                                 !polarizationAnalysisOn);
+  clearCachedWorkspaces();
   return true;
 }
 
@@ -1177,9 +1177,25 @@ bool ReflectometryReductionOneAuto3::sumBanks(Workspace_sptr &inputWorkspace) {
 
 MatrixWorkspace_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const MatrixWorkspace_sptr &ws) {
   const auto &flood = getFloodWorkspace(ws->getInstrument());
-  if (!flood || !ws)
+  if (!flood)
     return ws;
   return runFloodCorrectionAlg(flood, ws);
+}
+
+void ReflectometryReductionOneAuto3::applyFloodCorrectionToTransmissionRuns() {
+  m_firstTransmissionRun = getWorkspaceFromProperty("FirstTransmissionRun");
+  if (m_firstTransmissionRun)
+    m_firstTransmissionRun = applyFloodCorrection(m_firstTransmissionRun);
+
+  m_secondTransmissionRun = getWorkspaceFromProperty("SecondTransmissionRun");
+  if (m_secondTransmissionRun)
+    m_secondTransmissionRun = applyFloodCorrection(m_secondTransmissionRun);
+}
+
+void ReflectometryReductionOneAuto3::clearCachedWorkspaces() {
+  m_floodWorkspace.reset();
+  m_firstTransmissionRun.reset();
+  m_secondTransmissionRun.reset();
 }
 
 WorkspaceGroup_sptr ReflectometryReductionOneAuto3::applyFloodCorrection(const WorkspaceGroup_sptr &group) {

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -74,17 +74,21 @@ const std::string ReflectometryReductionOneAuto3::summary() const {
  * @return :: void
  */
 void ReflectometryReductionOneAuto3::validateTransmissionRun(std::map<std::string, std::string> &results,
-                                                             const std::string &transmissionRun) {
-  if (!transmissionRun.empty()) {
-    auto transmissionGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(transmissionRun);
-    // If it is not a group, we don't need to validate its size
-    if (!transmissionGroup)
-      return;
-    g_log.warning("Transmission run provided as a group. Only the first member of the group will be used.");
-    if (transmissionGroup->size() < 1) {
-      results[transmissionRun] = transmissionRun + " group is empty. ";
-    }
-  }
+                                                             const Property &transmissionRun) {
+  if (transmissionRun.isDefault())
+    return;
+
+  const auto transmissionRunName = transmissionRun.value();
+  if (transmissionRunName.empty())
+    return;
+
+  auto transmissionGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(transmissionRunName);
+  // If it is not a group, we don't need to validate its size
+  if (!transmissionGroup)
+    return;
+  g_log.warning("Transmission run provided as a group. Only the first member of the group will be used.");
+  if (transmissionGroup->size() < 1)
+    results[transmissionRun.name()] = transmissionRunName + " group is empty. ";
 }
 
 /** Validate transmission runs
@@ -94,10 +98,10 @@ void ReflectometryReductionOneAuto3::validateTransmissionRun(std::map<std::strin
 std::map<std::string, std::string> ReflectometryReductionOneAuto3::validateInputs() {
   std::map<std::string, std::string> results;
 
-  const std::string firstTrans = getPropertyValue("FirstTransmissionRun");
-  const std::string secondTrans = getPropertyValue("SecondTransmissionRun");
-  if (!secondTrans.empty() && firstTrans.empty()) {
-    results["SecondTransmissionRun"] =
+  const auto *firstTrans = getPointerToProperty("FirstTransmissionRun");
+  const auto *secondTrans = getPointerToProperty("SecondTransmissionRun");
+  if (!secondTrans->isDefault() && firstTrans->isDefault()) {
+    results[secondTrans->name()] =
         "If a second transmission run is provided, a first transmission run must also be provided.";
   }
 
@@ -110,8 +114,8 @@ std::map<std::string, std::string> ReflectometryReductionOneAuto3::validateInput
     return results;
 
   // First and second transmission runs
-  validateTransmissionRun(results, firstTrans);
-  validateTransmissionRun(results, secondTrans);
+  validateTransmissionRun(results, *firstTrans);
+  validateTransmissionRun(results, *secondTrans);
   return results;
 }
 

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -754,31 +754,64 @@ std::string ReflectometryWorkflowBase2::findProcessingInstructions(const Instrum
   return instructions;
 }
 
-/** Set transmission properties
+/** Populate transmission properties on alg, including application of flood correction if relevant
  *
  * @param alg :: The algorithm to populate parameters for
+ * @param flood :: The flood workspace to use for correction
  * @return Boolean, whether or not any transmission runs were found
  */
 bool ReflectometryWorkflowBase2::populateTransmissionProperties(const IAlgorithm_sptr &alg,
                                                                 const MatrixWorkspace_sptr &flood) {
-  bool transRunsExist = false;
-  auto firstWS = getWorkspaceFromProperty("FirstTransmissionRun");
-  if (firstWS) {
-    transRunsExist = true;
-    firstWS = (flood) ? runFloodCorrectionAlg(flood, firstWS) : firstWS;
-    alg->setProperty("FirstTransmissionRun", firstWS);
-    auto secondWS = getWorkspaceFromProperty("SecondTransmissionRun");
-    if (secondWS) {
-      secondWS = (flood) ? runFloodCorrectionAlg(flood, secondWS) : secondWS;
-      alg->setProperty("SecondTransmissionRun", secondWS);
-      alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
-      alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-      alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
-    }
-  }
+  const auto &firstWS = getWorkspaceFromProperty("FirstTransmissionRun");
+  const auto &secondWS = getWorkspaceFromProperty("SecondTransmissionRun");
+  if (!firstWS && !secondWS)
+    return false;
+  const auto &correctedWorkspaces = applyFloodCorrectionToTransmission(flood, firstWS, secondWS);
+  setTransmissionProperties(alg, correctedWorkspaces.first, correctedWorkspaces.second);
+  return true;
+}
 
-  return transRunsExist;
+/** Apply flood correction to transmission workspaces
+ *
+ * @param alg :: The algorithm to populate parameters for
+ * @param flood :: The flood workspace to use for correction
+ * @param firstWS :: The first transmission workspace
+ * @param secondWS :: The second transmission workspace
+ * @return std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr>, the corrected transmission workspaces
+ */
+std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> ReflectometryWorkflowBase2::applyFloodCorrectionToTransmission(
+    const MatrixWorkspace_sptr &flood, const MatrixWorkspace_sptr &firstWS, const MatrixWorkspace_sptr &secondWS) {
+  if (!flood) {
+    return {firstWS, secondWS};
+  }
+  MatrixWorkspace_sptr firstWSCorrected, secondWSCorrected;
+  if (firstWS) {
+    firstWSCorrected = runFloodCorrectionAlg(flood, firstWS);
+  }
+  if (secondWS) {
+    secondWSCorrected = runFloodCorrectionAlg(flood, secondWS);
+  }
+  return {firstWSCorrected, secondWSCorrected};
+}
+
+/** Set the transmission properties on the algorithm
+ *
+ * @param alg :: The algorithm to populate parameters for
+ * @param firstWS :: The first transmission workspace
+ * @param secondWS :: The second transmission workspace
+ */
+void ReflectometryWorkflowBase2::setTransmissionProperties(const IAlgorithm_sptr &alg,
+                                                           const MatrixWorkspace_sptr &firstWS,
+                                                           const MatrixWorkspace_sptr &secondWS) const {
+  if (firstWS)
+    alg->setProperty("FirstTransmissionRun", firstWS);
+  if (secondWS) {
+    alg->setProperty("SecondTransmissionRun", secondWS);
+    alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
+    alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
+    alg->setPropertyValue("Params", getPropertyValue("Params"));
+    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+  }
 }
 
 MatrixWorkspace_sptr ReflectometryWorkflowBase2::runFloodCorrectionAlg(const MatrixWorkspace_sptr &flood,

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -764,11 +764,10 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(const IAlgorithm
                                                                 const MatrixWorkspace_sptr &flood) {
   const auto &firstWS = getWorkspaceFromProperty("FirstTransmissionRun");
   const auto &secondWS = getWorkspaceFromProperty("SecondTransmissionRun");
-  if (!firstWS && !secondWS)
+  if (!firstWS)
     return false;
   const auto &correctedWorkspaces = applyFloodCorrectionToTransmission(flood, firstWS, secondWS);
-  setTransmissionProperties(alg, correctedWorkspaces.first, correctedWorkspaces.second);
-  return true;
+  return setTransmissionProperties(alg, correctedWorkspaces.first, correctedWorkspaces.second);
 }
 
 /** Apply flood correction to transmission workspaces
@@ -799,19 +798,23 @@ std::pair<MatrixWorkspace_sptr, MatrixWorkspace_sptr> ReflectometryWorkflowBase2
  * @param alg :: The algorithm to populate parameters for
  * @param firstWS :: The first transmission workspace
  * @param secondWS :: The second transmission workspace
+ * @return bool, returns true if properties have been set
  */
-void ReflectometryWorkflowBase2::setTransmissionProperties(const IAlgorithm_sptr &alg,
+bool ReflectometryWorkflowBase2::setTransmissionProperties(const IAlgorithm_sptr &alg,
                                                            const MatrixWorkspace_sptr &firstWS,
                                                            const MatrixWorkspace_sptr &secondWS) const {
-  if (firstWS)
+  if (firstWS) {
     alg->setProperty("FirstTransmissionRun", firstWS);
-  if (secondWS) {
-    alg->setProperty("SecondTransmissionRun", secondWS);
-    alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
-    alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setPropertyValue("Params", getPropertyValue("Params"));
-    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    if (secondWS) {
+      alg->setProperty("SecondTransmissionRun", secondWS);
+      alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
+      alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
+      alg->setPropertyValue("Params", getPropertyValue("Params"));
+      alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    }
+    return true;
   }
+  return false;
 }
 
 MatrixWorkspace_sptr ReflectometryWorkflowBase2::runFloodCorrectionAlg(const MatrixWorkspace_sptr &flood,

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -123,6 +123,17 @@ public:
     TS_ASSERT_THROWS_ANYTHING(alg.setProperty("SecondTransmissionRun", m_notTOF));
   }
 
+  void test_caches_are_cleared_when_execution_fails() {
+    MatrixWorkspace_sptr transmissionWorkspace = m_TOF->clone();
+    const auto alg = create_refl_algorithm(m_TOF, std::nullopt, "invalid", 1.0, 15.0);
+    alg->setProperty("FirstTransmissionRun", transmissionWorkspace);
+    const auto referenceCountBeforeExecution = transmissionWorkspace.use_count();
+
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+
+    TS_ASSERT_EQUALS(transmissionWorkspace.use_count(), referenceCountBeforeExecution);
+  }
+
   void test_correct_detector_position_INTER() {
     auto inter = loadRun("INTER00013460.nxs");
     const double theta = 0.7;

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -10,6 +10,7 @@
 
 #include "MantidReflectometry/ReflectometryReductionOneAuto3.h"
 
+#include "MantidAPI/AlgorithmHistory.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -1254,6 +1255,31 @@ public:
     TS_ASSERT_DELTA(out1->y(0)[0], 4.5, 0.000001);
     auto out2 = std::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(1));
     TS_ASSERT_DELTA(out2->y(0)[0], 9.0, 0.000001);
+    TS_ASSERT_EQUALS(countAlgorithmInHistory(out1, "ApplyFloodWorkspace"), 2);
+  }
+
+  void test_flood_correction_transmission_is_reused_for_group_members() {
+    auto inputWS1 = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    auto inputWS2 = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    auto group = std::make_shared<WorkspaceGroup>();
+    group->addWorkspace(inputWS1);
+    group->addWorkspace(inputWS2);
+    AnalysisDataService::Instance().addOrReplace(TEST_GROUP_NAME, group);
+
+    auto transWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    auto flood = createFloodWorkspace(inputWS1->getInstrument());
+    const auto alg = create_refl_algorithm(TEST_GROUP_NAME, 1.5, "2+3", 1.0, 15.0, true, false);
+    setup_optional_properties(alg, {{"MomentumTransferStep", 0.01},
+                                    {"AnalysisMode", "MultiDetectorAnalysis"},
+                                    {"DetectorCorrectionType", "RotateAroundSample"},
+                                    {"FloodWorkspace", flood},
+                                    {"FirstTransmissionRun", transWS}});
+
+    alg->execute();
+
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("IvsQ");
+    auto out1 = std::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(0));
+    TS_ASSERT_EQUALS(countAlgorithmInHistory(out1, "ApplyFloodWorkspace"), 3);
   }
 
   void test_flood_correction_polarization_correction() {
@@ -1277,6 +1303,7 @@ public:
     TS_ASSERT_DELTA(out3->y(0)[0], 70.0, 0.003);
     auto out4 = std::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(3));
     TS_ASSERT_DELTA(out4->y(0)[0], 60.0, 0.003);
+    TS_ASSERT_EQUALS(countAlgorithmInHistory(out1, "ApplyFloodWorkspace"), 4);
   }
 
   void test_flood_correction_parameter_file() {
@@ -1299,6 +1326,7 @@ public:
     TS_ASSERT_DELTA(out3->y(0)[0], 70.0, 1e-15);
     auto out4 = std::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(3));
     TS_ASSERT_DELTA(out4->y(0)[0], 60.0, 1e-14);
+    TS_ASSERT_EQUALS(countAlgorithmInHistory(out1, "CreateFloodWorkspace"), 1);
   }
 
   void test_flood_correction_parameter_file_no_flood_parameters() {
@@ -1612,6 +1640,21 @@ private:
     clearAlg.setProperty("InstrumentCache", true);
     clearAlg.execute();
   }
+
+  size_t countAlgorithmInHistory(const AlgorithmHistory_const_sptr &history, const std::string &algorithmName) {
+    size_t count = history->name() == algorithmName ? 1 : 0;
+    for (const auto &childHistory : history->getChildHistories())
+      count += countAlgorithmInHistory(childHistory, algorithmName);
+    return count;
+  }
+
+  size_t countAlgorithmInHistory(const MatrixWorkspace_sptr &workspace, const std::string &algorithmName) {
+    size_t count = 0;
+    for (const auto &history : workspace->getHistory().getAlgorithmHistories())
+      count += countAlgorithmInHistory(history, algorithmName);
+    return count;
+  }
+
   void check_algorithm_properties_in_child_histories(MatrixWorkspace_sptr &workspace, int topLevelIdx,
                                                      int childLevelIdx,
                                                      std::map<std::string, std::string> const &propValues) {

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1434,6 +1434,24 @@ public:
     TS_ASSERT(results.count("SecondTransmissionRun"));
   }
 
+  void test_second_transmission_run_requires_first_for_group_input() {
+    MatrixWorkspace_sptr inputWorkspace = m_TOF->clone();
+    auto inputGroup = std::make_shared<WorkspaceGroup>();
+    inputGroup->addWorkspace(inputWorkspace);
+    AnalysisDataService::Instance().addOrReplace("input", inputGroup);
+
+    MatrixWorkspace_sptr secondTransmissionRun = m_TOF->clone();
+    const auto alg = create_refl_algorithm("input", std::nullopt, "1", 1.0, 15.0);
+    alg->setProperty("SecondTransmissionRun", secondTransmissionRun);
+
+    const auto results = alg->validateInputs();
+    TS_ASSERT(results.count("SecondTransmissionRun"));
+    TS_ASSERT_THROWS_EQUALS(
+        alg->execute(), const std::runtime_error &e, std::string(e.what()),
+        "SecondTransmissionRun property: If a second transmission run is provided, a first transmission run must "
+        "also be provided.");
+  }
+
 private:
   MatrixWorkspace_sptr m_notTOF;
   MatrixWorkspace_sptr m_TOF;


### PR DESCRIPTION
### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

When I was looking to introduce masking into the Reflectometry reduction workflow, it occurred to me that flood correction should not be in the `performCoreReduction` function because:
- It is not aways performed, so needed a flag argument (arguably not core if not always performed).
- Only needs to be performed once for each input/transmission workspace, after this is done we should cache for subsequent calls.

This PR moves it to the parent `exec` or `processGroups` call.

### To test:

Follow instructions on:
https://github.com/mantidproject/mantid/pull/41335

Most functionality is generally covered by tests.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
