### PR TITLE
Fix HFIRPowderReduction saving issues

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -677,7 +677,7 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         iptsNumbers = set()
         runNumbers = []
         for filename in filenames or []:
-            match = re.search(r"IPTS-(\d+)\D.*[/\\]HB2[AC]_(\d+)\.nxs\.h5$", str(filename))
+            match = re.search(r"(?:^|[/\\])IPTS-(\d+)[/\\]nexus[/\\]HB2[AC]_(\d+)\.nxs\.h5$", str(filename))
             if match is None:
                 return None, []
             iptsNumbers.add(int(match.group(1)))
@@ -864,22 +864,28 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             self._checkMetadataConsistency(files, "Sample")
 
         if not self.getProperty("Overwrite").value and not self.getProperty("OutputDirectory").isDefault:
-            output_file = self._resolveOutputFile(self.getPropertyValue("OutputWorkspace"))
-            if os.path.exists(output_file):
-                issues["OutputDirectory"] = f"Output file {output_file} already exists and overwrite is set to False"
+            dat_file, nexus_file = self._resolveOutputFiles(self.getPropertyValue("OutputWorkspace"))
+            for output_file in (dat_file, nexus_file):
+                if os.path.exists(output_file):
+                    issues["OutputDirectory"] = (
+                        f"OutputDirectory destination resolves to existing file {output_file} and overwrite is set to False"
+                    )
 
         return issues
 
-    def _resolveOutputFile(self, workspace_name):
-        """Turn the OutputDirectory property into the full path of the .dat file that will be saved.
-
+    def _resolveOutputFiles(self, workspace_name):
+        """
+        Turn the OutputDirectory property into the full paths of the .dat and .nxs files that will be saved.
         The property normally holds a directory, in which case the output workspace name is used as the
