### PR TITLE
Move qsettings identifier stuff into a separate file

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -22,7 +22,7 @@ plugins.setup_library_paths()
 
 # Importing resources loads the data in. This must be imported before the
 # QApplication is created or paths to Qt's resources will not be set up correctly
-from workbench.config import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
+from workbench.identity import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
 
 import workbench.app.workbench_process as wp  # noqa: E402
 

--- a/qt/applications/workbench/workbench/app/workbench_process.py
+++ b/qt/applications/workbench/workbench/app/workbench_process.py
@@ -30,8 +30,7 @@ from qtpy.QtCore import QCoreApplication, Qt  # noqa: E402
 from workbench.app.resource_loader import register_resources, cleanup_resources  # noqa: E402
 
 register_resources()
-from workbench.config import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
-from workbench.widgets.about.presenter import AboutPresenter  # noqa: E402
+from workbench.identity import APPNAME, ORG_DOMAIN, ORGANIZATION  # noqa: E402
 
 # Constants
 SYSCHECK_INTERVAL = 50
@@ -117,6 +116,7 @@ def create_and_launch_workbench(app, command_line_options):
         # MainWindow needs to be imported locally to ensure the matplotlib
         # backend is not imported too early.
         from workbench.app.mainwindow import MainWindow
+        from workbench.widgets.about.presenter import AboutPresenter
 
         # The ordering here is very delicate. Test thoroughly when
         # changing anything!

--- a/qt/applications/workbench/workbench/config/__init__.py
+++ b/qt/applications/workbench/workbench/config/__init__.py
@@ -26,6 +26,8 @@ import mantid.kernel.environment as mtd_env
 from qtpy.QtCore import Qt, QSettings
 
 # local imports
+from workbench.identity import APPNAME, ORG_DOMAIN as ORG_DOMAIN, ORGANIZATION
+
 from .user import UserConfig
 
 # Type to hold properties for additional QMainWindow instances
@@ -41,13 +43,6 @@ _ADDITIONAL_MAINWINDOWS_PARENT = None
 # -----------------------------------------------------------------------------
 # Public Constants
 # -----------------------------------------------------------------------------
-# The strings APPNAME, ORG_DOMAIN, ORGANIZATION are duplicated
-# in mantidqt/dialogs/errorreports/main.py
-
-ORGANIZATION = "mantidproject"
-ORG_DOMAIN = "mantidproject.org"
-APPNAME = "mantidworkbench"
-
 DEFAULT_SCRIPT_CONTENT = ""
 DEFAULT_SCRIPT_CONTENT += (
     "# import mantid algorithms, numpy and matplotlib"

--- a/qt/applications/workbench/workbench/identity.py
+++ b/qt/applications/workbench/workbench/identity.py
@@ -1,0 +1,13 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+
+"""Side-effect-free application identity shared by Workbench processes."""
+
+ORGANIZATION = "mantidproject"
+ORG_DOMAIN = "mantidproject.org"
+APPNAME = "mantidworkbench"

--- a/qt/applications/workbench/workbench/test/test_import.py
+++ b/qt/applications/workbench/workbench/test/test_import.py
@@ -9,12 +9,30 @@
 #
 
 
+import subprocess
+import sys
 import unittest
 
 
 class ImportTest(unittest.TestCase):
     def test_import_workbench(self):
         import workbench  # noqa
+
+    def test_importing_launcher_does_not_construct_workbench_config(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; import workbench.app.start; "
+                "assert 'workbench.config' not in sys.modules; "
+                "assert 'workbench.widgets.about.presenter' not in sys.modules",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(0, result.returncode, msg=result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To avoid accidentally parsing `workbench.config` too early, move the string constants that identify the application into a separate python file. This supports the work for improving qsettings usage.

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

### To test:

Functionally, there is no difference. Looking at the source changes is the best way to review this.

*This does not require release notes* because it is a very internal refactor.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
