### PR TITLE
Add a CG3 instrument entry to Facilities.xml

### DIFF
--- a/docs/source/release/v7.0.0/SANS/Bugfixes/42084.rst
+++ b/docs/source/release/v7.0.0/SANS/Bugfixes/42084.rst
@@ -1,0 +1,1 @@
+- BIOSANS data now loads with its instrument parameters attached, so :ref:`algm-SolidAngle` works again. The instrument parameters had been missing since v6.16 whenever the instrument was loaded under its short name ``CG3``.

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -465,6 +465,10 @@
      </livedata>
    </instrument>
 
+   <instrument name="CG3" shortname="CG3">
+      <technique>Small Angle Scattering</technique>
+   </instrument>
+
    <instrument name="IMAGINE" shortname="CG4D">
      <technique>Neutron Diffraction</technique>
      <technique>Single Crystal Diffraction</technique>


### PR DESCRIPTION
### Description of work

Since #41319 the instrument parameter file is resolved through `ConfigService` by instrument name, rather than from the IDF filename or by appending to the name directly. BIOSANS is declared only as

```
    <instrument name="BIOSANS" shortname="CG3">
```

so `getInstrument("CG3").name()` returns "BIOSANS" and the date-based search selects `BIOSANS_Parameters*.xml`. Its `<component-link name="BIOSANS">` matches no component in a workspace whose IDF names the instrument CG3, so the file loads without error and attaches nothing, leaving `x-pixel-size` and `y-pixel-size` unset and `SolidAngle` failing for every method other than `GenericShape`.

Declare CG3 alongside BIOSANS, mirroring the CG2 entry that already sits next to GPSANS. `getInstrument("CG3")` then resolves to CG3, the search finds the `CG3_Parameters.xml` that Mantid already ships, and its `<component-link name="CG3">` applies.

This is the narrow fix. Any instrument whose IDF component name differs from its `ConfigService` name has the same problem, and a parameter file that contributes nothing still reports success either way.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

This resolves the failing test when moving `drtsans` to Mantid 6.16: https://github.com/neutrons/drtsans/pull/1163

### To test:

```
from mantid.simpleapi import LoadEmptyInstrument

ws = LoadEmptyInstrument(Filename="CG3_Definition.xml", OutputWorkspace="cg3")
inst = ws.getInstrument()
print(inst.getName())                              # CG3
print(inst.hasParameter("x-pixel-size"))           # 6.15: True     6.16: False     After change: True
print(len(inst.getParameterNames()))               # 6.15: 11       6.16: 0         After change: 11
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
