### PR TITLE
Instrument View 2.0: Refactor transform

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -126,6 +126,8 @@ class FullInstrumentViewModel:
         self._transform = np.eye(4)
         self._transformed_detector_positions = self.detector_positions.copy()
 
+        self._peaks_indices_in_detector_positions = np.array([], dtype=int)
+
     @property
     def workspace(self) -> Workspace2D:
         return self._workspace
@@ -613,16 +615,13 @@ class FullInstrumentViewModel:
         wrapped_workspaces = [
             WorkspaceDetectorPeaks(ws_name, self.get_integration_units(), self.integration_limits) for ws_name in selected_peaks_workspaces
         ]
-        indices_and_labels_by_pws = [
-            wws.get_peaks_indices_and_labels(self.detector_positions, self.pickable_detector_ids) for wws in wrapped_workspaces
-        ]
+        indices_and_labels_by_pws = [wws.get_peaks_indices_and_labels(self.pickable_detector_ids) for wws in wrapped_workspaces]
         indices_by_pws = [pair[0] for pair in indices_and_labels_by_pws]
         self._peaks_indices_in_detector_positions = np.concatenate(indices_by_pws or [np.array([], dtype=int)])
         positions_by_pws = [self.detector_positions[indices] for indices in indices_by_pws]
         labels_by_pws = [pair[1] for pair in indices_and_labels_by_pws]
 
         transformed_pos = [self._transform_vectors_with_matrix(p) for p in positions_by_pws]
-
         return transformed_pos, labels_by_pws, selected_peaks_workspaces
 
     def _get_index_of_closest_detector_with_peak(self, index_in_detector_positions: int) -> int:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -625,8 +625,8 @@ class FullInstrumentViewModel:
         return transformed_pos, labels_by_pws, selected_peaks_workspaces
 
     def _get_index_of_closest_detector_with_peak(self, index_in_detector_positions: int) -> int:
-        clicked_position = self.detector_positions[index_in_detector_positions]
-        positions_detectors_with_peaks = self.detector_positions[self._peaks_indices_in_detector_positions]
+        clicked_position = self.transformed_detector_positions[index_in_detector_positions]
+        positions_detectors_with_peaks = self.transformed_detector_positions[self._peaks_indices_in_detector_positions]
         if len(positions_detectors_with_peaks) == 0:
             return index_in_detector_positions
         closest_peak_index = np.argmin(np.linalg.norm(positions_detectors_with_peaks - clicked_position, axis=1))

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -123,6 +123,8 @@ class FullInstrumentViewModel:
         self.full_counts_limits = self._counts_limits
 
         self._sample_shape = self._get_sample_shape_from_workspace(self._workspace)
+        self._transform = np.eye(4)
+        self._transformed_detector_positions = self.detector_positions.copy()
 
     @property
     def workspace(self) -> Workspace2D:
@@ -463,6 +465,33 @@ class FullInstrumentViewModel:
         if self._projection_type == ProjectionType.THREE_D:
             return self._detector_positions_3d[self.is_pickable]
         return self._calculate_projection()[self.is_pickable]
+
+    @property
+    def transform(self) -> np.ndarray:
+        return self._transform
+
+    @transform.setter
+    def transform(self, value: np.ndarray) -> None:
+        self._transform = value
+
+    @property
+    def transformed_detector_positions(self) -> np.ndarray:
+        return self._transformed_detector_positions
+
+    def transform_vectors_with_matrix(self, points: np.ndarray, transform: Optional[np.ndarray] = None) -> np.ndarray:
+        if points.size == 0:
+            return points
+        if transform is None:
+            transform = self._transform
+
+        # The transform is a 4x4 matrix while the points are 3D vectors,
+        # so first append the homogeneous coordinate.
+        transformed_points = np.hstack([points, np.ones((points.shape[0], 1))])
+        transformed_points = transformed_points @ transform.T
+        return transformed_points[:, :3]
+
+    def update_transformed_detector_positions(self) -> None:
+        self._transformed_detector_positions = self.transform_vectors_with_matrix(self.detector_positions)
 
     @property
     def masked_positions(self) -> np.ndarray:

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewModel.py
@@ -473,12 +473,13 @@ class FullInstrumentViewModel:
     @transform.setter
     def transform(self, value: np.ndarray) -> None:
         self._transform = value
+        self._transformed_detector_positions = self._transform_vectors_with_matrix(self.detector_positions)
 
     @property
     def transformed_detector_positions(self) -> np.ndarray:
         return self._transformed_detector_positions
 
