### PR TITLE
Fix flaky test_interpreter unit test

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/completion.py
@@ -36,6 +36,8 @@ import warnings
 
 from inspect import getfullargspec
 
+from qtpy.compat import isalive
+
 from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.widgets.codeeditor.editor import CodeEditor
 
@@ -270,6 +272,10 @@ class CodeCompleter(object):
     def update_completion_api(self):
         with _ignore_matplotlib_deprecation_warnings():
             self._add_to_completions(self._get_completions_from_globals())
+
+        if not isalive(self.editor):
+            return
+
         self.editor.updateCompletionAPI(self.completions)
 
     def add_simpleapi_to_completions_if_required(self):

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt  # noqa # Needs importing so it's availiabe in t
 import numpy as np
 
 from mantid.simpleapi import FrameworkManager
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from mantidqt.widgets.codeeditor.completion import (
     CodeCompleter,
     generate_call_tips,
@@ -34,7 +34,10 @@ class CodeCompletionTest(unittest.TestCase):
     def _run_check_call_tip_generated(self, script_text, call_tip_regex):
         completer = self._get_completer(script_text)
         update_completion_api_mock = completer.editor.updateCompletionAPI
-        completer._add_simpleapi_to_completions_if_required()
+
+        with patch("mantidqt.widgets.codeeditor.completion.isalive", return_value=True):
+            completer._add_simpleapi_to_completions_if_required()
+
         call_tips = update_completion_api_mock.call_args_list[1][0][0]
         self.assertEqual(2, update_completion_api_mock.call_count)
         self.assertGreater(len(call_tips), 1)

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -126,6 +126,15 @@ class CodeCompletionTest(unittest.TestCase):
         for import_name, alias in aliases.items():
             self.assertEqual(alias, get_module_import_alias(import_name, script))
 
+    @patch("mantidqt.widgets.codeeditor.completion.isalive", return_value=False)
+    def test_update_completion_api_does_nothing_if_editor_is_not_alive(self, mock_isalive):
+        completer = self._get_completer("")
+        # editor.updateCompletionAPI() is called in the CodeCompleter init,
+        # so reset the mock before checking it's not called when running update_completion_api().
+        completer.editor.updateCompletionAPI.reset_mock()
+        completer.update_completion_api()
+        completer.editor.updateCompletionAPI.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #31983

### Description of work
Nightly failed [test_interpreter](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly/1367/testReport/junit/projectroot.qt.python/mantidqt/Build_and_test__Conda_packaging___build_and_test__linux_64___mantidqt_qt6_test_interpreter_test_interpreter/) with the following stacktrace:

```
........Traceback (most recent call last):
  File "/jenkins_workdir/workspace/main_nightly/source/qt/python/mantidqt/mantidqt/widgets/codeeditor/completion.py", line 273, in update_completion_api
    self.editor.updateCompletionAPI(self.completions)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
RuntimeError: wrapped C/C++ object of type ScriptEditor has been deleted
```

Looking back at the [unittest-monitor](https://mantidproject.github.io/unittest-monitor/Linux_table.html) and filtering by name to `test_interpreter`, you can see that the test fails sporadically with both qt versions every so often. We believe the test is failing more now since the move to Python 3.13, which makes this fix more crucial.

The cause of the problem is that an asynchronous task is started to update the code editor's "completion api", and if the editor is closed while the background task is still running, the Python wrapper can outlive the C++ object that it's wrapping.

The fix here is to simply check that the wrapped C++ object still exists when it's referenced at the location that the failure occurs.

`qtpy.compat.isalive()` is a wrapper around `sip.isdeleted()` (see [here](https://github.com/spyder-ide/qtpy/blob/2e2b6cff8c31b1915532bebb9c4e86fa1b16aa55/qtpy/compat.py#L194)).

### To test:
I managed to reproduce fairly reliably by running alongside a few other tests 100 times until failure:
`pixi run ctest -R "test_int|WeightedMean" --repeat until-fail:100 -j --output-on-failure --schedule-random`
Once I made the changes, it no longer fails.
Try it for yourself.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
