### PR TITLE
Allow live-data instruments from any facility

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/LiveDataAlgorithm.h
+++ b/Framework/LiveData/inc/MantidLiveData/LiveDataAlgorithm.h
@@ -9,7 +9,11 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/ILiveListener.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/FacilityInfo.h"
 #include "MantidLiveData/DllConfig.h"
+
+#include <string>
+#include <vector>
 
 namespace Mantid {
 namespace LiveData {
@@ -27,6 +31,12 @@ public:
   const std::string category() const override;
 
   void copyPropertyValuesFrom(const LiveDataAlgorithm &other);
+
+  /// The facility that 'Instrument' is resolved against: 'Facility' if given, else the Mantid default.
+  const Kernel::FacilityInfo &facility() const;
+
+  /// Instrument names, in `facility()`, that have a live listener configured.
+  std::vector<std::string> liveListenerInstruments() const;
 
   Mantid::API::ILiveListener_sptr getLiveListener(bool start = true);
   Mantid::API::ILiveListener_sptr createLiveListener(bool connect = false);

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -25,6 +25,11 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using Mantid::Types::Core::DateAndTime;
 
+namespace {
+/// `ConfigService` returns a placeholder facility, whose name is blank, when no default is set.
+bool isBlankFacilityName(const std::string &name) { return name.find_first_not_of(" \t\n\r") == std::string::npos; }
+} // namespace
+
 namespace Mantid::LiveData {
 
 /// Algorithm's category for identification. @see Algorithm::category
@@ -41,9 +46,19 @@ const std::string LiveDataAlgorithm::category() const { return "DataHandling\\Li
  */
 const Kernel::FacilityInfo &LiveDataAlgorithm::facility() const {
   const std::string facilityName = getPropertyValue("Facility");
-  // `getFacility("")` already returns the default facility, but be explicit about the intent.
-  return facilityName.empty() ? Kernel::ConfigService::Instance().getFacility()
-                              : Kernel::ConfigService::Instance().getFacility(facilityName);
+  if (!facilityName.empty()) {
+    return Kernel::ConfigService::Instance().getFacility(facilityName);
+  }
+
+  // `ConfigService::getFacility()` does not fail when 'default.facility' is unset: it returns a
+  // placeholder facility whose name is blank and which owns no real instruments.  Reject that here,
+  // rather than letting it surface further down as a baffling complaint that the instrument is not
+  // part of facility ' '.
+  const auto &defaultFacility = Kernel::ConfigService::Instance().getFacility();
+  if (isBlankFacilityName(defaultFacility.name())) {
+    throw Exception::NotFoundError("Facilities", "<no default facility is set>");
+  }
+  return defaultFacility;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -364,8 +379,13 @@ std::map<std::string, std::string> LiveDataAlgorithm::validateInputs() {
     std::transform(facilities.cbegin(), facilities.cend(), knownFacilities.begin(),
                    [](const auto &knownFacility) { return knownFacility->name(); });
     std::sort(knownFacilities.begin(), knownFacilities.end());
-    out["Facility"] = "Facility '" + facilityName + "' is not known to Mantid. Known facilities are: " +
-                      Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ") + ".";
+    const std::string known = Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ");
+    out["Facility"] = facilityName.empty() ? "No facility was specified and Mantid has no default facility set. Set "
+                                             "'Facility', or set a default facility in the Mantid configuration. "
+                                             "Known facilities are: " +
+                                                 known + "."
+                                           : "Facility '" + facilityName +
+                                                 "' is not known to Mantid. Known facilities are: " + known + ".";
     return out;
   }
 

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -11,10 +11,12 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/FacilityInfo.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Strings.h"
 
+#include <algorithm>
 #include <boost/algorithm/string/trim.hpp>
 #include <unordered_set>
 #include <utility>
@@ -32,15 +34,25 @@ const std::string LiveDataAlgorithm::category() const { return "DataHandling\\Li
 /** Initialize the algorithm's properties.
  */
 void LiveDataAlgorithm::initProps() {
-  // Add all the instruments (in the default facility) that have a listener
-  // specified
+  // Add all the instruments, in any facility, that have a listener specified.
+  //
+  // Note that these are deliberately *not* restricted to the default facility.  `createLiveListener`
+  // resolves the instrument using `ConfigService::getInstrument`, which searches every facility, so a
+  // list restricted to the default facility would reject instruments this algorithm is perfectly able
+  // to use -- and would be empty altogether for a user whose default facility has no live listeners.
+  // The `Facility` property below disambiguates when an instrument name occurs in more than one
+  // facility.
   std::vector<std::string> instruments;
-  const auto &instrInfo = Kernel::ConfigService::Instance().getFacility().instruments();
-  for (const auto &instrument : instrInfo) {
-    if (instrument.hasLiveListenerInfo()) {
-      instruments.emplace_back(instrument.name());
+  for (const auto &facility : Kernel::ConfigService::Instance().getFacilities()) {
+    for (const auto &instrument : facility->instruments()) {
+      if (instrument.hasLiveListenerInfo()) {
+        instruments.emplace_back(instrument.name());
+      }
     }
   }
+  // The same instrument name may appear in more than one facility.
+  std::sort(instruments.begin(), instruments.end());
+  instruments.erase(std::unique(instruments.begin(), instruments.end()), instruments.end());
 
   // All available listener class names
   auto listeners = LiveListenerFactory::Instance().getKeys();
@@ -49,6 +61,10 @@ void LiveDataAlgorithm::initProps() {
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("Instrument", "",
                                                                    std::make_shared<StringListValidator>(instruments)),
                   "Name of the instrument to monitor.");
+
+  declareProperty(std::make_unique<PropertyWithValue<std::string>>("Facility", "", Direction::Input),
+                  "Facility owning 'Instrument'. If not specified, the instrument is looked up in the "
+                  "default facility first, and then in all other facilities.");
 
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("Connection", "", Direction::Input),
                   "Selects the listener connection entry to use. "
@@ -203,9 +219,13 @@ ILiveListener_sptr LiveDataAlgorithm::getLiveListener(bool start) {
 ILiveListener_sptr LiveDataAlgorithm::createLiveListener(bool connect) {
   // Get the LiveListenerInfo from Facilities.xml
   std::string inst_name = this->getPropertyValue("Instrument");
+  std::string facility_name = this->getPropertyValue("Facility");
   std::string conn_name = this->getPropertyValue("Connection");
 
-  const auto &inst = ConfigService::Instance().getInstrument(inst_name);
+  // When a facility is named, resolve the instrument within it: `getInstrument` would otherwise
+  // search the default facility first, which silently prefers a same-named instrument there.
+  const auto &inst = facility_name.empty() ? ConfigService::Instance().getInstrument(inst_name)
+                                           : ConfigService::Instance().getFacility(facility_name).instrument(inst_name);
   const auto &conn = inst.liveListenerInfo(conn_name);
 
   // See if listener and/or address override has been specified
@@ -312,6 +332,30 @@ std::map<std::string, std::string> LiveDataAlgorithm::validateInputs() {
   std::map<std::string, std::string> out;
 
   const std::string instrument = getPropertyValue("Instrument");
+  const std::string facility = getPropertyValue("Facility");
+
+  // Resolve the instrument before anything else.  `createLiveListener` below throws a `NotFoundError`
+  // for an unknown facility or instrument, which escapes `validateInputs` as an exception rather than
+  // being reported against the offending property.
+  if (!facility.empty()) {
+    try {
+      const auto &facilityInfo = ConfigService::Instance().getFacility(facility);
+      try {
+        if (!facilityInfo.instrument(instrument).hasLiveListenerInfo()) {
+          out["Instrument"] = "Instrument '" + instrument + "' in facility '" + facility +
+                              "' has no live listener; live data cannot be collected from it.";
+          return out;
+        }
+      } catch (const Exception::NotFoundError &) {
+        out["Instrument"] = "Instrument '" + instrument + "' is not part of facility '" + facility + "'.";
+        return out;
+      }
+    } catch (const Exception::NotFoundError &) {
+      out["Facility"] = "Facility '" + facility + "' is not known to Mantid.";
+      return out;
+    }
+  }
+
   bool eventListener;
   if (m_listener) {
     eventListener = m_listener->buffersEvents();

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -353,10 +353,10 @@ std::map<std::string, std::string> LiveDataAlgorithm::validateInputs() {
     } catch (const Exception::NotFoundError &) {
       // List the known facilities: 'Facility' carries no list validator, so this message is the only
       // discoverability a caller gets.
-      std::vector<std::string> knownFacilities;
-      for (const auto &knownFacility : ConfigService::Instance().getFacilities()) {
-        knownFacilities.emplace_back(knownFacility->name());
-      }
+      const auto facilities = ConfigService::Instance().getFacilities();
+      std::vector<std::string> knownFacilities(facilities.size());
+      std::transform(facilities.cbegin(), facilities.cend(), knownFacilities.begin(),
+                     [](const auto &knownFacility) { return knownFacility->name(); });
       std::sort(knownFacilities.begin(), knownFacilities.end());
       out["Facility"] = "Facility '" + facility + "' is not known to Mantid. Known facilities are: " +
                         Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ") + ".";

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -351,7 +351,15 @@ std::map<std::string, std::string> LiveDataAlgorithm::validateInputs() {
         return out;
       }
     } catch (const Exception::NotFoundError &) {
-      out["Facility"] = "Facility '" + facility + "' is not known to Mantid.";
+      // List the known facilities: 'Facility' carries no list validator, so this message is the only
+      // discoverability a caller gets.
+      std::vector<std::string> knownFacilities;
+      for (const auto &knownFacility : ConfigService::Instance().getFacilities()) {
+        knownFacilities.emplace_back(knownFacility->name());
+      }
+      std::sort(knownFacilities.begin(), knownFacilities.end());
+      out["Facility"] = "Facility '" + facility + "' is not known to Mantid. Known facilities are: " +
+                        Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ") + ".";
       return out;
     }
   }

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -31,40 +31,55 @@ namespace Mantid::LiveData {
 const std::string LiveDataAlgorithm::category() const { return "DataHandling\\LiveData"; }
 
 //----------------------------------------------------------------------------------------------
+/** The facility that 'Instrument' is resolved against.
+ *
+ * An instrument name is only meaningful with respect to a facility, and instrument names are not
+ * unique across facilities.  Resolution is therefore confined to a single facility: the one named by
+ * 'Facility', or the Mantid default facility when that property is not set.
+ *
+ * @throw Exception::NotFoundError if 'Facility' names a facility Mantid does not know.
+ */
+const Kernel::FacilityInfo &LiveDataAlgorithm::facility() const {
+  const std::string facilityName = getPropertyValue("Facility");
+  // `getFacility("")` already returns the default facility, but be explicit about the intent.
+  return facilityName.empty() ? Kernel::ConfigService::Instance().getFacility()
+                              : Kernel::ConfigService::Instance().getFacility(facilityName);
+}
+
+//----------------------------------------------------------------------------------------------
+/// @return names of the instruments in `facility()` that have a live listener configured.
+std::vector<std::string> LiveDataAlgorithm::liveListenerInstruments() const {
+  const auto &instruments = facility().instruments();
+  std::vector<std::string> names;
+  names.reserve(instruments.size());
+  std::for_each(instruments.cbegin(), instruments.cend(), [&names](const auto &instrument) {
+    if (instrument.hasLiveListenerInfo()) {
+      names.emplace_back(instrument.name());
+    }
+  });
+  std::sort(names.begin(), names.end());
+  return names;
+}
+
+//----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
  */
 void LiveDataAlgorithm::initProps() {
-  // Add all the instruments, in any facility, that have a listener specified.
-  //
-  // Note that these are deliberately *not* restricted to the default facility.  `createLiveListener`
-  // resolves the instrument using `ConfigService::getInstrument`, which searches every facility, so a
-  // list restricted to the default facility would reject instruments this algorithm is perfectly able
-  // to use -- and would be empty altogether for a user whose default facility has no live listeners.
-  // The `Facility` property below disambiguates when an instrument name occurs in more than one
-  // facility.
-  std::vector<std::string> instruments;
-  for (const auto &facility : Kernel::ConfigService::Instance().getFacilities()) {
-    for (const auto &instrument : facility->instruments()) {
-      if (instrument.hasLiveListenerInfo()) {
-        instruments.emplace_back(instrument.name());
-      }
-    }
-  }
-  // The same instrument name may appear in more than one facility.
-  std::sort(instruments.begin(), instruments.end());
-  instruments.erase(std::unique(instruments.begin(), instruments.end()), instruments.end());
-
   // All available listener class names
   auto listeners = LiveListenerFactory::Instance().getKeys();
   listeners.emplace_back(""); // Allow not specifying a listener too
 
-  declareProperty(std::make_unique<PropertyWithValue<std::string>>("Instrument", "",
-                                                                   std::make_shared<StringListValidator>(instruments)),
+  // Note that 'Instrument' carries no list validator.  Which instruments are valid depends on the
+  // facility, and the facility is itself a property: property values are only set *after*
+  // initialization, so a validator built here could never take 'Facility' into account.  The
+  // instrument and the facility are therefore validated together in `validateInputs`, which is the
+  // first point at which the default facility, whether 'Facility' was given, and the instrument name
+  // are all known.
+  declareProperty(std::make_unique<PropertyWithValue<std::string>>("Instrument", "", Direction::Input),
                   "Name of the instrument to monitor.");
 
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("Facility", "", Direction::Input),
-                  "Facility owning 'Instrument'. If not specified, the instrument is looked up in the "
-                  "default facility first, and then in all other facilities.");
+                  "Facility owning 'Instrument'. The Mantid default facility is used if not specified.");
 
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("Connection", "", Direction::Input),
                   "Selects the listener connection entry to use. "
@@ -219,13 +234,13 @@ ILiveListener_sptr LiveDataAlgorithm::getLiveListener(bool start) {
 ILiveListener_sptr LiveDataAlgorithm::createLiveListener(bool connect) {
   // Get the LiveListenerInfo from Facilities.xml
   std::string inst_name = this->getPropertyValue("Instrument");
-  std::string facility_name = this->getPropertyValue("Facility");
   std::string conn_name = this->getPropertyValue("Connection");
 
-  // When a facility is named, resolve the instrument within it: `getInstrument` would otherwise
-  // search the default facility first, which silently prefers a same-named instrument there.
-  const auto &inst = facility_name.empty() ? ConfigService::Instance().getInstrument(inst_name)
-                                           : ConfigService::Instance().getFacility(facility_name).instrument(inst_name);
+  // Resolve the instrument within a single facility.  `ConfigService::getInstrument` would instead
+  // fall back to searching every other facility, which defeats the purpose of having a default
+  // facility and cannot cope with instrument names shared between facilities.  Naming 'Facility' is
+  // how an instrument outside the default facility is selected.
+  const auto &inst = facility().instrument(inst_name);
   const auto &conn = inst.liveListenerInfo(conn_name);
 
   // See if listener and/or address override has been specified
@@ -332,36 +347,46 @@ std::map<std::string, std::string> LiveDataAlgorithm::validateInputs() {
   std::map<std::string, std::string> out;
 
   const std::string instrument = getPropertyValue("Instrument");
-  const std::string facility = getPropertyValue("Facility");
+  const std::string facilityName = getPropertyValue("Facility");
 
-  // Resolve the instrument before anything else.  `createLiveListener` below throws a `NotFoundError`
-  // for an unknown facility or instrument, which escapes `validateInputs` as an exception rather than
-  // being reported against the offending property.
-  if (!facility.empty()) {
-    try {
-      const auto &facilityInfo = ConfigService::Instance().getFacility(facility);
-      try {
-        if (!facilityInfo.instrument(instrument).hasLiveListenerInfo()) {
-          out["Instrument"] = "Instrument '" + instrument + "' in facility '" + facility +
-                              "' has no live listener; live data cannot be collected from it.";
-          return out;
-        }
-      } catch (const Exception::NotFoundError &) {
-        out["Instrument"] = "Instrument '" + instrument + "' is not part of facility '" + facility + "'.";
-        return out;
-      }
-    } catch (const Exception::NotFoundError &) {
-      // List the known facilities: 'Facility' carries no list validator, so this message is the only
-      // discoverability a caller gets.
-      const auto facilities = ConfigService::Instance().getFacilities();
-      std::vector<std::string> knownFacilities(facilities.size());
-      std::transform(facilities.cbegin(), facilities.cend(), knownFacilities.begin(),
-                     [](const auto &knownFacility) { return knownFacility->name(); });
-      std::sort(knownFacilities.begin(), knownFacilities.end());
-      out["Facility"] = "Facility '" + facility + "' is not known to Mantid. Known facilities are: " +
-                        Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ") + ".";
+  // Validate the instrument together with the facility.  This is the first point at which all three
+  // of the default facility, whether 'Facility' was given, and the instrument name are known.  It
+  // must also happen before anything below, because `createLiveListener` throws a `NotFoundError` for
+  // an unresolvable instrument, which would escape `validateInputs` instead of being reported against
+  // the property at fault.
+  const Kernel::FacilityInfo *facilityInfo{nullptr};
+  try {
+    facilityInfo = &facility();
+  } catch (const Exception::NotFoundError &) {
+    // 'Facility' has no list validator, so this message is the only discoverability a caller gets.
+    const auto facilities = ConfigService::Instance().getFacilities();
+    std::vector<std::string> knownFacilities(facilities.size());
+    std::transform(facilities.cbegin(), facilities.cend(), knownFacilities.begin(),
+                   [](const auto &knownFacility) { return knownFacility->name(); });
+    std::sort(knownFacilities.begin(), knownFacilities.end());
+    out["Facility"] = "Facility '" + facilityName + "' is not known to Mantid. Known facilities are: " +
+                      Strings::join(knownFacilities.cbegin(), knownFacilities.cend(), ", ") + ".";
+    return out;
+  }
+
+  if (instrument.empty()) {
+    out["Instrument"] = "Must specify the Instrument.";
+    return out;
+  }
+
+  try {
+    if (!facilityInfo->instrument(instrument).hasLiveListenerInfo()) {
+      out["Instrument"] = "Instrument '" + instrument + "' in facility '" + facilityInfo->name() +
+                          "' has no live listener; live data cannot be collected from it.";
       return out;
     }
+  } catch (const Exception::NotFoundError &) {
+    const auto candidates = liveListenerInstruments();
+    out["Instrument"] = "Instrument '" + instrument + "' is not part of facility '" + facilityInfo->name() +
+                        "'. Instruments there with a live listener are: " +
+                        Strings::join(candidates.cbegin(), candidates.cend(), ", ") +
+                        ". Set 'Facility' to select an instrument from another facility.";
+    return out;
   }
 
   bool eventListener;

--- a/Framework/LiveData/src/StartLiveData.cpp
+++ b/Framework/LiveData/src/StartLiveData.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/Workspace.h"
 #include "MantidKernel/ArrayBoundedValidator.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/Exception.h"
 #include "MantidLiveData/LoadLiveData.h"
 #include "MantidLiveData/MonitorLiveData.h"
 #include "MantidTypes/Core/DateAndTime.h"
@@ -80,16 +81,26 @@ void StartLiveData::init() {
  * @param propName Name of property that was just set
  */
 void StartLiveData::afterPropertySet(const std::string &propName) {
-  // If any of these properties change, the listener class might change
-  if (propName == "Instrument" || propName == "Listener" || propName == "Connection") {
+  // If any of these properties change, the listener class might change.
+  //   'Facility' belongs here too: it selects which facility 'Instrument' is resolved against, and so
+  //   which listener applies.
+  if (propName == "Instrument" || propName == "Facility" || propName == "Listener" || propName == "Connection") {
     // Properties of old listener, if any, need to be removed
     removeListenerProperties();
 
-    // Get temp instance of listener for this instrument with current properties
-    auto listener = createLiveListener();
+    // Get temp instance of listener for this instrument with current properties.
+    //   The instrument may not be resolvable yet -- properties are set one at a time, so 'Facility'
+    //   may arrive before 'Instrument', or the pair may not (yet) be consistent.  There is nothing to
+    //   surface in that case, and the pair is properly reported against its property in
+    //   `validateInputs`; so do not let a partially configured algorithm throw from a property setter.
+    try {
+      auto listener = createLiveListener();
 
-    // Copy over properties of listener to this algorithm
-    copyListenerProperties(listener);
+      // Copy over properties of listener to this algorithm
+      copyListenerProperties(listener);
+    } catch (const Exception::NotFoundError &e) {
+      g_log.debug() << "Cannot list listener properties yet: " << e.what() << "\n";
+    }
   }
 }
 

--- a/Framework/LiveData/test/LiveDataAlgorithmTest.h
+++ b/Framework/LiveData/test/LiveDataAlgorithmTest.h
@@ -110,7 +110,8 @@ public:
     LiveDataAlgorithmImpl alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
 
-    const auto allowed = alg.getProperty("Instrument")->allowedValues();
+    const Mantid::Kernel::Property *instrumentProp = alg.getProperty("Instrument");
+    const auto allowed = instrumentProp->allowedValues();
     TSM_ASSERT("instrument in the default facility", contains(allowed, "DEFAULTLISTENER"));
     TSM_ASSERT("instrument in another facility", contains(allowed, "OTHERLISTENER"));
     TSM_ASSERT("instrument without live data", !contains(allowed, "NOLIVEDATA"));
@@ -126,9 +127,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Facility", "TESTOTHER"))
     alg.setPropertyValue("OutputWorkspace", "out_ws");
 
-    const auto errors = alg.validateInputs();
-    TS_ASSERT_EQUALS(errors.count("Instrument"), 0)
-    TS_ASSERT_EQUALS(errors.count("Facility"), 0)
+    auto errors = alg.validateInputs();
+    TSM_ASSERT("instrument from another facility is accepted", errors["Instrument"].empty());
+    TSM_ASSERT("named facility is accepted", errors["Facility"].empty());
   }
 
   void test_Facility_defaults_to_empty() {

--- a/Framework/LiveData/test/LiveDataAlgorithmTest.h
+++ b/Framework/LiveData/test/LiveDataAlgorithmTest.h
@@ -13,6 +13,7 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/Timer.h"
 #include "MantidLiveData/LiveDataAlgorithm.h"
+#include <algorithm>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid;
@@ -37,6 +38,11 @@ public:
 };
 
 class LiveDataAlgorithmTest : public CxxTest::TestSuite {
+private:
+  static bool contains(const std::vector<std::string> &values, const std::string &item) {
+    return std::find(values.cbegin(), values.cend(), item) != values.cend();
+  }
+
 public:
   void test_initProps() {
     LiveDataAlgorithmImpl alg;
@@ -89,6 +95,72 @@ public:
     alg.setPropertyValue("Instrument", "TESTHISTOLISTENER");
     alg.setPropertyValue("AccumulationMethod", "Add");
     TSM_ASSERT("Shouldn't add histograms", !alg.validateInputs()["AccumulationMethod"].empty());
+  }
+
+  /**
+   * The `Instrument` property must offer live-data instruments from *every* facility, not only from
+   * the default one.  `createLiveListener` resolves the instrument with
+   * `ConfigService::getInstrument`, which searches all facilities, so a list restricted to the
+   * default facility rejects instruments the algorithm can actually use -- and is empty altogether
+   * for a default facility that has no live listeners.
+   */
+  void test_instrument_allowed_values_span_all_facilities() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+
+    const auto allowed = alg.getProperty("Instrument")->allowedValues();
+    TSM_ASSERT("instrument in the default facility", contains(allowed, "DEFAULTLISTENER"));
+    TSM_ASSERT("instrument in another facility", contains(allowed, "OTHERLISTENER"));
+    TSM_ASSERT("instrument without live data", !contains(allowed, "NOLIVEDATA"));
+  }
+
+  /** An instrument from a non-default facility must be selectable, which is the whole point. */
+  void test_instrument_from_another_facility_is_accepted() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Instrument", "OTHERLISTENER"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Facility", "TESTOTHER"))
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    const auto errors = alg.validateInputs();
+    TS_ASSERT_EQUALS(errors.count("Instrument"), 0)
+    TS_ASSERT_EQUALS(errors.count("Facility"), 0)
+  }
+
+  void test_Facility_defaults_to_empty() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT_EQUALS(alg.getPropertyValue("Facility"), "")
+  }
+
+  void test_validateInputs_unknown_facility() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Instrument", "DEFAULTLISTENER");
+    alg.setPropertyValue("Facility", "NOT_A_FACILITY");
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    TSM_ASSERT("unknown facility is reported", !alg.validateInputs()["Facility"].empty());
+  }
+
+  void test_validateInputs_instrument_not_in_named_facility() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Instrument", "OTHERLISTENER");
+    alg.setPropertyValue("Facility", "TESTDEFAULT");
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    TSM_ASSERT("mismatched instrument is reported", !alg.validateInputs()["Instrument"].empty());
   }
 
   /** Test creating the processing algorithm.

--- a/Framework/LiveData/test/LiveDataAlgorithmTest.h
+++ b/Framework/LiveData/test/LiveDataAlgorithmTest.h
@@ -11,6 +11,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidFrameworkTestHelpers/FacilityHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Timer.h"
 #include "MantidLiveData/LiveDataAlgorithm.h"
 #include <algorithm>
@@ -195,6 +196,25 @@ public:
     alg.setPropertyValue("OutputWorkspace", "out_ws");
 
     TSM_ASSERT("instrument with no live listener is reported", !alg.validateInputs()["Instrument"].empty());
+  }
+
+  /** An unset default facility must be reported, not silently accepted as a blank facility. */
+  void test_validateInputs_no_default_facility() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    auto &config = Mantid::Kernel::ConfigService::Instance();
+    const std::string savedFacility = config.getString("default.facility");
+    config.setString("default.facility", "");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Instrument", "DEFAULTLISTENER");
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    const auto errors = alg.validateInputs();
+    config.setString("default.facility", savedFacility);
+
+    TSM_ASSERT("unset default facility is reported", !errors.at("Facility").empty());
   }
 
   void test_validateInputs_missing_instrument() {

--- a/Framework/LiveData/test/LiveDataAlgorithmTest.h
+++ b/Framework/LiveData/test/LiveDataAlgorithmTest.h
@@ -98,37 +98,58 @@ public:
   }
 
   /**
-   * The `Instrument` property must offer live-data instruments from *every* facility, not only from
-   * the default one.  `createLiveListener` resolves the instrument with
-   * `ConfigService::getInstrument`, which searches all facilities, so a list restricted to the
-   * default facility rejects instruments the algorithm can actually use -- and is empty altogether
-   * for a default facility that has no live listeners.
+   * An instrument name is only meaningful with respect to a facility, so `Instrument` carries no list
+   * validator: the valid set depends on `Facility`, whose value is not available until after
+   * initialization.  Validation happens in `validateInputs` instead.
    */
-  void test_instrument_allowed_values_span_all_facilities() {
+  void test_instrument_has_no_list_validator() {
     FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
 
     LiveDataAlgorithmImpl alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
 
     const Mantid::Kernel::Property *instrumentProp = alg.getProperty("Instrument");
-    const auto allowed = instrumentProp->allowedValues();
-    TSM_ASSERT("instrument in the default facility", contains(allowed, "DEFAULTLISTENER"));
-    TSM_ASSERT("instrument in another facility", contains(allowed, "OTHERLISTENER"));
-    TSM_ASSERT("instrument without live data", !contains(allowed, "NOLIVEDATA"));
+    TSM_ASSERT("no frozen allowed-values list", instrumentProp->allowedValues().empty());
   }
 
-  /** An instrument from a non-default facility must be selectable, which is the whole point. */
-  void test_instrument_from_another_facility_is_accepted() {
+  /** Resolution is confined to one facility: the default one when 'Facility' is not given. */
+  void test_liveListenerInstruments_uses_the_default_facility() {
     FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
 
     LiveDataAlgorithmImpl alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Instrument", "OTHERLISTENER"))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Facility", "TESTOTHER"))
+
+    const auto instruments = alg.liveListenerInstruments();
+    TSM_ASSERT("default facility's listener instrument", contains(instruments, "DEFAULTLISTENER"));
+    TSM_ASSERT("other facility is not searched", !contains(instruments, "OTHERLISTENER"));
+    TSM_ASSERT("instrument without live data", !contains(instruments, "NOLIVEDATA"));
+  }
+
+  /** Naming 'Facility' moves resolution to that facility. */
+  void test_liveListenerInstruments_uses_the_named_facility() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Facility", "TESTOTHER");
+
+    const auto instruments = alg.liveListenerInstruments();
+    TSM_ASSERT("named facility's listener instrument", contains(instruments, "OTHERLISTENER"));
+    TSM_ASSERT("default facility is no longer searched", !contains(instruments, "DEFAULTLISTENER"));
+  }
+
+  /** The point of the facility argument: an instrument outside the default facility is selectable. */
+  void test_instrument_in_named_facility_is_accepted() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Instrument", "OTHERLISTENER");
+    alg.setPropertyValue("Facility", "TESTOTHER");
     alg.setPropertyValue("OutputWorkspace", "out_ws");
 
     auto errors = alg.validateInputs();
-    TSM_ASSERT("instrument from another facility is accepted", errors["Instrument"].empty());
+    TSM_ASSERT("instrument in the named facility is accepted", errors["Instrument"].empty());
     TSM_ASSERT("named facility is accepted", errors["Facility"].empty());
   }
 
@@ -152,16 +173,38 @@ public:
     TSM_ASSERT("unknown facility is reported", !alg.validateInputs()["Facility"].empty());
   }
 
-  void test_validateInputs_instrument_not_in_named_facility() {
+  /** An instrument outside the resolved facility is rejected, rather than found elsewhere. */
+  void test_validateInputs_instrument_outside_the_resolved_facility() {
     FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
 
     LiveDataAlgorithmImpl alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    // 'OTHERLISTENER' exists, but in TESTOTHER, and no facility is named here.
     alg.setPropertyValue("Instrument", "OTHERLISTENER");
-    alg.setPropertyValue("Facility", "TESTDEFAULT");
     alg.setPropertyValue("OutputWorkspace", "out_ws");
 
-    TSM_ASSERT("mismatched instrument is reported", !alg.validateInputs()["Instrument"].empty());
+    TSM_ASSERT("instrument outside the default facility is reported", !alg.validateInputs()["Instrument"].empty());
+  }
+
+  void test_validateInputs_instrument_without_live_listener() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("Instrument", "NOLIVEDATA");
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    TSM_ASSERT("instrument with no live listener is reported", !alg.validateInputs()["Instrument"].empty());
+  }
+
+  void test_validateInputs_missing_instrument() {
+    FacilityHelper::ScopedFacilities loadTESTFacility("unit_testing/UnitTestFacilitiesMultiple.xml", "TESTDEFAULT");
+
+    LiveDataAlgorithmImpl alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setPropertyValue("OutputWorkspace", "out_ws");
+
+    TSM_ASSERT("missing instrument is reported", !alg.validateInputs()["Instrument"].empty());
   }
 
   /** Test creating the processing algorithm.

--- a/docs/source/algorithms/StartLiveData-v1.rst
+++ b/docs/source/algorithms/StartLiveData-v1.rst
@@ -103,6 +103,11 @@ Getting Started
 1. **Configure Mantid settings** - Open Workbench: File → Settings. Set Facility (e.g., "SNS" or "ISIS")
    and Default Instrument (e.g., "POWGEN", "REF_M")
 
+   This is a convenience rather than a requirement: any instrument with a live listener may be
+   selected, whichever facility owns it. Set the ``Facility`` property to name that facility
+   explicitly, which is also how an instrument name occurring in more than one facility is
+   disambiguated.
+
 2. **Open StartLiveData** - Click the algorithm search or press Ctrl+F, type "StartLiveData" and open it
 
 3. **Configure basic properties:**

--- a/docs/source/algorithms/StartLiveData-v1.rst
+++ b/docs/source/algorithms/StartLiveData-v1.rst
@@ -103,10 +103,10 @@ Getting Started
 1. **Configure Mantid settings** - Open Workbench: File → Settings. Set Facility (e.g., "SNS" or "ISIS")
    and Default Instrument (e.g., "POWGEN", "REF_M")
 
-   This is a convenience rather than a requirement: any instrument with a live listener may be
-   selected, whichever facility owns it. Set the ``Facility`` property to name that facility
-   explicitly, which is also how an instrument name occurring in more than one facility is
-   disambiguated.
+   The instrument list offered by this dialog comes from the default facility. To use an instrument
+   belonging to a different facility, set the ``Facility`` property, which selects the facility that
+   ``Instrument`` is resolved against. This is also how an instrument name occurring in more than one
+   facility is disambiguated.
 
 2. **Open StartLiveData** - Click the algorithm search or press Ctrl+F, type "StartLiveData" and open it
 

--- a/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/00000.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/00000.rst
@@ -1,9 +1,0 @@
-- The live-data algorithms (:ref:`StartLiveData <algm-StartLiveData>`, :ref:`LoadLiveData
-  <algm-LoadLiveData>` and :ref:`MonitorLiveData <algm-MonitorLiveData>`) no longer restrict their
-  ``Instrument`` property to instruments belonging to the *default* facility. Previously, selecting an
-  instrument was impossible whenever the user's default facility differed from the one owning that
-  instrument, even though execution itself has always resolved the instrument across all facilities.
-  For a default facility with no live listeners at all, the property accepted no value whatsoever.
-  A new optional ``Facility`` property has also been added, which disambiguates instrument names that
-  occur in more than one facility, and mismatches between ``Facility`` and ``Instrument`` are now
-  reported against the offending property instead of raising an exception.

--- a/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/00000.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/00000.rst
@@ -1,0 +1,9 @@
+- The live-data algorithms (:ref:`StartLiveData <algm-StartLiveData>`, :ref:`LoadLiveData
+  <algm-LoadLiveData>` and :ref:`MonitorLiveData <algm-MonitorLiveData>`) no longer restrict their
+  ``Instrument`` property to instruments belonging to the *default* facility. Previously, selecting an
+  instrument was impossible whenever the user's default facility differed from the one owning that
+  instrument, even though execution itself has always resolved the instrument across all facilities.
+  For a default facility with no live listeners at all, the property accepted no value whatsoever.
+  A new optional ``Facility`` property has also been added, which disambiguates instrument names that
+  occur in more than one facility, and mismatches between ``Facility`` and ``Instrument`` are now
+  reported against the offending property instead of raising an exception.

--- a/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/42089.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/42089.rst
@@ -1,5 +1,8 @@
-- The live-data algorithms, such as :ref:`StartLiveData <algm-StartLiveData>`, no longer restrict their
-  ``Instrument`` property to instruments belonging to the *default* facility. Choosing an instrument
-  owned by any other facility was previously impossible, even though execution has always resolved
-  instruments across every facility, and the property accepted no value at all when the default
-  facility had no live listeners.
+- The live-data algorithms, such as :ref:`StartLiveData <algm-StartLiveData>`, previously could not use
+  an instrument outside the default facility at all, since the allowed values for ``Instrument`` were
+  built from the default facility alone. Naming the new ``Facility`` property now selects the facility
+  that ``Instrument`` is resolved against.
+- Resolving ``Instrument`` no longer falls back to searching every other facility once the resolved
+  facility has been tried. That fallback made instrument names shared between facilities ambiguous, and
+  worked against the purpose of having a default facility. Scripts that relied on an instrument being
+  found outside the default facility must now name its ``Facility``.

--- a/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/42089.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/42089.rst
@@ -1,0 +1,5 @@
+- The live-data algorithms, such as :ref:`StartLiveData <algm-StartLiveData>`, no longer restrict their
+  ``Instrument`` property to instruments belonging to the *default* facility. Choosing an instrument
+  owned by any other facility was previously impossible, even though execution has always resolved
+  instruments across every facility, and the property accepted no value at all when the default
+  facility had no live listeners.

--- a/docs/source/release/v7.0.0/Framework/LiveData/New_features/42089.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/New_features/42089.rst
@@ -1,0 +1,5 @@
+- The live-data algorithms gain an optional ``Facility`` property, naming the facility that
+  ``Instrument`` is resolved against. This disambiguates instrument names appearing in more than one
+  facility; left empty, the default facility is searched first and then all others, as before.
+  Mismatched ``Facility`` and ``Instrument`` values are now reported against the offending property
+  rather than raising an exception.

--- a/docs/source/release/v7.0.0/Framework/LiveData/New_features/42089.rst
+++ b/docs/source/release/v7.0.0/Framework/LiveData/New_features/42089.rst
@@ -1,5 +1,4 @@
 - The live-data algorithms gain an optional ``Facility`` property, naming the facility that
-  ``Instrument`` is resolved against. This disambiguates instrument names appearing in more than one
-  facility; left empty, the default facility is searched first and then all others, as before.
-  Mismatched ``Facility`` and ``Instrument`` values are now reported against the offending property
-  rather than raising an exception.
+  ``Instrument`` is resolved against. The Mantid default facility is used when it is not set. An
+  instrument name is only meaningful with respect to a facility, so the two are now validated together,
+  and a mismatch is reported against the offending property rather than raising an exception.

--- a/instrument/unit_testing/UnitTestFacilitiesMultiple.xml
+++ b/instrument/unit_testing/UnitTestFacilitiesMultiple.xml
@@ -9,12 +9,14 @@
 
 <facility name="TESTDEFAULT" FileExtensions=".nxs,.dat,.xml">
 
-  <livedata listener="MockLiveListener"/>
+  <timezone>US/Eastern</timezone>
+
+  <livedata listener="FakeEventDataListener"/>
 
   <instrument name="DEFAULTLISTENER">
     <technique>Test Listener</technique>
     <livedata>
-      <connection name="default" address="127.0.0.1:0" listener="MockLiveListener" />
+      <connection name="default" address="127.0.0.1:0" listener="FakeEventDataListener" />
     </livedata>
   </instrument>
 
@@ -27,12 +29,14 @@
 
 <facility name="TESTOTHER" FileExtensions=".nxs,.dat,.xml">
 
-  <livedata listener="MockLiveListener"/>
+  <timezone>US/Eastern</timezone>
+
+  <livedata listener="FakeEventDataListener"/>
 
   <instrument name="OTHERLISTENER">
     <technique>Test Listener</technique>
     <livedata>
-      <connection name="default" address="127.0.0.1:0" listener="MockLiveListener" />
+      <connection name="default" address="127.0.0.1:0" listener="FakeEventDataListener" />
     </livedata>
   </instrument>
 

--- a/instrument/unit_testing/UnitTestFacilitiesMultiple.xml
+++ b/instrument/unit_testing/UnitTestFacilitiesMultiple.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Two facilities, each owning a live-data instrument, plus one instrument with no live-data
+  configuration at all.  This supports tests which need to distinguish "the default facility" from
+  "some other facility": for example, when checking that a live-data instrument can be selected from
+  a facility which is not the default one.
+-->
+<facilities>
+
+<facility name="TESTDEFAULT" FileExtensions=".nxs,.dat,.xml">
+
+  <livedata listener="MockLiveListener"/>
+
+  <instrument name="DEFAULTLISTENER">
+    <technique>Test Listener</technique>
+    <livedata>
+      <connection name="default" address="127.0.0.1:0" listener="MockLiveListener" />
+    </livedata>
+  </instrument>
+
+  <!-- Deliberately has no <livedata> block: live data cannot be collected from it. -->
+  <instrument name="NOLIVEDATA">
+    <technique>Test Neutron Diffraction</technique>
+  </instrument>
+
+</facility>
+
+<facility name="TESTOTHER" FileExtensions=".nxs,.dat,.xml">
+
+  <livedata listener="MockLiveListener"/>
+
+  <instrument name="OTHERLISTENER">
+    <technique>Test Listener</technique>
+    <livedata>
+      <connection name="default" address="127.0.0.1:0" listener="MockLiveListener" />
+    </livedata>
+  </instrument>
+
+</facility>
+
+</facilities>

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
@@ -49,6 +49,9 @@ private:
   /// Parse the input from the dialog when it has been accepted
   void parseInput() override;
 
+  /// Fill the instrument combo box from the default facility's live-data instruments.
+  void fillInstrumentComboBox();
+
   Mantid::API::Algorithm_sptr changeAlgorithm(MantidQt::MantidWidgets::AlgorithmSelectorWidget *selector,
                                               MantidQt::API::AlgorithmPropertiesWidget *propWidget);
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -13,8 +13,10 @@
 #include "MantidAPI/LiveListenerFactory.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/FacilityInfo.h"
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/LiveListenerInfo.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/SingletonHolder.h"
 #include "MantidQtWidgets/Common/AlgorithmInputHistory.h"
 #include "MantidQtWidgets/Common/PropertyWidgetFactory.h"
@@ -30,6 +32,8 @@ using Mantid::Kernel::ConfigService;
 using Mantid::Types::Core::DateAndTime;
 
 namespace {
+Mantid::Kernel::Logger g_log("StartLiveDataDialog");
+
 class LiveDataAlgInputHistoryImpl : public AbstractAlgorithmInputHistory {
 private:
   LiveDataAlgInputHistoryImpl() : AbstractAlgorithmInputHistory("LiveDataAlgorithms") {}
@@ -105,7 +109,10 @@ void StartLiveDataDialog::initLayout() {
   ui.postAlgo->setInputHistory(history2);
 
   // ========== Set previous values from history =============
-  fillAndSetComboBox("Instrument", ui.cmbInstrument);
+  // 'Instrument' no longer carries a list validator -- which instruments are valid depends on the
+  //   facility, which is itself a property -- so `fillAndSetComboBox` has nothing to offer here.
+  //   Populate the box from the algorithm's own view of its facility instead.
+  fillInstrumentComboBox();
   tie(ui.edtUpdateEvery, "UpdateEvery", ui.layoutUpdateEvery);
   fillAndSetComboBox("AccumulationMethod", ui.cmbAccumulationMethod);
 
@@ -442,6 +449,42 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
       tie(propWidget, propName, gridLayout);
     }
     ui.listenerProps->setVisible(true);
+  }
+}
+
+/**
+ * Fill the instrument combo box with the instruments that have a live listener in the algorithm's
+ * facility, and restore the previously used value if it is still one of them.
+ */
+void StartLiveDataDialog::fillInstrumentComboBox() {
+  ui.cmbInstrument->clear();
+
+  // The dialog offers the *default* facility's instruments; it has no facility selector of its own,
+  //   so it leaves the algorithm's 'Facility' property unset.  Selecting an instrument from another
+  //   facility is possible from a script, by naming 'Facility'.
+  std::vector<std::string> instruments;
+  try {
+    const auto &facility = ConfigService::Instance().getFacility();
+    for (const auto &instrument : facility.instruments()) {
+      if (instrument.hasLiveListenerInfo()) {
+        instruments.emplace_back(instrument.name());
+      }
+    }
+  } catch (const std::runtime_error &e) {
+    // A default facility Mantid cannot resolve should not stop the dialog from opening.
+    g_log.warning() << "Cannot list live-data instruments: " << e.what() << "\n";
+    return;
+  }
+  std::sort(instruments.begin(), instruments.end());
+
+  for (const auto &instrument : instruments) {
+    ui.cmbInstrument->addItem(QString::fromStdString(instrument));
+  }
+
+  const auto previous = AlgorithmInputHistory::Instance().previousInput("StartLiveData", "Instrument");
+  const auto index = ui.cmbInstrument->findText(previous);
+  if (index >= 0) {
+    ui.cmbInstrument->setCurrentIndex(index);
   }
 }
 


### PR DESCRIPTION
### Description of work

No linked GitHub issue. This came out of a defect found downstream in SNAPRed (EWM 15513), where
live data reduction failed for any user whose default facility was not SNS.

`LiveDataAlgorithm::initProps` builds the allowed values for its `Instrument` property from the
default facility only. `createLiveListener`, though, resolves the instrument using
`ConfigService::getInstrument`, which searches the default facility first and then every other
facility. So the validator has always been stricter than the implementation sitting behind it.

Two consequences. If your default facility is not the one that owns the instrument you want, you
cannot select that instrument at all, even though the algorithm is perfectly capable of using it.
And if your default facility has no live listeners at all, the allowed values come back empty, so
the property accepts no value whatsoever and you just get "The value X is not in the list of allowed
values" with nothing to choose from.

What I changed:

1. `initProps` now builds the instrument list from every facility, so validation matches what
   execution already does. Names are sorted and deduplicated, since the same instrument name can
   appear in more than one facility.
2. Added an optional `Facility` property. This is what disambiguates an instrument name that appears
   in more than one facility, which `getInstrument` would otherwise resolve in favour of the default
   facility. `createLiveListener` resolves within the named facility when one is given.
3. `validateInputs` now reports a mismatch between `Facility` and `Instrument` against the offending
   property, instead of letting a `NotFoundError` escape out of `createLiveListener`. It also catches
   the case where the instrument exists but has no live listener configured.
4. `StartLiveData::afterPropertySet` gains `Facility`, since that property selects which listener
   applies. Its `createLiveListener` call is now guarded: properties are set one at a time, so
   `Facility` can arrive before `Instrument` and the pair may not be consistent yet. A partially
   configured algorithm should not throw from a property setter, and the pair is properly reported in
   `validateInputs` anyway.

`LoadLiveData` and `MonitorLiveData` needed no changes. They inherit the properties, and
`copyPropertyValuesFrom` walks all properties, so `Facility` reaches the child algorithms already.

Tests use a new fixture with two facilities rather than extending `UnitTestFacilities.xml`, which has
only one facility and a lot of dependants.

### To test:

Any facility with no live listeners will do for the reproduction. I used ILL.

1. In Workbench, File > Settings > General, set Facility to ILL and pick any instrument.
2. Open `StartLiveData`. On `main` the Instrument dropdown is empty and no value can be set. With
   this branch it lists every instrument that has a live listener, across all facilities.
3. Set Instrument to SNAP and Facility to SNS. This should validate cleanly.
4. Now set Facility to HFIR, leaving Instrument as SNAP. You should get an error against Instrument
   telling you SNAP is not part of HFIR, rather than an exception.
5. Set Facility to something that does not exist. You should get an error against Facility.
6. Set Facility before setting Instrument. This should not raise anything.
7. Run `LiveDataAlgorithmTest`. Five new cases cover the allowed values spanning facilities, an
   instrument from another facility validating, the `Facility` default, an unknown facility, and an
   instrument that is not in the named facility.

Existing behaviour to confirm unchanged: with `Facility` left empty, everything resolves exactly as
before, so any current script or saved workflow keeps working.

Release notes are in `docs/source/release/v7.0.0/Framework/LiveData/Bugfixes/`.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->