-    def transform_vectors_with_matrix(self, points: np.ndarray, transform: Optional[np.ndarray] = None) -> np.ndarray:
+    def _transform_vectors_with_matrix(self, points: np.ndarray, transform: Optional[np.ndarray] = None) -> np.ndarray:
         if points.size == 0:
             return points
         if transform is None:
@@ -489,9 +490,6 @@ class FullInstrumentViewModel:
         transformed_points = np.hstack([points, np.ones((points.shape[0], 1))])
         transformed_points = transformed_points @ transform.T
         return transformed_points[:, :3]
-
-    def update_transformed_detector_positions(self) -> None:
-        self._transformed_detector_positions = self.transform_vectors_with_matrix(self.detector_positions)
 
     @property
     def masked_positions(self) -> np.ndarray:
@@ -622,7 +620,10 @@ class FullInstrumentViewModel:
         self._peaks_indices_in_detector_positions = np.concatenate(indices_by_pws or [np.array([], dtype=int)])
         positions_by_pws = [self.detector_positions[indices] for indices in indices_by_pws]
         labels_by_pws = [pair[1] for pair in indices_and_labels_by_pws]
-        return positions_by_pws, labels_by_pws, selected_peaks_workspaces
+
+        transformed_pos = [self._transform_vectors_with_matrix(p) for p in positions_by_pws]
+
+        return transformed_pos, labels_by_pws, selected_peaks_workspaces
 
     def _get_index_of_closest_detector_with_peak(self, index_in_detector_positions: int) -> int:
         clicked_position = self.detector_positions[index_in_detector_positions]

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -63,7 +63,6 @@ class FullInstrumentViewPresenter:
         self._view = view
         self._model = model
         self._closing = False
-        self._transform = np.eye(4)
         self._counts_label = "Integrated Counts"
         self._visible_label = "Visible Picked"
         self._count_scale_mode = self._LINEAR
@@ -303,7 +302,7 @@ class FullInstrumentViewPresenter:
         self._update_transform()
         for mesh in [self._detector_mesh, self._pickable_mesh, self._masked_mesh, monitor_mesh, sample_position_mesh]:
             if mesh is not None:
-                mesh.transform(self._transform, inplace=True)
+                mesh.transform(self._model.transform, inplace=True)
 
         # If refreshing the limits we reset both the contour and integration sliders.
         # If not, we need to manually update the contour limits to what they were set to before we added the
@@ -323,9 +322,10 @@ class FullInstrumentViewPresenter:
 
     def _update_transform(self) -> None:
         if not self._model.is_2d_projection or self._view.is_maintain_aspect_ratio_checkbox_checked():
-            self._transform = np.eye(4)
+            self._model.transform = np.eye(4)
         else:
-            self._transform = self._transform_mesh_to_fill_window()
+            self._model.transform = self._transform_mesh_to_fill_window()
+        self._model.update_transformed_detector_positions()
 
     def _transform_mesh_to_fill_window(self) -> np.ndarray:
         xmin, xmax, ymin, ymax, zmin, zmax = self._detector_mesh_bounds
@@ -351,16 +351,6 @@ class FullInstrumentViewPresenter:
         # The matrix below is the product of those three transformations
         c_x, c_y, _ = centre
         return np.array([[scale_x, 0, 0, c_x * (1 - scale_x)], [0, scale_y, 0, c_y * (1 - scale_y)], [0, 0, 1, 0], [0, 0, 0, 1]])
-
-    def _transform_vectors_with_matrix(self, points: np.ndarray, transform: np.ndarray) -> np.ndarray:
-        if points.size == 0:
-            return points
-        # The transform is a 4x4 matrix, the points are 3D vectors, first we need an extra
-        # entry on the points
-        transformed_points = np.hstack([points, np.ones((points.shape[0], 1))])
-        transformed_points = transformed_points @ transform.T
-        # Now remove extra point
-        return transformed_points[:, :3]
 
     def on_aspect_ratio_check_box_clicked(self) -> None:
         self._view.store_maintain_aspect_ratio_option()
