### PR TITLE
Include gtk-platformtheme in host section of mantidqt recipe

### DIFF
--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -44,6 +44,8 @@ requirements:
         - xorg-libxxf86vm
         - xorg-libx11
         - xorg-xorgproto
+        # needs to appear here to get right qt6-main version in run section
+        - qt6-gtk-platformtheme
     - if: osx or linux
       then:
         - libopenblas ${{ libopenblas }}


### PR DESCRIPTION
There is a conflict in dependencies in linux between building the mantidqt package and installing it in a sandbox to do test import. I'm not sure why it took until 2026-08-19T11:29EDT in [this job](https://github.com/mantidproject/mantid/actions/runs/32256744218/job/96117721437) to fail, but the qt6-main v6.11.2 conda package appeared in conda-forge at 2026-08-18T14:44Z. Combine this with the [qt-gtk-platformtheme recipe](https://github.com/conda-forge/qt-gtk-platformtheme-feedstock/blob/f0a7b67c09b9a9f11afa33bc0de08802bd4472df/recipe/meta.yaml#L1) pinning to qt v6.11.1 and you get to my hypothesis that we are building with a newer qt6-main version than qt6-gtk-platformtheme allows. Adding the dependency to the host section means the compatible version of qt6-main will be selected at that point.

### Description of work

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

There is no associated issue.

### To test:

The main thing to see is that the `conda-packaging-linux` build passes.

*This does not require release notes* because it is making the `host` dependencies consistent with the `run` dependencies for the linux mantidqt package.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
