### PR TITLE
Automatically set MPLCONFIGDIR when XDG_CACHE_HOME is set

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -19,6 +19,13 @@ fi
 
 @GSETTINGS_SCHEMA_DEFINITIONS@
 
+if [ -z "${MPLCONFIGDIR+x}" ]; then
+    # get the cache directory, defaults to ~/.cache/
+    XDG_CACHE_ROOT=${XDG_CACHE_HOME:-${HOME}/.cache}
+    # matplotlib will cache fonts here - useful on those pesky nfs systems
+    export MPLCONFIGDIR="${XDG_CACHE_ROOT}/matplotlib"
+fi
+
 # Force the xcb (X11/XWayland) Qt platform plugin to avoid rendering and
 # stability issues seen under the native Wayland plugin.
 if [ -z "${QT_QPA_PLATFORM}" ]; then

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -20,10 +20,13 @@ fi
 @GSETTINGS_SCHEMA_DEFINITIONS@
 
 if [ -z "${MPLCONFIGDIR+x}" ]; then
-    # get the cache directory, defaults to ~/.cache/
-    XDG_CACHE_ROOT=${XDG_CACHE_HOME:-${HOME}/.cache}
-    # matplotlib will cache fonts here - useful on those pesky nfs systems
-    export MPLCONFIGDIR="${XDG_CACHE_ROOT}/matplotlib"
+    # use XDG_CACHE_HOME if someone set it
+    # otherwise matplotlib defaults to ~/.cache/matplotlib/
+    if [ -z "${XDG_CACHE_HOME}" ]; then
+        # matplotlib will cache fonts here
+        # useful on those pesky nfs systems
+        export MPLCONFIGDIR="${XDG_CACHE_HOME}/matplotlib"
+    fi
 fi
 
 # Force the xcb (X11/XWayland) Qt platform plugin to avoid rendering and

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -22,7 +22,7 @@ fi
 if [ -z "${MPLCONFIGDIR+x}" ]; then
     # use XDG_CACHE_HOME if someone set it
     # otherwise matplotlib defaults to ~/.cache/matplotlib/
-    if [ -z "${XDG_CACHE_HOME}" ]; then
+    if [ -n "${XDG_CACHE_HOME}" ]; then
         # matplotlib will cache fonts here
         # useful on those pesky nfs systems
         export MPLCONFIGDIR="${XDG_CACHE_HOME}/matplotlib"

--- a/docs/source/release/v7.0.0/Framework/Dependencies/New_features/42067.rst
+++ b/docs/source/release/v7.0.0/Framework/Dependencies/New_features/42067.rst
@@ -1,0 +1,1 @@
+- Automatically set ``MPLCONFIGDIR`` to ``$XDG_CACHE_HOME/matplotlib`` when ``XDG_CACHE_HOME`` is set


### PR DESCRIPTION
At ORNL, the environment variable `XDG_CACHE_HOME` has been set to use local disk for caching information. This checks that the user hasn't already set `MPLCONFIGDIR` and moves it to `XDG_CACHE_HOME` when defined. This is intended to help with font cache issues since the fonts will be written to a fast local disk.

Reference: [matplotlib environment variables faq](https://matplotlib.org/stable/install/environment_variables_faq.html)

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

Refs #41904

### To test:

With both `XDG_CACHE_HOME` set and not, run
```sh
env -u MPLCONFIGDIR bin/launch_mantidworkbench.sh
```
and see that `MPLCONFIGDIR` gets set. `env -u MPLCONFIGDIR` is what prints the value of the variable at the end of the bash script.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