@@ -474,7 +464,8 @@ class FullInstrumentViewPresenter:
         manager each time it is dragged, resized or rotated, so the plot always shows what
         would be committed by Add ROI / Add Mask.
         """
-        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        self._update_transform()
+        centres = self._model.transformed_detector_positions
         # Projection uses VTK, so must be done on the Qt thread before queueing the rest
         self._view.project_and_cache_detector_points(centres)
         self._shape_update_generation += 1
@@ -522,7 +513,7 @@ class FullInstrumentViewPresenter:
         self.refresh_lineplot_peaks()
 
     def _on_add_item_clicked(self) -> None:
-        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        centres = self._model.transformed_detector_positions
         mask = self._view.get_shape_mask(centres)
         if not np.any(mask):
             return
@@ -534,7 +525,8 @@ class FullInstrumentViewPresenter:
         self._view.set_overlaid_shape_controls_checked(False)
 
     def on_add_item_clicked(self) -> None:
-        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        self._update_transform()
+        centres = self._model.transformed_detector_positions
         self._view.project_and_cache_detector_points(centres)
         self._callback_queue.put((self._on_add_item_clicked, ()))
 
@@ -759,7 +751,7 @@ class FullInstrumentViewPresenter:
     def refresh_plotter_peaks(self) -> None:
         self._view.clear_overlay_meshes()
         pos, labels, selected_peaks_workspaces = self._model.get_peak_overlay_arguments(self._view.selected_peaks_workspaces())
-        transformed_pos = [self._transform_vectors_with_matrix(p, self._transform) for p in pos]
+        transformed_pos = [self._model.transform_vectors_with_matrix(p) for p in pos]
         self._view.plot_overlay_meshes(transformed_pos, labels, selected_peaks_workspaces)
         # Everytime the pyvista plotter gets updated with peaks, the button for peak picking should be updated
         self._view.set_select_peaks_enabled(self._view.has_any_peak_overlays_in_pyvista_plotter())

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -108,8 +108,8 @@ class FullInstrumentViewPresenter:
     def setup(self):
         self._view.subscribe_presenter(self)
         self._view.set_projection_combo_options(self._model.get_projection_options())
-        self._view.setup_connections_to_presenter()
         self._view.set_default_projection(self._model.get_default_projection())
+        self._view.setup_connections_to_presenter()
         self._view.set_contour_range_limits(self._model.counts_limits)
         self._view.set_integration_range_limits(self._model.integration_limits)
         self._view.show_axes()
@@ -372,7 +372,6 @@ class FullInstrumentViewPresenter:
 
     def on_rubberband_zoom_toggled(self, checked: bool) -> None:
         if checked:
-            self._view.set_start_adding_peaks_checked(False)
             self._view.set_hover_pick_checked(False)
             self._view.delete_current_overlaid_shape()
         self._view.set_overlaid_shape_controls_enabled(not checked)

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -325,7 +325,6 @@ class FullInstrumentViewPresenter:
             self._model.transform = np.eye(4)
         else:
             self._model.transform = self._transform_mesh_to_fill_window()
-        self._model.update_transformed_detector_positions()
 
     def _transform_mesh_to_fill_window(self) -> np.ndarray:
         xmin, xmax, ymin, ymax, zmin, zmax = self._detector_mesh_bounds
@@ -464,7 +463,6 @@ class FullInstrumentViewPresenter:
         manager each time it is dragged, resized or rotated, so the plot always shows what
         would be committed by Add ROI / Add Mask.
         """
-        self._update_transform()
         centres = self._model.transformed_detector_positions
         # Projection uses VTK, so must be done on the Qt thread before queueing the rest
         self._view.project_and_cache_detector_points(centres)
@@ -525,7 +523,6 @@ class FullInstrumentViewPresenter:
         self._view.set_overlaid_shape_controls_checked(False)
 
     def on_add_item_clicked(self) -> None:
-        self._update_transform()
         centres = self._model.transformed_detector_positions
         self._view.project_and_cache_detector_points(centres)
         self._callback_queue.put((self._on_add_item_clicked, ()))
@@ -750,9 +747,7 @@ class FullInstrumentViewPresenter:
 
     def refresh_plotter_peaks(self) -> None:
         self._view.clear_overlay_meshes()
-        pos, labels, selected_peaks_workspaces = self._model.get_peak_overlay_arguments(self._view.selected_peaks_workspaces())
-        transformed_pos = [self._model.transform_vectors_with_matrix(p) for p in pos]
-        self._view.plot_overlay_meshes(transformed_pos, labels, selected_peaks_workspaces)
+        self._view.plot_overlay_meshes(*self._model.get_peak_overlay_arguments(self._view.selected_peaks_workspaces()))
         # Everytime the pyvista plotter gets updated with peaks, the button for peak picking should be updated
         self._view.set_select_peaks_enabled(self._view.has_any_peak_overlays_in_pyvista_plotter())
 

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py
@@ -28,8 +28,6 @@ from instrumentview.renderers.side_by_side_shape_renderer import SideBySideShape
 
 from instrumentview.InteractorStyles import InteractorStyles
 
