### PR TITLE
Add example cmake configuration for dependency graphs

### DIFF
--- a/dev-docs/source/CMakeGraphVizOptions.cmake
+++ b/dev-docs/source/CMakeGraphVizOptions.cmake
@@ -1,0 +1,20 @@
+# Include Mantid executable and library targets.
+set(GRAPHVIZ_EXECUTABLES TRUE)
+set(GRAPHVIZ_STATIC_LIBS TRUE)
+set(GRAPHVIZ_SHARED_LIBS TRUE)
+set(GRAPHVIZ_MODULE_LIBS TRUE)
+set(GRAPHVIZ_INTERFACE_LIBS TRUE)
+
+# Exclude CMake OBJECT-library targets. Individual object files are not represented as nodes in CMake's Graphviz output.
+set(GRAPHVIZ_OBJECT_LIBS FALSE)
+
+# Show only targets owned by the Mantid project, omitting linked third-party and otherwise unknown external libraries.
+set(GRAPHVIZ_EXTERNAL_LIBS FALSE)
+set(GRAPHVIZ_UNKNOWN_LIBS FALSE)
+
+# Limit output to executable and library target dependencies.
+set(GRAPHVIZ_CUSTOM_TARGETS FALSE)
+
+# Generate per-target dependency graphs, but not reverse-dependency graphs.
+set(GRAPHVIZ_GENERATE_PER_TARGET TRUE)
+set(GRAPHVIZ_GENERATE_DEPENDERS FALSE)

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -260,16 +260,58 @@ For example, to convert all loops classified as *risky* or above, we would appen
 
 clang-tidy does not have a concept of c++ standards it should use and leaves it to the developer to know which to turn on and off.
 
-Cmake chart of target dependencies
+CMake chart of target dependencies
 ----------------------------------
 
-Cmake has the ability to make graphviz dot files of the dependencies for targets in mantid.
-This is useful for understanding why compilation will wait for individual libraries to link before compiling more files.
+CMake can generate Graphviz DOT files
+showing the link dependencies between executable and library targets.
+These target-level graphs are useful
+for understanding direct and transitive dependencies
+without the source files
+and individual object files shown in a file-level build graph.
 
-.. code:: sh
+Use the following options
+to include only Mantid-owned executable and library targets.
+Download :download:`CMakeGraphVizOptions.cmake <CMakeGraphVizOptions.cmake>`
+and place it in the root of the CMake build directory.
+CMake searches the build directory for this file
+when generating the graphs.
 
-    cmake --graphviz=dependencies.dot .
-    dot -O -Tsvg dependencies.dot.WorkflowAlgorithms
+.. literalinclude:: CMakeGraphVizOptions.cmake
+   :language: cmake
 
+From the root of the build directory,
+generate the overall graph and a graph for each target
+in a dedicated subdirectory:
 
-`Cmake reference <https://cmake.org/cmake/help/latest/module/CMakeGraphVizOptions.html>`_ for configuring the tool options.
+.. code-block:: sh
+
+   mkdir -p graphviz
+   cmake --graphviz="$PWD/graphviz/mantid-targets.dot" .
+
+The overall graph is written to ``graphviz/mantid-targets.dot``.
+Each target graph appends the target name to that filename;
+for example,
+the dependencies needed to link ``APITest``
+are written to ``graphviz/mantid-targets.dot.APITest``.
+Render that graph as SVG
+and automatically name the output after the input file with:
+
+.. code-block:: sh
+
+   dot -Tsvg -O graphviz/mantid-targets.dot.APITest
+
+This writes ``graphviz/mantid-targets.dot.APITest.svg``.
+The ``-O`` option also accepts multiple input files
+and automatically names each output:
+
+.. code-block:: sh
+
+   dot -Tsvg -O graphviz/mantid-targets.dot.APITest graphviz/mantid-targets.dot.API
+
+See the CMake documentation for
+`generating Graphviz dependency graphs <https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-graphviz>`_
+and configuring the available
+`Graphviz options <https://cmake.org/cmake/help/latest/module/CMakeGraphVizOptions.html>`_.
+See the `dot documentation <https://graphviz.org/documentation/>`_
+for more options on converting the diagrams to something more easily viewed.


### PR DESCRIPTION
The cmake configuration makes sure that it is all of the mantid targets are shown at a high enough level where the details aren't lost.

Assisted-by: GPT-5.6 Codex <noreply@openai.com>

There is no associated issue.

### To test:

Build the developer docs and look at `dev-docs/html/ToolsOverview.html`. 

*This does not require release notes* because it is a change to the developer docs.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
