### PR TITLE
Fix compiler warnings

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -326,6 +326,7 @@ public:
 
   // The mutable legacy accessors require ISpectrum's own legacy interface
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   /// Deprecated, use mutableX() instead. Returns the x data
   [[deprecated("use mutableX() instead")]]
   virtual MantidVec &dataX(const std::size_t index) {
@@ -346,6 +347,7 @@ public:
   virtual MantidVec &dataDx(const std::size_t index) {
     return getSpectrumWithoutInvalidation(index).dataDx();
   }
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 
   /// Deprecated, use x() instead. Returns the x data const

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -1580,8 +1580,10 @@ private:
         // accessor can do this; the size-checked histogram types forbid it by design, so the
         // deprecation warning is suppressed rather than migrated.
         GNU_DIAG_OFF("deprecated-declarations")
+        MSVC_DIAG_OFF(4996)
         inputWs->dataDx(0).emplace_back(1);
         inputWs->dataDx(1).emplace_back(1);
+        MSVC_DIAG_ON(4996)
         GNU_DIAG_ON("deprecated-declarations")
       }
     }

--- a/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
@@ -70,6 +70,7 @@ public:
   // interface: handing out a mutable MantidVec would allow the length to be changed, so
   // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   /// Deprecated, use mutableY() instead. Returns the y data
   [[deprecated("use mutableY() instead")]]
   MantidVec &dataY() override {
@@ -80,6 +81,7 @@ public:
   MantidVec &dataE() override {
     return m_histogram.dataE();
   }
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 
   virtual std::size_t size() const { return m_histogram.y().size(); } ///< get pseudo size

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1394,7 +1394,9 @@ MantidVec &EventList::dataX() {
   // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend. The
   // deprecated legacy accessor is therefore the only way to express this.
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   return m_histogram.dataX();
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 }
 
@@ -1410,7 +1412,9 @@ Kernel::cow_ptr<HistogramData::HistogramX> EventList::ptrX() const { return m_hi
 
 /// Deprecated, use mutableDx() instead.
 GNU_DIAG_OFF("deprecated-declarations")
+MSVC_DIAG_OFF(4996)
 MantidVec &EventList::dataDx() { return m_histogram.dataDx(); }
+MSVC_DIAG_ON(4996)
 GNU_DIAG_ON("deprecated-declarations")
 /// Deprecated, use dx() instead.
 const MantidVec &EventList::dataDx() const { return m_histogram.dx().rawData(); }

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -501,6 +501,7 @@ size_t EventWorkspace::getMemorySize() const {
 // interface: handing out a mutable MantidVec would allow the length to be changed, so
 // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
 GNU_DIAG_OFF("deprecated-declarations")
+MSVC_DIAG_OFF(4996)
 
 /// Deprecated, use mutableX() instead. Return the data X vector at a given
 /// workspace index
@@ -514,6 +515,7 @@ MantidVec &EventWorkspace::dataX(const std::size_t index) { return getSpectrum(i
 /// @returns A reference to the vector of binned error values
 MantidVec &EventWorkspace::dataDx(const std::size_t index) { return getSpectrum(index).dataDx(); }
 
+MSVC_DIAG_ON(4996)
 GNU_DIAG_ON("deprecated-declarations")
 
 /// Deprecated, use mutableY() instead. Return the data Y vector at a given

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -55,10 +55,12 @@ void Histogram1D::setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) { m_
 // interface: handing out a mutable MantidVec would allow the length to be changed, so
 // FixedLengthVector::mutableRawData() is protected and Histogram is its only friend.
 GNU_DIAG_OFF("deprecated-declarations")
+MSVC_DIAG_OFF(4996)
 
 /// Deprecated, use mutableX() instead. Returns the x data
 MantidVec &Histogram1D::dataX() { return m_histogram.dataX(); }
 
+MSVC_DIAG_ON(4996)
 GNU_DIAG_ON("deprecated-declarations")
 
 /// Deprecated, use x() instead. Returns the x data const
@@ -71,8 +73,10 @@ const MantidVec &Histogram1D::readX() const { return m_histogram.x().rawData(); 
 Kernel::cow_ptr<HistogramData::HistogramX> Histogram1D::ptrX() const { return m_histogram.sharedX(); }
 
 GNU_DIAG_OFF("deprecated-declarations")
+MSVC_DIAG_OFF(4996)
 /// Deprecated, use mutableDx() instead.
 MantidVec &Histogram1D::dataDx() { return m_histogram.dataDx(); }
+MSVC_DIAG_ON(4996)
 GNU_DIAG_ON("deprecated-declarations")
 /// Deprecated, use dx() instead.
 const MantidVec &Histogram1D::dataDx() const { return m_histogram.dx().rawData(); }

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -908,7 +908,9 @@ public:
     // This test exists to cover the deprecated accessor itself, so the warning is suppressed
     // rather than migrated to x().
     GNU_DIAG_OFF("deprecated-declarations")
+    MSVC_DIAG_OFF(4996)
     const MantidVec &vec = el.dataX();
+    MSVC_DIAG_ON(4996)
     GNU_DIAG_ON("deprecated-declarations")
     TS_ASSERT_EQUALS(vec, inVec);
   }

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -283,6 +283,7 @@ public:
   // This test pins the error contract of the deprecated accessors themselves
   // The warnings are therefore suppressed rather than migrated.
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   void test_data_access() {
     // Non-const access throws errors for Y & E - not for X
     TS_ASSERT_THROWS_NOTHING(ew->dataX(1));
@@ -296,6 +297,7 @@ public:
 
     // Can't try the const access; copy constructors are not allowed.
   }
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 
   void test_setX_individually() {
@@ -796,6 +798,7 @@ public:
   // This test deliberately covers the deprecated accessors alongside the modern ones, so the
   // warnings are suppressed rather than migrated.
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   void test_readYE() {
     int numEvents = 2;
     int numHistograms = 2;
@@ -805,6 +808,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(ws->e(0));
     TS_ASSERT_THROWS_NOTHING(ws->dataE(0));
   }
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 
   void test_histogram() {

--- a/Framework/HistogramData/test/FixedLengthVectorTest.h
+++ b/Framework/HistogramData/test/FixedLengthVectorTest.h
@@ -220,6 +220,15 @@ public:
     TS_ASSERT_THROWS_NOTHING((values = {0.1, 0.2, 0.3}));
     TS_ASSERT_EQUALS(values.size(), 3);
     TS_ASSERT_EQUALS(values[2], 0.3);
+  }
+
+  // Deliberately separate from the test above: with the growing assignment and
+  // the failing one inlined into a single function, GCC 13 at -O3 merges their
+  // value ranges and reports a bogus -Wstringop-overflow against the assignment
+  // below, which checkAssignmentSize never actually reaches.
+  void test_assignment_after_growing_from_empty_throws() {
+    FixedLengthVectorTester values(0);
+    values = {0.1, 0.2, 0.3};
     TS_ASSERT_THROWS((values = {0.1, 0.2}), const std::logic_error &);
   }
 

--- a/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -375,7 +375,7 @@ MDTransfModQ::MDTransfModQ()
  * @return coord_t pair with min and max bounds of selected dimension.
  */
 std::pair<coord_t, coord_t> MDTransfModQ::getDimBounds(size_t dim) const {
-  return std::make_pair(m_DimMin[dim], m_DimMax[dim]);
+  return std::make_pair(static_cast<coord_t>(m_DimMin[dim]), static_cast<coord_t>(m_DimMax[dim]));
 }
 
 std::vector<std::string> MDTransfModQ::getEmodes() const { return Kernel::DeltaEMode::availableTypes(); }

--- a/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
@@ -174,7 +174,7 @@ MDTransfNoQ::MDTransfNoQ() : m_NMatrixDim(0), m_YAxis(nullptr), m_Det(nullptr) {
  * @return coord_t pair with min and max bounds of selected dimension.
  */
 std::pair<coord_t, coord_t> MDTransfNoQ::getDimBounds(size_t dim) const {
-  return std::make_pair(m_DimMin[dim], m_DimMax[dim]);
+  return std::make_pair(static_cast<coord_t>(m_DimMin[dim]), static_cast<coord_t>(m_DimMax[dim]));
 }
 
 /**

--- a/Framework/MDAlgorithms/test/LoadSQWTest.h
+++ b/Framework/MDAlgorithms/test/LoadSQWTest.h
@@ -77,8 +77,8 @@ class ExposedLoadSQW : public LoadSQW {
 public:
   ExposedLoadSQW() : LoadSQW() {}
   void exec() override {
-    std::runtime_error("Don't use this method, use setup instead, or the "
-                       "full-blown LoadSQW type.");
+    throw std::runtime_error("Don't use this method, use setup instead, or the "
+                             "full-blown LoadSQW type.");
   }
   // Call instead of execute to set-up.
   virtual void setup() {

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FakeObjects.h
@@ -73,10 +73,12 @@ public:
   void setX(const Mantid::Kernel::cow_ptr<Mantid::HistogramData::HistogramX> &X) override { m_histogram.setSharedX(X); }
   // The mutable legacy accessors below require Histogram's legacy interface
   GNU_DIAG_OFF("deprecated-declarations")
+  MSVC_DIAG_OFF(4996)
   MantidVec &dataX() override { return m_histogram.dataX(); }
   MantidVec &dataDx() override { return m_histogram.dataDx(); }
   MantidVec &dataY() override { return m_histogram.dataY(); }
   MantidVec &dataE() override { return m_histogram.dataE(); }
+  MSVC_DIAG_ON(4996)
   GNU_DIAG_ON("deprecated-declarations")
 
   const MantidVec &dataX() const override { return m_histogram.x().rawData(); }

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MDEventsTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/MDEventsTestHelper.h
@@ -446,11 +446,12 @@ template <size_t nd> static MDGridBox<MDLeanEvent<nd>, nd> *makeRecursiveMDGridB
   // Splits into splitInto x splitInto x ... boxes
   splitter->setSplitInto(splitInto);
   // Set the size to splitInto*1.0 in all directions
-  auto box = std::make_unique<MDBox<MDLeanEvent<nd>, nd>>(splitter);
+  MDBox<MDLeanEvent<nd>, nd> box(splitter);
   for (size_t d = 0; d < nd; d++)
-    box->setExtents(d, 0.0, static_cast<coord_t>(splitInto));
-  // Split into the gridbox.
-  auto gridbox = new MDGridBox<MDLeanEvent<nd>, nd>(box.get());
+    box.setExtents(d, 0.0, static_cast<coord_t>(splitInto));
+  // Split into the gridbox. MDGridBox copies the events out and does not take
+  // ownership, so the box can live on the stack.
+  auto gridbox = new MDGridBox<MDLeanEvent<nd>, nd>(&box);
   // Now recursively split more
   recurseSplit(gridbox, 0, levels);
 

--- a/qt/icons/src/Icon.cpp
+++ b/qt/icons/src/Icon.cpp
@@ -21,7 +21,9 @@ MantidQt::Icons::IconicFont &iconFontInstance() {
 
 QHash<QString, QVariant> loadJsonFile(const QString &charmapFileName) {
   QFile jsonFile(charmapFileName);
-  jsonFile.open(QFile::ReadOnly);
+  if (!jsonFile.open(QFile::ReadOnly)) {
+    throw std::runtime_error("Failed to open icon charmap file: " + charmapFileName.toStdString());
+  }
   const auto jsonDocument = QJsonDocument().fromJson(jsonFile.readAll());
   const auto jsonObject = jsonDocument.object();
   // VariantHash = QHash<QString, QVariant> in this case QVaraint = QString

--- a/qt/widgets/instrumentview/src/DetXMLFile.cpp
+++ b/qt/widgets/instrumentview/src/DetXMLFile.cpp
@@ -10,6 +10,7 @@
 #include <QTemporaryFile>
 
 #include <fstream>
+#include <stdexcept>
 
 namespace MantidQt::MantidWidgets {
 /**
@@ -48,7 +49,10 @@ DetXMLFile::DetXMLFile(const std::vector<int> &dets, Option opt, const QString &
 
   if (fname.isEmpty()) {
     QTemporaryFile mapFile;
-    mapFile.open();
+    // Opened only to reserve a unique name; the grouping is written to a sibling ".xml" path.
+    if (!mapFile.open()) {
+      throw std::runtime_error("Failed to create a temporary file for the detector grouping");
+    }
     m_fileName = mapFile.fileName() + ".xml";
     mapFile.close();
     m_delete = true;


### PR DESCRIPTION
There are distinct fixes in this
1. msvc did not share a warning suppression with gcc. The compiler specific change has been made so they match.
2. One unit in `FixedLengthVectorTest` was split so there is no longer a warning from misusing the standard library.
3. `MDEventsTestHelper` was modified for a memory issue only seen in `-O2`/`RelWithDebugInfo`.

There is no associated issue.

### To test:

Look at the annotations on the main pr-build. There won't be any more compiler warnings in `Framework`.

*This does not require release notes* because it is minor changes to fix compiler warnings. Two of which are only on test.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