-from vtkmodules.vtkRenderingCore import vtkCoordinate
-
 
 class SuppressRendering:
     def __init__(self, plotter):
@@ -335,18 +333,12 @@ class FullInstrumentViewPresenter:
         max_point = np.array([xmax, ymax, zmax])
 
         # Convert to display coordinates (pixels)
-        plotter = self._view.main_plotter
-        coordinate = vtkCoordinate()
-        coordinate.SetCoordinateSystemToWorld()
-        display_coords = []
-        for p in (min_point, max_point):
-            coordinate.SetValue(*p)
-            display_coords.append(coordinate.GetComputedDisplayValue(plotter.renderer))
+        display_coords = [self._view.world_to_display(*p) for p in (min_point, max_point)]
 
         mesh_width = display_coords[1][0] - display_coords[0][0]
         mesh_height = display_coords[1][1] - display_coords[0][1]
 
-        window_width, window_height = plotter.window_size
+        window_width, window_height = self._view.main_plotter.window_size
 
         # Safeguard against division by zero
         mesh_width = mesh_width if mesh_width > 0 else window_width

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -1248,9 +1248,6 @@ class FullInstrumentViewView(QWidget):
             removed = list_to_clear.takeItem(i)
             del removed
 
-    def has_any_peak_overlays_in_lineplot(self) -> bool:
-        return len(self._lineplot_overlays) > 0
-
     def _on_axes_click_during_peak_selection(self, event) -> None:
         if self._plot_toolbar.zoom_enabled() or self._plot_toolbar.pan_enabled():
             # Delegate to matplotlib's default click callbacks when zoom is active.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -1039,6 +1039,14 @@ class FullInstrumentViewView(QWidget):
         world_x, world_y, world_z, world_w = renderer.GetWorldPoint()
         return world_x / world_w, world_y / world_w, world_z / world_w
 
+    def world_to_display(self, x, y, z):
+        # Convert from world coordinates to display coordinates
+        renderer = self.main_plotter.renderer
+        renderer.SetWorldPoint(x, y, z, 1.0)
+        renderer.WorldToDisplay()
+        display_x, display_y, display_z = renderer.GetDisplayPoint()
+        return display_x, display_y, display_z
+
     def get_shape_mask(self, points: np.ndarray) -> np.ndarray:
         """Return a boolean mask of which 3D points are inside the current selection shape.
 

--- a/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/WorkspaceDetectorPeaks.py
@@ -39,7 +39,7 @@ class WorkspaceDetectorPeaks:
     def detector_peaks(self):
         return self._detector_peaks
 
-    def get_peaks_indices_and_labels(self, detector_positions, detector_ids) -> tuple[np.ndarray, list]:
+    def get_peaks_indices_and_labels(self, detector_ids) -> tuple[np.ndarray, list]:
         peaks_ids = np.array([p.detector_id for p in self._detector_peaks])
         if len(peaks_ids) == 0 or len(detector_ids) == 0:
             return np.array([], dtype=int), []

--- a/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
+++ b/qt/python/instrumentview/instrumentview/Peaks/test/test_detector_peaks.py
@@ -43,7 +43,7 @@ class TestWorkspaceDetectorPeaks(unittest.TestCase):
 
     def test_get_peaks_indices_and_labels_empty(self):
         wdp = self._create_workspace_detector_peaks([])
-        positions_and_labels = wdp.get_peaks_indices_and_labels(np.array([[0, 0, 0]]), np.array([1]))
+        positions_and_labels = wdp.get_peaks_indices_and_labels(np.array([1]))
         # Should still return a tuple with two items
         self.assertEqual(2, len(positions_and_labels))
 
@@ -51,9 +51,8 @@ class TestWorkspaceDetectorPeaks(unittest.TestCase):
         peak1 = Peak(1, 0, (1, 0, 0), 100, 10, 10, 10)
         peak2 = Peak(2, 1, (0, 1, 0), 200, 20, 20, 20)
         wdp = self._create_workspace_detector_peaks([DetectorPeaks([peak1]), DetectorPeaks([peak2])])
-        detector_positions = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])
         detector_ids = np.array([1, 2, 3])
-        indices, labels = wdp.get_peaks_indices_and_labels(detector_positions, detector_ids)
+        indices, labels = wdp.get_peaks_indices_and_labels(detector_ids)
         np.testing.assert_array_equal(indices, [0, 1])
         self.assertEqual(["(1, 0, 0)", "(0, 1, 0)"], labels)
 
@@ -85,9 +84,8 @@ class TestWorkspaceDetectorPeaks(unittest.TestCase):
         # filter it out so the result is empty rather than raising an IndexError.
         peak = Peak(999, 0, (1, 0, 0), 100, 10, 10, 10)
         wdp = self._create_workspace_detector_peaks([DetectorPeaks([peak])])
-        detector_positions = np.array([[1, 1, 1], [2, 2, 2]])
         detector_ids = np.array([1, 2])
-        indices, labels = wdp.get_peaks_indices_and_labels(detector_positions, detector_ids)
+        indices, _labels = wdp.get_peaks_indices_and_labels(detector_ids)
         self.assertEqual(0, len(indices))
 
     @mock.patch("instrumentview.Peaks.WorkspaceDetectorPeaks.AnalysisDataService")

--- a/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewPresenter.py
+++ b/qt/python/instrumentview/instrumentview/alfview/ALFInstrumentViewPresenter.py
@@ -63,14 +63,14 @@ class ALFInstrumentViewPresenter(FullInstrumentViewPresenter):
         manager each time it is dragged, resized or rotated, so that the ALF tube selection
         always follows the rectangle.
         """
