### PR TITLE
Modify version pinning for Python and setuptools

### DIFF
--- a/conda/recipes/mantid/recipe.yaml
+++ b/conda/recipes/mantid/recipe.yaml
@@ -96,7 +96,7 @@ outputs:
         - occt ${{ occt }}
         - pycifrw
         - pydantic ${{ pydantic }}
-        - python
+        - python ${{ python }}
         - pyyaml ${{ pyyaml }}
         - scipy ${{ scipy }}
         - euphonic ${{ euphonic }}

--- a/conda/recipes/mantidqt/recipe.yaml
+++ b/conda/recipes/mantidqt/recipe.yaml
@@ -54,7 +54,7 @@ requirements:
     - matplotlib ${{ matplotlib }}
     - qscintilla2 ${{ qscintilla2 }}
     - qtpy ${{ qtpy }}
-    - python
+    - python ${{ python }}
     - ${{ pin_compatible("qt6-main", upper_bound="x.x") }}
     - if: linux
       then:

--- a/conda/recipes/mantidworkbench/recipe.yaml
+++ b/conda/recipes/mantidworkbench/recipe.yaml
@@ -41,12 +41,11 @@ requirements:
     - ipykernel
     - mantidqt == ${{ version }}
     - psutil ${{ psutil }}
-    - ${{ pin_compatible("python", lower_bound="x.x", upper_bound="x.x") }}
+    - python ${{ python }}
     - matplotlib ${{ matplotlib }}
     - pyvista ${{ pyvista }}
     - pyvistaqt ${{ pyvistaqt }}
     - superqt
-    - ${{ pin_compatible("setuptools", lower_bound="x.x", upper_bound="x.x") }}
     # qtconsole-base avoids pulling in PyQt5 on the Qt6 build
     - qtconsole-base ${{ qtconsole }}
     - if: linux

--- a/conda/recipes/mantidworkbench/recipe.yaml
+++ b/conda/recipes/mantidworkbench/recipe.yaml
@@ -41,12 +41,12 @@ requirements:
     - ipykernel
     - mantidqt == ${{ version }}
     - psutil ${{ psutil }}
-    - ${{ pin_compatible("python", upper_bound="x.x") }}
+    - ${{ pin_compatible("python", lower_bound="x.x", upper_bound="x.x") }}
     - matplotlib ${{ matplotlib }}
     - pyvista ${{ pyvista }}
     - pyvistaqt ${{ pyvistaqt }}
     - superqt
-    - ${{ pin_compatible("setuptools", upper_bound="x.x") }}
+    - ${{ pin_compatible("setuptools", lower_bound="x.x", upper_bound="x.x") }}
     # qtconsole-base avoids pulling in PyQt5 on the Qt6 build
     - qtconsole-base ${{ qtconsole }}
     - if: linux


### PR DESCRIPTION
Updated Python and setuptools version pinning to include lower bounds.

### Description of work

It has been noted that we require python to `x.x.x` as part of the `mantidworkbench` recipe. More flexibility and alignment with our actual pin is desirable.

The cause of this is ``${{ pin_compatible("python", upper_bound="x.x") }}`` defaulting the `lower_bound` of the pin to `x.x.x`

It has been decided we don't need to use `pin_compatible` at all, and that just a normal pin in line with our build/host environments will suffice.

Downloaded the package built through this PR. Installed successfully with python 3.13.

`Conda-tree` shows the following:`mantidworkbench 6.16.20260825.1548.dev8 [required: 3.13.*]`

### To test:

- Download `https://api.github.com/repos/mantidproject/mantid/actions/artifacts/9604377827` on linux.
- Use `conda index` on the resultant directory to make it into a conda channel.
- Try to install workbench using `micromamba install -c file://<directory> mantidworkbench python==3.13 --channel-priority flexible (this is for latest version of `micromamba`, adapt.
- See Python `3.13.0` in environment (previously was pinned to `3.13.15`).
- Try to open, see it is successful.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->


We may also want to do the same thing here: https://github.com/mantidproject/mantid/blob/0b3c2a239932e408f279ca6bcb4563abea8c5f27/conda/recipes/mantidqt/recipe.yaml#L58


______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