-        file name, but a full file path ending in .dat is also accepted and used as-is.
+        file name, but a full file path ending in .dat is also accepted and used as-is for the ASCII output.
+        The Nexus output uses the same base name with a .nxs extension.
         """
         output_path = self.getProperty("OutputDirectory").value
         if output_path.endswith(".dat"):
-            return output_path
-        return os.path.join(output_path, workspace_name + ".dat")
+            base_path = output_path[:-4]
+            return output_path, base_path + ".nxs"
+        base_path = os.path.join(output_path, workspace_name)
+        return base_path + ".dat", base_path + ".nxs"
 
     def _warn_unset_optional_fields(self):
         """Log warnings for optional fields that are not set (excludes fields already checked by validateInputs)."""
@@ -1025,9 +1031,9 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         if not self.getProperty("OutputDirectory").isDefault:
             # Step 6: Save
             logger.information("Step 6: Saving output to file")
-            output_file = self._resolveOutputFile(outWS.name())
-            SaveAscii(InputWorkspace=outWS, Filename=output_file, EnableLogging=False)
-            SaveNexus(InputWorkspace=outWS, Filename=output_file[: -len(".dat")] + ".nxs")
+            output_dat_file, output_nexus_file = self._resolveOutputFiles(outWS.name())
+            SaveAscii(InputWorkspace=outWS, Filename=output_dat_file, EnableLogging=False)
+            SaveNexus(InputWorkspace=outWS, Filename=output_nexus_file)
 
         # Step 7: Cleanup
         logger.information("Step 7: Cleaning up temporary workspaces")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -62,6 +62,7 @@ from mantid.simpleapi import (
 import h5py
 import numpy as np
 import os
+import re
 
 logger = Logger(__name__)
 
@@ -234,13 +235,14 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
 
         self.declareProperty(
             WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
-            doc="Output Workspace",
+            doc="Output Workspace. Defaults to IPTS<ipts>_Run<runs> built from the sample IPTS and run numbers, "
+            "where <runs> collapses consecutive runs into ranges, e.g. IPTS1234_Run5-7_9.",
         )
         self.getProperty("OutputWorkspace").setDisableReplaceWSButton(True)
         self.declareProperty(
-            FileProperty(
-                name="OutputDirectory", defaultValue="~/HFIRPowderReductionOutput", action=FileAction.OptionalSave, extensions=[".dat"]
-            )
+            FileProperty(name="OutputDirectory", defaultValue="~/HFIRPowderReductionOutput", action=FileAction.OptionalDirectory),
+            doc="Directory the reduced data is written to. A full file path ending in .dat may also be entered, "
+            "in which case that name is used for the saved files instead of the output workspace name.",
         )
         self.declareProperty("Overwrite", True, "If True previous file will be overwritten")
 
@@ -636,6 +638,69 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             "VanadiumBackgroundIPTS", SetDefaultWhenProperty("SampleRunNumbers", checkRunNumbersforVanadiumBackgroundIPTS)
         )
 
+        def checkSampleforOutputWorkspace(algo, currentProp, watchedProp):
+            outputName = self._defaultOutputWorkspaceName()
+            if not outputName:
+                return False
+            logger.information(f"Auto-populating OutputWorkspace: {outputName}")
+            self.setPropertyValue("OutputWorkspace", outputName)
+            return True
+
+        self.setPropertySettings("OutputWorkspace", SetDefaultWhenProperty("SampleIPTS", checkSampleforOutputWorkspace))
+        self.setPropertySettings("OutputWorkspace", SetDefaultWhenProperty("SampleRunNumbers", checkSampleforOutputWorkspace))
+        self.setPropertySettings("OutputWorkspace", SetDefaultWhenProperty("SampleFilename", checkSampleforOutputWorkspace))
+
+    def _defaultOutputWorkspaceName(self):
+        """Build the default output workspace name from the sample IPTS and run numbers.
+
+        The name is IPTS<ipts>_Run<runs>, where <runs> is the run numbers collapsed by
+        `_collapseRunNumbers`, so that runs 5, 6, 7 and 9 of IPTS-1234 give IPTS1234_Run5-7_9.
+        The IPTS and run numbers are taken from SampleIPTS and SampleRunNumbers, or, when those
+        are unset, from the paths in SampleFilename.  Returns an empty string when neither
+        provides them.
+        """
+        ipts = self.getProperty("SampleIPTS").value
+        runNumbers = self.getProperty("SampleRunNumbers").value
+        if ipts == Property.EMPTY_INT or len(runNumbers) == 0:
+            ipts, runNumbers = self._iptsAndRunNumbersFromFilenames(self.getProperty("SampleFilename").value)
+        if ipts is None or len(runNumbers) == 0:
+            return ""
+        return f"IPTS{ipts}_Run{self._collapseRunNumbers(runNumbers)}"
+
+    def _iptsAndRunNumbersFromFilenames(self, filenames):
+        """Extract the IPTS number and run numbers from sample file paths.
+
+        Only the standard HFIR layout, /HFIR/HB2?/IPTS-<ipts>/nexus/HB2?_<run>.nxs.h5, is
+        recognised.  Returns (None, []) unless every path matches that layout and they all
+        share the same IPTS number.
+        """
+        iptsNumbers = set()
+        runNumbers = []
+        for filename in filenames or []:
+            match = re.search(r"IPTS-(\d+)\D.*[/\\]HB2[AC]_(\d+)\.nxs\.h5$", str(filename))
+            if match is None:
+                return None, []
+            iptsNumbers.add(int(match.group(1)))
+            runNumbers.append(int(match.group(2)))
+        if len(iptsNumbers) != 1:
+            return None, []
+        return iptsNumbers.pop(), runNumbers
+
+    def _collapseRunNumbers(self, runNumbers):
+        """Collapse run numbers into the compact form used in the default output name.
+
+        Runs are sorted and de-duplicated, each group of consecutive runs becomes
+        "<first>-<last>", isolated runs are left as they are, and the groups are joined with
+        "_", so 5, 6, 7, 9, 10 and 12 give "5-7_9-10_12".
+        """
+        groups = []
+        for run in sorted({int(run) for run in runNumbers}):
+            if groups and run == groups[-1][-1] + 1:
+                groups[-1].append(run)
+            else:
+                groups.append([run])
+        return "_".join(str(group[0]) if len(group) == 1 else f"{group[0]}-{group[-1]}" for group in groups)
+
     def _checkMetadataConsistency(self, files, field_name):
         """Check that metadata is consistent across multiple run files."""
         if len(files) <= 1:
@@ -799,11 +864,22 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             self._checkMetadataConsistency(files, "Sample")
 
         if not self.getProperty("Overwrite").value and not self.getProperty("OutputDirectory").isDefault:
-            output_dir = self.getProperty("OutputDirectory").value
-            if os.path.exists(output_dir):
-                issues["OutputDirectory"] = f"Output directory {output_dir} already exists and overwrite is set to False"
+            output_file = self._resolveOutputFile(self.getPropertyValue("OutputWorkspace"))
+            if os.path.exists(output_file):
+                issues["OutputDirectory"] = f"Output file {output_file} already exists and overwrite is set to False"
 
         return issues
+
+    def _resolveOutputFile(self, workspace_name):
+        """Turn the OutputDirectory property into the full path of the .dat file that will be saved.
+
+        The property normally holds a directory, in which case the output workspace name is used as the
+        file name, but a full file path ending in .dat is also accepted and used as-is.
+        """
+        output_path = self.getProperty("OutputDirectory").value
+        if output_path.endswith(".dat"):
+            return output_path
+        return os.path.join(output_path, workspace_name + ".dat")
 
     def _warn_unset_optional_fields(self):
         """Log warnings for optional fields that are not set (excludes fields already checked by validateInputs)."""
@@ -949,16 +1025,9 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         if not self.getProperty("OutputDirectory").isDefault:
             # Step 6: Save
             logger.information("Step 6: Saving output to file")
-            output_dir = self.getProperty("OutputDirectory").value
-            # If directory ends with .dat, user has set the directoy with the browse button and no extra checking is required
-            if not output_dir.endswith(".dat"):
-                if not output_dir.endswith("/"):
-                    output_dir += "/"
-                if not output_dir.endswith(outWS.name()):
-                    output_dir += outWS.name()
-                output_dir += ".dat"
-            SaveAscii(InputWorkspace=outWS, Filename=output_dir, EnableLogging=False)
-            SaveNexus(InputWorkspace=outWS, Filename=output_dir.replace(".dat", ".nxs"))
+            output_file = self._resolveOutputFile(outWS.name())
+            SaveAscii(InputWorkspace=outWS, Filename=output_file, EnableLogging=False)
+            SaveNexus(InputWorkspace=outWS, Filename=output_file[: -len(".dat")] + ".nxs")
 
         # Step 7: Cleanup
         logger.information("Step 7: Cleaning up temporary workspaces")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -975,6 +975,70 @@ class AutoPopulateTests(unittest.TestCase):
             shutil.rmtree(temp_dir, ignore_errors=True)
 
 
+class OutputWorkspaceNameTests(unittest.TestCase):
+    """The default OutputWorkspace name is built from the sample IPTS and run numbers, and the
+    default name of the saved files follows from it."""
+
+    def _auto_populated_name(self, **properties):
+        algo = AlgorithmManager.create("HFIRPowderReduction")
+        algo.initialize()
+        for name, value in properties.items():
+            algo.setProperty(name, value)
+        prop = algo.getProperty("OutputWorkspace")
+        settings = prop.settings if isinstance(prop.settings, list) else [prop.settings]
+        for setting in settings:
+            if hasattr(setting, "_applyChanges"):
+                setting._applyChanges(algo, "OutputWorkspace")
+        return algo.getPropertyValue("OutputWorkspace")
+
+    def test_single_run(self):
+        self.assertEqual(self._auto_populated_name(SampleIPTS=1234, SampleRunNumbers=[456]), "IPTS1234_Run456")
+
+    def test_continuous_range_of_runs(self):
+        self.assertEqual(self._auto_populated_name(SampleIPTS=1234, SampleRunNumbers=[5, 6, 7]), "IPTS1234_Run5-7")
+
+    def test_several_continuous_ranges_of_runs(self):
+        self.assertEqual(self._auto_populated_name(SampleIPTS=1234, SampleRunNumbers=[5, 6, 7, 9, 10]), "IPTS1234_Run5-7_9-10")
+
+    def test_discontinuous_runs(self):
+        self.assertEqual(self._auto_populated_name(SampleIPTS=1234, SampleRunNumbers=[5, 7, 9]), "IPTS1234_Run5_7_9")
+
+    def test_runs_are_sorted_and_deduplicated(self):
+        self.assertEqual(self._auto_populated_name(SampleIPTS=1234, SampleRunNumbers=[10, 6, 5, 6]), "IPTS1234_Run5-6_10")
+
+    def test_name_entered_by_the_user_is_not_overwritten(self):
+        name = self._auto_populated_name(OutputWorkspace="my_workspace", SampleIPTS=1234, SampleRunNumbers=[456])
+        self.assertEqual(name, "my_workspace")
+
+    def test_not_populated_without_ipts_and_run_numbers(self):
+        algo = _create_algo()
+        self.assertEqual(algo._defaultOutputWorkspaceName(), "")
+
+    def test_not_populated_without_ipts(self):
+        algo = _create_algo(SampleRunNumbers=[456])
+        self.assertEqual(algo._defaultOutputWorkspaceName(), "")
+
+    def test_ipts_and_runs_taken_from_filenames(self):
+        # files in the standard HFIR layout carry the IPTS and run numbers in their paths
+        algo = _create_algo()
+        files = [f"/HFIR/HB2C/IPTS-1234/nexus/HB2C_{run}.nxs.h5" for run in (5, 6, 8)]
+        self.assertEqual(algo._iptsAndRunNumbersFromFilenames(files), (1234, [5, 6, 8]))
+
+    def test_midas_filenames(self):
+        algo = _create_algo()
+        self.assertEqual(algo._iptsAndRunNumbersFromFilenames(["/HFIR/HB2A/IPTS-99/nexus/HB2A_7.nxs.h5"]), (99, [7]))
+
+    def test_filenames_outside_the_standard_layout_are_ignored(self):
+        algo = _create_algo()
+        self.assertEqual(algo._iptsAndRunNumbersFromFilenames(["/home/user/my_data.nxs.h5"]), (None, []))
+        self.assertEqual(algo._iptsAndRunNumbersFromFilenames(["/HFIR/HB2C/IPTS-1234/shared/reduced.nxs.h5"]), (None, []))
+
+    def test_filenames_from_different_ipts_are_ignored(self):
+        algo = _create_algo()
+        files = ["/HFIR/HB2C/IPTS-1234/nexus/HB2C_5.nxs.h5", "/HFIR/HB2C/IPTS-5678/nexus/HB2C_6.nxs.h5"]
+        self.assertEqual(algo._iptsAndRunNumbersFromFilenames(files), (None, []))
+
+
 class MetadataConsistencyTests(unittest.TestCase):
     def test_metadata_consistency_single_file(self):
         """Test that single file does not trigger metadata check"""
@@ -1642,6 +1706,31 @@ class ReductionExecutionTests(unittest.TestCase):
         # Load the output file and check it contains a workspace
         output_ws = Load(output_file_name)
         self.assertIsInstance(output_ws, MatrixWorkspace)
+
+    def test_save_to_directory(self):
+        # check that OutputDirectory accepts a directory, naming the files after the output workspace
+
+        data, cal, bkg = self._create_workspaces()
+
+        output_dir = os.path.join(self._test_dir, "reduction_output")
+        os.mkdir(output_dir)
+
+        HFIRPowderReduction(
+            SampleFilename=data,
+            XUnits="2Theta",
+            NormaliseBy="None",
+            Sum=False,
+            XMin=0,
+            XMax=70,
+            Instrument="WAND^2",
+            Wavelength=1.6513,
+            VanadiumDiameter=0.5,
+            OutputWorkspace="output_workspace",
+            OutputDirectory=output_dir,
+        )
+
+        self.assertTrue(os.path.isfile(os.path.join(output_dir, "output_workspace.dat")))
+        self.assertTrue(os.path.isfile(os.path.join(output_dir, "output_workspace.nxs")))
 
 
 class VanadiumAbsorptionCorrectionTests(unittest.TestCase):

--- a/docs/source/algorithms/HFIRPowderReduction-v1.rst
+++ b/docs/source/algorithms/HFIRPowderReduction-v1.rst
@@ -143,6 +143,18 @@ molecular mass of ``SampleChemicalFormula``, :math:`\rho_S` is ``SampleCrystalDe
 radii of the vanadium and sample cylinders as above. This requires
 ``VanadiumDiameter``, ``VanadiumHeight`` and ``SampleHeight`` to all be greater than zero.
 
+
+Saving Results
+##############
+
+The default ``OutputWorkspace`` name is built from the sample IPTS and run numbers as ``IPTS<ipts>_Run<runs>``,
+where consecutive runs are collapsed into ranges. For IPTS-1234 this gives ``IPTS1234_Run5`` for the single run 5,
+``IPTS1234_Run5-7`` for the runs 5 to 7, ``IPTS1234_Run5-7_9-10`` for the runs 5 to 7 and 9 to 10, and
+``IPTS1234_Run5_7_9`` for the runs 5, 7 and 9. The IPTS and run numbers are taken from ``SampleIPTS`` and
+``SampleRunNumbers``, or from the paths in ``SampleFilename`` when those files are in the standard HFIR layout.
+When ``OutputDirectory`` is a directory, the saved files are named after the output workspace, so the reduction of
+runs 5 to 7 of IPTS-1234 is saved as ``IPTS1234_Run5-7.dat`` and ``IPTS1234_Run5-7.nxs``.
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42115.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42115.rst
@@ -1,0 +1,1 @@
+- In :ref:`algm-HFIRPowderReduction`, the ``OutputWorskpace`` field now has a defualt based on the IPTS and run number. ``OutputDirectory`` now browses to a directory and user can manually set the file name by typing it in the box.

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42115.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42115.rst
@@ -1,1 +1,1 @@
-- In :ref:`algm-HFIRPowderReduction`, the ``OutputWorskpace`` field now has a defualt based on the IPTS and run number. ``OutputDirectory`` now browses to a directory and user can manually set the file name by typing it in the box.
+- In :ref:`algm-HFIRPowderReduction`, the ``OutputWorskspace`` field now has a default based on the IPTS and run number. ``OutputDirectory`` now browses to a directory and user can manually set the file name by typing it in the box.


### PR DESCRIPTION
### Description of work

Updated HFIRPowderReduction so that OutputWorkspace is generated by default based on IPTS and run numbers; OutputDirectory now lets user browse to directory and user can manually set the output file name by typing in the box. It was requested originally that clicking browse on OutputDirectory would let user select either folder or file, but qt only lets user do one or the other. 

Assisted-by: Opus 5 [noreply@anthropic.com](mailto:noreply@anthropic.com)

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

EWM Item [17539](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17539)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Open the dialog box for HFIRPowderReduction on analysis and select a WAND run; that is located under /HFIR/HB2C/IPTS-<number>/nexus/HB2C_<run number>.nxs.h5. When you select the file, scroll down to the OutputWorkspace field and notice the output name is now "IPTS<number>_Run<number>". Check that multiple runs shows in the output name by unsetting the sample file name and just set the sample IPTS and run numbers. A range of runs shows as "IPTS<number>_Run<number>-<number>", while specific runs will show as "IPTS<number>_Run<number>_<number>". Make sure the browse button for output directory works by clicking the brows button and selecting a directory. You can specify the output filename by manually adding <name>.dat in the output directory box. If no name is specified, it should just be the output workspace name + .dat.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
