### PR TITLE
Texture Planning UI - Speed up for Large Instruments

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from mantid.simpleapi import ConvertUnits, CopySample, MonteCarloAbsorption, RotateSampleShape
+from mantid.simpleapi import ConvertUnits, CopySample, MonteCarloAbsorption, RotateSampleShape, DeleteLog
 from mantid.api import MatrixWorkspace
 from mantid.kernel import logger
 from Engineering.texture.correction.correction_model import read_attenuation_coefficient_at_value
@@ -98,7 +98,10 @@ class AbsorptionCalculator:
             RotateSampleShape(wsm.WS_MC_INPUT, f"{ang},{vec[0]},{vec[1]},{vec[2]},1")
 
         # define the gauge volume
-        define_gauge_volume(mc_ws, wsm.gauge_volume_str)
+        if wsm.gauge_volume_str:
+            define_gauge_volume(mc_ws, wsm.gauge_volume_str)
+        elif mc_ws.run().hasProperty("GaugeVolume"):
+            DeleteLog(Workspace=mc_ws, Name="GaugeVolume")
 
     def calc_all(self) -> None:
         for i in self._model.orientations.keys():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import numpy as np
 
 from mantid.simpleapi import ConvertUnits, CopySample, MonteCarloAbsorption, RotateSampleShape, DeleteLog
-from mantid.api import MatrixWorkspace
+from mantid.api import AnalysisDataService as ADS, MatrixWorkspace
 from mantid.kernel import logger
 from Engineering.texture.correction.correction_model import read_attenuation_coefficient_at_value
 from Engineering.texture.texture_helper import define_gauge_volume
@@ -37,6 +37,7 @@ class AbsorptionCalculator:
             "SimulateScatteringPointIn": "SampleOnly",
             "ResimulateTracksForDifferentWavelengths": False,
         }
+        self.mc_ws_init_args = None
 
     def calc_for_index(self, index: int) -> None:
         wsm = self._model.workspaces
@@ -62,13 +63,24 @@ class AbsorptionCalculator:
 
     def _create_mc_ws(self) -> MatrixWorkspace:
         wsm = self._model.workspaces
-        # create a ws with params binned around the evaluation point
-        src_ws = wsm.create_simulation_workspace(
-            wsm.WS_MC_INPUT,
-            unit=wsm.attenuation_kwargs["unit"],
-            bin_params=wsm.create_bin_params_around_point(wsm.attenuation_kwargs["point"]),
-        )
-        mc_ws = ConvertUnits(InputWorkspace=src_ws, Target="Wavelength", OutputWorkspace=wsm.WS_MC_INPUT)
+        # create a ws with params binned around the evaluation point, if the init args have changed
+        input_args = (wsm.WS_MC_INPUT, wsm.attenuation_kwargs["unit"], wsm.attenuation_kwargs["point"])
+        # if the workspace isn't in the ADS it needs to be rebuilt
+        # if the workspace is in the ADS rebuild it if the args have changes
+        rebuild = input_args != self.mc_ws_init_args if ADS.doesExist(wsm.WS_MC_INPUT) else True
+        if rebuild:
+            src_ws = wsm.create_simulation_workspace(
+                wsm.WS_MC_INPUT,
+                unit=wsm.attenuation_kwargs["unit"],
+                bin_params=wsm.create_bin_params_around_point(wsm.attenuation_kwargs["point"]),
+            )
+            mc_ws = ConvertUnits(InputWorkspace=src_ws, Target="Wavelength", OutputWorkspace=wsm.WS_MC_INPUT)
+            mc_ws.run().getGoniometer().setR(np.eye(3))
+            self.mc_ws_init_args = input_args
+            return mc_ws
+        # to reach here rebuild must be False and so "ADS.doesExist(wsm.WS_MC_INPUT)" check must be True
+        # and the args must be the same, just retrieve the ws and ensure the goniometer is I
+        mc_ws = ADS.retrieve(wsm.WS_MC_INPUT)
         mc_ws.run().getGoniometer().setR(np.eye(3))
         return mc_ws
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/absorption.py
@@ -63,8 +63,10 @@ class AbsorptionCalculator:
 
     def _create_mc_ws(self) -> MatrixWorkspace:
         wsm = self._model.workspaces
-        # create a ws with params binned around the evaluation point, if the init args have changed
-        input_args = (wsm.WS_MC_INPUT, wsm.attenuation_kwargs["unit"], wsm.attenuation_kwargs["point"])
+        # create a ws with params binned around the evaluation point, if the init args have changed.
+        # instr is in the key because this ws carries its detectors and update_ws does not rebuild it
+        # on an instrument switch, so the absorption would otherwise run on the old geometry
+        input_args = (wsm.WS_MC_INPUT, wsm.instr, wsm.attenuation_kwargs["unit"], wsm.attenuation_kwargs["point"])
         # if the workspace isn't in the ADS it needs to be rebuilt
         # if the workspace is in the ADS rebuild it if the args have changes
         rebuild = input_args != self.mc_ws_init_args if ADS.doesExist(wsm.WS_MC_INPUT) else True

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/instrument.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/instrument.py
@@ -14,6 +14,7 @@ from mantid.kernel import logger
 from Engineering.EnggUtils import CALIB_DIR
 from Engineering.common.instrument_config import get_instr_config, SUPPORTED_INSTRUMENTS
 from typing import TYPE_CHECKING, List, Sequence
+from functools import lru_cache
 
 if TYPE_CHECKING:
     from mantidqtinterfaces.TexturePlanner.model import TexturePlannerModel
@@ -81,20 +82,10 @@ class InstrumentHelper:
         untouched) rather than with a bare try/except around the real recompute. A leading null
         group is tolerated to match DetectorGeometry.recompute, but any other detector-less group
         means the file references detectors this instrument does not have - i.e. it does not fit.