-        centres = self._transform_vectors_with_matrix(np.array(self._model.detector_positions), self._transform)
+        centres = self._model.transformed_detector_positions
         # Projection uses VTK, so must be done on the Qt thread before queueing the rest
         self._view.project_and_cache_detector_points(centres)
         self._callback_queue.put((self._on_roi_shape_changed, (centres,)))
 
     def _on_roi_shape_changed(self, centres: np.ndarray) -> None:
         mask = self._view.get_shape_mask(centres)
-        if self._select_bank_tube:
+        if self._view.is_select_bank_tube_checked():
             mask = self._model.expand_pickable_mask_to_parent_subtrees(mask)
         # A single stored key so that moving the rectangle replaces the selection rather than adding to it
         self._model.set_detector_key(self._ROI_SELECTION_KEY, mask.tolist(), CurrentTab.Grouping)

--- a/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_presenter.py
+++ b/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_presenter.py
@@ -58,7 +58,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
     def test_on_roi_shape_changed_picks_the_detectors_inside_the_shape(self):
         mask = self._mask_for_first_n_pickable_detectors(5)
         self._mock_view.get_shape_mask.return_value = mask
-        self._presenter._select_bank_tube = False
+        self._mock_view.is_select_bank_tube_checked.return_value = False
 
         with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
             self._presenter._on_roi_shape_changed(np.zeros((self._n_pickable, 3)))
@@ -68,7 +68,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
     def test_on_roi_shape_changed_expands_the_selection_to_whole_tubes(self):
         expanded_mask = self._mask_for_first_n_pickable_detectors(64)
         self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(5)
-        self._presenter._select_bank_tube = True
+        self._mock_view.is_select_bank_tube_checked.return_value = True
         self._model.expand_pickable_mask_to_parent_subtrees = MagicMock(return_value=expanded_mask)
 
         with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
@@ -81,7 +81,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
         first_mask = self._mask_for_first_n_pickable_detectors(10)
         second_mask = np.zeros(self._n_pickable, dtype=bool)
         second_mask[20:30] = True
-        self._presenter._select_bank_tube = False
+        self._mock_view.is_select_bank_tube_checked.return_value = False
 
         with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
             self._mock_view.get_shape_mask.return_value = first_mask
@@ -93,7 +93,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
         self.assertEqual(self._model.cached_pick_selections_keys, [ALFInstrumentViewPresenter._ROI_SELECTION_KEY])
 
     def test_empty_shape_clears_the_selection(self):
-        self._presenter._select_bank_tube = False
+        self._mock_view.is_select_bank_tube_checked.return_value = False
 
         with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
             self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(10)
@@ -106,7 +106,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
     def test_on_roi_shape_changed_stores_the_selection_as_a_grouping_item(self):
         mask = self._mask_for_first_n_pickable_detectors(5)
         self._mock_view.get_shape_mask.return_value = mask
