### PR TITLE
Allow Nexus File to read unitialized values

### DIFF
--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -208,20 +208,35 @@ std::string NXClass::getString(const std::string &name) const {
 
 double NXClass::getDouble(const std::string &name) const {
   NXDouble number = openNXDouble(name);
-  number.load();
-  return *number();
+  try {
+    number.load();
+    return *number();
+  } catch (std::runtime_error &) {
+    // deals with reading uninitialized/empty data
+    return 0.0;
+  }
 }
 
 float NXClass::getFloat(const std::string &name) const {
   NXFloat number = openNXFloat(name);
-  number.load();
-  return *number();
+  try {
+    number.load();
+    return *number();
+  } catch (std::runtime_error &) {
+    // deals with reading uninitialized/empty data
+    return 0.0f;
+  }
 }
 
 int32_t NXClass::getInt(const std::string &name) const {
   NXInt number = openNXInt(name);
-  number.load();
-  return *number();
+  try {
+    number.load();
+    return *number();
+  } catch (std::runtime_error &) {
+    // deals with reading uninitialized/empty data
+    return 0;
+  }
 }
 /** Returns whether an individual group (or group) is present
  *  @param query :: the class name to search for

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -88,6 +88,48 @@ static herr_t getEntriesCallback(hid_t gid, const char *name, const H5L_info2_t 
   return 0;
 }
 
+std::size_t getStringDataLength(hid_t const data_id, hid_t const type_id, hid_t const space_id) {
+  std::size_t length = 0;
+  if (H5Tis_variable_str(type_id)) {
+    if (H5Sget_simple_extent_ndims(space_id) == 0) {
+      // H5Dvlen_get_buf_size is unreliable with H5S_SCALAR in some HDF5 versions.
+      // Read the single vlen string and measure directly.
+      char *vbuf = nullptr;
+      if (H5Dread(data_id, type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &vbuf) < 0)
+        throw Mantid::Nexus::Exception("Failed to read scalar variable-length string length");
+      length = vbuf ? strlen(vbuf) : 0; // treat null pointer as empty string
+      H5free_memory(vbuf);
+    } else if (H5Dvlen_get_buf_size(data_id, type_id, space_id, &length) < 0) {
+      throw Mantid::Nexus::Exception("Failed to read string length for variable-length string");
+    }
+  } else {
+    // fixed-length: byte width is encoded in the datatype itself
+    length = H5Tget_size(type_id);
+  }
+  return length;
+}
+
+/** Trim leading and trailing whitespace from a null-terminated character buffer, in place.
+ */
+void trimWhiteSpace(std::vector<char> &str) {
+  // the buffer holds a NUL-terminated string -- bound the search by the buffer itself
+  char const *begin = str.data();
+  char const *end = begin + strnlen(str.data(), str.size());
+  // cast to unsigned char: isspace() has undefined behaviour for >= 0x80 (as in UTF8)
+  while (begin < end && isspace(static_cast<unsigned char>(*begin))) {
+    ++begin;
+  }
+  while (end > begin && isspace(static_cast<unsigned char>(end[-1]))) {
+    --end;
+  }
+  std::size_t const length = static_cast<std::size_t>(end - begin);
+
+  // move before resizing
+  std::memmove(str.data(), begin, length);
+  str.resize(length + 1);
+  str[length] = '\0';
+}
+
 } // end of anonymous namespace
 
 namespace Mantid::Nexus {
@@ -677,7 +719,7 @@ template <typename NumT> void File::putData(const vector<NumT> &data) {
 // GET DATA -- STRING / CHAR
 
 template <> void File::getData<char>(char *data) {
-  if (H5Iis_valid(m_current_data_id) <= 0) {
+  if (!isDataSetOpen()) {
     throw NXEXCEPTION("getData ERROR: no dataset open");
   }
 
@@ -690,12 +732,16 @@ template <> void File::getData<char>(char *data) {
   if (H5Tis_variable_str(m_current_type_id)) {
     char *cdata = nullptr;
     ret = H5Dread(m_current_data_id, m_current_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &cdata);
-    if (ret < 0 || cdata == nullptr)
+    if (ret < 0) {
       throw NXEXCEPTION("getData ERROR: failed to read variable length string dataset");
-
-    size = strlen(cdata);
-    buffer.assign(cdata, cdata + size + 1);
-    H5free_memory(cdata);
+    } else if (!cdata) {
+      size = 0;
+      buffer.assign(1, '\0');
+    } else {
+      size = strlen(cdata);
+      buffer.assign(cdata, cdata + size + 1);
+      H5free_memory(cdata);
+    }
   } else {
     hsize_t len = H5Tget_size(m_current_type_id);
     for (int i = 0; i < rank; i++) {
@@ -713,32 +759,8 @@ template <> void File::getData<char>(char *data) {
 
   // strip whitespace
   if (rank == 0 || rank == 1) {
-    if (size == 1) {
-      if (isspace(buffer[0])) {
-        *data = '\0'; // if the only character is whitespace, return null
-      } else if (buffer[0] == '\0') {
-        *data = '\0'; // if the only character is null, return null
-      } else {
-        *data = buffer[0];
-      }
-      return;
-    }
-    // skip over any front whitespace
-    char *start = buffer.data();
-    while (*start && isspace(*start))
-      ++start;
-    // work from back until first non-whitespace char found
-    int i = (int)strlen(start);
-    while (--i >= 0) {
-      if (!isspace(start[i])) {
-        break;
-      }
-    }
-    // add a null terminator to the end
-    start[++i] = '\0';
-
-    std::memcpy(data, start, i);
-    data[i] = '\0';
+    trimWhiteSpace(buffer);
+    std::memcpy(data, buffer.data(), strlen(buffer.data()) + 1);
   } else {
     std::memcpy(data, buffer.data(), size);
   }
@@ -761,28 +783,11 @@ string File::getStrData() {
     msg << "getStrData() only understands rank<=1 data. Found rank=" << rank;
     throw NXEXCEPTION(msg.str());
   }
-  // determine storage size: type_size × npoints (mirrors H5Cpp's getInMemDataSize approach)
-  dimsize_t storage_size;
-  if (H5Tis_variable_str(m_current_type_id)) {
-    if (rank == 0) {
-      // H5Dvlen_get_buf_size is unreliable with H5S_SCALAR in some HDF5 versions.
-      char *vbuf = nullptr;
-      if (H5Dread(m_current_data_id, m_current_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &vbuf) < 0 || !vbuf)
-        throw NXEXCEPTION("Failed to read scalar variable-length string");
-      storage_size = strlen(vbuf);
-      H5free_memory(vbuf);
-    } else if (H5Dvlen_get_buf_size(m_current_data_id, m_current_type_id, m_current_space_id, &storage_size) < 0) {
-      throw NXEXCEPTION("Failed to read string length for variable-length string");
-    }
-  } else {
-    hssize_t npoints = H5Sget_simple_extent_npoints(m_current_space_id);
-    if (npoints < 0)
-      throw NXEXCEPTION("Failed to get dataspace extent");
-    storage_size = H5Tget_size(m_current_type_id) * static_cast<dimsize_t>(npoints);
-  }
-  std::vector<char> value(static_cast<size_t>(storage_size) + 1, '\0');
-  this->getData(value.data());
-  return std::string(value.data(), strlen(value.data()));
+  std::size_t len = getStringDataLength(m_current_data_id, m_current_type_id, m_current_space_id);
+  std::string value(len, '\0');
+  this->getData<char>(value.data());
+  value.resize(strlen(value.c_str())); // trim to actual length
+  return value;
 }
 
 // GET DATA -- NUMERIC
@@ -1388,23 +1393,7 @@ Info File::getInfo() {
   // String scalars (rank=0 in HDF5) were promoted to rank=1 with dims={1} above,
   // so they fall into this branch uniformly.
   if (tclass == H5T_STRING && !info.dims.empty() && info.dims.back() == 1) {
-    dimsize_t length;
-    if (H5Tis_variable_str(m_current_type_id)) {
-      if (H5Sget_simple_extent_ndims(m_current_space_id) == 0) {
-        // H5Dvlen_get_buf_size is unreliable with H5S_SCALAR in some HDF5 versions.
-        // Read the single vlen string and measure directly.
-        char *vbuf = nullptr;
-        if (H5Dread(m_current_data_id, m_current_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &vbuf) < 0 || !vbuf)
-          throw NXEXCEPTION("Failed to read scalar variable-length string length");
-        length = strlen(vbuf);
-        H5free_memory(vbuf);
-      } else if (H5Dvlen_get_buf_size(m_current_data_id, m_current_type_id, m_current_space_id, &length) < 0) {
-        throw NXEXCEPTION("Failed to read string length for variable-length string");
-      }
-    } else {
-      // fixed-length: byte width is encoded in the datatype itself
-      length = H5Tget_size(m_current_type_id);
-    }
+    dimsize_t length = getStringDataLength(m_current_data_id, m_current_type_id, m_current_space_id);
     info.dims.back() = length;
   }
 

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -764,8 +764,15 @@ template <> void File::getData<char>(char *data) {
 
   // strip whitespace
   if (rank == 0 || rank == 1) {
-    trimWhiteSpace(buffer);
-    std::memcpy(data, buffer.data(), strlen(buffer.data()) + 1);
+    // if reading a single char, do not null-terminate
+    if (size == 1) {
+      // a lone whitespace or null character reads back as null
+      buffer[0] = isspace(static_cast<unsigned char>(buffer[0])) ? '\0' : buffer[0];
+      *data = buffer[0];
+    } else {
+      trimWhiteSpace(buffer);
+      std::memcpy(data, buffer.data(), strlen(buffer.data()) + 1);
+    }
   } else {
     std::memcpy(data, buffer.data(), size);
   }

--- a/Framework/Nexus/src/NexusFile.cpp
+++ b/Framework/Nexus/src/NexusFile.cpp
@@ -99,8 +99,13 @@ std::size_t getStringDataLength(hid_t const data_id, hid_t const type_id, hid_t 
         throw Mantid::Nexus::Exception("Failed to read scalar variable-length string length");
       length = vbuf ? strlen(vbuf) : 0; // treat null pointer as empty string
       H5free_memory(vbuf);
-    } else if (H5Dvlen_get_buf_size(data_id, type_id, space_id, &length) < 0) {
-      throw Mantid::Nexus::Exception("Failed to read string length for variable-length string");
+    } else {
+      // MacOS treats size_T as ulonglong, which is not the same as hsize_t.  Use hsize_t to avoid warnings.
+      hsize_t buf_size = 0;
+      if (H5Dvlen_get_buf_size(data_id, type_id, space_id, &buf_size) < 0) {
+        throw Mantid::Nexus::Exception("Failed to read string length for variable-length string");
+      }
+      length = static_cast<std::size_t>(buf_size);
     }
   } else {
     // fixed-length: byte width is encoded in the datatype itself

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -9,6 +9,7 @@
 #include "MantidNexus/NexusClasses.h"
 #include "MantidNexus/NexusException.h"
 #include "test_helper.h"
+#include <H5Cpp.h>
 #include <cxxtest/TestSuite.h>
 #include <filesystem>
 
@@ -133,5 +134,55 @@ public:
     auto radius = entry.openNXDouble(radiusPath);
     TS_ASSERT_EQUALS(radius.rank(), 0);
     TS_ASSERT_DELTA(entry.getDouble(radiusPath), 2400.0, 0.1);
+  }
+
+  void test_handle_empty() {
+    std::cout << "test handle empty float, double, int" << std::endl;
+    NexusTest::FileResource resource("test_nexus_null.h5");
+    std::string const filename = resource.fullPath();
+
+    // Nexus::File cannot create this fixture itself: must use HDF5 directly
+    {
+      // file permissions
+      Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+      H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+      Mantid::Nexus::UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+      // put an initial entry
+      Mantid::Nexus::GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // add a NX_class attribute
+      Mantid::Nexus::DataTypeID attrtype = H5Tcopy(H5T_C_S1);
+      H5Tset_size(attrtype, 7);
+      Mantid::Nexus::DataSpaceID attrspce = H5Screate(H5S_SCALAR);
+      Mantid::Nexus::AttributeID attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
+      H5Awrite(attrid, attrtype, "NXpants");
+
+      // setup the empty datasets
+      hsize_t const zero[] = {0};
+      Mantid::Nexus::DataSpaceID dataspace = H5Screate_simple(1, zero, nullptr); // H5Screate(H5S_SCALAR);
+      // empty int32
+      Mantid::Nexus::DataSetID i32 =
+          H5Dcreate(groupid, "empty_int32", H5T_NATIVE_INT32, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(i32, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
+      // empty float
+      Mantid::Nexus::DataSetID f32 =
+          H5Dcreate(groupid, "empty_float", H5T_NATIVE_FLOAT, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(f32, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
+      // empty double
+      Mantid::Nexus::DataSetID d64 =
+          H5Dcreate(groupid, "empty_double", H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(d64, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
+      // cleanup and close file
+      H5Fclose(fid.release());
+    }
+
+    // all three must read back as zero
+    Mantid::Nexus::NXRoot root(filename);
+    auto entry = root.openEntry("entry");
+    // check the int32
+    TS_ASSERT_EQUALS(entry.getInt("empty_int32"), 0);
+    // check the float
+    TS_ASSERT_EQUALS(entry.getFloat("empty_float"), 0.0f);
+    // check the double);
+    TS_ASSERT_EQUALS(entry.getDouble("empty_double"), 0.0);
   }
 };

--- a/Framework/Nexus/test/NexusClassesTest.h
+++ b/Framework/Nexus/test/NexusClassesTest.h
@@ -158,19 +158,16 @@ public:
 
       // setup the empty datasets
       hsize_t const zero[] = {0};
-      Mantid::Nexus::DataSpaceID dataspace = H5Screate_simple(1, zero, nullptr); // H5Screate(H5S_SCALAR);
+      Mantid::Nexus::DataSpaceID dataspace = H5Screate_simple(1, zero, nullptr);
       // empty int32
       Mantid::Nexus::DataSetID i32 =
           H5Dcreate(groupid, "empty_int32", H5T_NATIVE_INT32, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      H5Dwrite(i32, H5T_NATIVE_INT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
       // empty float
       Mantid::Nexus::DataSetID f32 =
           H5Dcreate(groupid, "empty_float", H5T_NATIVE_FLOAT, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      H5Dwrite(f32, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
       // empty double
       Mantid::Nexus::DataSetID d64 =
           H5Dcreate(groupid, "empty_double", H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      H5Dwrite(d64, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullptr);
       // cleanup and close file
       H5Fclose(fid.release());
     }

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -508,8 +508,9 @@ public:
   void test_data_get_null_vlen_string() {
     // this test guards against regressions in the handling of NULL variable-length strings
     // at some point, certain muon data files were written to assign numerical data to
-    // a null pointer to a variable-length string.  That is technically legal HDF5, but illegal NeXus.
-    // this test ensures these 2files can be read without raising errors
+    // a null pointer to a variable-length string
+    // that is technically legal HDF5, but undefined in NeXus.
+    // this test ensures these files can be read without raising errors
     cout << "\ntest dataset read -- NULL variable-length UTF-8 string" << std::endl;
 
     FileResource resource("test_nexus_null_vlen_string.h5");
@@ -733,6 +734,98 @@ public:
     TS_ASSERT_EQUALS(info.dims.size(), 1);
     TS_ASSERT_EQUALS(info.dims.front(), ind.size());
     TS_ASSERT_EQUALS(ind, outd);
+  }
+
+  void test_data_putget_empty_array() {
+    cout << "\ntest dataset read/write -- empty array\n" << std::flush;
+
+    // open a file
+    FileResource resource("test_nexus_file_dataRW_empty.h5");
+    std::string filename = resource.fullPath();
+    Mantid::Nexus::File file(filename, NXaccess::CREATE5);
+    file.makeGroup("entry", "NXentry", true);
+
+    // put/get an empty int array
+    Mantid::Nexus::DimVector nodims{};
+    std::vector<int32_t> in{}, out;
+    // trying to make a dataset with empty dimension array should throw an error
+    TS_ASSERT_THROWS(file.makeData("data_int", NXnumtype::INT32, nodims, true), Mantid::Nexus::Exception const &);
+    // but we can make a dataset from the input's length (here, zero)
+    // a dimension of 0 is interpreted as "unlimited" data, which is saved with a length of 1
+    TS_ASSERT_THROWS_NOTHING(file.makeData("data_int", NXnumtype::INT32, in.size(), true));
+    // trying to put an empty array should throw an exception, as it is not a valid dataset
+    TS_ASSERT_THROWS(file.putData(in), Mantid::Nexus::Exception const &);
+    TS_ASSERT_THROWS(file.putData(in.data()), Mantid::Nexus::Exception const &);
+    // we can still read the empty dataset -- will be a vector of length 1, holding value 0
+    std::vector<int32_t> expected{0};
+    file.getData(out);
+    Mantid::Nexus::Info info = file.getInfo();
+    file.closeData();
+    // confirm -- dims mutated to {1}, the data holds {0}
+    TS_ASSERT_EQUALS(info.dims.size(), 1);
+    TS_ASSERT_EQUALS(info.dims.front(), 1);
+    TS_ASSERT_EQUALS(out, expected);
+  }
+
+  void test_data_get_null_array() {
+    // this test guards against regressions in the handling of NULL numerical arrays
+    cout << "\ntest dataset read -- uninitialized or empty data" << std::endl;
+
+    FileResource resource("test_nexus_null_array.h5");
+    std::string const filename = resource.fullPath();
+    std::size_t constexpr ARRAYSIZE(8);
+
+    // Nexus::File cannot create this fixture itself: must use HDF5 directly
+    {
+      // file permissions
+      Mantid::Nexus::ParameterID fapl = H5Pcreate(H5P_FILE_ACCESS);
+      H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+      Mantid::Nexus::UniqueFileID fid = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+      // put an initial entry
+      Mantid::Nexus::GroupID groupid = H5Gcreate(fid, "entry", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // add a NX_class attribute
+      Mantid::Nexus::DataTypeID attrtype = H5Tcopy(H5T_C_S1);
+      H5Tset_size(attrtype, 7);
+      Mantid::Nexus::DataSpaceID attrspce = H5Screate(H5S_SCALAR);
+      Mantid::Nexus::AttributeID attrid = H5Acreate(groupid, "NX_class", attrtype, attrspce, H5P_DEFAULT, H5P_DEFAULT);
+      H5Awrite(attrid, attrtype, "NXpants");
+
+      // setup the empty datasets
+      hsize_t const array1d[] = {ARRAYSIZE};
+      Mantid::Nexus::DataSpaceID dataspace = H5Screate_simple(1, array1d, nullptr);
+      // unwritten array
+      Mantid::Nexus::DataSetID unwrit =
+          H5Dcreate(groupid, "unwritten_array", H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // deliberately don't write
+      // nullptr as array
+      double *nullarray = nullptr;
+      Mantid::Nexus::DataSetID nullar =
+          H5Dcreate(groupid, "null_array", H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(nullar, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, nullarray);
+      // zero array
+      double empty[ARRAYSIZE] = {0.0};
+      Mantid::Nexus::DataSetID write =
+          H5Dcreate(groupid, "empty_array", H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(write, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, empty);
+      // NOTE: another check might try saving `double uninit[8];`, which could also count as an "empty" array
+      // that results in undefined behavior and will save whatever happens to be in memory into the file,
+      // making deterministic testing impossible
+      // cleanup and close file
+      H5Fclose(fid.release());
+    }
+
+    // all three must read back cleanly, as an empty string
+    Mantid::Nexus::File file(filename, NXaccess::READ);
+    for (std::string const name : {"unwritten_array", "null_array", "empty_array"}) {
+      std::string const address("/entry/" + name);
+
+      TS_ASSERT_THROWS_NOTHING(file.openAddress(address));
+
+      std::vector<double> value(ARRAYSIZE, 999.0); // junk data
+      std::vector<double> expected(ARRAYSIZE, 0.0);
+      TSM_ASSERT_THROWS_NOTHING(address, file.getData(value));
+      TSM_ASSERT_EQUALS(address, value, expected);
+    }
   }
 
   void test_data_string_array_as_char_array() {

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -505,14 +505,11 @@ public:
     TS_ASSERT_EQUALS(in, out);
   }
 
-  /** A NULL-valued variable-length string is legal HDF5, and occurs in real ISIS muon
-   * files -- /raw_data_1/instrument/source/notes in a HIFI run is one, produced by a
-   * pre-allocated NeXus skeleton whose string fields were never populated.  H5Dread
-   * reports *success* and hands back a NULL pointer, so the condition cannot be
-   * detected from the return code alone.  NeXus has no concept of null, so the only
-   * sane mapping is the empty string -- which is also what h5py yields for these.
-   */
   void test_data_get_null_vlen_string() {
+    // this test guards against regressions in the handling of NULL variable-length strings
+    // at some point, certain muon data files were written to assign numerical data to
+    // a null pointer to a variable-length string.  That is technically legal HDF5, but illegal NeXus.
+    // this test ensures these 2files can be read without raising errors
     cout << "\ntest dataset read -- NULL variable-length UTF-8 string" << std::endl;
 
     FileResource resource("test_nexus_null_vlen_string.h5");
@@ -558,6 +555,36 @@ public:
       std::string value("XXXXXXXXXX"); // junk data
       TSM_ASSERT_THROWS_NOTHING(address, value = file.getStrData());
       TSM_ASSERT_EQUALS(address, value, "");
+    }
+  }
+
+  void test_data_get_char_writes_exactly_one_byte() {
+    // this test handles the use of getData<char>() for a *single* char, instead of a string
+    // this can have its own problems, especially around trimming whitespace
+    cout << "\ntest dataset read -- single character does not overrun the caller" << std::endl;
+
+    FileResource resource("test_nexus_char_no_overrun.h5");
+    Mantid::Nexus::File file(resource.fullPath(), NXaccess::CREATE5);
+    file.makeGroup("entry", "NXentry", true);
+
+    std::vector<char> input{'x', ' ', '\0'};
+    std::vector<char> expected{'x', '\0', '\0'};
+    std::size_t const GUARD_SIZE(8);
+    for (std::size_t c = 0; c < input.size(); c++) {
+      std::string const name("c" + std::to_string(c));
+
+      file.makeData(name, NXnumtype::CHAR, 1, true);
+      file.putData(&input[c]);
+
+      // over-allocate, but hand getData only the address of the first byte
+      std::vector<char> guarded(GUARD_SIZE, '?');
+      file.getData(guarded.data());
+      file.closeData();
+
+      TS_ASSERT_EQUALS(guarded.front(), expected[c]);
+      for (std::size_t i = 1; i < GUARD_SIZE; i++) {
+        TSM_ASSERT_EQUALS("getData<char> wrote past the one byte of a single-character dataset", guarded[i], '?');
+      }
     }
   }
 

--- a/Framework/Nexus/test/NexusFileTest.h
+++ b/Framework/Nexus/test/NexusFileTest.h
@@ -505,6 +505,62 @@ public:
     TS_ASSERT_EQUALS(in, out);
   }
 
+  /** A NULL-valued variable-length string is legal HDF5, and occurs in real ISIS muon
+   * files -- /raw_data_1/instrument/source/notes in a HIFI run is one, produced by a
+   * pre-allocated NeXus skeleton whose string fields were never populated.  H5Dread
+   * reports *success* and hands back a NULL pointer, so the condition cannot be
+   * detected from the return code alone.  NeXus has no concept of null, so the only
+   * sane mapping is the empty string -- which is also what h5py yields for these.
+   */
+  void test_data_get_null_vlen_string() {
+    cout << "\ntest dataset read -- NULL variable-length UTF-8 string" << std::endl;
+
+    FileResource resource("test_nexus_null_vlen_string.h5");
+    std::string const filename = resource.fullPath();
+
+    // Nexus::File cannot create this fixture itself: makeData always produces a
+    // fixed-length ASCII string, so build the file with raw HDF5.
+    {
+      H5::H5File h5file(filename, H5F_ACC_TRUNC);
+      H5::StrType vlenUtf8(H5::PredType::C_S1, H5T_VARIABLE);
+      vlenUtf8.setCset(H5T_CSET_UTF8);
+      vlenUtf8.setStrpad(H5T_STR_NULLTERM);
+      H5::DataSpace const scalar(H5S_SCALAR);
+
+      H5::Group entry = h5file.createGroup("entry");
+      entry.createAttribute("NX_class", vlenUtf8, scalar).write(vlenUtf8, std::string("NXentry"));
+
+      // created but never written -- how the ISIS skeleton leaves an unset field
+      entry.createDataSet("unwritten", vlenUtf8, scalar);
+
+      // a NULL pointer written deliberately -- same observable result
+      char const *nothing = nullptr;
+      entry.createDataSet("explicit_null", vlenUtf8, scalar).write(&nothing, vlenUtf8);
+
+      // control: a genuine zero-length string, which must behave identically
+      char const *empty = "";
+      entry.createDataSet("empty_string", vlenUtf8, scalar).write(&empty, vlenUtf8);
+    }
+
+    // all three must read back cleanly, as an empty string
+    Mantid::Nexus::File file(filename, NXaccess::READ);
+    for (std::string const name : {"unwritten", "explicit_null", "empty_string"}) {
+      std::string const address("/entry/" + name);
+
+      TS_ASSERT_THROWS_NOTHING(file.openAddress(address));
+
+      Mantid::Nexus::Info info;
+      TSM_ASSERT_THROWS_NOTHING(address, info = file.getInfo());
+      TSM_ASSERT_EQUALS(address, info.type, NXnumtype::CHAR);
+      TSM_ASSERT_EQUALS(address, info.dims.size(), 1);
+      TSM_ASSERT_EQUALS(address, info.dims.front(), 0);
+
+      std::string value("XXXXXXXXXX"); // junk data
+      TSM_ASSERT_THROWS_NOTHING(address, value = file.getStrData());
+      TSM_ASSERT_EQUALS(address, value, "");
+    }
+  }
+
   void test_check_str_length() {
     cout << "\ntest dataset read/write -- string length" << std::endl;
     FileResource resource("test_nexus_str_len.h5");


### PR DESCRIPTION
### Description of work

There was a problem with muon files not reading.

The issue was caused by the muon file writer:
1. creating datasets without actually writing to them (leaving `null` values behind)
2. saving numerical quantities (currents, energies, etc.) as variable-length strings

If the muon team at ISIS agree to fix the problems with their NeXus file writer, then we can merge this, which is able to handle incorrectly or only partially written data files to nevertheless pass through Mantid's NeXus file reader without error.

### To test:

There are new tests ensuring unfilled datasets can still be read.

Build this branch.  From workbench, load the file `HIFI616.nxs`.  Ask if you need a copy.  It should load and create a workspace.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