+
+        Calls are cached for quick evaluation of repeated calls
         """
-        if not instrument or not grouping_path:
-            return False
-        try:
-            ws = CreateSimulationWorkspace(Instrument=instrument, BinParams="0,1,2", StoreInADS=False)
-            grouped = GroupDetectors(InputWorkspace=ws, MapFile=grouping_path, StoreInADS=False)
-        except (RuntimeError, ValueError):
-            return False
-        spec_info = grouped.spectrumInfo()
-        n_hist = grouped.getNumberHistograms()
-        first = 0
-        while first < n_hist and not spec_info.hasDetectors(first):
-            first += 1
-        return first < n_hist and all(spec_info.hasDetectors(i) for i in range(first, n_hist))
+        return _is_grouping_file_applicable(instrument, grouping_path)
 
     def set_group(self, group_str: str) -> None:
         if group_str == CUSTOM_GROUP:
@@ -128,3 +119,29 @@ class InstrumentHelper:
             # user-supplied file is already an absolute path
             return self.custom_grouping_file
         return os.path.join(CALIB_DIR, self.get_grouping_file())
+
+
+@lru_cache(maxsize=32)
+def _is_grouping_file_applicable(instrument: str, grouping_path: str) -> bool:
+    """Whether grouping_path can be applied to instrument.
+
+    Checked on throwaway workspaces (StoreInADS=False, so the live state and the ADS are
+    untouched) rather than with a bare try/except around the real recompute. A leading null
+    group is tolerated to match DetectorGeometry.recompute, but any other detector-less group
+    means the file references detectors this instrument does not have - i.e. it does not fit.
+
+    cached for repeated calls
+    """
+    if not instrument or not grouping_path:
+        return False
+    try:
+        ws = CreateSimulationWorkspace(Instrument=instrument, BinParams="0,1,2", StoreInADS=False)
+        grouped = GroupDetectors(InputWorkspace=ws, MapFile=grouping_path, StoreInADS=False)
+    except (RuntimeError, ValueError):
+        return False
+    spec_info = grouped.spectrumInfo()
+    n_hist = grouped.getNumberHistograms()
+    first = 0
+    while first < n_hist and not spec_info.hasDetectors(first):
+        first += 1
+    return first < n_hist and all(spec_info.hasDetectors(i) for i in range(first, n_hist))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/instrument.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/instrument.py
@@ -76,15 +76,7 @@ class InstrumentHelper:
 
     @staticmethod
     def is_grouping_file_applicable(instrument: str, grouping_path: str) -> bool:
-        """Whether grouping_path can be applied to instrument.
-
-        Checked on throwaway workspaces (StoreInADS=False, so the live state and the ADS are
-        untouched) rather than with a bare try/except around the real recompute. A leading null
-        group is tolerated to match DetectorGeometry.recompute, but any other detector-less group
-        means the file references detectors this instrument does not have - i.e. it does not fit.
-
-        Calls are cached for quick evaluation of repeated calls
-        """
+        """Whether grouping_path can be applied to instrument (see _is_grouping_file_applicable)."""
         return _is_grouping_file_applicable(instrument, grouping_path)
 
     def set_group(self, group_str: str) -> None:
@@ -130,7 +122,9 @@ def _is_grouping_file_applicable(instrument: str, grouping_path: str) -> bool:
     group is tolerated to match DetectorGeometry.recompute, but any other detector-less group
     means the file references detectors this instrument does not have - i.e. it does not fit.
 
-    cached for repeated calls
+    The check builds an instrument, so results are cached for the life of the process and are
+    keyed on the path, not the file's contents: editing a grouping file in place mid-session
+    keeps the previous answer until cache_clear() is called.
     """
     if not instrument or not grouping_path:
         return False

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_absorption.py
@@ -24,6 +24,7 @@ def _make_wsm(offset=(0.0, 0.0, 0.0), init_R=None, gauge_volume_str="<gv/>"):
     wsm.WS_MC_INPUT = WS_MC_INPUT
     wsm.WS_MC_OUTPUT = WS_MC_OUTPUT
     wsm.wsname = WS_DATA
+    wsm.instr = "ENGINX"
     wsm.mesh_ws = "mesh_ws"
     wsm.offset = offset
     wsm.init_R = init_R if init_R is not None else Rotation.identity()
@@ -47,19 +48,19 @@ def _make_model(R=None, n_orientations=1, spec_inds=None):
     return model, orient
 
 
+def _make_calculator(point=1.5, unit="dSpacing"):
+    model, _ = _make_model()
+    model.workspaces.attenuation_kwargs = {"point": point, "unit": unit}
+    model.workspaces.create_bin_params_around_point.return_value = "1.4775,0.015,1.5225"
+    return AbsorptionCalculator(model), model.workspaces
+
+
 @patch(file_path + ".ConvertUnits")
 class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
-    @staticmethod
-    def _make_calculator(point=1.5, unit="dSpacing"):
-        model, _ = _make_model()
-        model.workspaces.attenuation_kwargs = {"point": point, "unit": unit}
-        model.workspaces.create_bin_params_around_point.return_value = "1.4775,0.015,1.5225"
-        return AbsorptionCalculator(model), model.workspaces
-
     def test_bins_the_source_ws_around_the_evaluation_point(self, mock_convert):
         # the source grid must bracket the point so that read_attenuation_coefficient_at_value can
         # interpolate there - a grid that does not reach the point raises instead
-        calc, wsm = self._make_calculator(point=7.5, unit="dSpacing")
+        calc, wsm = _make_calculator(point=7.5, unit="dSpacing")
 
         calc._create_mc_ws()
 
@@ -72,14 +73,14 @@ class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
         # a single dSpacing point maps to a different wavelength in every detector (lambda = 2 d sin(theta)),
         # so the grid is built in the requested unit and converted per spectrum; binning directly in
         # wavelength would evaluate the whole bank at one detector's wavelength
-        calc, wsm = self._make_calculator(unit="dSpacing")
+        calc, wsm = _make_calculator(unit="dSpacing")
 
         calc._create_mc_ws()
 
         self.assertEqual(wsm.create_simulation_workspace.call_args.kwargs["unit"], "dSpacing")
 
     def test_converts_source_ws_to_wavelength_for_the_mc_input(self, mock_convert):
-        calc, wsm = self._make_calculator()
+        calc, wsm = _make_calculator()
 
         result = calc._create_mc_ws()
 
@@ -90,7 +91,7 @@ class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
 
     def test_still_converts_when_point_is_already_in_wavelength(self, mock_convert):
         # MonteCarloAbsorption needs a wavelength axis, and ConvertUnits is a no-op when already there
-        calc, wsm = self._make_calculator(point=4.0, unit="Wavelength")
+        calc, wsm = _make_calculator(point=4.0, unit="Wavelength")
 
         calc._create_mc_ws()
 