-        self._presenter._select_bank_tube = False
+        self._mock_view.is_select_bank_tube_checked.return_value = False
         self._model.set_detector_key = MagicMock(return_value=ALFInstrumentViewPresenter._ROI_SELECTION_KEY)
 
         with mock.patch.object(self._presenter, "update_picked_detectors_on_view"):
@@ -118,7 +118,7 @@ class TestALFInstrumentViewPresenter(unittest.TestCase):
 
     def test_on_roi_shape_changed_updates_the_view_and_notifies_alf(self):
         self._mock_view.get_shape_mask.return_value = self._mask_for_first_n_pickable_detectors(5)
-        self._presenter._select_bank_tube = False
+        self._mock_view.is_select_bank_tube_checked.return_value = False
 
         with mock.patch.object(self._presenter, "notify_cpp_callback") as mock_notify:
             with mock.patch.object(ALFInstrumentViewPresenter.__bases__[0], "update_picked_detectors_on_view"):

--- a/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
+++ b/qt/python/instrumentview/instrumentview/test/test_interactor_styles.py
@@ -216,6 +216,26 @@ class TestRubberBandZoomInteractorStyle(unittest.TestCase):
         style = RubberBandZoomInteractorStyle(plotter)
         return style, plotter
 
+    def _create_style_with_super_spy(self, **plotter_kwargs):
+        parent_calls = []
+
+        class _RubberBandZoomSuperSpy(RubberBandZoomInteractorStyle.__bases__[0]):
+            def OnLeftButtonDown(self):
+                parent_calls.append("left-down")
+
+            def OnMouseMove(self):
+                parent_calls.append("mouse-move")
+
+            def OnLeftButtonUp(self):
+                parent_calls.append("left-up")
+
+        class _RubberBandZoomStyleSpy(RubberBandZoomInteractorStyle, _RubberBandZoomSuperSpy):
+            pass
+
+        plotter = _make_mock_plotter(**plotter_kwargs)
+        style = _RubberBandZoomStyleSpy(plotter)
+        return style, plotter, parent_calls
+
     def test_set_picking_callback_stores_callback(self):
         style, _ = self._create_style()
         callback = mock.MagicMock()
@@ -242,6 +262,30 @@ class TestRubberBandZoomInteractorStyle(unittest.TestCase):
             style._on_left_button_press_event("obj", "event")
 
         self.assertTrue(style._ignore_rubberband_interaction)
+
+    def test_left_press_without_modifier_delegates_to_rubberband_zoom(self):
+        style, _, parent_calls = self._create_style_with_super_spy()
+
+        with mock.patch.object(style, "_modifier_key_pressed", return_value=False):
+            style._on_left_button_press_event("obj", "event")
+
+        self.assertEqual(parent_calls, ["left-down"])
+        self.assertFalse(style._ignore_rubberband_interaction)
+
+    def test_mouse_move_without_ignore_delegates_to_rubberband_zoom(self):
+        style, _, parent_calls = self._create_style_with_super_spy()
+
+        style._on_mouse_move_event("obj", "event")
+
+        self.assertEqual(parent_calls, ["mouse-move"])
+
+    def test_left_button_release_without_ignore_delegates_to_rubberband_zoom(self):
+        style, _, parent_calls = self._create_style_with_super_spy()
+
+        style._on_left_button_release_event("obj", "event")
+
+        self.assertEqual(parent_calls, ["left-up"])
+        self.assertFalse(style._ignore_rubberband_interaction)
 
     def test_left_button_release_clears_ignore_state(self):
         style, _ = self._create_style()

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -522,22 +522,22 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_peaks_workspaces_in_ads.assert_called_once()
         self.assertEqual([self._ws.name(), self._ws.name()], workspaces)
 
-    @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._transform_vectors_with_matrix")
+    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.transform_vectors_with_matrix")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.get_peak_overlay_arguments")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.refresh_lineplot_peaks")
     def test_on_peaks_workspace_selected(
         self,
         mock_refresh_lineplot_peaks,
         mock_get_peak_overlay_arguments,
-        mock_transform,
+        mock_model_transform,
     ):
         mock_get_peak_overlay_arguments.return_value = ([np.zeros((1, 3))], [["(1, 1, 1)"]], ["ws1"])
-        mock_transform.return_value = np.zeros((1, 3))
+        mock_model_transform.return_value = np.zeros((1, 3))
         self._presenter.on_peaks_workspace_selected()
         mock_refresh_lineplot_peaks.assert_called_once()
         self._mock_view.clear_overlay_meshes.assert_called_once()
         self._mock_view.plot_overlay_meshes.assert_called_once()
