### PR TITLE
Grype scan windows and mac packages

### DIFF
--- a/.github/actions/grype/merge_sarif.py
+++ b/.github/actions/grype/merge_sarif.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+"""Merge the per-platform grype reports produced by .github/workflows/grype.yml.
+
+Every leg of that workflow's matrix installs the same conda packages for a
+different platform, so most vulnerabilities are reported once per platform.
+Uploaded separately they list each shared CVE once per platform in code
+scanning. This rewrites the reports into a single one, where a finding seen on
+several platforms becomes a single result naming the platforms it was found on.
+
+Usage: merge_sarif.py OUTPUT REPORT [REPORT ...]
+
+Each REPORT must be named grype-<platform>.sarif; the label comes from the name.
+"""
+
+import json
+import pathlib
+import sys
+
+# grype scans the environment that pixi installs into the workflow's temporary
+# project, so every location it reports sits underneath this directory
+SCAN_ROOT_MARKER = "/.pixi/envs/default"
+CONDA_META = "/conda-meta/"
+REPORT_PREFIX = "grype-"
+REPORT_SUFFIX = ".sarif"
+
+
+def _platform(report: pathlib.Path) -> str:
+    name = report.name
+    if not name.startswith(REPORT_PREFIX) or not name.endswith(REPORT_SUFFIX):
+        raise ValueError(f"cannot read a platform from '{name}', expected {REPORT_PREFIX}<platform>{REPORT_SUFFIX}")
+
+    return name[len(REPORT_PREFIX) : -len(REPORT_SUFFIX)]
+
+
+def _relative_to_scan_root(uri: str) -> str:
+    """Rewrite a location as a path relative to the scanned environment.
+
+    Windows locations arrive looking like
+    "D:/a/_temp/grype-scan/.pixi/envs/default/\\conda-meta\\python-3.13.15-h254dcb4_101_cp313.json".
+    Grype prepends the scan root to any location that go does not consider
+    absolute, and a rooted windows path without a drive letter is not absolute.
+    Code scanning rejects the whole report if a location keeps its drive letter,
+    reading the "D:" as a URI scheme.
+    """
+    path = uri.replace("\\", "/")
+    root = path.find(SCAN_ROOT_MARKER)
+    if root != -1:
+        path = path[root + len(SCAN_ROOT_MARKER) :]
+    elif len(path) > 1 and path[1] == ":":
+        path = path[2:]
+
+    while "//" in path:
+        path = path.replace("//", "/")
+
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _without_conda_build_string(uri: str) -> str:
+    """Drop the build string from a conda-meta location.
+
+    The build string differs between platforms - python 3.13.15 is recorded as
+    conda-meta/python-3.13.15-hb101c97_101_cp313.json on linux-64 and
+    conda-meta/python-3.13.15-h254dcb4_101_cp313.json on win-64 - so it has to
+    go for the two to be recognised as the same finding.
+    """
+    if CONDA_META not in uri or not uri.endswith(".json"):
+        return uri
+
+    directory, _, name = uri.rpartition("/")
+    package, separator, _build = name[: -len(".json")].rpartition("-")
+    if not separator:
+        return uri
+
+    return f"{directory}/{package}.json"
+
+
+def _canonical_locations(result: dict) -> tuple:
+    """Canonicalise the result's locations in place, returning them for matching."""
+    uris = []
+    for location in result.get("locations", []):
+        artifact = location.get("physicalLocation", {}).get("artifactLocation", {})
+        uri = artifact.get("uri")
+        if uri is None:
+            continue
+
+        uri = _without_conda_build_string(_relative_to_scan_root(uri))
+        artifact["uri"] = uri
+        uris.append(uri)
+
+    return tuple(uris)
+
+
+def _collect(reports: list, rules: dict, results: dict, platforms: dict) -> dict:
+    """Read every report, returning the first one as the envelope to merge into."""
+    envelope = None
+
+    for report in sorted(reports):
+        platform = _platform(report)
+        with report.open() as handle:
+            sarif = json.load(handle)
+
+        runs = sarif.get("runs", [])
+        if envelope is None and runs:
+            envelope = sarif
+
+        for run in runs:
+            for rule in run.get("tool", {}).get("driver", {}).get("rules", []):
+                rules.setdefault(rule["id"], rule)
+
+            for result in run.get("results", []):
+                key = (result.get("ruleId"), _canonical_locations(result))
+                # grype fingerprints the location it found, which no longer
+                # exists once the build string is dropped; leave the fingerprint
+                # for code scanning to compute from the canonical location
+                result.pop("partialFingerprints", None)
+                results.setdefault(key, result)
+                platforms.setdefault(key, {})[platform] = None
+
+        print(f"{report.name}: {sum(len(run.get('results', [])) for run in runs)} results on {platform}")
+
+    return envelope
+
+
+def main() -> int:
+    output = pathlib.Path(sys.argv[1])
+    reports = [pathlib.Path(argument) for argument in sys.argv[2:]]
+    if not reports:
+        raise SystemExit("no reports were given to merge")
+
+    rules = {}
+    results = {}
+    platforms = {}
+    envelope = _collect(reports, rules, results, platforms)
+    if envelope is None:
+        raise SystemExit("the reports contained no runs")
+
+    ordered = sorted(results.items(), key=lambda item: (item[0][0] or "", item[0][1]))
+    for key, result in ordered:
+        found_on = ", ".join(platforms[key])
+        message = result.setdefault("message", {})
+        message["text"] = f"{message.get('text', key[0])} (detected on: {found_on})"
+
+    run = envelope["runs"][0]
+    run["tool"]["driver"]["rules"] = list(rules.values())
+    run["results"] = [result for _key, result in ordered]
+    envelope["runs"] = [run]
+
+    with output.open("w") as handle:
+        json.dump(envelope, handle, indent=2)
+
+    print(f"{output.name}: {len(run['results'])} merged results, {len(rules)} rules")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -99,6 +99,31 @@ jobs:
           fail-build: false
           only-fixed: true
 
