### PR TITLE
Fix uncommitted suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 
+# CxxTest was copied into the repository; retain its Makefiles as part of the source tree.
+!Testing/Tools/cxxtest/**/Makefile
+
 # Ignore CMakeUserPresets
 CMakeUserPresets.json
 
@@ -72,6 +75,13 @@ local.properties
 *.exe
 *.vcxproj
 *.filters
+
+# VS project files for using ArielToMantidXML
+!tools/ArielToMantidXML/ArielToMantidXML.sln
+!tools/ArielToMantidXML/ArielToMantidXML/ArielToMantidXML.vcproj
+
+# Visual leak detector tool
+!vld-2.0-setup.exe
 
 # User-specific files
 *.suo


### PR DESCRIPTION
### Description of work
Several files were in the repo that matched filters in the .gitignore file. After the recent rattler-build upgrade, this has been causing versioningit to add a `+uncommitted` suffix to the version number.

I've removed the obviously bogus file and added the rest as exceptions in the .gitignore. file.

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. Make a temporary directory somewhere for rattler-build to use, e.g.:
`mkdir ~/conda-package-build`
2. Navigate to `buildconfig/Jenkins/Conda` in the mantid source repo
3. Run the packaging script, with the first argument as the directory you just created:
`./package-conda ~/conda-package-build --build-mantid`
4. You can cancel the build with ctrl+c as soon as it starts building, when you see:
```
 │ │ [1/1989] Building CXX object Framework/LegacyNexus/CMakeFiles/LegacyNexus.dir/src/NeXusException.cpp.o
 │ │ [2/1989] Building CXX object Framework/Json/CMakeFiles/Json.dir/src/Json.cpp.o
 │ │ [3/1989] Building CXX object Framework/LegacyNexus/CMakeFiles/LegacyNexus.dir/src/napi.cpp.o
 │ │ [4/1989] Building CXX object Framework/LegacyNexus/CMakeFiles/LegacyNexus.dir/src/stptok.cpp.o
 │ │ [5/1989] Building CXX object Framework/LegacyNexus/CMakeFiles/LegacyNexus.dir/src/NeXusFileID.cpp.o
 │ │ [6/1989] Linking CXX shared library bin/libMantidJson.so
```
5. Scroll up a little bit to find the version number:
```
 │ │ -- Version: 6.16.20260825.1548.dev6
 │ │ -- Major: 6
 │ │ -- Minor: 16
 │ │ -- Patch: 20260825.1548
 │ │ -- Tweak: .dev6
```

Run those steps on `main` to see the `+uncommitted` string in the version number, then again on this branch to see that it goes away.




<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
