### PR TITLE
Remove double separator in macOS directory setting

### DIFF
--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -312,7 +312,10 @@ void ManageUserDirectories::selectSaveDir() {
                                                         QFileDialog::ShowDirsOnly);
 
   if (!newDir.isEmpty()) {
-    const auto path = newDir + QDir::separator();
+    auto path = QDir::cleanPath(newDir);
+    if (!path.endsWith(QDir::separator())) {
+      path += QDir::separator();
+    }
     MantidQt::MantidWidgets::QSettingsChangeAware(settings).setValue(QSettingsKeys::LastDirectory, path);
     m_uiForm.leDefaultSave->setText(path);
   }


### PR DESCRIPTION

### Description of work

See #41994 
<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->
In Qt6 the path return in macos from QFileDialog::getExistingDirectory has a separator at the end. This causes the double separator as latter in the code another separator is added by default to the path. I've use QDir::cleanPath, followed by a check of the separator to add just one separator. 
Closes #41994 . <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

- Testing on macOS, the issue no longer happens. 

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

Not sure it requires a release note, as it is a qt6 related change that has not been exposed to users yet (Except the nightly)
______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