@@ -100,7 +101,7 @@ class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
     def test_resets_goniometer_to_identity(self, mock_convert):
         # _set_mc_sample_state CopySamples onto this ws, and CopySample bakes the *destination's*
         # goniometer into the shape, so a stale rotation here would be applied twice
-        calc, _ = self._make_calculator()
+        calc, _ = _make_calculator()
         gonio = MagicMock()
         mock_convert.return_value.run.return_value.getGoniometer.return_value = gonio
 
@@ -108,6 +109,64 @@ class TestAbsorptionCalculator_CreateMcWs(unittest.TestCase):
 
         gonio.setR.assert_called_once()
         np.testing.assert_array_equal(gonio.setR.call_args.args[0], np.eye(3))
+
+
+@patch(file_path + ".ADS")
+@patch(file_path + ".ConvertUnits")
+class TestAbsorptionCalculator_CreateMcWsCaching(unittest.TestCase):
+    # building the mc input ws is slow, so it is reused across orientations. It is only safe to reuse
+    # while the workspace still matches the args it was built from and is still in the ADS.
+    def test_reuses_the_cached_ws_when_args_are_unchanged(self, mock_convert, mock_ads):
+        calc, wsm = _make_calculator()
+        mock_ads.doesExist.return_value = True
+
+        calc._create_mc_ws()
+        result = calc._create_mc_ws()
+
+        wsm.create_simulation_workspace.assert_called_once()
+        self.assertIs(result, mock_ads.retrieve.return_value)
+
+    def test_resets_goniometer_on_the_cached_ws_too(self, mock_convert, mock_ads):
+        # the reuse branch hands the ws straight to _set_mc_sample_state, which CopySamples onto it;
+        # the previous orientation's rotation must not be left on the goniometer to be baked in again
+        calc, _ = _make_calculator()
+        mock_ads.doesExist.return_value = True
+        gonio = mock_ads.retrieve.return_value.run.return_value.getGoniometer.return_value
+
+        calc._create_mc_ws()
+        calc._create_mc_ws()
+
+        gonio.setR.assert_called_once()
+        np.testing.assert_array_equal(gonio.setR.call_args.args[0], np.eye(3))
+
+    def test_rebuilds_when_a_key_arg_changes(self, mock_convert, mock_ads):
+        # the ws is binned around the evaluation point and carries the instrument's detectors, so any
+        # of these leaves the cached ws wrong. The instrument especially: update_ws rebuilds WS_DATA
+        # on a switch but not this ws, so without it in the key absorption runs on the old geometry
+        for name, mutate in (
+            ("point", lambda wsm: wsm.attenuation_kwargs.update(point=7.5)),
+            ("unit", lambda wsm: wsm.attenuation_kwargs.update(unit="Wavelength")),
+            ("instrument", lambda wsm: setattr(wsm, "instr", "IMAT")),
+        ):
+            with self.subTest(changed=name):
+                calc, wsm = _make_calculator()
+                mock_ads.doesExist.return_value = True
+
+                calc._create_mc_ws()
+                mutate(wsm)
+                calc._create_mc_ws()
+
+                self.assertEqual(wsm.create_simulation_workspace.call_count, 2)
+
+    def test_rebuilds_when_the_ws_is_gone_from_the_ads(self, mock_convert, mock_ads):
+        # matching args are not enough on their own; something else may have removed the ws
+        calc, wsm = _make_calculator()
+        mock_ads.doesExist.return_value = False
+
+        calc._create_mc_ws()
+        calc._create_mc_ws()
+
+        self.assertEqual(wsm.create_simulation_workspace.call_count, 2)
 
 
 @patch(file_path + ".define_gauge_volume")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_instrument.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_instrument.py
@@ -9,7 +9,7 @@ import unittest
 
 from unittest.mock import patch, MagicMock
 
-from mantidqtinterfaces.TexturePlanner.helpers.instrument import InstrumentHelper
+from mantidqtinterfaces.TexturePlanner.helpers.instrument import InstrumentHelper, _is_grouping_file_applicable
 
 FILE_PATH = "mantidqtinterfaces.TexturePlanner.helpers.instrument"
 
@@ -148,6 +148,11 @@ class TestInstrumentHelper_GroupingPath(unittest.TestCase):
 @patch(FILE_PATH + ".GroupDetectors")
 @patch(FILE_PATH + ".CreateSimulationWorkspace")
 class TestInstrumentHelper_IsGroupingFileApplicable(unittest.TestCase):
+    def setUp(self):
+        # the lookup is cached, so without this the first result for a given
+        # (instrument, path) pair would be reused by every later test
+        _is_grouping_file_applicable.cache_clear()
+
     @staticmethod
     def _grouped_with(has_detectors):
         grouped = MagicMock()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -175,21 +175,6 @@ class TestWorkspaceManager_InitWss(unittest.TestCase):
         )
         self.assertIs(wm.ws, sim_ws)
 
