### PR TITLE
Fix normalization of SampleBackground in HFIRPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -203,7 +203,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             "Scale",
             1.0,
             validator=FloatBoundedValidator(0.0),
-            doc="The background will be scaled by this number before being subtracted.",
+            doc="Overall scale factor (s) applied to the output. Use SampleBackgroundScaleFactor to scale the background.",
         )
         # TODO: This field below will be autopopulated from the sample file in a future PR, handled by EWM item 13209
         self.declareProperty(

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -993,16 +993,30 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
                     raw_vanadium_background_ws, ws_name, mask_name, xMin, xMax, self.vanadium_ws
                 )
 
+            # The sample is put onto the vanadium's monitor/time scale here. Anything later
+            # subtracted from it has to be brought onto that same scale first.
+            normalisation_scale = self._get_scale(self.vanadium_ws)
+
             Scale(
                 InputWorkspace=ws_name,
                 OutputWorkspace=ws_name,
-                Factor=self._get_scale(self.vanadium_ws) / self._get_scale(ws_name),
+                Factor=normalisation_scale / self._get_scale(ws_name),
                 EnableLogging=False,
             )
 
             if raw_sample_background_ws is not None:
                 self.sample_background_ws = self._resample_background(
                     raw_sample_background_ws, ws_name, mask_name, xMin, xMax, self.vanadium_ws
+                )
+                # Match the normalisation just applied to the sample, and apply fB, so that
+                # _apply_sample_absorption_correction subtracts SB in the sample's units.
+                Scale(
+                    InputWorkspace=self.sample_background_ws,
+                    OutputWorkspace=self.sample_background_ws,
+                    Factor=self.getProperty("SampleBackgroundScaleFactor").value
+                    * normalisation_scale
+                    / self._get_scale(raw_sample_background_ws),
+                    EnableLogging=False,
                 )
 
             # Calibration & Normalization (vanadium correction)
@@ -1439,7 +1453,9 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         absolute-intensity normalization factor if AbsoluteIntensityUnits=True,
         otherwise fnorm = 1.
 
-        When DoAttenuationCorrection=False, BG subtraction is applied here
+        When DoAttenuationCorrection=False, BG subtraction is applied here. sample_bg_ws
+        has already been scaled by fB * (V_scale / SB_scale) in _resample_inputs, matching
+        the normalisation applied to sample_ws, so it is subtracted as-is.
         """
         s = self.getProperty("Scale").value
         do_attenuation = self.getProperty("DoAttenuationCorrection").value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -2137,7 +2137,7 @@ class SampleBackgroundAndNormalisationTests(unittest.TestCase):
             Wavelength=1.4865,
             VanadiumDiameter=0,
         )
-        np.testing.assert_allclose(result.extractY(), np.zeros_like(result.extractY()))
+        np.testing.assert_allclose(result.extractY(), 0)
 
     def test_sample_vanadium(self):
         """Sample normalized by vanadium. Sample divided by itself should yield 1."""
@@ -2150,7 +2150,7 @@ class SampleBackgroundAndNormalisationTests(unittest.TestCase):
             Wavelength=1.4865,
             VanadiumDiameter=0,
         )
-        np.testing.assert_allclose(result.extractY(), np.ones_like(result.extractY()))
+        np.testing.assert_allclose(result.extractY(), 1)
 
 
 # A minimal but valid instrument definition file with a distinctive name. When applied via the

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -2123,6 +2123,36 @@ class SampleAbsorptionCorrectionTests(unittest.TestCase):
         self.assertLess(fnorm, 10000)
 
 
+class SampleBackgroundAndNormalisationTests(unittest.TestCase):
+    """Basic tests for SampleBackground and Vanadium handling"""
+
+    def test_sample_background(self):
+        """Sample background subtraction test. Sample background subtracted by itself should yield zero."""
+        result = HFIRPowderReduction(
+            SampleFilename="HB2C_7000",
+            SampleBackgroundFilename="HB2C_7000",
+            Instrument="WAND^2",
+            XMin=10,
+            XMax=170,
+            Wavelength=1.4865,
+            VanadiumDiameter=0,
+        )
+        np.testing.assert_allclose(result.extractY(), np.zeros_like(result.extractY()))
+
+    def test_sample_vanadium(self):
+        """Sample normalized by vanadium. Sample divided by itself should yield 1."""
+        result = HFIRPowderReduction(
+            SampleFilename="HB2C_7000",
+            VanadiumFilename="HB2C_7000",
+            Instrument="WAND^2",
+            XMin=10,
+            XMax=170,
+            Wavelength=1.4865,
+            VanadiumDiameter=0,
+        )
+        np.testing.assert_allclose(result.extractY(), np.ones_like(result.extractY()))
+
+
 # A minimal but valid instrument definition file with a distinctive name. When applied via the
 # IDFFilename property, the loaded workspace's instrument name becomes this file's basename.
 _CUSTOM_IDF = """<?xml version='1.0' encoding='UTF-8'?>