-        mock_transform.assert_called_once()
+        mock_model_transform.assert_called_once()
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.get_peak_lineplot_overlay_arguments")
     def test_refresh_lineplot_peaks(self, mock_get_lineplot_args):
@@ -618,14 +618,21 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._transform_mesh_to_fill_window")
     def test_update_transform(self, mock_transform_mesh):
         self._presenter._update_transform()
-        np.testing.assert_allclose(np.eye(4), self._presenter._transform, atol=1e-10)
+        np.testing.assert_allclose(np.eye(4), self._model.transform, atol=1e-10)
+        np.testing.assert_allclose(self._model.detector_positions, self._model.transformed_detector_positions, atol=1e-10)
         mock_transform_mesh.assert_not_called()
         self._mock_view.is_maintain_aspect_ratio_checkbox_checked.return_value = True
         self._presenter._update_transform()
-        np.testing.assert_allclose(np.eye(4), self._presenter._transform, atol=1e-10)
+        np.testing.assert_allclose(np.eye(4), self._model.transform, atol=1e-10)
+        np.testing.assert_allclose(self._model.detector_positions, self._model.transformed_detector_positions, atol=1e-10)
         mock_transform_mesh.assert_not_called()
+        scale_transform = np.eye(4)
+        scale_transform[0][0] = 2
+        scale_transform[1][1] = 3
+        mock_transform_mesh.return_value = scale_transform
         self._mock_view.is_maintain_aspect_ratio_checkbox_checked.return_value = False
         self._presenter._update_transform()
+        np.testing.assert_allclose(scale_transform, self._model.transform, atol=1e-10)
         mock_transform_mesh.assert_called()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._scale_matrix_relative_to_centre")
@@ -678,7 +685,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         scale_matrix = np.eye(4)
         scale_matrix[0][0] = 3
         scale_matrix[1][1] = 10
-        transformed_vectors = self._presenter._transform_vectors_with_matrix(vectors, scale_matrix)
+        transformed_vectors = self._model.transform_vectors_with_matrix(vectors, scale_matrix)
         expected_vectors = np.array([[3, 0, 0], [0, 10, 0]])
         np.testing.assert_allclose(expected_vectors, transformed_vectors)
 

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -522,22 +522,23 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_peaks_workspaces_in_ads.assert_called_once()
         self.assertEqual([self._ws.name(), self._ws.name()], workspaces)
 
-    @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.transform_vectors_with_matrix")
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.get_peak_overlay_arguments")
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter.refresh_lineplot_peaks")
     def test_on_peaks_workspace_selected(
         self,
         mock_refresh_lineplot_peaks,
         mock_get_peak_overlay_arguments,
-        mock_model_transform,
     ):
-        mock_get_peak_overlay_arguments.return_value = ([np.zeros((1, 3))], [["(1, 1, 1)"]], ["ws1"])
-        mock_model_transform.return_value = np.zeros((1, 3))
+        expected_positions = [np.zeros((1, 3))]
+        mock_get_peak_overlay_arguments.return_value = (expected_positions, [["(1, 1, 1)"]], ["ws1"])
         self._presenter.on_peaks_workspace_selected()
         mock_refresh_lineplot_peaks.assert_called_once()
         self._mock_view.clear_overlay_meshes.assert_called_once()
         self._mock_view.plot_overlay_meshes.assert_called_once()
-        mock_model_transform.assert_called_once()
+        args, _ = self._mock_view.plot_overlay_meshes.call_args
+        np.testing.assert_array_equal(args[0], expected_positions)
+        self.assertEqual(args[1], [["(1, 1, 1)"]])
+        self.assertEqual(args[2], ["ws1"])
 
     @mock.patch("instrumentview.FullInstrumentViewModel.FullInstrumentViewModel.get_peak_lineplot_overlay_arguments")
     def test_refresh_lineplot_peaks(self, mock_get_lineplot_args):
@@ -685,7 +686,7 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         scale_matrix = np.eye(4)
         scale_matrix[0][0] = 3
         scale_matrix[1][1] = 10
-        transformed_vectors = self._model.transform_vectors_with_matrix(vectors, scale_matrix)
+        transformed_vectors = self._model._transform_vectors_with_matrix(vectors, scale_matrix)
         expected_vectors = np.array([[3, 0, 0], [0, 10, 0]])
         np.testing.assert_allclose(expected_vectors, transformed_vectors)
 

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -634,26 +634,12 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         mock_mask_mesh = MagicMock(bounds=[0, 1, -1, 1, -1, 1])
 
         self._mock_view.main_plotter.window_size = (10, 10)