-    def test_fills_y_with_ones_for_each_histogram(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
-        wm = _make_manager("ENGINX")
-        sim_ws = MagicMock()
-        sim_ws.getNumberHistograms.return_value = 3
-        sim_ws.y.return_value = np.zeros(4)
-        mock_create_sim.return_value = sim_ws
-
-        wm._init_wss()
-
-        # numpy arrays inside mock.call don't compare cleanly with ==, so check each call explicitly
-        spec_indices = [c.args[0] for c in sim_ws.setSharedY.call_args_list]
-        self.assertEqual(spec_indices, [0, 1, 2])
-        for c in sim_ws.setSharedY.call_args_list:
-            np.testing.assert_array_equal(c.args[1], np.ones(4))
-
     def test_clones_mesh_neutral_and_material_from_sim_ws(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
         wm = _make_manager("ENGINX")
         sim_ws = MagicMock()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -158,15 +158,16 @@ class TestWorkspaceManager_UpdateWorkspace(unittest.TestCase):
 @patch(file_path + ".SetSampleShape")
 @patch(file_path + ".CloneWorkspace")
 @patch(file_path + ".CreateSimulationWorkspace")
+@patch(file_path + ".CreateSampleWorkspace")
 class TestWorkspaceManager_InitWss(unittest.TestCase):
-    def test_creates_sim_workspace_with_expected_args(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+    def test_creates_sim_workspace_with_expected_args(self, mock_create_shape, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
         wm = _make_manager("ENGINX")
         sim_ws = MagicMock()
-        sim_ws.getNumberHistograms.return_value = 0
         mock_create_sim.return_value = sim_ws
 
         wm._init_wss()
 
+        # only WS_DATA has its detectors read, so it is the only ws built on the real instrument
         mock_create_sim.assert_called_once_with(
             Instrument="ENGINX",
             BinParams=WorkspaceManager.DEFAULT_BIN_PARAMS,
@@ -175,45 +176,46 @@ class TestWorkspaceManager_InitWss(unittest.TestCase):
         )
         self.assertIs(wm.ws, sim_ws)
 
-    def test_clones_mesh_neutral_and_material_from_sim_ws(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+    def test_builds_mesh_wss_as_stub_instrument_shape_wss(
+        self, mock_create_shape, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat
+    ):
+        # the mesh workspaces are pure sample holders; building them on the real instrument would
+        # cost a full IDF load each for geometry that is never queried
         wm = _make_manager("ENGINX")
-        sim_ws = MagicMock()
-        sim_ws.getNumberHistograms.return_value = 0
-        mock_create_sim.return_value = sim_ws
-        mock_clone.side_effect = ["mesh", "neutral", "material"]
+        mock_create_shape.side_effect = ["mesh", "neutral"]
 
         wm._init_wss()
 
-        self.assertEqual(
-            mock_clone.call_args_list,
-            [
-                call(InputWorkspace=sim_ws, OutputWorkspace=wm.WS_MESH_RAW),
-                call(InputWorkspace=sim_ws, OutputWorkspace=wm.WS_MESH_NEUTRAL),
-                # material holder is cloned from the (cube-shaped) mesh ws so it owns a shape
-                call(InputWorkspace="mesh", OutputWorkspace=wm.WS_MATERIAL),
-            ],
-        )
+        built = [c.kwargs["OutputWorkspace"] for c in mock_create_shape.call_args_list]
+        self.assertEqual(built, [wm.WS_MESH_RAW, wm.WS_MESH_NEUTRAL])
         self.assertEqual(wm.mesh_ws, "mesh")
         self.assertEqual(wm.updated_mesh_ws, "neutral")
+
+    def test_clones_material_holder_from_mesh_ws(self, mock_create_shape, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+        wm = _make_manager("ENGINX")
+        mock_create_shape.side_effect = ["mesh", "neutral"]
+        mock_clone.return_value = "material"
+
+        wm._init_wss()
+
+        # material holder is cloned from the (cube-shaped) mesh ws so it owns a shape
+        mock_clone.assert_called_once_with(InputWorkspace="mesh", OutputWorkspace=wm.WS_MATERIAL)
         self.assertEqual(wm.material_ws, "material")
 
-    def test_seeds_material_holder_with_default(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+    def test_seeds_material_holder_with_default(self, mock_create_shape, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
         wm = _make_manager("ENGINX")
-        sim_ws = MagicMock()
-        sim_ws.getNumberHistograms.return_value = 0
-        mock_create_sim.return_value = sim_ws
-        mock_clone.side_effect = ["mesh", "neutral", "material"]
+        mock_create_shape.side_effect = ["mesh", "neutral"]
+        mock_clone.return_value = "material"
 
         wm._init_wss()
 
         mock_set_mat.assert_called_once_with("material", WorkspaceManager.DEFAULT_MATERIAL)
 
-    def test_sets_default_cube_shape_on_all_three_wss(self, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
+    def test_sets_default_cube_shape_on_all_three_wss(self, mock_create_shape, mock_create_sim, mock_clone, mock_set_shape, mock_set_mat):
         wm = _make_manager("ENGINX")
         sim_ws = MagicMock()
-        sim_ws.getNumberHistograms.return_value = 0
         mock_create_sim.return_value = sim_ws
-        mock_clone.side_effect = ["mesh", "neutral", "material"]
+        mock_create_shape.side_effect = ["mesh", "neutral"]
 
         wm._init_wss()
 
@@ -225,101 +227,124 @@ class TestWorkspaceManager_InitWss(unittest.TestCase):
 
 
 class TestWorkspaceManager_UpdateExistingWss(unittest.TestCase):
-    def test_rebuilds_three_wss_via_create_new_helper(self):
+    def test_rebuilds_only_the_data_ws(self):
         wm = _make_manager("ENGINX")
         wm.ws = "old_ws"
         wm.mesh_ws = "old_mesh"
         wm.updated_mesh_ws = "old_neutral"
-        wm._create_new_ws_with_copied_sample = MagicMock(side_effect=["new_ws", "new_mesh", "new_neutral"])
+        wm.material_ws = "old_material"
+        wm._create_new_ws_with_copied_sample = MagicMock(return_value="new_ws")
 
         wm._update_existing_wss()
 
-        # ws and updated_mesh_ws hold the initial shape rotation and must preserve it across the
-        # instrument switch; the raw mesh_ws is un-rotated and is copied as-is
-        self.assertEqual(
-            wm._create_new_ws_with_copied_sample.call_args_list,
-            [
-                call(wm.WS_DATA, "old_ws", clone=True, preserve_initial_rotation=True),
-                call(wm.WS_MESH_RAW, "old_mesh", clone=True),
-                call(wm.WS_MESH_NEUTRAL, "old_neutral", clone=True, preserve_initial_rotation=True),
-            ],
-        )
+        # ws holds the initial shape rotation and must preserve it across the instrument switch
+        wm._create_new_ws_with_copied_sample.assert_called_once_with(wm.WS_DATA, "old_ws", preserve_initial_rotation=True)
         self.assertEqual(wm.ws, "new_ws")
-        self.assertEqual(wm.mesh_ws, "new_mesh")
-        self.assertEqual(wm.updated_mesh_ws, "new_neutral")
+
+    def test_leaves_the_instrument_free_sample_holders_untouched(self):
+        # the mesh and material workspaces carry a stub instrument, so an instrument switch has
+        # nothing to rebuild on them - rebuilding would cost IDF loads for no behavioural gain
+        wm = _make_manager("ENGINX")
+        wm.ws = "old_ws"
+        wm.mesh_ws = "old_mesh"
+        wm.updated_mesh_ws = "old_neutral"
+        wm.material_ws = "old_material"
+        wm._create_new_ws_with_copied_sample = MagicMock(return_value="new_ws")
+
+        wm._update_existing_wss()
+
+        self.assertEqual(wm.mesh_ws, "old_mesh")
+        self.assertEqual(wm.updated_mesh_ws, "old_neutral")
+        self.assertEqual(wm.material_ws, "old_material")
 
 
 @patch(file_path + ".ADS")
 @patch(file_path + ".CopySample")
 @patch(file_path + ".CreateSimulationWorkspace")
-@patch(file_path + ".CloneWorkspace")
+@patch(file_path + ".CreateSampleWorkspace")
 class TestWorkspaceManager_CreateNewWsWithCopiedSample(unittest.TestCase):
-    def test_clone_true_clones_sample_into_shape_tmp(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+    def test_stashes_sample_on_a_stub_shape_ws(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
+        # create_simulation_workspace is about to overwrite new_wsname in the ADS, so the sample is
+        # parked on a throwaway ws first. That stash only holds a sample, so it needs no real
+        # instrument - cloning the (potentially huge) source workspace would defeat the point.
         wm = _make_manager("ENGINX")
         sample = MagicMock(name="sample")
-        mock_clone.return_value = "shape_tmp"
+        mock_create_shape.return_value = "shape_tmp"
         mock_create_sim.return_value = "new_ws"
         mock_ads.doesExist.return_value = True
 
-        wm._create_new_ws_with_copied_sample("dest_ws", sample, clone=True)
+        wm._create_new_ws_with_copied_sample("dest_ws", sample)
 
-        mock_clone.assert_called_once_with(InputWorkspace=sample, OutputWorkspace=wm._SHAPE_TMP)
+        mock_create_shape.assert_called_once()
+        self.assertEqual(mock_create_shape.call_args.kwargs["OutputWorkspace"], wm._SHAPE_TMP)
+        self.assertEqual(mock_copy.call_args_list[0], call(InputWorkspace=sample, OutputWorkspace="shape_tmp", **COPY_KWARGS))
 
-    def test_clone_true_copies_from_shape_tmp_into_new_ws(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+    def test_copies_from_shape_tmp_into_new_ws(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
         wm = _make_manager("ENGINX")
-        mock_clone.return_value = "shape_tmp"
+        sample = MagicMock(name="sample")
+        mock_create_shape.return_value = "shape_tmp"
         mock_create_sim.return_value = "new_ws"
         mock_ads.doesExist.return_value = True
 
-        result = wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+        result = wm._create_new_ws_with_copied_sample("dest_ws", sample)
 
         mock_create_sim.assert_called_once_with(
             Instrument="ENGINX", BinParams=WorkspaceManager.DEFAULT_BIN_PARAMS, OutputWorkspace="dest_ws", UnitX="dSpacing"
         )
-        mock_copy.assert_called_once_with(InputWorkspace="shape_tmp", OutputWorkspace="dest_ws", **COPY_KWARGS)
+        self.assertEqual(
+            mock_copy.call_args_list,
+            [
+                call(InputWorkspace=sample, OutputWorkspace="shape_tmp", **COPY_KWARGS),
+                call(InputWorkspace="shape_tmp", OutputWorkspace="new_ws", **COPY_KWARGS),
+            ],
+        )
         self.assertEqual(result, "new_ws")
 
-    def test_clone_true_removes_shape_tmp_when_it_exists(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+    def test_removes_shape_tmp_when_it_exists(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
         wm = _make_manager("ENGINX")
-        mock_clone.return_value = "shape_tmp"
+        mock_create_shape.return_value = "shape_tmp"
         mock_ads.doesExist.return_value = True
 
-        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock())
 
         mock_ads.doesExist.assert_called_once_with(wm._SHAPE_TMP)
         mock_ads.remove.assert_called_once_with(wm._SHAPE_TMP)
 
-    def test_clone_true_skips_remove_if_shape_tmp_missing(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+    def test_skips_remove_if_shape_tmp_missing(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
         wm = _make_manager("ENGINX")
         mock_ads.doesExist.return_value = False
 
-        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True)
+        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock())
 
         mock_ads.remove.assert_not_called()
 
-    def test_clone_false_copies_directly_from_sample(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
+    def test_removes_shape_tmp_when_the_copy_fails(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
+        # the stash is built inside the try, so a failure part-way through cannot leave it behind
+        wm = _make_manager("ENGINX")
+        mock_create_shape.return_value = "shape_tmp"
+        mock_ads.doesExist.return_value = True
+        mock_copy.side_effect = RuntimeError("CopySample failed")
+
+        with self.assertRaises(RuntimeError):
+            wm._create_new_ws_with_copied_sample("dest_ws", MagicMock())
+
+        mock_ads.remove.assert_called_once_with(wm._SHAPE_TMP)
+
+    def test_preserve_initial_rotation_used_for_both_hops(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
+        # both hops must use the same copy semantics: the preserving helper is idempotent, but
+        # mixing it with a bare CopySample would re-bake init_R on one hop and strip it on the other
         wm = _make_manager("ENGINX")
         sample = MagicMock(name="sample")
-        mock_create_sim.return_value = "new_ws"
-
-        result = wm._create_new_ws_with_copied_sample("dest_ws", sample, clone=False)
-
-        mock_clone.assert_not_called()
-        mock_copy.assert_called_once_with(InputWorkspace=sample, OutputWorkspace="dest_ws", **COPY_KWARGS)
-        mock_ads.remove.assert_not_called()
-        self.assertEqual(result, "new_ws")
-
-    def test_preserve_initial_rotation_delegates_to_preserving_copy(self, mock_clone, mock_create_sim, mock_copy, mock_ads):
-        # when asked to preserve init_R, the bare CopySample is bypassed in favour of the helper that
-        # re-bakes init_R onto the destination (a plain CopySample drops it for a CSG shape)
-        wm = _make_manager("ENGINX")
-        mock_clone.return_value = "shape_tmp"
+        mock_create_shape.return_value = "shape_tmp"
         mock_create_sim.return_value = "new_ws"
         wm.copy_sample_preserving_initial_rotation = MagicMock()
 
-        wm._create_new_ws_with_copied_sample("dest_ws", MagicMock(), clone=True, preserve_initial_rotation=True)
+        wm._create_new_ws_with_copied_sample("dest_ws", sample, preserve_initial_rotation=True)
 
-        wm.copy_sample_preserving_initial_rotation.assert_called_once_with("shape_tmp", "new_ws")
+        self.assertEqual(
+            wm.copy_sample_preserving_initial_rotation.call_args_list,
+            [call(sample, "shape_tmp"), call("shape_tmp", "new_ws")],
+        )
         mock_copy.assert_not_called()
 
 
@@ -620,17 +645,21 @@ class TestWorkspaceManager_UpdateInitialShape(unittest.TestCase):
         wm.ws.run.return_value.getGoniometer.return_value = gonio
         wm.mesh_ws = MagicMock()
         wm.updated_mesh_ws = "neutral"
-        wm._create_new_ws_with_copied_sample = MagicMock(return_value="tmp_ws")
+        wm.create_shape_workspace = MagicMock(return_value="tmp_ws")
+        wm._copy_sample = MagicMock()
         wm.translate_shape = MagicMock()
         wm.rotate_samples_by_initial_goniometer = MagicMock()
         return wm, gonio
 
     def test_creates_tmp_ws_from_mesh(self, mock_copy, mock_ads):
+        # this runs on every tick of the six initial-shape spin boxes, so the working copy is a
+        # stub-instrument shape ws - it only ever holds a sample
         wm, _ = self._make_wm_with_ws()
 
         wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
-        wm._create_new_ws_with_copied_sample.assert_called_once_with(wm.WS_TMP, wm.mesh_ws)
+        wm.create_shape_workspace.assert_called_once_with(wm.WS_TMP)
+        wm._copy_sample.assert_called_once_with(wm.mesh_ws, "tmp_ws", preserve_initial_rotation=False)
 
     def test_stores_offset_and_translates_tmp_ws(self, mock_copy, mock_ads):
         wm, _ = self._make_wm_with_ws()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/test/test_workspace_manager.py
@@ -26,6 +26,21 @@ def _make_manager(instr="ENGINX"):
     return WorkspaceManager(model)
 
 
+class _FakeCsgWs:
+    """A CSG-shaped workspace tracking the rotation baked into its shape and the one on its run
+    goniometer, so a CopySample stand-in can model how the two interact."""
+
+    def __init__(self):
+        self.baked = np.eye(3)
+        self.gonio_R = np.eye(3)
+        gonio = MagicMock()
+        gonio.setR.side_effect = lambda R: setattr(self, "gonio_R", np.asarray(R))
+        self.run = MagicMock()
+        self.run.return_value.getGoniometer.return_value = gonio
+        self.sample = MagicMock()
+        self.sample.return_value.getShape.return_value = type("CSGObject", (), {})()
+
+
 class TestWorkspaceManager_Init(unittest.TestCase):
     def test_default_attributes(self):
         wm = _make_manager("ENGINX")
@@ -346,6 +361,23 @@ class TestWorkspaceManager_CreateNewWsWithCopiedSample(unittest.TestCase):
             [call(sample, "shape_tmp"), call("shape_tmp", "new_ws")],
         )
         mock_copy.assert_not_called()
+
+    def test_two_hops_leave_init_R_baked_in_once(self, mock_create_shape, mock_create_sim, mock_copy, mock_ads):
+        # the idempotence the two hops rely on comes from CopySample -> copyParameters ->
+        # addGoniometerTag *replacing* a CSG shape's <goniometer> tag with the destination's run
+        # goniometer, discarding whatever the tag held. Were it to compose instead, the sample would
+        # come out of an instrument switch at init_R squared - so pin the value, not just the flag.
+        wm = _make_manager("ENGINX")
+        wm.init_R = Rotation.from_euler("x", 30, degrees=True)
+        mock_create_shape.return_value = _FakeCsgWs()
+        new_ws = mock_create_sim.return_value = _FakeCsgWs()
+        mock_copy.side_effect = lambda InputWorkspace, OutputWorkspace, **kw: setattr(OutputWorkspace, "baked", OutputWorkspace.gonio_R)
+
+        wm._create_new_ws_with_copied_sample("dest_ws", _FakeCsgWs(), preserve_initial_rotation=True)
+
+        np.testing.assert_allclose(new_ws.baked, wm.init_R.as_matrix(), atol=1e-12)
+        # init_R must live in the shape, never left behind on the run goniometer
+        np.testing.assert_allclose(new_ws.gonio_R, np.eye(3), atol=1e-12)
 
 
 @patch(file_path + ".CopySample")
@@ -737,6 +769,17 @@ class TestWorkspaceManager_UpdateInitialShape(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             wm.update_initial_shape(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        mock_ads.remove.assert_called_once_with(wm.WS_TMP)
+
+    def test_tmp_workspace_removed_even_when_translate_raises(self, mock_copy, mock_ads):
+        # everything that touches the temp ws sits inside the try, so a throw on the way to the
+        # CopySamples cannot leak it into the ADS until the window is closed
+        wm, _ = self._make_wm_with_ws()
+        wm.translate_shape.side_effect = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            wm.update_initial_shape(0.0, 0.0, 0.0, 1.0, 0.0, 0.0)
 
         mock_ads.remove.assert_called_once_with(wm.WS_TMP)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -158,8 +158,6 @@ class WorkspaceManager:
 
     def _init_wss(self) -> None:
         ws = self.create_simulation_workspace(self.wsname)
-        for ispec in range(ws.getNumberHistograms()):
-            ws.setSharedY(ispec, np.ones_like(ws.y(ispec)))
         mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_RAW)
         updated_mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_NEUTRAL)
         self.ws = ws

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -14,6 +14,7 @@ from scipy.spatial.transform import Rotation
 from mantid.simpleapi import (
     CloneWorkspace,
     CopySample,
+    CreateSampleWorkspace,
     CreateSimulationWorkspace,
     DeleteLog,
     LoadSampleShape,
@@ -69,6 +70,14 @@ class WorkspaceManager:
         #                    reloaded, so it survives shape changes and lets set_material re-apply the
         #                    full material (formula + number/mass density) via CopySample rather than a
         #                    round-trip through SetSampleMaterial.
+        #
+        # Only WS_DATA, WS_UNGROUPED, WS_MC_INPUT and WS_REFERENCE carry the real instrument, because
+        # only they have their detectors read (GroupDetectors, spectrumInfo/componentInfo positions,
+        # MonteCarloAbsorption, the saved reference file). The rest are pure sample holders built by
+        # create_shape_workspace: nothing ever queries their geometry, and building the real IDF for
+        # them costs seconds on a large instrument. They are not instrument-free only because
+        # LoadSampleShape declares an InstrumentValidator, which needs a sample position and nothing
+        # more - so a stub instrument is behaviourally identical here.
         suffix = f"_{uuid4().hex[:8]}"
         self.WS_DATA = "__texture_planning_ws" + suffix
         self.WS_UNGROUPED = "__texture_planning_ws_ungrouped" + suffix
@@ -132,7 +141,7 @@ class WorkspaceManager:
         if self.ws:
             # rebuilding for a new instrument: _update_existing_wss copies the sample (including
             # whatever material the user set via the SetSampleMaterial dialog) onto the new
-            # workspaces, so we must not reset the material here
+            # workspace, so we must not reset the material here
             self._update_existing_wss()
         else:
             # brand-new workspaces have no material; seed the default so absorption works out of the box
@@ -143,23 +152,16 @@ class WorkspaceManager:
             define_gauge_volume(self.ws, self.gauge_volume_str)
 
     def _update_existing_wss(self) -> None:
-        # ws and updated_mesh_ws carry the user's initial shape rotation (init_R); it must survive the
+        # ws carries the user's initial shape rotation (init_R); it must survive the
         # instrument switch, but a plain CopySample drops it for a CSG shape (see
-        # copy_sample_preserving_initial_rotation), so preserve it explicitly. mesh_ws is the pristine,
-        # un-rotated sample and is copied as-is.
-        ws = self._create_new_ws_with_copied_sample(self.wsname, self.ws, clone=True, preserve_initial_rotation=True)
-        mesh_ws = self._create_new_ws_with_copied_sample(self.WS_MESH_RAW, self.mesh_ws, clone=True)
-        updated_mesh_ws = self._create_new_ws_with_copied_sample(
-            self.WS_MESH_NEUTRAL, self.updated_mesh_ws, clone=True, preserve_initial_rotation=True
-        )
+        # copy_sample_preserving_initial_rotation), so preserve it explicitly.
+        ws = self._create_new_ws_with_copied_sample(self.wsname, self.ws, preserve_initial_rotation=True)
         self.ws = ws
-        self.mesh_ws = mesh_ws
-        self.updated_mesh_ws = updated_mesh_ws
 
     def _init_wss(self) -> None:
         ws = self.create_simulation_workspace(self.wsname)
-        mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_RAW)
-        updated_mesh_ws = CloneWorkspace(InputWorkspace=ws, OutputWorkspace=self.WS_MESH_NEUTRAL)
+        mesh_ws = self.create_shape_workspace(self.WS_MESH_RAW)
+        updated_mesh_ws = self.create_shape_workspace(self.WS_MESH_NEUTRAL)
         self.ws = ws
         self.mesh_ws = mesh_ws
         self.updated_mesh_ws = updated_mesh_ws
@@ -237,7 +239,10 @@ class WorkspaceManager:
     def update_initial_shape(
         self, x_rot: float | int, y_rot: float | int, z_rot: float | int, x_pos: float | int, y_pos: float | int, z_pos: float | int
     ) -> None:
-        _tmp_ws = self._create_new_ws_with_copied_sample(self.WS_TMP, self.mesh_ws)
+        # this runs on every tick of the six initial-shape spin boxes, and the working copy only ever
+        # holds a sample, so build it as a stub-instrument shape ws rather than on the real instrument
+        _tmp_ws = self.create_shape_workspace(self.WS_TMP)
+        self._copy_sample(self.mesh_ws, _tmp_ws, preserve_initial_rotation=False)
         self.offset = (x_pos, y_pos, z_pos)
         rots_zero = self._all_rots_zero(x_rot, y_rot, z_rot)
         # The initial orientation should be applied before the initial translation:
@@ -304,22 +309,36 @@ class WorkspaceManager:
             DeleteLog(Workspace=self.ws, Name="GaugeVolume")
 
     def _create_new_ws_with_copied_sample(
-        self, new_wsname: str, sample_to_copy: MatrixWorkspace, clone: bool = False, preserve_initial_rotation: bool = False
+        self, new_wsname: str, sample_to_copy: MatrixWorkspace, preserve_initial_rotation: bool = False
     ) -> MatrixWorkspace:
-        if clone:
-            shape_ws = CloneWorkspace(InputWorkspace=sample_to_copy, OutputWorkspace=self._SHAPE_TMP)
-        else:
-            shape_ws = sample_to_copy
+        """Rebuild new_wsname on the current instrument, carrying sample_to_copy's sample across.
+
+        sample_to_copy is normally the workspace living at new_wsname, which
+        create_simulation_workspace is about to overwrite in the ADS, so the sample is first
+        stashed on a throwaway shape workspace. That stash only ever holds a sample, so it is a
+        cheap stub-instrument workspace rather than a clone of what may be a very large workspace.
+
+        Both hops use the same copy semantics: repeating
+        copy_sample_preserving_initial_rotation is idempotent (it re-bakes init_R from the
+        *destination's* goniometer, and CopySample preserves the shape type so _shape_is_mesh
+        answers the same each time), whereas mixing the two would re-bake init_R on one hop and
+        strip it on the other.
+        """
         try:
+            shape_ws = self.create_shape_workspace(self._SHAPE_TMP)
+            self._copy_sample(sample_to_copy, shape_ws, preserve_initial_rotation)
             new_ws = self.create_simulation_workspace(new_wsname)
-            if preserve_initial_rotation:
-                self.copy_sample_preserving_initial_rotation(shape_ws, new_ws)
-            else:
-                CopySample(InputWorkspace=shape_ws, OutputWorkspace=new_wsname, CopyName=False, CopyEnvironment=False, CopyLattice=False)
+            self._copy_sample(shape_ws, new_ws, preserve_initial_rotation)
         finally:
-            if clone and ADS.doesExist(self._SHAPE_TMP):
+            if ADS.doesExist(self._SHAPE_TMP):
                 ADS.remove(self._SHAPE_TMP)
         return new_ws
+
+    def _copy_sample(self, source_ws: MatrixWorkspace, dest_ws: MatrixWorkspace, preserve_initial_rotation: bool) -> None:
+        if preserve_initial_rotation:
+            self.copy_sample_preserving_initial_rotation(source_ws, dest_ws)
+        else:
+            CopySample(InputWorkspace=source_ws, OutputWorkspace=dest_ws, CopyName=False, CopyEnvironment=False, CopyLattice=False)
 
     @staticmethod
     def _shape_is_mesh(ws: MatrixWorkspace) -> bool:
@@ -345,6 +364,19 @@ class WorkspaceManager:
     def create_simulation_workspace(self, name: str, unit: str = "dSpacing", bin_params: str | None = None) -> MatrixWorkspace:
         return CreateSimulationWorkspace(
             Instrument=self.instr, BinParams=bin_params or self.DEFAULT_BIN_PARAMS, OutputWorkspace=name, UnitX=unit
+        )
+
+    @staticmethod
+    def create_shape_workspace(wsname: str) -> MatrixWorkspace:
+        """A minimal single-spectrum workspace used purely as a sample shape/material holder.
+
+        Carries a stub instrument rather than the real one: nothing reads detectors from these
+        workspaces, but LoadSampleShape declares an InstrumentValidator (which only requires a
+        sample position), so they cannot be instrument-free. Building the real IDF here costs
+        seconds on a large instrument, for geometry that is never queried.
+        """
+        return CreateSampleWorkspace(
+            OutputWorkspace=wsname, WorkspaceType="Histogram", NumBanks=1, BankPixelWidth=1, XMin=0, XMax=1, BinWidth=1
         )
 
     @staticmethod

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/helpers/workspace_manager.py
@@ -239,25 +239,21 @@ class WorkspaceManager:
     def update_initial_shape(
         self, x_rot: float | int, y_rot: float | int, z_rot: float | int, x_pos: float | int, y_pos: float | int, z_pos: float | int
     ) -> None:
-        # this runs on every tick of the six initial-shape spin boxes, and the working copy only ever
-        # holds a sample, so build it as a stub-instrument shape ws rather than on the real instrument
-        _tmp_ws = self.create_shape_workspace(self.WS_TMP)
-        self._copy_sample(self.mesh_ws, _tmp_ws, preserve_initial_rotation=False)
-        self.offset = (x_pos, y_pos, z_pos)
-        rots_zero = self._all_rots_zero(x_rot, y_rot, z_rot)
-        # The initial orientation should be applied before the initial translation:
-        # this feels like the more intuative order as
-        # sample position will be determined by the stage etc. where as the initial orientation will be
-        # determined by the mounting of the sample onto this stage.
-        #
-        # init_R must therefore be resolved
-        # before the translation, because initial_translation_vector expresses the offset in the
-        # sample's pre-orientation frame due to how the sample goniometer works
-        # (see initial_translation_vector).
-        self.init_R = Rotation.identity() if rots_zero else Rotation.from_euler("xyz", (x_rot, y_rot, z_rot), degrees=True)
-        self.translate_shape(_tmp_ws, *self.initial_translation_vector())
-
         try:
+            # this runs on every tick of the six initial-shape spin boxes, and the working copy only
+            # ever holds a sample, so build it as a stub-instrument shape ws not the real instrument
+            _tmp_ws = self.create_shape_workspace(self.WS_TMP)
+            self._copy_sample(self.mesh_ws, _tmp_ws, preserve_initial_rotation=False)
+            self.offset = (x_pos, y_pos, z_pos)
+            rots_zero = self._all_rots_zero(x_rot, y_rot, z_rot)
+            # The initial orientation is applied before the initial translation, the more intuitive
+            # order: sample position is determined by the stage, whereas the initial orientation is
+            # determined by how the sample is mounted onto that stage. init_R must therefore be
+            # resolved before the translation, because initial_translation_vector expresses the
+            # offset in the sample's pre-orientation frame (see its docstring).
+            self.init_R = Rotation.identity() if rots_zero else Rotation.from_euler("xyz", (x_rot, y_rot, z_rot), degrees=True)
+            self.translate_shape(_tmp_ws, *self.initial_translation_vector())
+
             # CopySample bakes the destination workspace's current goniometer R into the new
             # shape's XML (see CopySample::copyParameters -> addGoniometerTag), and the plotter
             # leaves a non-identity R on self.ws on every redraw.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -282,7 +282,7 @@ class TexturePlannerPresenter(AlgorithmObserver):
 
     def on_directions_updated(self) -> None:
         self.set_model_texture_directions()
-        self.model.geometry.recompute()
+        self.refresh_scattering_geometry()
         self.model.update_all_projected_data()
         self.update_plots()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
@@ -284,13 +284,16 @@ class TestTexturePlannerPresenter_DirectionsUpdated(unittest.TestCase):
         model.set_ax_transform.reset_mock()
         model.set_dir_names.reset_mock()
         model.geometry.recompute.reset_mock()
+        model.geometry.recompute_scattering_geometry.reset_mock()
         model.update_all_projected_data.reset_mock()
 
         presenter.on_directions_updated()
 
         model.set_ax_transform.assert_called_once_with("1,0,0", "0,1,0", "0,0,1")
         model.set_dir_names.assert_called_once_with("RD", "ND", "TD")
-        model.geometry.recompute.assert_called_once_with()
+        # new directions only move the scattering geometry; the detector grouping is unchanged
+        model.geometry.recompute_scattering_geometry.assert_called_once_with()
+        model.geometry.recompute.assert_not_called()
         model.update_all_projected_data.assert_called_once_with()
         presenter.update_plots.assert_called_once_with()
 


### PR DESCRIPTION
### Description of work

Initial MVP of the interface allowed users to specify any Mantid instrument however usability testing was only done with the intended ENGIN-X and IMAT, so there was a reasonable amount of rebuilding full instrument workspaces that was fine for the Engineering Diffraction instruments but makes the UI far too slow to be useable for the larger instruments - like WISH

### To test:

Try both on main and the branch:

- Interfaces > Diffraction > Texture Planner
- Experimental Setup tab
- Instrument: Custom >WISH
- Grouping File: [wish_panel_4x5.xml](https://github.com/user-attachments/files/31228502/wish_panel_4x5.xml)

play around with the rest of the interface (go through the tutorial to get an idea of how to use it!), hopefully you will find these changes to be a bit slow, but useable and main to be unusably slow


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