--- a/docs/source/algorithms/HFIRPowderReduction-v1.rst
+++ b/docs/source/algorithms/HFIRPowderReduction-v1.rst
@@ -18,6 +18,131 @@ and reduction steps are slightly modified.
 By default the instrument geometry is determined by the sample file. An instrument definition file (IDF) can
 optionally be supplied through the ``IDFFilename`` property to override the geometry used by the sample file.
 
+Reduction formula
+-----------------
+
+Four inputs take part in the reduction: the sample :math:`S`, the sample background
+:math:`S_B`, the vanadium :math:`V` and the vanadium background :math:`V_B`. Each one is
+normalised by its **own** monitor count or counting time, so that all four are on a
+common per-unit-exposure scale before anything is subtracted or divided.
+
+Normalisation
+#############
+
+For a workspace :math:`X` the normalisation scale :math:`c_X` is chosen by ``NormaliseBy``:
+
+.. math::
+
+   c_X = \begin{cases}
+   1                          & \texttt{None} \\
+   \texttt{gd\_prtn\_chrg}    & \texttt{Monitor} \quad \text{(the integrated monitor count)} \\
+   \texttt{duration}          & \texttt{Time}
+   \end{cases}
+
+Throughout this section a hat denotes the normalised workspace,
+:math:`\hat{X} = X / c_X`. ``NormaliseBy`` defaults to ``Monitor`` for WAND² and to
+``Time`` for MIDAS; with ``None`` every scale is 1 and the expressions below reduce to
+raw counts.
+
+Vanadium calibration
+####################
+
+The vanadium background is subtracted from the vanadium, and the result is corrected for
+absorption and multiple scattering:
+
+.. math::
+
+   \hat{V}_\mathrm{corr} = \left( \hat{V} - \hat{V}_B \right) \frac{1 - \Delta_V}{A_V}
+
+Sample
+######
+
+The sample background is scaled by ``SampleBackgroundScaleFactor`` (:math:`f_B`) and
+subtracted, and the result is corrected for absorption and multiple scattering:
+
+.. math::
+
+   \hat{S}_\mathrm{corr} = \left( \hat{S} - f_B \hat{S}_B \right) \frac{1 - \Delta_S}{A_S}
+
+Because both terms are normalised first, the subtraction is independent of the relative
+exposure of the sample and background runs.
+
+Output
+######
+
+.. math::
+
+   S_\mathrm{out} = s \, f_\mathrm{norm} \, \frac{\hat{S}_\mathrm{corr}}{\hat{V}_\mathrm{corr}}
+
+where :math:`s` is the ``Scale`` property (default 1) and :math:`f_\mathrm{norm}` is the
+absolute-intensity factor described below (:math:`f_\mathrm{norm} = 1` unless
+``AbsoluteIntensityUnits`` is set).
+
+Any input that is not supplied simply drops out of the expression: with no vanadium the
+division by :math:`\hat{V}_\mathrm{corr}` is skipped, and with no background the
+corresponding subtraction is skipped.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 88
+
+   * - Symbol
+     - Property
+   * - :math:`S`
+     - ``SampleFilename``, or ``SampleIPTS`` and ``SampleRunNumbers``
+   * - :math:`S_B`
+     - ``SampleBackgroundFilename``, or ``SampleBackgroundIPTS`` and ``SampleBackgroundRunNumbers``
+   * - :math:`V`
+     - ``VanadiumFilename``, or ``VanadiumIPTS`` and ``VanadiumRunNumbers``
+   * - :math:`V_B`
+     - ``VanadiumBackgroundFilename``, or ``VanadiumBackgroundIPTS`` and ``VanadiumBackgroundRunNumbers``
+   * - :math:`c_X`
+     - ``NormaliseBy``
+   * - :math:`f_B`
+     - ``SampleBackgroundScaleFactor``
+   * - :math:`s`
+     - ``Scale``
+
+Absorption and multiple scattering
+##################################
+
+:math:`A` (absorption) and :math:`\Delta` (multiple scattering factor) are computed with
+:ref:`algm-CylinderAbsorptionCW` using the ``Sabine`` method, at the wavelength given by
+``Wavelength``.
+
+For the vanadium, the correction is applied only when ``VanadiumDiameter`` is greater than
+zero; otherwise :math:`A_V = 1` and :math:`\Delta_V = 0`, so
+:math:`\hat{V}_\mathrm{corr} = \hat{V} - \hat{V}_B`. The rod is modelled as vanadium metal
+at 6.1172 g/cm³ with radius ``VanadiumDiameter``/2 and height ``VanadiumHeight``.
+
+For the sample, the correction is applied only when ``DoAttenuationCorrection`` is set;
+otherwise :math:`A_S = 1` and :math:`\Delta_S = 0`. The sample is modelled with
+``SampleChemicalFormula`` at a mass density of
+``SampleCrystalDensity`` × ``SamplePackingFraction``, with radius ``SampleDiameter``/2 and
+height ``SampleHeight``. Multiple scattering is included only when
+``DoMultipleScatteringCorrection`` is also set; when it is not, :math:`\Delta_S = 0` while
+the absorption correction :math:`A_S` still applies.
+
+Absolute intensity units
+########################
+
+When ``AbsoluteIntensityUnits`` is set the output is put on an absolute scale of
+mb/sr/formula unit by comparing the scattering power of the sample cylinder with that of
+the vanadium cylinder:
+
+.. math::
+
+   f_\mathrm{norm} = \frac{1000}{4\pi} \,
+   \frac{M_S \, \sigma_V \, \rho_V \, h_V \, r_V^2}
+        {M_V \, f_S \, \rho_S \, h_S \, r_S^2}
+
+with :math:`\sigma_V = 5.08` barn (total scattering cross-section of vanadium),
+:math:`\rho_V = 6.1172` g/cm³ and :math:`M_V = 50.94` g/mol. :math:`M_S` is the relative
+molecular mass of ``SampleChemicalFormula``, :math:`\rho_S` is ``SampleCrystalDensity``,
+:math:`f_S` is ``SamplePackingFraction``, and :math:`h` and :math:`r` are the heights and
+radii of the vanadium and sample cylinders as above. This requires
+``VanadiumDiameter``, ``VanadiumHeight`` and ``SampleHeight`` to all be greater than zero.
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/HFIRPowderReduction-v1.rst
+++ b/docs/source/algorithms/HFIRPowderReduction-v1.rst
@@ -113,12 +113,12 @@ Absorption and multiple scattering
 For the vanadium, the correction is applied only when ``VanadiumDiameter`` is greater than
 zero; otherwise :math:`A_V = 1` and :math:`\Delta_V = 0`, so
 :math:`\hat{V}_\mathrm{corr} = \hat{V} - \hat{V}_B`. The rod is modelled as vanadium metal