+        self._mock_view.world_to_display.side_effect = [(-4, -4, -4), (4, 4, 4)]
 
-        class mock_vtkCoordinate(MagicMock):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.GetComputedDisplayValueCount = 0
-
-            def GetComputedDisplayValue(self, _):
-                self.GetComputedDisplayValueCount += 1
-                if self.GetComputedDisplayValueCount % 2 == 1:
-                    return [-4, -4, -4]
-                return [4, 4, 4]
-
-        with mock.patch("instrumentview.FullInstrumentViewPresenter.vtkCoordinate") as mock_vtk:
-            mock_vtk_instance = mock_vtkCoordinate()
-            mock_vtk.return_value = mock_vtk_instance
-            self._presenter._detector_mesh = mock_det_mesh
-            self._presenter._masked_mesh = mock_mask_mesh
-            self._presenter._transform_mesh_to_fill_window()
-            mock_vtk.assert_called_once()
-            self.assertEqual(2, mock_vtk_instance.GetComputedDisplayValueCount)
+        self._presenter._detector_mesh = mock_det_mesh
+        self._presenter._masked_mesh = mock_mask_mesh
+        self._presenter._transform_mesh_to_fill_window()
+        self._mock_view.world_to_display.assert_has_calls([mock.call(-1, -1, -1), mock.call(1, 1, 1)])
 
         # The mesh width and height in pixels are 8 each, the window is width 10,
         # hence the scale factor should be 10 / 8 = 1.25

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -633,6 +633,9 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
         self._mock_view.is_maintain_aspect_ratio_checkbox_checked.return_value = False
         self._presenter._update_transform()
         np.testing.assert_allclose(scale_transform, self._model.transform, atol=1e-10)
+        np.testing.assert_allclose(
+            self._model.detector_positions * np.array([2, 3, 1]), self._model.transformed_detector_positions, atol=1e-10
+        )
         mock_transform_mesh.assert_called()
 
     @mock.patch("instrumentview.FullInstrumentViewPresenter.FullInstrumentViewPresenter._scale_matrix_relative_to_centre")

--- a/qt/python/instrumentview/instrumentview/test/test_presenter.py
+++ b/qt/python/instrumentview/instrumentview/test/test_presenter.py
@@ -166,7 +166,6 @@ class TestFullInstrumentViewPresenter(unittest.TestCase):
 
         self._presenter.on_rubberband_zoom_toggled(True)
 
-        self._mock_view.set_start_adding_peaks_checked.assert_called_once_with(False)
         self._mock_view.set_hover_pick_checked.assert_called_once_with(False)
         self._mock_view.delete_current_overlaid_shape.assert_called_once()
         self._mock_view.set_overlaid_shape_controls_enabled.assert_called_once_with(False)


### PR DESCRIPTION
### Description of work
Small refactor to store the transform in the model rather than on the presenter. Now it's easier to access the transformed coordinates rather than having to apply the transform every single time.

- [ ] Current finding of nearest peak happens prior to non-aspect ratio maintaining [transformations](https://github.com/mantidproject/mantid/blob/e0f3effbb95a3edff2ded9cce1d3122509072ef9/qt/python/instrumentview/instrumentview/FullInstrumentViewPresenter.py#L328) designed better fit large detectors onto the screen. Due to this, the nearest peak found may not be the nearest peak from a visual perspective.
- [ ] The transformation code is in the presenter, this should be moved to a model.
- [ ] detector_positions arg not used in get_peaks_indices_and_labels function.

Since this is a refactor work, there is no change from the users perspective, so I haven't included a release note.
Closes #42082. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Open Instrument View on an instrument of your choosing
2. Check Apply aspect ratio in the settings tab
3. Add a circle mask or a ROI
4. Uncheck Apply aspect ratio
5. Add a circle mask or a ROI
6. The circles added with and without aspect ratio should appear different
7. Check a peaks workspace (or add peaks)
8. Apply/Unapply aspect ratio and check that peaks positions are updated
9. Pick/Unpick detectors in normal mode (left mouse click)
10. Toggle `Select Peaks` button and check that left mouse click picks nearest peak detector
11. Change aspect ratio and verify that picking behaves the same

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