+      - name: Normalize SARIF paths
+        # grype prepends the scan root to every location unless the location is
+        # already absolute. On windows "\conda-meta\..." is not absolute to go, so
+        # results come out as "D:/.../default/\conda-meta\openssl.json" and code
+        # scanning rejects the file - it reads the "D:" drive letter as a URI
+        # scheme. Rewrite the locations relative to the scanned environment, which
+        # is the form grype already emits on linux.
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        env:
+          ENV_DIR: ${{ steps.pixi-project.outputs.environment_dir }}
+        run: |
+          sarif=$(cygpath --mixed "${{ steps.scan.outputs.sarif }}")
+          jq --arg root "$ENV_DIR" '
+            (.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri) |=
+              ( gsub("\\\\"; "/")
+              | if startswith($root) then .[($root | length):] else . end
+              | gsub("/+"; "/")
+              | if startswith("/") then . else "/" + . end )
+          ' "$sarif" > "$sarif.normalized"
+          mv "$sarif.normalized" "$sarif"
+          echo "::group::Normalized locations"
+          jq -r '[.runs[].results[].locations[].physicalLocation.artifactLocation.uri] | unique | .[]' "$sarif"
+          echo "::endgroup::"
+
       - name: Upload vulnerability report
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -33,6 +33,8 @@ jobs:
             platform: linux-64
           - os: windows-latest
             platform: win-64
+          - os: macos-latest
+            platform: osx-arm64
 
     steps:
       - name: Checkout workflow dependencies

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -29,8 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
+        include:
+          - os: ubuntu-latest
+            platform: linux-64
+          - os: windows-latest
+            platform: win-64
 
     steps:
       - name: Checkout workflow dependencies
@@ -50,12 +53,18 @@ jobs:
         id: pixi-project
         shell: bash
         run: |
-          project_dir="${RUNNER_TEMP}/grype-scan"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # git-bash reports RUNNER_TEMP with backslashes - use a mixed path
+            # (e.g. D:/a/_temp) that both bash and native executables accept
+            project_dir="$(cygpath --mixed "$RUNNER_TEMP")/grype-scan"
+          else
+            project_dir="${RUNNER_TEMP}/grype-scan"
+          fi
           mkdir -p "$project_dir"
           cat > "$project_dir/pixi.toml" <<'EOF'
           [workspace]
           channels = ["conda-forge", "mantid/label/nightly", "mantid", "neutrons"]
-          platforms = ["linux-64"]
+          platforms = ["${{ matrix.platform }}"]
 
           [dependencies]
           mantidworkbench = "*"
@@ -95,3 +104,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+          # distinct category per platform so matrix uploads do not overwrite each other
+          category: grype-${{ matrix.platform }}

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/grype.yml
+      - .github/actions/grype/merge_sarif.py
       - .grype.yaml
   schedule:
     - cron: '0 12 * * *'
@@ -23,8 +24,6 @@ jobs:
     if: ${{ github.repository_owner == 'mantidproject' }}
     permissions:
       contents: read
-      security-events: write
-      actions: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -99,35 +98,67 @@ jobs:
           fail-build: false
           only-fixed: true
 