-at 6.1172 g/cm³ with radius ``VanadiumDiameter``/2 and height ``VanadiumHeight``.
+at 6.1172 g/cm³ with radius ``VanadiumDiameter`` / 2 and height ``VanadiumHeight``.
 
 For the sample, the correction is applied only when ``DoAttenuationCorrection`` is set;
 otherwise :math:`A_S = 1` and :math:`\Delta_S = 0`. The sample is modelled with
 ``SampleChemicalFormula`` at a mass density of
-``SampleCrystalDensity`` × ``SamplePackingFraction``, with radius ``SampleDiameter``/2 and
+``SampleCrystalDensity`` × ``SamplePackingFraction``, with radius ``SampleDiameter`` / 2 and
 height ``SampleHeight``. Multiple scattering is included only when
 ``DoMultipleScatteringCorrection`` is also set; when it is not, :math:`\Delta_S = 0` while
 the absorption correction :math:`A_S` still applies.

--- a/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/42095.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Powder/Bugfixes/42095.rst
@@ -1,0 +1,1 @@
+- Fixed :ref:`algm-HFIRPowderReduction` producing incorrect results when SampleBackgroundFilename was supplied. The sample background was subtracted without being normalised to monitor or time, and ``SampleBackgroundScaleFactor`` was ignored.


### PR DESCRIPTION
### Description of work

The sample background wasn't being normalized correctly. This fixes that.

I also had Claude update the algorithm docs with the reduction formula as to make it easier to understand what the algorithm is doing.

Refs: [17541: [MIDAS] Allow user to perform reduction backend (defects)](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/17541)

### To test:

Subtracting a sample from itself should result in 0 but before this fix it didn't.

```python
result = HFIRPowderReduction(SampleFilename="HB2C_7000", SampleBackgroundFilename="HB2C_7000", Instrument="WAND^2", XMin=10, XMax=170, Wavelength=1.4865, VanadiumDiameter=0)
```

Before fix:
<img width="588" height="441" alt="result-2" src="https://github.com/user-attachments/assets/a19a5943-f67a-4876-9164-734d7d919a22" />

After fix:
<img width="588" height="441" alt="result-1" src="https://github.com/user-attachments/assets/81e3d5c8-9992-464e-be5f-c675045eb19c" />


<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
