### PR TITLE
Improve logic for linking to release notes from version number

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -126,11 +126,13 @@ std::string MantidVersion::versionForReleaseNotes(const VersionInfo &version) {
   // Convert here in those cases where patch number is of the form "20131022.1356".
   const unsigned long patchVersion = std::stoul(version.patch);
 
-  // Released versions point to their own release notes.
-  if ((patchVersion < 100 && version.tweak.empty()) || version.tweak[0] == '+' || version.tweak.substr(0, 2) == "rc") {
+  // A development/nightly version has either a .dev suffix or date-based patch.
+  const bool isDevelopmentVersion = version.tweak.starts_with(".dev") || patchVersion > 100;
+
+  // Released versions and release candidates point to their own release notes.
+  if (!isDevelopmentVersion) {
     std::stringstream versionLabel;
-    versionLabel << version.major << "." << version.minor;
-    versionLabel << "." << patchVersion;
+    versionLabel << version.major << "." << version.minor << "." << patchVersion;
     return versionLabel.str();
   }
 

--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -125,21 +125,27 @@ const MantidVersion::VersionInfo MantidVersion::versionInfo() {
 std::string MantidVersion::versionForReleaseNotes(const VersionInfo &version) {
   // Convert here in those cases where patch number is of the form "20131022.1356".
   const unsigned long patchVersion = std::stoul(version.patch);
-  // For major/minor/patch/rc/local releases we point users to a specific release-notes.
-  // For dev and nightly versions we point to the next main release notes.
-  // We assume that the next main release version number will be one minor version higher.
 
-  std::stringstream versionLabel;
-
+  // Released versions point to their own release notes.
   if ((patchVersion < 100 && version.tweak.empty()) || version.tweak[0] == '+' || version.tweak.substr(0, 2) == "rc") {
+    std::stringstream versionLabel;
     versionLabel << version.major << "." << version.minor;
     versionLabel << "." << patchVersion;
-  } else {
-    const unsigned long minorVersion = std::stoul(version.minor);
-    versionLabel << version.major << "." << minorVersion + 1 << "." << "0";
+    return versionLabel.str();
   }
 
-  return versionLabel.str();
+  // Development and nightly versions point to the next release's notes.
+  // Normally this is the next minor version, except when the next release is a major version.
+  if (version.major == "6" && version.minor == "16") {
+    // The next release after 6.16 is 7.0, rather than 6.17.
+    return "7.0.0";
+  }
+
+  const unsigned long minorVersion = std::stoul(version.minor);
+  std::stringstream nextMinorVersionLabel;
+  nextMinorVersionLabel << version.major << "." << minorVersion + 1 << "." << "0";
+
+  return nextMinorVersionLabel.str();
 }
 
 std::string MantidVersion::releaseNotes() {

--- a/Framework/Kernel/test/MantidVersionTest.h.in
+++ b/Framework/Kernel/test/MantidVersionTest.h.in
@@ -58,12 +58,20 @@ public:
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "20230310.1142", ""}), "1.3.0");
   }
 
+  void testReleaseNotesNightlyUncommitted() {
+    TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "20230310.1142", "+uncommitted"}), "1.3.0");
+  }
+
   void testReleaseNotesLocalRelease() {
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "3", "+something"}), "1.2.3");
   }
 
   void testReleaseNotesNightlyVersion7() {
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"6", "16", "20260821.1142", ""}), "7.0.0");
+  }
+
+  void testReleaseNotesDevVersion7() {
+    TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"6", "16", "3", ".dev16"}), "7.0.0");
   }
 
   void testReleaseNotesNightlyAfterVersion7() {

--- a/Framework/Kernel/test/MantidVersionTest.h.in
+++ b/Framework/Kernel/test/MantidVersionTest.h.in
@@ -62,4 +62,12 @@ public:
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "3", "+something"}), "1.2.3");
   }
 
+  void testReleaseNotesNightlyVersion7() {
+    TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"6", "16", "20260821.1142", ""}), "7.0.0");
+  }
+
+  void testReleaseNotesNightlyAfterVersion7() {
+    TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"7", "0", "20261010.1234", ""}), "7.1.0");
+  }
+
 };


### PR DESCRIPTION
### Description of work
The logic was assuming that we always increment the minor version number, so was trying to link to the 6.17.0 release notes. I added a special case for 7.0.

I also refactored the logic a bit so that it's easier to read and makes more sense.

There was also the possibility of undefined behaviour when accessing elements of the `tweak` string, which can often be an empty string. Using `starts_with` avoids this, and is available to us now we use C++20.

Closes #41990

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
- Read the logic in the code.
- New test cases provide good coverage.
- Install Linux package from here  [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_branch&build=1707)](https://builds.mantidproject.org/job/build_branch/1707/) 
`mamba install -c mantid-test/label/release-notes-fix mantidworkbench mantiddocs`
- Try opening release notes from the about widget
- Install the standalone package and try again.
Should be working in both cases.
Note that it's not working if you don't have the docs installed, I opened a [separate issue](https://github.com/mantidproject/mantid/issues/42149) for that.


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