-      - name: Normalize SARIF paths
-        # grype prepends the scan root to every location unless the location is
-        # already absolute. On windows "\conda-meta\..." is not absolute to go, so
-        # results come out as "D:/.../default/\conda-meta\openssl.json" and code
-        # scanning rejects the file - it reads the "D:" drive letter as a URI
-        # scheme. Rewrite the locations relative to the scanned environment, which
-        # is the form grype already emits on linux.
-        if: ${{ runner.os == 'Windows' }}
+      - name: Stage SARIF report
+        id: report
         shell: bash
         env:
-          ENV_DIR: ${{ steps.pixi-project.outputs.environment_dir }}
+          SARIF: ${{ steps.scan.outputs.sarif }}
         run: |
-          sarif=$(cygpath --mixed "${{ steps.scan.outputs.sarif }}")
-          jq --arg root "$ENV_DIR" '
-            (.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri) |=
-              ( gsub("\\\\"; "/")
-              | if startswith($root) then .[($root | length):] else . end
-              | gsub("/+"; "/")
-              | if startswith("/") then . else "/" + . end )
-          ' "$sarif" > "$sarif.normalized"
-          mv "$sarif.normalized" "$sarif"
-          echo "::group::Normalized locations"
-          jq -r '[.runs[].results[].locations[].physicalLocation.artifactLocation.uri] | unique | .[]' "$sarif"
-          echo "::endgroup::"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source_path=$(cygpath --mixed "$SARIF")
+            temp_dir=$(cygpath --mixed "$RUNNER_TEMP")
+          else
+            source_path="$SARIF"
+            temp_dir="$RUNNER_TEMP"
+          fi
+          # the merge job reads the platform from the file name
+          report="$temp_dir/grype-${{ matrix.platform }}.sarif"
+          cp "$source_path" "$report"
+          echo "path=$report" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SARIF report
+        uses: actions/upload-artifact@v7
+        with:
+          name: grype-sarif-${{ matrix.platform }}
+          path: ${{ steps.report.outputs.path }}
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-and-upload:
+    # every platform has to report for the platform labels to be complete, so
+    # this deliberately does not run when one leg of the matrix failed
+    needs: scan-package
+    if: ${{ github.repository_owner == 'mantidproject' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout workflow dependencies
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/actions/grype/merge_sarif.py
+          sparse-checkout-cone-mode: false
+
+      - name: Download SARIF reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: grype-sarif-*
+          path: ${{ runner.temp }}/reports
+          merge-multiple: true
+
+      - name: Merge SARIF reports
+        run: |
+          python3 .github/actions/grype/merge_sarif.py \
+            "${{ runner.temp }}/grype.sarif" "${{ runner.temp }}"/reports/grype-*.sarif
 
       - name: Upload vulnerability report
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
-          # distinct category per platform so matrix uploads do not overwrite each other
-          category: grype-${{ matrix.platform }}
+          sarif_file: ${{ runner.temp }}/grype.sarif
+          # one category for all platforms, so the merged results are a single analysis
+          category: grype

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -164,3 +164,6 @@ jobs:
           sarif_file: ${{ runner.temp }}/grype.sarif
           # one category for all platforms, so the merged results are a single analysis
           category: grype
+      - name: Remove SARIF file
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true' }}
+        run: rm ${{ runner.temp }}/grype.sarif

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,4 +1,10 @@
 ignore:
+  # the interpreter once per executable and library that embeds it
+  # lets only track the conda version
   - package:
       name: python
+      type: binary
+  # windows is uppercase
+  - package:
+      name: Python
       type: binary


### PR DESCRIPTION
Extends the nightly grype scan to windows and macos, turning the single-runner job into a matrix and combines CVEs with descriptions about platforms affected. Strips the conda build string so the same package version matches across platforms, and groups results by rule and location, so a CVE present everywhere becomes a single alert whose message names where it was found (`... (detected on: linux-64, osx-arm64, win-64)`) rather than one alert per platform. Since everything now uploads under a single `grype` category, the stale analyses from the previous auto-generated category on main should be deleted once this has run successfully, or their alerts will stay open with nothing left to close them.

Assisted-by: Opus 4.8 <noreply@anthropic.com>

There is no associated issue.

### To test:

Look at [code scanning results for this branch](https://github.com/mantidproject/mantid/security/code-scanning?query=is%3Aopen+branch%3Agrype_about_windows++) and see that there are windows issues now too. CVE-2026-27171 is specifically windows only.

*This does not require release notes* because it is security scanning of dependencies.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
