### PR TITLE
Removed the line appearing along QProgressBars at few mantid widgets in Qt6

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/memorywidget/memoryview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/memorywidget/memoryview.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import Qt, Slot, Signal
 
 NORMAL_STYLE = """
 QProgressBar {
+    text-align: center;
     border-radius: 3px;
 }
 QProgressBar::chunk {
@@ -22,6 +23,7 @@ QProgressBar::chunk {
 
 CRITICAL_STYLE = """
 QProgressBar {
+    text-align: center;
     border-radius: 3px;
 }
 QProgressBar::chunk {
@@ -31,7 +33,7 @@ QProgressBar::chunk {
 }
 """
 
-CRITICAL_PERCENTAGE = 40
+CRITICAL_PERCENTAGE = 90
 
 
 def from_normal_to_critical(critical: int, current_value: int, new_value: int) -> bool:

--- a/qt/python/mantidqt/mantidqt/widgets/memorywidget/memoryview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/memorywidget/memoryview.py
@@ -10,18 +10,28 @@ from qtpy.QtWidgets import QWidget, QProgressBar
 from qtpy.QtCore import Qt, Slot, Signal
 
 NORMAL_STYLE = """
+QProgressBar {
+    border-radius: 3px;
+}
 QProgressBar::chunk {
     background-color: lightgreen;
+    border-radius: 3px;
+    border: 1px solid transparent;
 }
 """
 
 CRITICAL_STYLE = """
+QProgressBar {
+    border-radius: 3px;
+}
 QProgressBar::chunk {
     background-color: red;
+    border-radius: 3px;
+    border: 1px solid transparent;
 }
 """
 
-CRITICAL_PERCENTAGE = 90
+CRITICAL_PERCENTAGE = 40
 
 
 def from_normal_to_critical(critical: int, current_value: int, new_value: int) -> bool:
@@ -58,10 +68,12 @@ class MemoryView(QWidget):
         self.critical = CRITICAL_PERCENTAGE
 
         self.mantid_memory_bar = QProgressBar(self)
+        self.mantid_memory_bar.setStyleSheet(NORMAL_STYLE)
         self.mantid_memory_bar.setAlignment(Qt.AlignCenter)
         self.set_mantid_value.connect(self._set_mantid_value)
 
         self.memory_bar = QProgressBar(self)
+        self.memory_bar.setStyleSheet(NORMAL_STYLE)
         self.memory_bar.setAlignment(Qt.AlignCenter)
         self.set_value.connect(self._set_value)
 
@@ -75,8 +87,6 @@ class MemoryView(QWidget):
             self.memory_bar.setStyleSheet(CRITICAL_STYLE)
         elif from_critical_to_normal(self.critical, current_value, new_value):
             self.memory_bar.setStyleSheet(NORMAL_STYLE)
-        else:
-            pass
 
     def set_mantid_bar_color(self, current_value: int, new_value: int):
         """

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogWidget.cpp
@@ -60,7 +60,16 @@ AlgorithmProgressDialogWidget::addAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
   m_tree->addTopLevelItem(item);
   auto progressBar = new QProgressBar(m_tree);
   progressBar->setAlignment(Qt::AlignHCenter);
-
+  progressBar->setStyleSheet(R"(
+    QProgressBar {
+        text-align: center;
+        border-radius: 3px;
+    }
+    QProgressBar::chunk {
+        background-color: lightgreen;
+        border-radius: 3px;
+    }
+    )");
   const auto cancelButton = new AlgorithmProgressDialogWidgetCancelButton(alg, m_tree);
 
   m_tree->setItemWidget(item, 1, progressBar);

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressWidget.cpp
@@ -18,6 +18,18 @@ AlgorithmProgressWidget::AlgorithmProgressWidget(QWidget *parent)
       m_detailsButton{new QPushButton("Details")},
       m_presenter{std::make_unique<AlgorithmProgressPresenter>(parent, this)} {
   m_progressBar->setAlignment(Qt::AlignHCenter);
+  m_progressBar->setStyleSheet(R"(
+    QProgressBar {
+      text-align: center;
+      border-radius: 3px;
+    }
+    QProgressBar::chunk {
+      background-color: lightgreen;
+      border-radius: 3px;
+    }
+    )");
+  m_progressBar->setValue(0);
+  m_progressBar->setFormat("Idle.");
   m_layout->addWidget(m_progressBar);
   m_layout->addWidget(m_detailsButton);
   this->setLayout(m_layout);


### PR DESCRIPTION
### Description of work
This PR fixes a disturbing line appearing along QProgress bars found at following widgets(there can be more) in Windows. 
- Memory usage widget
- Algorithm progress bar of the mantid workbench
- Details of the Algorithm progress bar

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #41946. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Build and launch mantid in `Windows`
2. observe the QProgressBar given above while making the workbench busy. ex: load data/run a reducation workflow.
3. There should not be any lines visible along the progress bars as shown in the [original issue](https://github.com/mantidproject/mantid/issues/41946)
4. If possible, please check whether the above progress bars work fine in an other OS(ex `Linux`/`MacOS`).

Release notes were not added since this issue has started appearing only in this release after migrating to Qt6.

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
