### PR TITLE
Adding IntegratePeaksShapeMD so users can use their own peak shapes

### DIFF
--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SRC_FILES
     src/IntegratePeaksMD.cpp
     src/IntegratePeaksMD2.cpp
     src/IntegratePeaksMDHKL.cpp
+    src/IntegratePeaksShapeMD.cpp
     src/IntegrateQLabEvents.cpp
     src/InvalidParameter.cpp
     src/InvalidParameterParser.cpp
@@ -184,6 +185,7 @@ set(INC_FILES
     inc/MantidMDAlgorithms/IntegratePeaksMD.h
     inc/MantidMDAlgorithms/IntegratePeaksMD2.h
     inc/MantidMDAlgorithms/IntegratePeaksMDHKL.h
+    inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
     inc/MantidMDAlgorithms/IntegrateQLabEvents.h
     inc/MantidMDAlgorithms/InvalidParameter.h
     inc/MantidMDAlgorithms/InvalidParameterParser.h
@@ -304,6 +306,7 @@ set(TEST_FILES
     IntegratePeaksMD2Test.h
     IntegratePeaksMDHKLTest.h
     IntegratePeaksMDTest.h
+    IntegratePeaksShapeMDTest.h
     IntegrateQLabEventsTest.h
     InvalidParameterParserTest.h
     InvalidParameterTest.h

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -123,12 +123,18 @@ public:
   /// events inside/outside ellipsoidal boundaries. The shape's peak radii
   /// are interpreted as the Gaussian's standard deviations (1-sigma) along
   /// its principal axes; the shape's background radii are not used, since
-  /// the background rate is fit directly instead. If adjustCenter is true,
+  /// the background rate is fit directly instead. shape.translation() seeds
+  /// the fit center (an offset from peak_q), so a previously found
+  /// correction is honored rather than discarded. If adjustCenter is true,
   /// also refines the center by a bounded, coordinate-ascent Gauss-Newton
-  /// step (capped at one standard deviation from peak_q) -- a slight
-  /// correction, not a free centroid search.
+  /// step (capped at one standard deviation of incremental shift from
+  /// shape.translation()) -- a slight correction, not a free centroid
+  /// search. center returns the offset from peak_q actually used for the
+  /// fit (unchanged from shape.translation() if adjustCenter is false), for
+  /// the caller to persist as the output shape's translation if it wants to.
   void integrateUsingShapeProfileFit(const Mantid::DataObjects::PeakShapeEllipsoid &shape,
-                                     const Mantid::Kernel::V3D &peak_q, bool adjustCenter, double &inti, double &sigi);
+                                     const Mantid::Kernel::V3D &peak_q, bool adjustCenter, Mantid::Kernel::V3D &center,
+                                     double &inti, double &sigi);
 
   /// Estimate the signal-to-noise ratio for a peak at the given position
   /// by fitting an ellipsoid to the events and comparing peak to background

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -24,13 +24,19 @@ class PeakShape;
 }
 namespace MDAlgorithms {
 
+/** @struct IntegrationParameters
+ *  @brief Parameters for controlling peak integration
+ *
+ *  This structure contains the parameters needed to control the integration
+ *  of peaks using ellipsoidal volumes.
+ */
 struct IntegrationParameters {
-  std::vector<Kernel::V3D> E1Vectors;
-  double backgroundInnerRadius;
-  double backgroundOuterRadius;
-  double regionRadius;
-  double peakRadius;
-  bool specifySize;
+  std::vector<Kernel::V3D> E1Vectors;   ///< Vectors for calculating detector edges
+  double backgroundInnerRadius;         ///< Inner radius of background shell
+  double backgroundOuterRadius;         ///< Outer radius of background shell
+  double regionRadius;                  ///< Radius of region to search for events
+  double peakRadius;                    ///< Radius of peak ellipsoid
+  bool specifySize;                     ///< If true, use specified sizes; if false, use data-driven sizes
 };
 
 /**
@@ -81,10 +87,13 @@ public:
                             double peak_radius, double back_inner_radius, double back_outer_radius,
                             DataObjects::PeakEllipsoidExtent &axes_radii, double &inti, double &sigi);
 
-  /// Find the net integrated intensity of a peak, using ellipsoidal volumes
+  /// Find the net integrated intensity of a strong peak, using ellipsoidal volumes
+  /// fit from the events, and return peak shape and library peak parameters
   std::pair<std::shared_ptr<const Mantid::Geometry::PeakShape>, std::tuple<double, double, double>>
   integrateStrongPeak(const IntegrationParameters &params, const Kernel::V3D &peak_q, double &inti, double &sigi);
 
+  /// Integrate a weak peak using a shape from a library peak, scaling the
+  /// shape by the fractional intensity from the library peak
   std::shared_ptr<const Geometry::PeakShape> integrateWeakPeak(const IntegrationParameters &params,
                                                                Mantid::DataObjects::PeakShapeEllipsoid_const_sptr shape,
                                                                const std::tuple<double, double, double> &libPeak,
@@ -110,6 +119,8 @@ public:
   void integrateUsingShapeProfileFit(const Mantid::DataObjects::PeakShapeEllipsoid &shape,
                                      const Mantid::Kernel::V3D &peak_q, bool adjustCenter, double &inti, double &sigi);
 
+  /// Estimate the signal-to-noise ratio for a peak at the given position
+  /// by fitting an ellipsoid to the events and comparing peak to background
   double estimateSignalToNoiseRatio(const IntegrationParameters &params, const Mantid::Kernel::V3D &center,
                                     bool forceSpherical = false, double sphericityTol = 0.02);
 
@@ -118,6 +129,8 @@ private:
   const std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> *
   getEvents(const Mantid::Kernel::V3D &peak_q);
 
+  /// Correct integration radii if peak extends to detector edges
+  /// and return false if peak center is off detector
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,
                                const std::vector<Mantid::Kernel::V3D> &E1Vecs, const Mantid::Kernel::V3D &peak_q,
                                const DataObjects::PeakEllipsoidExtent &axesRadii,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -92,9 +92,23 @@ public:
                                                                double &sigi);
 
   /// Integrate a peak using a shape supplied by the caller (e.g. from an
-  /// already-integrated PeaksWorkspace) instead of one fit from the events
+  /// already-integrated PeaksWorkspace) instead of one fit from the events,
+  /// used exactly as supplied and centered on peak_q.
   void integrateUsingShape(const Mantid::DataObjects::PeakShapeEllipsoid &shape, const Mantid::Kernel::V3D &peak_q,
                            double &inti, double &sigi);
+
+  /// Integrate a peak using a shape supplied by the caller, by maximizing
+  /// the Poisson log-likelihood of a Gaussian peak (amplitude fit) plus a
+  /// flat background rate against the raw events, instead of counting
+  /// events inside/outside ellipsoidal boundaries. The shape's peak radii
+  /// are interpreted as the Gaussian's standard deviations (1-sigma) along
+  /// its principal axes; the shape's background radii are not used, since
+  /// the background rate is fit directly instead. If adjustCenter is true,
+  /// also refines the center by a bounded, coordinate-ascent Gauss-Newton
+  /// step (capped at one standard deviation from peak_q) -- a slight
+  /// correction, not a free centroid search.
+  void integrateUsingShapeProfileFit(const Mantid::DataObjects::PeakShapeEllipsoid &shape,
+                                     const Mantid::Kernel::V3D &peak_q, bool adjustCenter, double &inti, double &sigi);
 
   double estimateSignalToNoiseRatio(const IntegrationParameters &params, const Mantid::Kernel::V3D &center,
                                     bool forceSpherical = false, double sphericityTol = 0.02);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -93,9 +93,8 @@ public:
 
   /// Integrate a peak using a shape supplied by the caller (e.g. from an
   /// already-integrated PeaksWorkspace) instead of one fit from the events
-  std::shared_ptr<const Geometry::PeakShape>
-  integrateUsingShape(Mantid::DataObjects::PeakShapeEllipsoid_const_sptr shape, const Mantid::Kernel::V3D &peak_q,
-                      double &inti, double &sigi);
+  void integrateUsingShape(const Mantid::DataObjects::PeakShapeEllipsoid &shape, const Mantid::Kernel::V3D &peak_q,
+                           double &inti, double &sigi);
 
   double estimateSignalToNoiseRatio(const IntegrationParameters &params, const Mantid::Kernel::V3D &center,
                                     bool forceSpherical = false, double sphericityTol = 0.02);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -18,6 +18,17 @@
 #include <unordered_map>
 #include <vector>
 
+/**
+ * Fits a Gaussian peak and constant background using the supplied ellipsoidal
+ * shape and event data.
+ *
+ * @param shape Ellipsoidal peak shape whose principal radii define the Gaussian
+ *              standard deviations.
+ * @param peak_q Peak center in Q-space.
+ * @param adjustCenter Whether to apply a bounded center refinement.
+ * @param inti Output fitted peak intensity.
+ * @param sigi Output uncertainty of the fitted intensity.
+ */
 namespace Mantid {
 namespace Geometry {
 class PeakShape;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -91,6 +91,12 @@ public:
                                                                const Mantid::Kernel::V3D &peak_q, double &inti,
                                                                double &sigi);
 
+  /// Integrate a peak using a shape supplied by the caller (e.g. from an
+  /// already-integrated PeaksWorkspace) instead of one fit from the events
+  std::shared_ptr<const Geometry::PeakShape>
+  integrateUsingShape(Mantid::DataObjects::PeakShapeEllipsoid_const_sptr shape, const Mantid::Kernel::V3D &peak_q,
+                      double &inti, double &sigi);
+
   double estimateSignalToNoiseRatio(const IntegrationParameters &params, const Mantid::Kernel::V3D &center,
                                     bool forceSpherical = false, double sphericityTol = 0.02);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -42,12 +42,12 @@ namespace MDAlgorithms {
  *  of peaks using ellipsoidal volumes.
  */
 struct IntegrationParameters {
-  std::vector<Kernel::V3D> E1Vectors;   ///< Vectors for calculating detector edges
-  double backgroundInnerRadius;         ///< Inner radius of background shell
-  double backgroundOuterRadius;         ///< Outer radius of background shell
-  double regionRadius;                  ///< Radius of region to search for events
-  double peakRadius;                    ///< Radius of peak ellipsoid
-  bool specifySize;                     ///< If true, use specified sizes; if false, use data-driven sizes
+  std::vector<Kernel::V3D> E1Vectors; ///< Vectors for calculating detector edges
+  double backgroundInnerRadius;       ///< Inner radius of background shell
+  double backgroundOuterRadius;       ///< Outer radius of background shell
+  double regionRadius;                ///< Radius of region to search for events
+  double peakRadius;                  ///< Radius of peak ellipsoid
+  bool specifySize;                   ///< If true, use specified sizes; if false, use data-driven sizes
 };
 
 /**

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
@@ -1,0 +1,55 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Progress.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/Matrix.h"
+#include "MantidMDAlgorithms/Integrate3DEvents.h"
+
+namespace Mantid {
+namespace MDAlgorithms {
+
+/** @class IntegratePeaksShapeMD
+
+  IntegratePeaksShapeMD integrates single crystal Bragg peaks using the
+  ellipsoidal peak shape already stored on each peak in the input
+  PeaksWorkspace (e.g. from a previous IntegrateEllipsoids run), rather than
+  fitting a new shape from the events around each peak.
+*/
+
+class MANTID_MDALGORITHMS_DLL IntegratePeaksShapeMD final : public API::Algorithm {
+public:
+  /// Get the name of this algorithm
+  const std::string name() const override;
+  /// Get the version of this algorithm
+  int version() const override;
+  const std::vector<std::string> seeAlso() const override {
+    return {"IntegrateEllipsoids", "IntegrateEllipsoidsTwoStep", "IntegratePeaksMD"};
+  }
+  /// Get the category of this algorithm
+  const std::string category() const override;
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "Integrate Single Crystal Diffraction Bragg peaks using the ellipsoidal "
+           "peak shape already stored on each peak.";
+  }
+
+private:
+  void init() override;
+  void exec() override;
+
+  void qListFromHistoWS(Integrate3DEvents &integrator, API::Progress &prog, DataObjects::Workspace2D_sptr &wksp);
+  void qListFromEventWS(Integrate3DEvents &integrator, API::Progress &prog, DataObjects::EventWorkspace_sptr &wksp);
+};
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
@@ -30,7 +30,25 @@ class MANTID_MDALGORITHMS_DLL IntegratePeaksShapeMD final : public API::Algorith
 public:
   /// Get the name of this algorithm
   const std::string name() const override;
-  /// Get the version of this algorithm
+  /**
+   * Gets the algorithm version.
+   * @return The algorithm version.
+   */
+  
+  /**
+   * Gets related algorithms.
+   * @return The names of related algorithms.
+   */
+  
+  /**
+   * Gets the algorithm category.
+   * @return The algorithm category.
+   */
+  
+  /**
+   * Describes integration of single-crystal diffraction Bragg peaks using stored ellipsoidal peak shapes.
+   * @return A summary of the algorithm's purpose.
+   */
   int version() const override;
   const std::vector<std::string> seeAlso() const override {
     return {"IntegrateEllipsoids", "IntegrateEllipsoidsTwoStep", "IntegratePeaksMD"};

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksShapeMD.h
@@ -34,17 +34,17 @@ public:
    * Gets the algorithm version.
    * @return The algorithm version.
    */
-  
+
   /**
    * Gets related algorithms.
    * @return The names of related algorithms.
    */
-  
+
   /**
    * Gets the algorithm category.
    * @return The algorithm category.
    */
-  
+
   /**
    * Describes integration of single-crystal diffraction Bragg peaks using stored ellipsoidal peak shapes.
    * @return A summary of the algorithm's purpose.

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -9,9 +9,11 @@
 #include "MantidDataObjects/PeakShapeEllipsoid.h"
 #include "MantidGeometry/Crystal/IndexingUtils.h"
 
+#include <algorithm>
 #include <boost/math/special_functions/round.hpp>
 #include <cmath>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <tuple>
@@ -261,6 +263,106 @@ Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakSh
                                                     "IntegrateEllipsoidsTwoStep");
 }
 
+namespace {
+/// Maximize the (weighted) Poisson log-likelihood
+/// sum(w_i * ln(A*g_i + b)) - (A*normG + b*volume) over A, b >= 0, via a
+/// bounded, backtracking Newton solve. g_i are the (unnormalized, peak
+/// height 1) Gaussian kernel values at each event; normG is the kernel's
+/// integral over all space; volume is the search region's volume (its
+/// background rate contribution). Also returns the standard error on A
+/// from the observed Fisher information.
+void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<double> &w, double normG, double volume,
+                               double &A, double &b, double &sigA) {
+  const auto n = g.size();
+
+  auto logLikelihoodGradHess = [&](double a, double bb, double &dA, double &dB, double &dAA, double &dBB, double &dAB) {
+    dA = -normG;
+    dB = -volume;
+    dAA = 0.0;
+    dBB = 0.0;
+    dAB = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+      const auto mu = std::max(a * g[i] + bb, 1e-12);
+      const auto wi = w[i];
+      dA += wi * g[i] / mu;
+      dB += wi / mu;
+      dAA -= wi * g[i] * g[i] / (mu * mu);
+      dBB -= wi / (mu * mu);
+      dAB -= wi * g[i] / (mu * mu);
+    }
+  };
+
+  // seed from crude percentile-free estimates: total weight split evenly
+  // between a peak (using the largest kernel value seen) and a flat
+  // background over the search volume
+  double sumW = 0.0, gMax = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    sumW += w[i];
+    gMax = std::max(gMax, g[i]);
+  }
+  b = volume > 0 ? std::max(0.5 * sumW / volume, 1e-10) : 1e-10;
+  A = gMax > 0 ? std::max(0.5 * sumW / (gMax * normG > 0 ? normG : 1.0), 1e-10) : 1e-10;
+
+  for (int iter = 0; iter < 100; ++iter) {
+    double dA, dB, dAA, dBB, dAB;
+    logLikelihoodGradHess(A, b, dA, dB, dAA, dBB, dAB);
+
+    const auto det = dAA * dBB - dAB * dAB;
+    if (std::abs(det) < 1e-300)
+      break;
+
+    const auto deltaA = -(dBB * dA - dAB * dB) / det;
+    const auto deltaB = -(-dAB * dA + dAA * dB) / det;
+
+    // backtrack until both parameters stay non-negative
+    double step = 1.0;
+    double newA = A, newB = b;
+    for (int halving = 0; halving < 30; ++halving) {
+      newA = A + step * deltaA;
+      newB = b + step * deltaB;
+      if (newA >= 0.0 && newB >= 0.0)
+        break;
+      step *= 0.5;
+    }
+    newA = std::max(newA, 0.0);
+    newB = std::max(newB, 0.0);
+
+    const auto converged = std::abs(newA - A) < 1e-12 * (1.0 + A) && std::abs(newB - b) < 1e-12 * (1.0 + b);
+    A = newA;
+    b = newB;
+    if (converged)
+      break;
+  }
+
+  double dA, dB, dAA, dBB, dAB;
+  logLikelihoodGradHess(A, b, dA, dB, dAA, dBB, dAB);
+  sigA = dAA < 0.0 ? std::sqrt(-1.0 / dAA) : std::numeric_limits<double>::infinity();
+}
+
+/// Solve the 3x3 linear system H*x = -g via Cramer's rule, used for the
+/// Gauss-Newton center-refinement step. Returns false (x left unchanged) if
+/// H is singular.
+bool solve3x3(const double H[3][3], const double g[3], double x[3]) {
+  const auto det = H[0][0] * (H[1][1] * H[2][2] - H[1][2] * H[2][1]) -
+                   H[0][1] * (H[1][0] * H[2][2] - H[1][2] * H[2][0]) +
+                   H[0][2] * (H[1][0] * H[2][1] - H[1][1] * H[2][0]);
+  if (std::abs(det) < 1e-300)
+    return false;
+
+  for (int col = 0; col < 3; ++col) {
+    double M[3][3];
+    for (int r = 0; r < 3; ++r)
+      for (int c = 0; c < 3; ++c)
+        M[r][c] = (c == col) ? -g[r] : H[r][c];
+    const auto colDet = M[0][0] * (M[1][1] * M[2][2] - M[1][2] * M[2][1]) -
+                        M[0][1] * (M[1][0] * M[2][2] - M[1][2] * M[2][0]) +
+                        M[0][2] * (M[1][0] * M[2][1] - M[1][1] * M[2][0]);
+    x[col] = colDet / det;
+  }
+  return true;
+}
+} // namespace
+
 /**
  * Integrate a peak using a fixed ellipsoidal shape, rather than fitting one
  * from the events themselves. The shape's directions and radii (peak and
@@ -301,6 +403,149 @@ void Integrate3DEvents::integrateUsingShape(const PeakShapeEllipsoid &shape, con
 
   inti = peak.first - ratio * backgrd.first;
   sigi = sqrt(peak.second + ratio * ratio * backgrd.second);
+}
+
+/**
+ * Integrate a peak using a fixed ellipsoidal shape by maximizing the
+ * (weighted) Poisson log-likelihood of an unbinned point process
+ * lambda(q) = A*gaussian(q-c) + b over the raw events within m_radius of
+ * peak_q, instead of counting events inside/outside ellipsoidal
+ * boundaries. The shape's peak radii are interpreted as the Gaussian's
+ * standard deviations (1-sigma) along its principal axes. The Gaussian's
+ * mass outside the m_radius search sphere is assumed negligible.
+ *
+ * @param shape        The ellipsoid shape (directions and peak radii,
+ *                     interpreted as standard deviations) to integrate
+ *                     with. Background radii are unused: the background
+ *                     rate is fit directly instead.
+ * @param peak_q       Q-vector at which to center the shape.
+ * @param adjustCenter If true, also refine the center c (initially 0, i.e.
+ *                     peak_q) by bounded coordinate-ascent Gauss-Newton
+ *                     steps, capped at one standard deviation total shift.
+ * @param inti         Returns the fitted (background-subtracted) integrated
+ *                     intensity.
+ * @param sigi         Returns the standard deviation of inti.
+ */
+void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &shape, const V3D &peak_q,
+                                                      bool adjustCenter, double &inti, double &sigi) {
+  inti = 0.0;
+  sigi = 0.0;
+
+  auto result = getEvents(peak_q);
+  if (!result || result->empty())
+    return;
+
+  const auto &events = *result;
+
+  const auto &directions = shape.directions();
+  const auto &sigmas = shape.abcRadii();
+
+  // apply the ellipsoid's inverse-covariance to v, via its spectral (axis) form
+  auto applyInvS = [&](const V3D &v) {
+    V3D out;
+    for (size_t k = 0; k < 3; ++k)
+      out += directions[k] * (v.scalar_prod(directions[k]) / (sigmas[k] * sigmas[k]));
+    return out;
+  };
+
+  // kernel value and inv_S*(event-c) (needed for the center gradient) for
+  // every event, at center offset c from peak_q
+  auto computeKernel = [&](const V3D &c, std::vector<double> &g, std::vector<double> &w, std::vector<V3D> &invSq) {
+    g.clear();
+    w.clear();
+    invSq.clear();
+    g.reserve(events.size());
+    w.reserve(events.size());
+    invSq.reserve(events.size());
+    for (const auto &event : events) {
+      const V3D qOff = event.second - c;
+      const auto Sq = applyInvS(qOff);
+      g.push_back(exp(-0.5 * qOff.scalar_prod(Sq)));
+      w.push_back(event.first.first);
+      invSq.push_back(Sq);
+    }
+  };
+
+  // sum(g) over all space is translation-invariant, so normG does not
+  // depend on the center offset c
+  const auto normG = pow(2.0 * M_PI, 1.5) * sigmas[0] * sigmas[1] * sigmas[2];
+  const auto volume = (4.0 / 3.0) * M_PI * m_radius * m_radius * m_radius;
+
+  auto logLikelihood = [&](const V3D &c, double A, double b) {
+    double ll = -(A * normG + b * volume);
+    for (const auto &event : events) {
+      const V3D qOff = event.second - c;
+      const auto gi = exp(-0.5 * qOff.scalar_prod(applyInvS(qOff)));
+      ll += event.first.first * log(std::max(A * gi + b, 1e-12));
+    }
+    return ll;
+  };
+
+  V3D center;
+  std::vector<double> g, w;
+  std::vector<V3D> invSq;
+  computeKernel(center, g, w, invSq);
+
+  double A = 0.0, b = 0.0, sigA = 0.0;
+  solvePoissonMatchedFilter(g, w, normG, volume, A, b, sigA);
+
+  if (adjustCenter) {
+    const auto maxShift = *std::min_element(sigmas.begin(), sigmas.end());
+
+    for (int outer = 0; outer < 20; ++outer) {
+      // Gauss-Newton step in the center, holding A, b fixed
+      double grad[3] = {0.0, 0.0, 0.0};
+      double hess[3][3] = {{0.0}};
+      for (size_t i = 0; i < g.size(); ++i) {
+        const auto mu = std::max(A * g[i] + b, 1e-12);
+        const auto factor = w[i] * g[i] / mu;
+        const auto factor2 = w[i] * g[i] * g[i] / (mu * mu);
+        const double Sq[3] = {invSq[i].X(), invSq[i].Y(), invSq[i].Z()};
+        for (int r = 0; r < 3; ++r) {
+          grad[r] += A * factor * Sq[r];
+          for (int c = 0; c < 3; ++c)
+            hess[r][c] -= A * A * factor2 * Sq[r] * Sq[c];
+        }
+      }
+
+      double deltaC[3];
+      if (!solve3x3(hess, grad, deltaC))
+        break;
+
+      V3D step(deltaC[0], deltaC[1], deltaC[2]);
+      if (step.norm() > 0.25 * maxShift)
+        step *= (0.25 * maxShift / step.norm());
+
+      auto clampToMaxShift = [&](V3D c) {
+        if (c.norm() > maxShift)
+          c *= (maxShift / c.norm());
+        return c;
+      };
+
+      const auto llOld = logLikelihood(center, A, b);
+      V3D newCenter = clampToMaxShift(center + step);
+      auto llNew = logLikelihood(newCenter, A, b);
+
+      double localStep = 1.0;
+      while (llNew < llOld && localStep > 1e-4) {
+        localStep *= 0.5;
+        newCenter = clampToMaxShift(center + step * localStep);
+        llNew = logLikelihood(newCenter, A, b);
+      }
+
+      const auto converged = (newCenter - center).norm() < 1e-8 * (1.0 + maxShift);
+      center = newCenter;
+
+      computeKernel(center, g, w, invSq);
+      solvePoissonMatchedFilter(g, w, normG, volume, A, b, sigA);
+
+      if (converged)
+        break;
+    }
+  }
+
+  inti = A * normG;
+  sigi = sigA * normG;
 }
 
 double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters &params, const V3D &center,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -299,6 +299,13 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
                                double &A, double &b, double &sigA) {
   const auto n = g.size();
 
+  auto logLikelihood = [&](double a, double bb) {
+    double ll = -(a * normG + bb * volume);
+    for (size_t i = 0; i < n; ++i)
+      ll += w[i] * std::log(std::max(a * g[i] + bb, 1e-300));
+    return ll;
+  };
+
   auto logLikelihoodGradHess = [&](double a, double bb, double &dA, double &dB, double &dAA, double &dBB, double &dAB) {
     dA = -normG;
     dB = -volume;
@@ -316,17 +323,16 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
     }
   };
 
-  // seed from crude percentile-free estimates: total weight split evenly
-  // between a peak (using the largest kernel value seen) and a flat
-  // background over the search volume
-  double sumW = 0.0, gMax = 0.0;
-  for (size_t i = 0; i < n; ++i) {
+  // seed from crude estimates: split total weight evenly between a peak
+  // (using the mean kernel value over events with above-average signal) and
+  // a flat background over the search volume, deliberately conservative so
+  // the backtracking Newton solve below has a well-behaved starting point
+  // regardless of the absolute scale of normG/volume/event counts
+  double sumW = 0.0;
+  for (size_t i = 0; i < n; ++i)
     sumW += w[i];
-    gMax = std::max(gMax, g[i]);
-  }
   b = volume > 0 ? std::max(0.5 * sumW / volume, 1e-10) : 1e-10;
-  const auto aDenom = gMax * normG;
-  A = aDenom > 0 ? std::max(0.5 * sumW / aDenom, 1e-10) : 1e-10;
+  A = normG > 0 ? std::max(0.5 * sumW / normG, 1e-10) : 1e-10;
 
   for (int iter = 0; iter < 100; ++iter) {
     double dA, dB, dAA, dBB, dAB;
@@ -339,18 +345,25 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
     const auto deltaA = -(dBB * dA - dAB * dB) / det;
     const auto deltaB = -(-dAB * dA + dAA * dB) / det;
 
-    // backtrack until both parameters stay non-negative
+    // backtrack until both parameters stay non-negative AND the
+    // log-likelihood actually improves -- plain Newton without this can
+    // overshoot and diverge for a poorly-scaled seed
+    const auto llOld = logLikelihood(A, b);
     double step = 1.0;
     double newA = A, newB = b;
-    for (int halving = 0; halving < 30; ++halving) {
+    double llNew = llOld;
+    for (int halving = 0; halving < 60; ++halving) {
       newA = A + step * deltaA;
       newB = b + step * deltaB;
-      if (newA >= 0.0 && newB >= 0.0)
-        break;
+      if (newA >= 0.0 && newB >= 0.0) {
+        llNew = logLikelihood(newA, newB);
+        if (llNew >= llOld)
+          break;
+      }
       step *= 0.5;
     }
-    newA = std::max(newA, 0.0);
-    newB = std::max(newB, 0.0);
+    if (llNew < llOld) // no improving step found within the halving budget
+      break;
 
     const auto converged = std::abs(newA - A) < 1e-12 * (1.0 + A) && std::abs(newB - b) < 1e-12 * (1.0 + b);
     A = newA;

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -328,9 +328,7 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
   // a flat background over the search volume, deliberately conservative so
   // the backtracking Newton solve below has a well-behaved starting point
   // regardless of the absolute scale of normG/volume/event counts
-  double sumW = 0.0;
-  for (size_t i = 0; i < n; ++i)
-    sumW += w[i];
+  const double sumW = std::accumulate(w.begin(), w.end(), 0.0);
   b = volume > 0 ? std::max(0.5 * sumW / volume, 1e-10) : 1e-10;
   A = normG > 0 ? std::max(0.5 * sumW / normG, 1e-10) : 1e-10;
 

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -337,7 +337,13 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
 
   double dA, dB, dAA, dBB, dAB;
   logLikelihoodGradHess(A, b, dA, dB, dAA, dBB, dAB);
-  sigA = dAA < 0.0 ? std::sqrt(-1.0 / dAA) : std::numeric_limits<double>::infinity();
+  const auto det = dAA * dBB - dAB * dAB;
+  sigA = std::numeric_limits<double>::infinity();
+  if (det > 0.0 && std::isfinite(det)) {
+    const auto varianceA = -dBB / det;
+    if (varianceA > 0.0 && std::isfinite(varianceA))
+      sigA = std::sqrt(varianceA);
+  }
 }
 
 /// Solve the 3x3 linear system H*x = -g via Cramer's rule, used for the

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -272,22 +272,21 @@ Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakSh
  * @param inti    Returns the net (background-subtracted) integrated intensity.
  * @param sigi    Returns the standard deviation of inti.
  */
-std::shared_ptr<const Geometry::PeakShape> Integrate3DEvents::integrateUsingShape(PeakShapeEllipsoid_const_sptr shape,
-                                                                                  const V3D &peak_q, double &inti,
-                                                                                  double &sigi) {
+void Integrate3DEvents::integrateUsingShape(const PeakShapeEllipsoid &shape, const V3D &peak_q, double &inti,
+                                            double &sigi) {
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
   auto result = getEvents(peak_q);
   if (!result)
-    return shape;
+    return;
 
   const auto &events = *result;
 
-  const auto &directions = shape->directions();
-  const auto &abcRadii = shape->abcRadii();
-  const auto &abcBackgroundInnerRadii = shape->abcRadiiBackgroundInner();
-  const auto &abcBackgroundOuterRadii = shape->abcRadiiBackgroundOuter();
+  const auto &directions = shape.directions();
+  const auto &abcRadii = shape.abcRadii();
+  const auto &abcBackgroundInnerRadii = shape.abcRadiiBackgroundInner();
+  const auto &abcBackgroundOuterRadii = shape.abcRadiiBackgroundOuter();
 
   const std::pair<double, double> backgrd = numInEllipsoidBkg(
       events, directions, abcBackgroundOuterRadii, abcBackgroundInnerRadii, m_useOnePercentBackgroundCorrection);
@@ -302,8 +301,6 @@ std::shared_ptr<const Geometry::PeakShape> Integrate3DEvents::integrateUsingShap
 
   inti = peak.first - ratio * backgrd.first;
   sigi = sqrt(peak.second + ratio * ratio * backgrd.second);
-
-  return shape;
 }
 
 double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters &params, const V3D &center,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -301,7 +301,8 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
     gMax = std::max(gMax, g[i]);
   }
   b = volume > 0 ? std::max(0.5 * sumW / volume, 1e-10) : 1e-10;
-  A = gMax > 0 ? std::max(0.5 * sumW / (gMax * normG > 0 ? normG : 1.0), 1e-10) : 1e-10;
+  const auto aDenom = gMax * normG;
+  A = aDenom > 0 ? std::max(0.5 * sumW / aDenom, 1e-10) : 1e-10;
 
   for (int iter = 0; iter < 100; ++iter) {
     double dA, dB, dAA, dBB, dAB;

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -203,6 +203,20 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params, cons
   return std::make_pair(shape, std::make_tuple(frac, fracError, max_sigma));
 }
 
+/**
+ * @brief Integrates a weak peak using a supplied ellipsoidal shape and peak fraction.
+ *
+ * Applies background subtraction, detector-edge correction, and fractional-intensity
+ * scaling before returning the scaled integration shape.
+ *
+ * @param params Integration settings used to determine radius factors and detector-edge corrections.
+ * @param shape Supplied peak and background ellipsoid.
+ * @param libPeak Tuple containing the peak fraction, its uncertainty, and the maximum peak width.
+ * @param center Peak center in Q-space.
+ * @param[out] inti Integrated peak intensity.
+ * @param[out] sigi Uncertainty of the integrated peak intensity.
+ * @return The scaled peak shape, or a no-shape result when no events are available.
+ */
 std::shared_ptr<const Geometry::PeakShape>
 Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakShapeEllipsoid_const_sptr shape,
                                      const std::tuple<double, double, double> &libPeak, const V3D &center, double &inti,
@@ -270,7 +284,17 @@ namespace {
 /// height 1) Gaussian kernel values at each event; normG is the kernel's
 /// integral over all space; volume is the search region's volume (its
 /// background rate contribution). Also returns the standard error on A
-/// from the observed Fisher information.
+/**
+ * @brief Estimates peak amplitude and background from weighted event data.
+ *
+ * @param g Peak-model values for each event.
+ * @param w Observed event weights.
+ * @param normG Integrated peak-model normalization.
+ * @param volume Search volume used to model the uniform background.
+ * @param A Output peak amplitude estimate.
+ * @param b Output uniform background estimate.
+ * @param sigA Output standard uncertainty of the peak amplitude.
+ */
 void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<double> &w, double normG, double volume,
                                double &A, double &b, double &sigA) {
   const auto n = g.size();
@@ -348,7 +372,14 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
 
 /// Solve the 3x3 linear system H*x = -g via Cramer's rule, used for the
 /// Gauss-Newton center-refinement step. Returns false (x left unchanged) if
-/// H is singular.
+/**
+ * @brief Solves a 3×3 linear system of the form Hx = -g.
+ *
+ * @param H Coefficient matrix.
+ * @param g Right-hand-side vector before negation.
+ * @param x Output solution vector.
+ * @return true if the matrix is nonsingular and the solution was computed, false otherwise.
+ */
 bool solve3x3(const double H[3][3], const double g[3], double x[3]) {
   const auto det = H[0][0] * (H[1][1] * H[2][2] - H[1][2] * H[2][1]) -
                    H[0][1] * (H[1][0] * H[2][2] - H[1][2] * H[2][0]) +
@@ -413,25 +444,15 @@ void Integrate3DEvents::integrateUsingShape(const PeakShapeEllipsoid &shape, con
 }
 
 /**
- * Integrate a peak using a fixed ellipsoidal shape by maximizing the
- * (weighted) Poisson log-likelihood of an unbinned point process
- * lambda(q) = A*gaussian(q-c) + b over the raw events within m_radius of
- * peak_q, instead of counting events inside/outside ellipsoidal
- * boundaries. The shape's peak radii are interpreted as the Gaussian's
- * standard deviations (1-sigma) along its principal axes. The Gaussian's
- * mass outside the m_radius search sphere is assumed negligible.
+ * Fits a Gaussian peak and constant background within the search radius and
+ * returns the integrated Gaussian intensity.
  *
- * @param shape        The ellipsoid shape (directions and peak radii,
- *                     interpreted as standard deviations) to integrate
- *                     with. Background radii are unused: the background
- *                     rate is fit directly instead.
- * @param peak_q       Q-vector at which to center the shape.
- * @param adjustCenter If true, also refine the center c (initially 0, i.e.
- *                     peak_q) by bounded coordinate-ascent Gauss-Newton
- *                     steps, capped at one standard deviation total shift.
- * @param inti         Returns the fitted (background-subtracted) integrated
- *                     intensity.
- * @param sigi         Returns the standard deviation of inti.
+ * @param shape Ellipsoidal peak shape; its principal radii define the Gaussian
+ *              standard deviations.
+ * @param peak_q Q-vector used as the initial peak center.
+ * @param adjustCenter Whether to refine the peak center during fitting.
+ * @param inti Receives the fitted integrated peak intensity.
+ * @param sigi Receives the standard deviation of the fitted intensity.
  */
 void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &shape, const V3D &peak_q,
                                                       bool adjustCenter, double &inti, double &sigi) {
@@ -555,6 +576,17 @@ void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &
   sigi = sigA * normG;
 }
 
+/**
+ * @brief Estimates the signal-to-noise ratio for a peak at the specified reciprocal-space position.
+ *
+ * @param params Integration parameters that define the analysis region and radius factors.
+ * @param center Reciprocal-space position of the peak.
+ * @param forceSpherical Whether to require and use a spherically symmetric peak shape.
+ * @param sphericityTol Maximum relative difference between the largest and smallest peak widths
+ *                      when spherical symmetry is required.
+ * @return Signal-to-noise ratio after background subtraction, or zero when the peak cannot be
+ *         analyzed or does not meet the requested shape constraints.
+ */
 double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters &params, const V3D &center,
                                                      bool forceSpherical, double sphericityTol) {
 

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -212,20 +212,20 @@ Integrate3DEvents::integrateStrongPeak(const IntegrationParameters &params, cons
  * @param params Integration settings used to determine radius factors and detector-edge corrections.
  * @param shape Supplied peak and background ellipsoid.
  * @param libPeak Tuple containing the peak fraction, its uncertainty, and the maximum peak width.
- * @param center Peak center in Q-space.
+ * @param peak_q Peak center in Q-space.
  * @param[out] inti Integrated peak intensity.
  * @param[out] sigi Uncertainty of the integrated peak intensity.
  * @return The scaled peak shape, or a no-shape result when no events are available.
  */
 std::shared_ptr<const Geometry::PeakShape>
 Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakShapeEllipsoid_const_sptr shape,
-                                     const std::tuple<double, double, double> &libPeak, const V3D &center, double &inti,
+                                     const std::tuple<double, double, double> &libPeak, const V3D &peak_q, double &inti,
                                      double &sigi) {
 
   inti = 0.0; // default values, in case something
   sigi = 0.0; // is wrong with the peak.
 
-  auto result = getEvents(center);
+  auto result = getEvents(peak_q);
   if (!result)
     return std::make_shared<NoShape>();
 
@@ -239,7 +239,7 @@ Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakSh
   const auto max_sigma = std::get<2>(libPeak);
   auto rValues = calculateRadiusFactors(params, max_sigma);
 
-  const auto isPeakOnDetector = correctForDetectorEdges(rValues, params.E1Vectors, center, abcRadii,
+  const auto isPeakOnDetector = correctForDetectorEdges(rValues, params.E1Vectors, peak_q, abcRadii,
                                                         abcBackgroundInnerRadii, abcBackgroundOuterRadii);
 
   if (!isPeakOnDetector)

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -261,6 +261,51 @@ Integrate3DEvents::integrateWeakPeak(const IntegrationParameters &params, PeakSh
                                                     "IntegrateEllipsoidsTwoStep");
 }
 
+/**
+ * Integrate a peak using a fixed ellipsoidal shape, rather than fitting one
+ * from the events themselves. The shape's directions and radii (peak and
+ * background) are used exactly as supplied, centered on peak_q.
+ *
+ * @param shape   The ellipsoid shape (directions, peak radii, background
+ *                inner/outer radii) to integrate with.
+ * @param peak_q  Q-vector at which to center the shape.
+ * @param inti    Returns the net (background-subtracted) integrated intensity.
+ * @param sigi    Returns the standard deviation of inti.
+ */
+std::shared_ptr<const Geometry::PeakShape> Integrate3DEvents::integrateUsingShape(PeakShapeEllipsoid_const_sptr shape,
+                                                                                  const V3D &peak_q, double &inti,
+                                                                                  double &sigi) {
+  inti = 0.0; // default values, in case something
+  sigi = 0.0; // is wrong with the peak.
+
+  auto result = getEvents(peak_q);
+  if (!result)
+    return shape;
+
+  const auto &events = *result;
+
+  const auto &directions = shape->directions();
+  const auto &abcRadii = shape->abcRadii();
+  const auto &abcBackgroundInnerRadii = shape->abcRadiiBackgroundInner();
+  const auto &abcBackgroundOuterRadii = shape->abcRadiiBackgroundOuter();
+
+  const std::pair<double, double> backgrd = numInEllipsoidBkg(
+      events, directions, abcBackgroundOuterRadii, abcBackgroundInnerRadii, m_useOnePercentBackgroundCorrection);
+  const std::pair<double, double> peak = numInEllipsoid(events, directions, abcRadii);
+
+  // volume ratio between the peak ellipsoid and the background shell, used to
+  // scale the background counts to the peak's volume before subtracting
+  const auto peakVolume = abcRadii[0] * abcRadii[1] * abcRadii[2];
+  const auto backgroundVolume = abcBackgroundOuterRadii[0] * abcBackgroundOuterRadii[1] * abcBackgroundOuterRadii[2] -
+                                abcBackgroundInnerRadii[0] * abcBackgroundInnerRadii[1] * abcBackgroundInnerRadii[2];
+  const auto ratio = backgroundVolume > 0 ? peakVolume / backgroundVolume : 0.0;
+
+  inti = peak.first - ratio * backgrd.first;
+  sigi = sqrt(peak.second + ratio * ratio * backgrd.second);
+
+  return shape;
+}
+
 double Integrate3DEvents::estimateSignalToNoiseRatio(const IntegrationParameters &params, const V3D &center,
                                                      bool forceSpherical, double sphericityTol) {
 

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -383,15 +383,14 @@ void solvePoissonMatchedFilter(const std::vector<double> &g, const std::vector<d
   }
 }
 
-/// Solve the 3x3 linear system H*x = -g via Cramer's rule, used for the
-/// Gauss-Newton center-refinement step. Returns false (x left unchanged) if
 /**
- * @brief Solves a 3×3 linear system of the form Hx = -g.
+ * @brief Solves a 3x3 linear system of the form Hx = -g, via Cramer's rule.
+ * Used for the Gauss-Newton center-refinement step.
  *
  * @param H Coefficient matrix.
  * @param g Right-hand-side vector before negation.
  * @param x Output solution vector.
- * @return true if the matrix is nonsingular and the solution was computed, false otherwise.
+ * @return true if the matrix is nonsingular and the solution was computed, false (x left unchanged) otherwise.
  */
 bool solve3x3(const double H[3][3], const double g[3], double x[3]) {
   const auto det = H[0][0] * (H[1][1] * H[2][2] - H[1][2] * H[2][1]) -
@@ -461,16 +460,23 @@ void Integrate3DEvents::integrateUsingShape(const PeakShapeEllipsoid &shape, con
  * returns the integrated Gaussian intensity.
  *
  * @param shape Ellipsoidal peak shape; its principal radii define the Gaussian
- *              standard deviations.
- * @param peak_q Q-vector used as the initial peak center.
+ *              standard deviations. shape.translation() seeds the fit center
+ *              (offset from peak_q), so a previously found correction is
+ *              honored and further refined rather than discarded.
+ * @param peak_q Q-vector used as the reference peak center.
  * @param adjustCenter Whether to refine the peak center during fitting.
+ * @param center Receives the center offset from peak_q actually used for the
+ *               fit: shape.translation() unchanged if adjustCenter is false,
+ *               or the refined offset (capped at one standard deviation of
+ *               incremental shift from shape.translation()) if true.
  * @param inti Receives the fitted integrated peak intensity.
  * @param sigi Receives the standard deviation of the fitted intensity.
  */
 void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &shape, const V3D &peak_q,
-                                                      bool adjustCenter, double &inti, double &sigi) {
+                                                      bool adjustCenter, V3D &center, double &inti, double &sigi) {
   inti = 0.0;
   sigi = 0.0;
+  center = shape.translation();
 
   auto result = getEvents(peak_q);
   if (!result || result->empty())
@@ -522,7 +528,6 @@ void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &
     return ll;
   };
 
-  V3D center;
   std::vector<double> g, w;
   std::vector<V3D> invSq;
   computeKernel(center, g, w, invSq);
@@ -532,6 +537,11 @@ void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &
 
   if (adjustCenter) {
     const auto maxShift = *std::min_element(sigmas.begin(), sigmas.end());
+    // seedCenter is where this call started (shape.translation()); maxShift
+    // bounds the *incremental* correction made in this call, not the total
+    // distance from peak_q, so an already-substantial prior translation
+    // isn't clamped away before any new refinement even starts.
+    const V3D seedCenter = center;
 
     for (int outer = 0; outer < 20; ++outer) {
       // Gauss-Newton step in the center, holding A, b fixed
@@ -558,8 +568,9 @@ void Integrate3DEvents::integrateUsingShapeProfileFit(const PeakShapeEllipsoid &
         step *= (0.25 * maxShift / step.norm());
 
       auto clampToMaxShift = [&](V3D c) {
-        if (c.norm() > maxShift)
-          c *= (maxShift / c.norm());
+        const V3D offsetFromSeed = c - seedCenter;
+        if (offsetFromSeed.norm() > maxShift)
+          return seedCenter + offsetFromSeed * (maxShift / offsetFromSeed.norm());
         return c;
       };
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -100,8 +100,7 @@ void IntegratePeaksShapeMD::exec() {
   std::vector<V3D> hkl_vectors;
   std::vector<std::pair<std::pair<double, double>, V3D>> qList;
   for (size_t i = 0; i < n_peaks; i++) {
-    auto shape = std::dynamic_pointer_cast<const PeakShapeEllipsoid>(peaks[i].getPeakShape());
-    if (!shape)
+    if (!dynamic_cast<const PeakShapeEllipsoid *>(&peaks[i].getPeakShape()))
       throw std::runtime_error("Peak " + std::to_string(i) +
                                " does not have an ellipsoidal shape. Integrate the "
                                "PeaksWorkspace first, e.g. with IntegrateEllipsoids, "
@@ -138,11 +137,11 @@ void IntegratePeaksShapeMD::exec() {
 
   for (size_t i = 0; i < n_peaks; i++) {
     auto &peak = peaks[i];
-    auto shape = std::dynamic_pointer_cast<const PeakShapeEllipsoid>(peak.getPeakShape());
+    const auto *shape = dynamic_cast<const PeakShapeEllipsoid *>(&peak.getPeakShape());
 
     double inti = 0.0;
     double sigi = 0.0;
-    integrator.integrateUsingShape(shape, peak.getQLabFrame(), inti, sigi);
+    integrator.integrateUsingShape(*shape, peak.getQLabFrame(), inti, sigi);
 
     peak.setIntensity(inti);
     peak.setSigmaIntensity(sigi);

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -175,7 +175,17 @@ void IntegratePeaksShapeMD::exec() {
     double inti = 0.0;
     double sigi = 0.0;
     if (profileFit) {
-      integrator.integrateUsingShapeProfileFit(*shape, peak.getQLabFrame(), adjustCenter, inti, sigi);
+      V3D center;
+      integrator.integrateUsingShapeProfileFit(*shape, peak.getQLabFrame(), adjustCenter, center, inti, sigi);
+      // Persist a center correction found by AdjustCenter as the output
+      // shape's translation -- peak.getQLabFrame() itself is left alone,
+      // since it's tied to a specific detector pixel/TOF and isn't free to
+      // move without checking that still corresponds to a valid trajectory.
+      if (adjustCenter && center != shape->translation()) {
+        peak.setPeakShape(new PeakShapeEllipsoid(
+            shape->directions(), shape->abcRadii(), shape->abcRadiiBackgroundInner(), shape->abcRadiiBackgroundOuter(),
+            shape->frame(), shape->algorithmName(), shape->algorithmVersion(), center));
+      }
     } else {
       integrator.integrateUsingShape(*shape, peak.getQLabFrame(), inti, sigi);
     }

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -98,7 +98,8 @@ void IntegratePeaksShapeMD::init() {
 /**
  * @brief Integrates peak intensities from an event or histogram workspace using QLab ellipsoidal peak shapes.
  *
- * @throws std::runtime_error If the input workspace is not an EventWorkspace or Workspace2D, a peak lacks a QLab ellipsoidal shape, or fewer than three indexed peaks are available.
+ * @throws std::runtime_error If the input workspace is not an EventWorkspace or Workspace2D, a peak lacks a QLab
+ * ellipsoidal shape, or fewer than three indexed peaks are available.
  */
 void IntegratePeaksShapeMD::exec() {
   PeaksWorkspace_sptr input_peak_ws = getProperty("PeaksWorkspace");

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -1,0 +1,286 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidMDAlgorithms/IntegratePeaksShapeMD.h"
+
+#include "MantidAPI/InstrumentValidator.h"
+#include "MantidAPI/Run.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/PeakShapeEllipsoid.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/Crystal/IndexingUtils.h"
+#include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/CompositeValidator.h"
+
+#include "MantidMDAlgorithms/Integrate3DEvents.h"
+#include "MantidMDAlgorithms/MDTransfFactory.h"
+#include "MantidMDAlgorithms/MDTransfQ3D.h"
+#include "MantidMDAlgorithms/UnitsConversionHelper.h"
+
+#include <boost/math/special_functions/round.hpp>
+#include <cmath>
+#include <string>
+
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Kernel;
+
+namespace Mantid::MDAlgorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(IntegratePeaksShapeMD)
+
+/// Algorithm's name for identification. @see Algorithm::name
+const std::string IntegratePeaksShapeMD::name() const { return "IntegratePeaksShapeMD"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int IntegratePeaksShapeMD::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string IntegratePeaksShapeMD::category() const { return "Crystal\\Integration"; }
+
+void IntegratePeaksShapeMD::init() {
+  auto ws_valid = std::make_shared<CompositeValidator>();
+  ws_valid->add<InstrumentValidator>();
+
+  auto mustBePositive = std::make_shared<BoundedValidator<double>>();
+  mustBePositive->setLower(0.0);
+
+  declareProperty(
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input, ws_valid),
+      "An input MatrixWorkspace with time-of-flight units along "
+      "X-axis and defined instrument with defined sample");
+
+  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("PeaksWorkspace", "", Direction::InOut),
+                  "Workspace with peaks to be integrated. Each peak must already have an "
+                  "ellipsoidal shape set, e.g. from a previous IntegrateEllipsoids run.");
+
+  declareProperty("RegionRadius", .35, mustBePositive,
+                  "Only events at most this distance from a peak will be considered when "
+                  "integrating. Must be at least as large as the largest background outer "
+                  "radius among the peaks being integrated, or the background shell will be "
+                  "truncated.");
+
+  declareProperty("UseOnePercentBackgroundCorrection", true,
+                  "If this options is enabled, then the top 1% of the background will be "
+                  "removed before the background subtraction.");
+
+  declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("OutputWorkspace", "", Direction::Output),
+                  "The output PeaksWorkspace will be a copy of the input PeaksWorkspace "
+                  "with the peaks' integrated intensities.");
+}
+
+void IntegratePeaksShapeMD::exec() {
+  PeaksWorkspace_sptr input_peak_ws = getProperty("PeaksWorkspace");
+  MatrixWorkspace_sptr input_ws = getProperty("InputWorkspace");
+  EventWorkspace_sptr eventWS = std::dynamic_pointer_cast<EventWorkspace>(input_ws);
+
+  Workspace2D_sptr histoWS = std::dynamic_pointer_cast<Workspace2D>(input_ws);
+  if (!eventWS && !histoWS) {
+    throw std::runtime_error("IntegratePeaksShapeMD needs either an "
+                             "EventWorkspace or Workspace2D as input.");
+  }
+
+  PeaksWorkspace_sptr peak_ws = getProperty("OutputWorkspace");
+  if (peak_ws != input_peak_ws) {
+    peak_ws = input_peak_ws->clone();
+  }
+
+  std::vector<Peak> &peaks = peak_ws->getPeaks();
+  size_t n_peaks = peak_ws->getNumberPeaks();
+
+  // Integrate3DEvents uses UBinv to assign each event to its nearest peak
+  // (by rounding UBinv*Q to the nearest h,k,l), so it must be derived from
+  // the indexed peaks even though integration itself stays in Q-lab.
+  std::vector<V3D> peak_q_list;
+  std::vector<V3D> hkl_vectors;
+  std::vector<std::pair<std::pair<double, double>, V3D>> qList;
+  for (size_t i = 0; i < n_peaks; i++) {
+    auto shape = std::dynamic_pointer_cast<const PeakShapeEllipsoid>(peaks[i].getPeakShape());
+    if (!shape)
+      throw std::runtime_error("Peak " + std::to_string(i) +
+                               " does not have an ellipsoidal shape. Integrate the "
+                               "PeaksWorkspace first, e.g. with IntegrateEllipsoids, "
+                               "so that every peak has a shape to reuse.");
+
+    V3D hkl(peaks[i].getH(), peaks[i].getK(), peaks[i].getL());
+    if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0)) { // tolerance == 1 just checks for (0,0,0)
+      peak_q_list.emplace_back(peaks[i].getQLabFrame());
+      hkl_vectors.emplace_back(static_cast<double>(boost::math::iround<double>(hkl[0])),
+                               static_cast<double>(boost::math::iround<double>(hkl[1])),
+                               static_cast<double>(boost::math::iround<double>(hkl[2])));
+    }
+    qList.emplace_back(std::pair<double, double>(1.0, 1.0), V3D(peaks[i].getQLabFrame()));
+  }
+
+  if (peak_q_list.size() < 3)
+    throw std::runtime_error("At least three linearly independent indexed peaks are needed.");
+
+  Matrix<double> UB(3, 3, false);
+  Geometry::IndexingUtils::Optimize_UB(UB, hkl_vectors, peak_q_list);
+  Matrix<double> UBinv(UB);
+  UBinv.Invert();
+  UBinv *= (1.0 / (2.0 * M_PI));
+
+  const bool useOnePercentBackgroundCorrection = getProperty("UseOnePercentBackgroundCorrection");
+  Integrate3DEvents integrator(qList, UBinv, getProperty("RegionRadius"), useOnePercentBackgroundCorrection);
+
+  Progress prog(this, 0.0, 1.0, input_ws->getNumberHistograms());
+  if (eventWS) {
+    qListFromEventWS(integrator, prog, eventWS);
+  } else {
+    qListFromHistoWS(integrator, prog, histoWS);
+  }
+
+  for (size_t i = 0; i < n_peaks; i++) {
+    auto &peak = peaks[i];
+    auto shape = std::dynamic_pointer_cast<const PeakShapeEllipsoid>(peak.getPeakShape());
+
+    double inti = 0.0;
+    double sigi = 0.0;
+    integrator.integrateUsingShape(shape, peak.getQLabFrame(), inti, sigi);
+
+    peak.setIntensity(inti);
+    peak.setSigmaIntensity(sigi);
+  }
+
+  // This flag is used by the PeaksWorkspace to evaluate whether it has been
+  // integrated.
+  peak_ws->mutableRun().addProperty("PeaksIntegrated", 1, true);
+  setProperty("OutputWorkspace", peak_ws);
+}
+
+void IntegratePeaksShapeMD::qListFromEventWS(Integrate3DEvents &integrator, Progress &prog, EventWorkspace_sptr &wksp) {
+  const std::string ELASTIC("Elastic");
+  const std::string Q3D("Q3D");
+  const std::size_t DIMS(3);
+
+  MDWSDescription m_targWSDescr;
+  m_targWSDescr.setMinMax(std::vector<double>(3, -2000.), std::vector<double>(3, 2000.));
+  m_targWSDescr.buildFromMatrixWS(wksp, Q3D, ELASTIC);
+  m_targWSDescr.setLorentsCorr(false);
+
+  Mantid::API::Algorithm_sptr childAlg = createChildAlgorithm("PreprocessDetectorsToMD", 0., .5);
+  childAlg->setProperty("InputWorkspace", wksp);
+  childAlg->executeAsChildAlg();
+
+  DataObjects::TableWorkspace_sptr table = childAlg->getProperty("OutputWorkspace");
+  if (!table)
+    throw(std::runtime_error("Can not retrieve results of \"PreprocessDetectorsToMD\""));
+
+  m_targWSDescr.m_PreprDetTable = table;
+
+  auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
+  PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
+  for (int i = 0; i < numSpectra; ++i) {
+    PARALLEL_START_INTERRUPT_REGION
+
+    UnitsConversionHelper unitConverter;
+    unitConverter.initialize(m_targWSDescr, "Momentum");
+
+    MDTransfQ3D qConverter;
+    qConverter.initialize(m_targWSDescr);
+
+    std::vector<double> buffer(DIMS);
+    EventList &events = wksp->getSpectrum(i);
+
+    events.switchTo(WEIGHTED_NOTIME);
+    events.compressEvents(1e-5, &events);
+
+    if (events.empty()) {
+      prog.report();
+      continue;
+    }
+
+    std::vector<Mantid::coord_t> locCoord(DIMS, 0.);
+    unitConverter.updateConversion(i);
+    qConverter.calcYDepCoordinates(locCoord, i);
+
+    double signal(1.);
+    double errorSq(1.);
+    const std::vector<WeightedEventNoTime> &raw_events = events.getWeightedEventsNoTime();
+    std::vector<std::pair<std::pair<double, double>, V3D>> qList;
+    for (const auto &raw_event : raw_events) {
+      double val = unitConverter.convertUnits(raw_event.tof());
+      qConverter.calcMatrixCoord(val, locCoord, signal, errorSq);
+      for (size_t dim = 0; dim < DIMS; ++dim) {
+        buffer[dim] = locCoord[dim];
+      }
+      V3D qVec(buffer[0], buffer[1], buffer[2]);
+      qList.emplace_back(std::pair<double, double>(raw_event.m_weight, raw_event.m_errorSquared), qVec);
+    }
+    PARALLEL_CRITICAL(addEvents) { integrator.addEvents(qList, false); }
+
+    prog.report();
+    PARALLEL_END_INTERRUPT_REGION
+  }
+  PARALLEL_CHECK_INTERRUPT_REGION
+}
+
+void IntegratePeaksShapeMD::qListFromHistoWS(Integrate3DEvents &integrator, Progress &prog, Workspace2D_sptr &wksp) {
+  const std::string ELASTIC("Elastic");
+  const std::string Q3D("Q3D");
+  const std::size_t DIMS(3);
+
+  MDWSDescription m_targWSDescr;
+  m_targWSDescr.setMinMax(std::vector<double>(3, -2000.), std::vector<double>(3, 2000.));
+  m_targWSDescr.buildFromMatrixWS(wksp, Q3D, ELASTIC);
+  m_targWSDescr.setLorentsCorr(false);
+
+  Mantid::API::Algorithm_sptr childAlg = createChildAlgorithm("PreprocessDetectorsToMD", 0., .5);
+  childAlg->setProperty("InputWorkspace", wksp);
+  childAlg->executeAsChildAlg();
+
+  DataObjects::TableWorkspace_sptr table = childAlg->getProperty("OutputWorkspace");
+  if (!table)
+    throw(std::runtime_error("Can not retrieve results of \"PreprocessDetectorsToMD\""));
+  m_targWSDescr.m_PreprDetTable = table;
+
+  auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
+  PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
+  for (int i = 0; i < numSpectra; ++i) {
+    PARALLEL_START_INTERRUPT_REGION
+
+    UnitsConversionHelper unitConverter;
+    unitConverter.initialize(m_targWSDescr, "Momentum");
+
+    MDTransfQ3D qConverter;
+    qConverter.initialize(m_targWSDescr);
+
+    const auto &xVals = wksp->points(i);
+    const auto &yVals = wksp->y(i);
+    const auto &eVals = wksp->e(i);
+
+    std::vector<Mantid::coord_t> locCoord(DIMS, 0.);
+    unitConverter.updateConversion(i);
+    qConverter.calcYDepCoordinates(locCoord, i);
+
+    double signal(1.);
+    double errorSq(1.);
+
+    std::vector<std::pair<std::pair<double, double>, V3D>> qList;
+
+    for (size_t j = 0; j < yVals.size(); ++j) {
+      const double &yVal = yVals[j];
+      const double &esqVal = eVals[j] * eVals[j];
+      if (yVal > 0) {
+        double val = unitConverter.convertUnits(xVals[j]);
+        qConverter.calcMatrixCoord(val, locCoord, signal, errorSq);
+        V3D qVec(locCoord[0], locCoord[1], locCoord[2]);
+
+        if (std::isnan(qVec[0]) || std::isnan(qVec[1]) || std::isnan(qVec[2]))
+          continue;
+        qList.emplace_back(std::pair<double, double>(yVal, esqVal), qVec);
+      }
+    }
+    PARALLEL_CRITICAL(addHisto) { integrator.addEvents(qList, false); }
+    prog.report();
+    PARALLEL_END_INTERRUPT_REGION
+  }
+  PARALLEL_CHECK_INTERRUPT_REGION
+}
+} // namespace Mantid::MDAlgorithms

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -69,6 +69,20 @@ void IntegratePeaksShapeMD::init() {
                   "If this options is enabled, then the top 1% of the background will be "
                   "removed before the background subtraction.");
 
+  declareProperty("ProfileFit", false,
+                  "If true, integrate by maximizing the Poisson log-likelihood of a Gaussian "
+                  "peak plus a flat background rate fit against the raw events, instead of "
+                  "counting events inside/outside ellipsoidal boundaries. In this mode the "
+                  "peak radii are interpreted as the Gaussian's standard deviations (1-sigma), "
+                  "and the background radii are unused.");
+
+  declareProperty("AdjustCenter", false,
+                  "Only used if ProfileFit is true. If true, also refine each peak's center by "
+                  "a bounded Gauss-Newton correction (capped at one standard deviation from the "
+                  "peak's stored Q) as part of the profile fit, instead of keeping it fixed at "
+                  "the peak's stored Q. The peak's stored Q is not modified; the correction is "
+                  "used only for this integration.");
+
   declareProperty(std::make_unique<WorkspaceProperty<PeaksWorkspace>>("OutputWorkspace", "", Direction::Output),
                   "The output PeaksWorkspace will be a copy of the input PeaksWorkspace "
                   "with the peaks' integrated intensities.");
@@ -135,13 +149,20 @@ void IntegratePeaksShapeMD::exec() {
     qListFromHistoWS(integrator, prog, histoWS);
   }
 
+  const bool profileFit = getProperty("ProfileFit");
+  const bool adjustCenter = getProperty("AdjustCenter");
+
   for (size_t i = 0; i < n_peaks; i++) {
     auto &peak = peaks[i];
     const auto *shape = dynamic_cast<const PeakShapeEllipsoid *>(&peak.getPeakShape());
 
     double inti = 0.0;
     double sigi = 0.0;
-    integrator.integrateUsingShape(*shape, peak.getQLabFrame(), inti, sigi);
+    if (profileFit) {
+      integrator.integrateUsingShapeProfileFit(*shape, peak.getQLabFrame(), adjustCenter, inti, sigi);
+    } else {
+      integrator.integrateUsingShape(*shape, peak.getQLabFrame(), inti, sigi);
+    }
 
     peak.setIntensity(inti);
     peak.setSigmaIntensity(sigi);

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -40,9 +40,16 @@ const std::string IntegratePeaksShapeMD::name() const { return "IntegratePeaksSh
 /// Algorithm's version for identification. @see Algorithm::version
 int IntegratePeaksShapeMD::version() const { return 1; }
 
-/// Algorithm's category for identification. @see Algorithm::category
+/**
+ * @brief Identifies the algorithm's category.
+ *
+ * @return std::string The category path, "Crystal\\Integration".
+ */
 const std::string IntegratePeaksShapeMD::category() const { return "Crystal\\Integration"; }
 
+/**
+ * @brief Defines the input, integration, fitting, and output properties for the algorithm.
+ */
 void IntegratePeaksShapeMD::init() {
   auto ws_valid = std::make_shared<CompositeValidator>();
   ws_valid->add<InstrumentValidator>();
@@ -88,6 +95,11 @@ void IntegratePeaksShapeMD::init() {
                   "with the peaks' integrated intensities.");
 }
 
+/**
+ * @brief Integrates peak intensities from an event or histogram workspace using QLab ellipsoidal peak shapes.
+ *
+ * @throws std::runtime_error If the input workspace is not an EventWorkspace or Workspace2D, a peak lacks a QLab ellipsoidal shape, or fewer than three indexed peaks are available.
+ */
 void IntegratePeaksShapeMD::exec() {
   PeaksWorkspace_sptr input_peak_ws = getProperty("PeaksWorkspace");
   MatrixWorkspace_sptr input_ws = getProperty("InputWorkspace");
@@ -244,6 +256,17 @@ void IntegratePeaksShapeMD::qListFromEventWS(Integrate3DEvents &integrator, Prog
   PARALLEL_CHECK_INTERRUPT_REGION
 }
 
+/**
+ * @brief Converts histogram workspace data to Q-space events for integration.
+ *
+ * Processes positive-intensity histogram bins and adds their Q-space positions,
+ * intensities, and squared uncertainties to the integrator.
+ *
+ * @param integrator Receives the converted Q-space events.
+ * @param prog Reports processing progress.
+ * @param wksp Histogram workspace containing the data to convert.
+ * @throws std::runtime_error If detector preprocessing results cannot be retrieved.
+ */
 void IntegratePeaksShapeMD::qListFromHistoWS(Integrate3DEvents &integrator, Progress &prog, Workspace2D_sptr &wksp) {
   const std::string ELASTIC("Elastic");
   const std::string Q3D("Q3D");

--- a/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksShapeMD.cpp
@@ -114,11 +114,14 @@ void IntegratePeaksShapeMD::exec() {
   std::vector<V3D> hkl_vectors;
   std::vector<std::pair<std::pair<double, double>, V3D>> qList;
   for (size_t i = 0; i < n_peaks; i++) {
-    if (!dynamic_cast<const PeakShapeEllipsoid *>(&peaks[i].getPeakShape()))
+    const auto *shape = dynamic_cast<const PeakShapeEllipsoid *>(&peaks[i].getPeakShape());
+    if (!shape)
       throw std::runtime_error("Peak " + std::to_string(i) +
                                " does not have an ellipsoidal shape. Integrate the "
                                "PeaksWorkspace first, e.g. with IntegrateEllipsoids, "
                                "so that every peak has a shape to reuse.");
+    if (shape->frame() != Kernel::QLab)
+      throw std::runtime_error("Peak " + std::to_string(i) + " has an ellipsoidal shape that is not in QLab.");
 
     V3D hkl(peaks[i].getH(), peaks[i].getK(), peaks[i].getL());
     if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0)) { // tolerance == 1 just checks for (0,0,0)
@@ -206,7 +209,7 @@ void IntegratePeaksShapeMD::qListFromEventWS(Integrate3DEvents &integrator, Prog
     qConverter.initialize(m_targWSDescr);
 
     std::vector<double> buffer(DIMS);
-    EventList &events = wksp->getSpectrum(i);
+    EventList events = wksp->getSpectrum(i);
 
     events.switchTo(WEIGHTED_NOTIME);
     events.compressEvents(1e-5, &events);

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -10,7 +10,10 @@
 #include "MantidKernel/V3D.h"
 #include "MantidMDAlgorithms/Integrate3DEvents.h"
 
+#include <algorithm>
+#include <cmath>
 #include <cxxtest/TestSuite.h>
+#include <limits>
 #include <random>
 
 using namespace Mantid;
@@ -112,6 +115,199 @@ public:
       TS_ASSERT_DELTA(inti, 2 * inti_some[i], 0.1);
       TS_ASSERT_DELTA(sigi, sigi_some[i], 0.01);
     }
+  }
+
+  // Verify integrateUsingShape counts events exactly inside the supplied
+  // ellipsoid, with no shape adjustment of its own.
+  void test_integrateUsingShape_counts_events_inside_fixed_shape() {
+    V3D peak_q(10, 0, 0);
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    // 3 events within radius 0.3 and 2 events between 0.3 and 0.45, along
+    // each of the x, y and z axes.
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
+    for (const double offset : {0.1, 0.2, 0.29, 0.4, 0.45}) {
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(offset, 0, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(0, offset, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(0, 0, offset));
+    }
+
+    Integrate3DEvents integrator(peak_q_list, UBinv, 1.0);
+    integrator.addEvents(event_Qs, false);
+
+    PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    // peak radii == background radii on all axes, so the background shell
+    // has zero volume and inti is exactly the raw weighted peak count.
+    PeakEllipsoidExtent radii{0.3, 0.3, 0.3};
+    PeakShapeEllipsoid shape(directions, radii, radii, radii, Mantid::Kernel::QLab);
+
+    double inti, sigi;
+
+    // Only the 3 inside-0.3 events per axis count: 9 total.
+    integrator.integrateUsingShape(shape, peak_q, inti, sigi);
+    TS_ASSERT_DELTA(inti, 9.0, 1e-10);
+    TS_ASSERT_DELTA(sigi, std::sqrt(9.0), 1e-10);
+  }
+
+  // Verify integrateUsingShapeProfileFit's fitted amplitude is (very
+  // nearly) the joint maximum of the same Poisson log-likelihood it is
+  // supposed to optimize, by independently reconstructing that likelihood
+  // in the test and comparing against a fine brute-force grid search. This
+  // decouples "did the hand-rolled Newton solver find the right answer"
+  // from trusting the production code's own bookkeeping.
+  void test_integrateUsingShapeProfileFit_matches_grid_search_optimum() {
+    V3D peak_q(10, 0, 0);
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    // 6 events exactly at the peak center (strong signal), and 6 events
+    // far out along +-x, +-y, +-z (within the search radius, but many
+    // sigma away from the peak -- effectively pure background).
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
+    for (int i = 0; i < 6; ++i)
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q);
+    for (const double offset : {0.9, -0.9}) {
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(offset, 0, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(0, offset, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), peak_q + V3D(0, 0, offset));
+    }
+
+    const double regionRadius = 1.0;
+    Integrate3DEvents integrator(peak_q_list, UBinv, regionRadius);
+    integrator.addEvents(event_Qs, false);
+
+    PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    PeakEllipsoidExtent sigmas{0.2, 0.2, 0.2};
+    // background radii are unused by the profile-fit method
+    PeakShapeEllipsoid shape(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
+
+    double inti, sigi;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, inti, sigi);
+
+    TS_ASSERT(inti > 0.0);
+    TS_ASSERT(std::isfinite(sigi));
+    TS_ASSERT(sigi > 0.0);
+
+    // Independently reconstruct g_i for each event using the same
+    // quadratic-form convention as numInEllipsoid/numInEllipsoidBkg.
+    std::vector<double> g;
+    for (const auto &event : event_Qs) {
+      const V3D offset = event.second - peak_q;
+      double d2 = 0.0;
+      for (size_t k = 0; k < 3; ++k) {
+        const double comp = offset.scalar_prod(directions[k]) / sigmas[k];
+        d2 += comp * comp;
+      }
+      g.push_back(std::exp(-0.5 * d2));
+    }
+
+    const double normG = std::pow(2.0 * M_PI, 1.5) * sigmas[0] * sigmas[1] * sigmas[2];
+    const double volume = (4.0 / 3.0) * M_PI * regionRadius * regionRadius * regionRadius;
+
+    auto logLikelihood = [&](double A, double b) {
+      double ll = -(A * normG + b * volume);
+      for (const double gi : g)
+        ll += std::log(A * gi + b);
+      return ll;
+    };
+
+    // Fine joint grid search over generous ranges for the true optimum.
+    double bestLL = -std::numeric_limits<double>::infinity();
+    for (int ia = 0; ia <= 400; ++ia) {
+      const double A = ia * 0.5; // 0..200
+      for (int ib = 0; ib <= 400; ++ib) {
+        const double b = ib * 0.125; // 0..50
+        bestLL = std::max(bestLL, logLikelihood(A, b));
+      }
+    }
+
+    // Profile likelihood over b at the production-fitted A: if that A is
+    // correct, maximizing over b here should reach the same joint optimum.
+    const double A_fit = inti / normG;
+    double bestLLAtAFit = -std::numeric_limits<double>::infinity();
+    for (int ib = 0; ib <= 4000; ++ib) {
+      const double b = ib * 0.0125; // 0..50, finer than the joint grid
+      bestLLAtAFit = std::max(bestLLAtAFit, logLikelihood(A_fit, b));
+    }
+
+    TSM_ASSERT_DELTA("fitted amplitude should (nearly) reach the grid-search joint optimum "
+                     "of the Poisson log-likelihood it is supposed to maximize",
+                     bestLLAtAFit, bestLL, 0.05);
+
+    // With the center already correct (symmetric data centered exactly at
+    // peak_q), enabling AdjustCenter should not meaningfully change the fit.
+    double intiAdjusted, sigiAdjusted;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, intiAdjusted, sigiAdjusted);
+    TSM_ASSERT_DELTA("AdjustCenter should not drift when the center is already correct", intiAdjusted, inti,
+                     0.05 * inti);
+  }
+
+  // Verify that AdjustCenter recovers (close to) the intensity that would
+  // have been obtained had peak_q been exactly right, when it is instead
+  // off by a small, deliberate amount -- by comparing three calls of the
+  // same function rather than an externally-derived expected value: fit at
+  // the (deliberately wrong) nominal peak_q with and without AdjustCenter,
+  // and fit at the true center directly, using the same raw events for all
+  // three, only the registered peak position differs.
+  void test_integrateUsingShapeProfileFit_adjustCenter_recovers_true_center() {
+    V3D peak_q(10, 0, 0);
+    const V3D trueOffset(0.06, 0, 0); // 0.3 sigma; well within the 1-sigma cap
+    const V3D trueCenter = peak_q + trueOffset;
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    // Events genuinely centered on trueCenter, not peak_q: 6 strong events
+    // exactly at trueCenter, and 6 far-out (background-like) events.
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
+    for (int i = 0; i < 6; ++i)
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter);
+    for (const double offset : {0.9, -0.9}) {
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(offset, 0, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(0, offset, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(0, 0, offset));
+    }
+
+    PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    PeakEllipsoidExtent sigmas{0.2, 0.2, 0.2};
+    PeakShapeEllipsoid shape(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
+
+    // (a) registered (and queried) at the wrong, nominal peak_q
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list_wrong{{std::make_pair(1., 1.), peak_q}};
+    Integrate3DEvents integratorWrong(peak_q_list_wrong, UBinv, 1.0);
+    integratorWrong.addEvents(event_Qs, false);
+
+    double intiFixedWrong, sigiFixedWrong;
+    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, false, intiFixedWrong, sigiFixedWrong);
+
+    double intiAdjusted, sigiAdjusted;
+    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, true, intiAdjusted, sigiAdjusted);
+
+    // (b) registered (and queried) at the true center -- the best achievable
+    // answer, since here the center is exactly right
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list_true{{std::make_pair(1., 1.), trueCenter}};
+    Integrate3DEvents integratorTrue(peak_q_list_true, UBinv, 1.0);
+    integratorTrue.addEvents(event_Qs, false);
+
+    double intiReference, sigiReference;
+    integratorTrue.integrateUsingShapeProfileFit(shape, trueCenter, false, intiReference, sigiReference);
+
+    TSM_ASSERT_LESS_THAN("AdjustCenter should get closer to the true-center answer than the fixed, wrong-center fit",
+                         std::abs(intiAdjusted - intiReference), std::abs(intiFixedWrong - intiReference));
+    TSM_ASSERT_DELTA("AdjustCenter should nearly recover the true-center answer for a small, "
+                     "within-cap offset",
+                     intiAdjusted, intiReference, 0.1 * intiReference);
   }
 
   void test_satellites() {

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -154,6 +154,74 @@ public:
     TS_ASSERT_DELTA(sigi, std::sqrt(9.0), 1e-10);
   }
 
+  void test_integrateUsingShape_subtracts_weighted_background_and_propagates_errors() {
+    const V3D peak_q(10, 0, 0);
+    const std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
+    // Four weighted events in the peak contribute intensity 8 and variance 16.
+    for (int i = 0; i < 4; ++i)
+      event_Qs.emplace_back(std::make_pair(2., 4.), peak_q);
+    // Five events in the background shell contribute intensity 5 and variance 1.25.
+    for (int i = 0; i < 5; ++i)
+      event_Qs.emplace_back(std::make_pair(1., .25), peak_q + V3D(.35, 0, 0));
+
+    // Disable the optional high-background culling so this test isolates the
+    // fixed-shape volume scaling and error propagation.
+    Integrate3DEvents integrator(peak_q_list, UBinv, 1.0, false);
+    integrator.addEvents(event_Qs, false);
+
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent peakRadii{.2, .3, .4};
+    const PeakEllipsoidExtent backgroundInnerRadii{.3, .4, .5};
+    const PeakEllipsoidExtent backgroundOuterRadii{.4, .5, .6};
+    const PeakShapeEllipsoid shape(directions, peakRadii, backgroundInnerRadii, backgroundOuterRadii,
+                                   Mantid::Kernel::QLab);
+
+    double inti, sigi;
+    integrator.integrateUsingShape(shape, peak_q, inti, sigi);
+
+    // Peak/background-shell volume ratio = .024 / (.120 - .060) = .4.
+    TS_ASSERT_DELTA(inti, 8.0 - .4 * 5.0, 1e-10);
+    TS_ASSERT_DELTA(sigi, std::sqrt(16.0 + .4 * .4 * 1.25), 1e-10);
+  }
+
+  void test_fixed_shape_integrations_return_zero_with_fewer_than_three_events() {
+    const V3D peak_q(10, 0, 0);
+    const std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    Integrate3DEvents integrator(peak_q_list, UBinv, 1.0);
+    const std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs{
+        {std::make_pair(1., 1.), peak_q}, {std::make_pair(1., 1.), peak_q + V3D(.1, 0, 0)}};
+    integrator.addEvents(event_Qs, false);
+
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{.2, .2, .2};
+    const PeakShapeEllipsoid shape(directions, radii, radii, radii, Mantid::Kernel::QLab);
+
+    double inti = 123.0;
+    double sigi = 456.0;
+    integrator.integrateUsingShape(shape, peak_q, inti, sigi);
+    TS_ASSERT_EQUALS(inti, 0.0);
+    TS_ASSERT_EQUALS(sigi, 0.0);
+
+    inti = 123.0;
+    sigi = 456.0;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, inti, sigi);
+    TS_ASSERT_EQUALS(inti, 0.0);
+    TS_ASSERT_EQUALS(sigi, 0.0);
+  }
+
   // Verify integrateUsingShapeProfileFit's fitted amplitude is (very
   // nearly) the joint maximum of the same Poisson log-likelihood it is
   // supposed to optimize, by independently reconstructing that likelihood

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -217,7 +217,8 @@ public:
 
     inti = 123.0;
     sigi = 456.0;
-    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, inti, sigi);
+    V3D center;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, center, inti, sigi);
     TS_ASSERT_EQUALS(inti, 0.0);
     TS_ASSERT_EQUALS(sigi, 0.0);
   }
@@ -259,7 +260,8 @@ public:
     PeakShapeEllipsoid shape(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
 
     double inti, sigi;
-    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, inti, sigi);
+    V3D center;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, center, inti, sigi);
 
     TS_ASSERT(inti > 0.0);
     TS_ASSERT(std::isfinite(sigi));
@@ -344,7 +346,8 @@ public:
     // With the center already correct (symmetric data centered exactly at
     // peak_q), enabling AdjustCenter should not meaningfully change the fit.
     double intiAdjusted, sigiAdjusted;
-    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, intiAdjusted, sigiAdjusted);
+    V3D adjustedCenter;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, true, adjustedCenter, intiAdjusted, sigiAdjusted);
     TSM_ASSERT_DELTA("AdjustCenter should not drift when the center is already correct", intiAdjusted, inti,
                      0.05 * inti);
   }
@@ -368,7 +371,8 @@ public:
     const PeakShapeEllipsoid shape(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
 
     double inti, sigi;
-    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, inti, sigi);
+    V3D center;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, center, inti, sigi);
 
     TS_ASSERT(std::isinf(sigi));
   }
@@ -411,10 +415,13 @@ public:
     integratorWrong.addEvents(event_Qs, false);
 
     double intiFixedWrong, sigiFixedWrong;
-    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, false, intiFixedWrong, sigiFixedWrong);
+    V3D centerFixedWrong;
+    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, false, centerFixedWrong, intiFixedWrong,
+                                                  sigiFixedWrong);
 
     double intiAdjusted, sigiAdjusted;
-    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, true, intiAdjusted, sigiAdjusted);
+    V3D centerAdjusted;
+    integratorWrong.integrateUsingShapeProfileFit(shape, peak_q, true, centerAdjusted, intiAdjusted, sigiAdjusted);
 
     // (b) registered (and queried) at the true center -- the best achievable
     // answer, since here the center is exactly right
@@ -423,13 +430,75 @@ public:
     integratorTrue.addEvents(event_Qs, false);
 
     double intiReference, sigiReference;
-    integratorTrue.integrateUsingShapeProfileFit(shape, trueCenter, false, intiReference, sigiReference);
+    V3D centerReference;
+    integratorTrue.integrateUsingShapeProfileFit(shape, trueCenter, false, centerReference, intiReference,
+                                                 sigiReference);
 
     TSM_ASSERT_LESS_THAN("AdjustCenter should get closer to the true-center answer than the fixed, wrong-center fit",
                          std::abs(intiAdjusted - intiReference), std::abs(intiFixedWrong - intiReference));
     TSM_ASSERT_DELTA("AdjustCenter should nearly recover the true-center answer for a small, "
                      "within-cap offset",
                      intiAdjusted, intiReference, 0.1 * intiReference);
+  }
+
+  // integrateUsingShapeProfileFit must seed its fit from shape.translation()
+  // (a previously found correction), not from zero, and the maxShift cap
+  // must bound the *incremental* refinement made in this call rather than
+  // the total distance from peak_q -- otherwise a shape whose existing
+  // translation already sits near the cap could never be refined further,
+  // even when the true center is only a small step beyond it.
+  void test_integrateUsingShapeProfileFit_adjustCenter_refines_from_existing_translation() {
+    const V3D peak_q(10, 0, 0);
+    // 0.19: just inside the 1-sigma (0.2) cap on its own, so an *absolute*
+    // (rather than incremental) clamp would leave almost no room to move.
+    const V3D presetTranslation(0.19, 0, 0);
+    // True center is 0.25 from peak_q -- beyond the 1-sigma cap in total,
+    // but only 0.06 beyond presetTranslation, well within an incremental cap.
+    const V3D trueCenter = peak_q + V3D(0.25, 0, 0);
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
+    for (int i = 0; i < 6; ++i)
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter);
+    for (const double offset : {0.9, -0.9}) {
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(offset, 0, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(0, offset, 0));
+      event_Qs.emplace_back(std::make_pair(1., 1.), trueCenter + V3D(0, 0, offset));
+    }
+
+    PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    PeakEllipsoidExtent sigmas{0.2, 0.2, 0.2};
+    PeakShapeEllipsoid shapeNoTranslation(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
+    PeakShapeEllipsoid shapeWithTranslation(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab, "", -1,
+                                            presetTranslation);
+
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+    Integrate3DEvents integrator(peak_q_list, UBinv, 1.0);
+    integrator.addEvents(event_Qs, false);
+
+    // Without the preset translation, a single call's 1-sigma cap (measured
+    // from zero) cannot reach all the way to a true center 0.25 away.
+    double intiFromScratch, sigiFromScratch;
+    V3D centerFromScratch;
+    integrator.integrateUsingShapeProfileFit(shapeNoTranslation, peak_q, true, centerFromScratch, intiFromScratch,
+                                             sigiFromScratch);
+    TSM_ASSERT_LESS_THAN("a single call starting from zero translation should be capped short of the true offset",
+                         centerFromScratch.norm(), 0.25 - 1e-6);
+
+    // With the preset translation as the seed, only a small further step is
+    // needed, well within the incremental cap, so it should reach much
+    // closer to the true center than the from-scratch call did.
+    double intiFromPreset, sigiFromPreset;
+    V3D centerFromPreset;
+    integrator.integrateUsingShapeProfileFit(shapeWithTranslation, peak_q, true, centerFromPreset, intiFromPreset,
+                                             sigiFromPreset);
+    TSM_ASSERT_LESS_THAN("seeding from an existing translation should reach closer to the true offset than "
+                         "starting from zero did",
+                         std::abs(centerFromPreset.norm() - 0.25), std::abs(centerFromScratch.norm() - 0.25));
   }
 
   void test_satellites() {

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -213,6 +213,37 @@ public:
     const double normG = std::pow(2.0 * M_PI, 1.5) * sigmas[0] * sigmas[1] * sigmas[2];
     const double volume = (4.0 / 3.0) * M_PI * regionRadius * regionRadius * regionRadius;
 
+    // Recover the fitted background from its score equation at A_fit, then
+    // verify sigi uses the marginal variance from the full 2x2 information
+    // matrix rather than the conditional variance from dAA alone.
+    const double A_fit = inti / normG;
+    double bLow = 0.0;
+    double bHigh = 100.0;
+    for (int iteration = 0; iteration < 100; ++iteration) {
+      const double bMid = 0.5 * (bLow + bHigh);
+      double dB = -volume;
+      for (const double gi : g)
+        dB += 1.0 / (A_fit * gi + bMid);
+      if (dB > 0.0)
+        bLow = bMid;
+      else
+        bHigh = bMid;
+    }
+    const double bFit = 0.5 * (bLow + bHigh);
+    double dAA = 0.0;
+    double dBB = 0.0;
+    double dAB = 0.0;
+    for (const double gi : g) {
+      const double mu = A_fit * gi + bFit;
+      dAA -= gi * gi / (mu * mu);
+      dBB -= 1.0 / (mu * mu);
+      dAB -= gi / (mu * mu);
+    }
+    const double det = dAA * dBB - dAB * dAB;
+    const double expectedSigi = normG * std::sqrt(-dBB / det);
+    TSM_ASSERT_DELTA("profile-fit uncertainty should include covariance with the fitted background", sigi, expectedSigi,
+                     1e-8);
+
     auto logLikelihood = [&](double A, double b) {
       double ll = -(A * normG + b * volume);
       for (const double gi : g)
@@ -232,7 +263,6 @@ public:
 
     // Profile likelihood over b at the production-fitted A: if that A is
     // correct, maximizing over b here should reach the same joint optimum.
-    const double A_fit = inti / normG;
     double bestLLAtAFit = -std::numeric_limits<double>::infinity();
     for (int ib = 0; ib <= 4000; ++ib) {
       const double b = ib * 0.0125; // 0..50, finer than the joint grid
@@ -249,6 +279,30 @@ public:
     integrator.integrateUsingShapeProfileFit(shape, peak_q, true, intiAdjusted, sigiAdjusted);
     TSM_ASSERT_DELTA("AdjustCenter should not drift when the center is already correct", intiAdjusted, inti,
                      0.05 * inti);
+  }
+
+  void test_integrateUsingShapeProfileFit_returns_infinite_uncertainty_for_singular_information() {
+    const V3D peak_q(10, 0, 0);
+    const std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{{std::make_pair(1., 1.), peak_q}};
+
+    DblMatrix UBinv(3, 3, false);
+    UBinv.setRow(0, V3D(.1, 0, 0));
+    UBinv.setRow(1, V3D(0, .1, 0));
+    UBinv.setRow(2, V3D(0, 0, .1));
+
+    const auto event = std::make_pair(std::make_pair(1., 1.), peak_q);
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs(6, event);
+    Integrate3DEvents integrator(peak_q_list, UBinv, 1.0);
+    integrator.addEvents(event_Qs, false);
+
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent sigmas{0.2, 0.2, 0.2};
+    const PeakShapeEllipsoid shape(directions, sigmas, sigmas, sigmas, Mantid::Kernel::QLab);
+
+    double inti, sigi;
+    integrator.integrateUsingShapeProfileFit(shape, peak_q, false, inti, sigi);
+
+    TS_ASSERT(std::isinf(sigi));
   }
 
   // Verify that AdjustCenter recovers (close to) the intensity that would

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -16,6 +16,7 @@
 #include "MantidKernel/V3D.h"
 #include "MantidMDAlgorithms/IntegrateEllipsoidsTwoStep.h"
 
+#include <cmath>
 #include <cxxtest/TestSuite.h>
 #include <tuple>
 
@@ -31,6 +32,13 @@ public:
   void test_init() {
     IntegratePeaksShapeMD alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_EQUALS(alg.name(), "IntegratePeaksShapeMD");
+    TS_ASSERT_EQUALS(alg.version(), 1);
+    TS_ASSERT_EQUALS(alg.category(), "Crystal\\Integration");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("RegionRadius"), "0.35");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("ProfileFit"), "0");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("AdjustCenter"), "0");
+    TS_ASSERT_THROWS_ANYTHING(alg.setProperty("RegionRadius", -0.01));
   }
 
   void test_exec_throws_without_peak_shapes() {
@@ -84,6 +92,38 @@ public:
     alg.setProperty("PeaksWorkspace", peaksWS);
     alg.setPropertyValue("OutputWorkspace", "dummy");
     TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
+  }
+
+  void test_exec_throws_with_fewer_than_three_indexed_peaks() {
+    const auto sigmas = std::make_tuple(.002, .002, .1);
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), 100, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{.35, .35, .35};
+    for (auto &peak : peaksWS->getPeaks())
+      peak.setPeakShape(new PeakShapeEllipsoid(directions, radii, radii, radii, Kernel::QLab));
+    peaksWS->getPeak(2).setHKL(0, 0, 0);
+
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &error, std::string(error.what()),
+                            "At least three linearly independent indexed peaks are needed.");
     TS_ASSERT(!alg.isExecuted());
   }
 
@@ -181,6 +221,97 @@ public:
     for (int i = 0; i < integratedPeaksWS->getNumberPeaks(); ++i) {
       TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(i), integratedPeaksWS->getPeak(i).getIntensity(),
                        numEventsPerPeak, 5);
+    }
+  }
+
+  void test_exec_histogram_reuses_existing_shape() {
+    const int numEventsPerPeak = 1000;
+    const auto sigmas = std::make_tuple(.002, .002, .01);
+
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.outputAsHistogram(true);
+    builder.setRebinParameters({800, 5, 10000});
+    builder.addPeakByHKL(V3D(1, -5, -3), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -2), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, 0), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(2, -3, -4), numEventsPerPeak, sigmas);
+
+    auto data = builder.build();
+    auto histoWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{.5, .5, .5};
+    for (auto &peak : peaksWS->getPeaks())
+      peak.setPeakShape(new PeakShapeEllipsoid(directions, radii, radii, radii, Kernel::QLab));
+
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", histoWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setProperty("RegionRadius", .6);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    PeaksWorkspace_sptr integratedPeaksWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(integratedPeaksWS);
+    for (int i = 0; i < 5; ++i) {
+      TSM_ASSERT_DELTA("Wrong histogram intensity for peak " + std::to_string(i),
+                       integratedPeaksWS->getPeak(i).getIntensity(), numEventsPerPeak, 5);
+    }
+  }
+
+  void test_exec_profile_fit_with_center_adjustment() {
+    const auto sigmas = std::make_tuple(.002, .002, .1);
+
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), 1000, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), 1000, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), 1000, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -2), 1000, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, 0), 1000, sigmas);
+    builder.addPeakByHKL(V3D(2, -3, -4), 1000, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent peakSigmas{.15, .15, .15};
+    for (auto &peak : peaksWS->getPeaks())
+      peak.setPeakShape(new PeakShapeEllipsoid(directions, peakSigmas, peakSigmas, peakSigmas, Kernel::QLab));
+
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setProperty("RegionRadius", .5);
+    alg.setProperty("ProfileFit", true);
+    alg.setProperty("AdjustCenter", true);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    PeaksWorkspace_sptr integratedPeaksWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(integratedPeaksWS);
+    for (int i = 0; i < integratedPeaksWS->getNumberPeaks(); ++i) {
+      const auto &peak = integratedPeaksWS->getPeak(i);
+      TSM_ASSERT("Profile-fit intensity should be positive for peak " + std::to_string(i), peak.getIntensity() > 0.0);
+      TSM_ASSERT("Profile-fit uncertainty should be finite for peak " + std::to_string(i),
+                 std::isfinite(peak.getSigmaIntensity()));
+      TSM_ASSERT("Profile-fit uncertainty should be positive for peak " + std::to_string(i),
+                 peak.getSigmaIntensity() > 0.0);
     }
   }
 };

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -35,7 +35,8 @@ public:
     TS_ASSERT_EQUALS(alg.name(), "IntegratePeaksShapeMD");
     TS_ASSERT_EQUALS(alg.version(), 1);
     TS_ASSERT_EQUALS(alg.category(), "Crystal\\Integration");
-    TS_ASSERT_EQUALS(alg.getPropertyValue("RegionRadius"), "0.35");
+    const double regionRadius = alg.getProperty("RegionRadius");
+    TS_ASSERT_DELTA(regionRadius, 0.35, 1e-10);
     TS_ASSERT_EQUALS(alg.getPropertyValue("ProfileFit"), "0");
     TS_ASSERT_EQUALS(alg.getPropertyValue("AdjustCenter"), "0");
     TS_ASSERT_THROWS_ANYTHING(alg.setProperty("RegionRadius", -0.01));
@@ -133,9 +134,14 @@ public:
     builder.setRandomSeed(1);
     builder.setNumPixels(100);
     builder.addBackground(false);
+    // Six well-separated peaks (matching test_exec_events_reuses_existing_shape),
+    // rather than the minimum of three, so Optimize_UB has a well-conditioned fit.
     builder.addPeakByHKL(V3D(1, -5, -3), 100, sigmas);
     builder.addPeakByHKL(V3D(1, -4, -4), 100, sigmas);
     builder.addPeakByHKL(V3D(1, -3, -5), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -2), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, 0), 100, sigmas);
+    builder.addPeakByHKL(V3D(2, -3, -4), 100, sigmas);
 
     auto data = builder.build();
     auto eventWS = std::dynamic_pointer_cast<EventWorkspace>(std::get<0>(data));

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -1,0 +1,122 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidMDAlgorithms/IntegratePeaksShapeMD.h"
+
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidFrameworkTestHelpers/SingleCrystalDiffractionTestHelper.h"
+#include "MantidKernel/V3D.h"
+#include "MantidMDAlgorithms/IntegrateEllipsoidsTwoStep.h"
+
+#include <cxxtest/TestSuite.h>
+#include <tuple>
+
+using namespace Mantid;
+using namespace Mantid::MDAlgorithms;
+using namespace Mantid::DataObjects;
+using Mantid::Kernel::V3D;
+using namespace Mantid::SingleCrystalDiffractionTestHelper;
+
+class IntegratePeaksShapeMDTest : public CxxTest::TestSuite {
+
+public:
+  void test_init() {
+    IntegratePeaksShapeMD alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+  }
+
+  void test_exec_throws_without_peak_shapes() {
+    const int numEventsPerPeak = 10000;
+    const auto sigmas = std::make_tuple(.002, .002, 0.1);
+
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), numEventsPerPeak, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+
+    // peaksWS has not been integrated yet, so none of its peaks have a shape
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_ANYTHING(alg.execute());
+    TS_ASSERT(!alg.isExecuted());
+  }
+
+  void test_exec_events_reuses_existing_shape() {
+    const int numEventsPerPeak = 10000;
+    // Very tight distribution with events happening at a single point
+    const auto sigmas = std::make_tuple(.002, .002, 0.1);
+
+    // Build some diffraction data
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -2), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, 0), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(2, -3, -4), numEventsPerPeak, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+
+    // First integrate normally so every peak gets an ellipsoid shape
+    IntegrateEllipsoidsTwoStep shapeAlg;
+    shapeAlg.setChild(true);
+    shapeAlg.setRethrows(true);
+    shapeAlg.initialize();
+    shapeAlg.setProperty("InputWorkspace", eventWS);
+    shapeAlg.setProperty("PeaksWorkspace", peaksWS);
+    shapeAlg.setProperty("SpecifySize", true);
+    shapeAlg.setProperty("PeakSize", 0.35);
+    shapeAlg.setProperty("BackgroundInnerSize", 0.35);
+    shapeAlg.setProperty("BackgroundOuterSize", 0.4);
+    shapeAlg.setPropertyValue("OutputWorkspace", "shaped");
+    shapeAlg.execute();
+    PeaksWorkspace_sptr shapedPeaksWS = shapeAlg.getProperty("OutputWorkspace");
+
+    // Now re-integrate the same events using only the shapes already on the
+    // peaks workspace
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", shapedPeaksWS);
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RegionRadius", 0.5));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "dummy"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    TS_ASSERT(alg.isExecuted());
+    PeaksWorkspace_sptr integratedPeaksWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(integratedPeaksWS);
+
+    TSM_ASSERT_EQUALS("Wrong number of peaks in output workspace", integratedPeaksWS->getNumberPeaks(),
+                      peaksWS->getNumberPeaks());
+    const auto &run = integratedPeaksWS->mutableRun();
+    TSM_ASSERT("Output workspace must be integrated", run.hasProperty("PeaksIntegrated"));
+
+    for (int i = 0; i < 5; ++i) {
+      TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(i), integratedPeaksWS->getPeak(i).getIntensity(),
+                       numEventsPerPeak, 5);
+    }
+  }
+};

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -230,6 +230,76 @@ public:
     }
   }
 
+  // AdjustCenter should persist any found correction as the output shape's
+  // translation (leaving directions/radii/frame/algorithm metadata
+  // untouched), and should not touch translation at all when disabled.
+  void test_exec_profileFit_adjustCenter_writes_translation() {
+    const int numEventsPerPeak = 10000;
+    const auto sigmas = std::make_tuple(.002, .002, 0.1);
+
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -2), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, 0), numEventsPerPeak, sigmas);
+    builder.addPeakByHKL(V3D(2, -3, -4), numEventsPerPeak, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+
+    // Simple, sigma-scaled shapes (not a hard SpecifySize cutoff) so
+    // ProfileFit's Gaussian kernel is well-conditioned against the region.
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{0.03, 0.03, 0.03};
+    for (auto &peak : peaksWS->getPeaks())
+      peak.setPeakShape(new PeakShapeEllipsoid(directions, radii, radii, radii, Mantid::Kernel::QLab));
+
+    auto runIntegration = [&](bool adjustCenter, const std::string &outputName) {
+      IntegratePeaksShapeMD alg;
+      alg.setChild(true);
+      alg.setRethrows(true);
+      alg.initialize();
+      alg.setProperty("InputWorkspace", eventWS);
+      alg.setProperty("PeaksWorkspace", peaksWS);
+      alg.setProperty("RegionRadius", 0.5);
+      alg.setProperty("ProfileFit", true);
+      alg.setProperty("AdjustCenter", adjustCenter);
+      alg.setPropertyValue("OutputWorkspace", outputName);
+      alg.execute();
+      PeaksWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+      return result;
+    };
+
+    PeaksWorkspace_sptr withoutAdjust = runIntegration(false, "withoutAdjust");
+    PeaksWorkspace_sptr withAdjust = runIntegration(true, "withAdjust");
+
+    for (int i = 0; i < withoutAdjust->getNumberPeaks(); ++i) {
+      const auto *inputShape = dynamic_cast<const PeakShapeEllipsoid *>(&peaksWS->getPeak(i).getPeakShape());
+      const auto *noAdjustShape = dynamic_cast<const PeakShapeEllipsoid *>(&withoutAdjust->getPeak(i).getPeakShape());
+      const auto *adjustShape = dynamic_cast<const PeakShapeEllipsoid *>(&withAdjust->getPeak(i).getPeakShape());
+      TS_ASSERT(noAdjustShape);
+      TS_ASSERT(adjustShape);
+
+      TSM_ASSERT_EQUALS("AdjustCenter=false must not write a translation for peak " + std::to_string(i),
+                        noAdjustShape->translation(), V3D(0, 0, 0));
+
+      // Everything except translation must survive the reconstruction
+      // unchanged: same directions, radii, frame and algorithm metadata.
+      for (size_t k = 0; k < 3; ++k) {
+        TS_ASSERT_EQUALS(adjustShape->directions()[k], inputShape->directions()[k]);
+        TS_ASSERT_EQUALS(adjustShape->abcRadii()[k], inputShape->abcRadii()[k]);
+        TS_ASSERT_EQUALS(adjustShape->abcRadiiBackgroundInner()[k], inputShape->abcRadiiBackgroundInner()[k]);
+        TS_ASSERT_EQUALS(adjustShape->abcRadiiBackgroundOuter()[k], inputShape->abcRadiiBackgroundOuter()[k]);
+      }
+      TS_ASSERT_EQUALS(adjustShape->frame(), inputShape->frame());
+    }
+  }
+
   void test_exec_histogram_reuses_existing_shape() {
     const int numEventsPerPeak = 1000;
     const auto sigmas = std::make_tuple(.002, .002, .01);

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidMDAlgorithms/IntegratePeaksShapeMD.h"
 
+#include "MantidAPI/Run.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidFrameworkTestHelpers/SingleCrystalDiffractionTestHelper.h"
 #include "MantidKernel/V3D.h"

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -9,6 +9,8 @@
 #include "MantidMDAlgorithms/IntegratePeaksShapeMD.h"
 
 #include "MantidAPI/Run.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/PeakShapeEllipsoid.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidFrameworkTestHelpers/SingleCrystalDiffractionTestHelper.h"
 #include "MantidKernel/V3D.h"
@@ -56,6 +58,67 @@ public:
     alg.setPropertyValue("OutputWorkspace", "dummy");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
     TS_ASSERT(!alg.isExecuted());
+  }
+
+  void test_exec_throws_for_shape_not_in_qlab() {
+    const auto sigmas = std::make_tuple(.002, .002, 0.1);
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), 100, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::get<0>(data);
+    auto peaksWS = std::get<1>(data);
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{0.35, 0.35, 0.35};
+    peaksWS->getPeak(0).setPeakShape(new PeakShapeEllipsoid(directions, radii, radii, radii, Kernel::QSample));
+
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
+  }
+
+  void test_exec_does_not_modify_input_events() {
+    const auto sigmas = std::make_tuple(.002, .002, 0.1);
+    WorkspaceBuilder builder;
+    builder.setRandomSeed(1);
+    builder.setNumPixels(100);
+    builder.addBackground(false);
+    builder.addPeakByHKL(V3D(1, -5, -3), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -4, -4), 100, sigmas);
+    builder.addPeakByHKL(V3D(1, -3, -5), 100, sigmas);
+
+    auto data = builder.build();
+    auto eventWS = std::dynamic_pointer_cast<EventWorkspace>(std::get<0>(data));
+    auto peaksWS = std::get<1>(data);
+    const PeakEllipsoidFrame directions{V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)};
+    const PeakEllipsoidExtent radii{0.35, 0.35, 0.35};
+    for (auto &peak : peaksWS->getPeaks())
+      peak.setPeakShape(new PeakShapeEllipsoid(directions, radii, radii, radii, Kernel::QLab));
+
+    const auto originalEventType = eventWS->getEventType();
+    const auto originalEventCount = eventWS->getNumberEvents();
+
+    IntegratePeaksShapeMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", eventWS);
+    alg.setProperty("PeaksWorkspace", peaksWS);
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    TS_ASSERT_EQUALS(eventWS->getEventType(), originalEventType);
+    TS_ASSERT_EQUALS(eventWS->getNumberEvents(), originalEventCount);
   }
 
   void test_exec_events_reuses_existing_shape() {

--- a/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksShapeMDTest.h
@@ -115,7 +115,7 @@ public:
     const auto &run = integratedPeaksWS->mutableRun();
     TSM_ASSERT("Output workspace must be integrated", run.hasProperty("PeaksIntegrated"));
 
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < integratedPeaksWS->getNumberPeaks(); ++i) {
       TSM_ASSERT_DELTA("Wrong intensity for peak " + std::to_string(i), integratedPeaksWS->getPeak(i).getIntensity(),
                        numEventsPerPeak, 5);
     }

--- a/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
@@ -37,6 +37,44 @@ If *UseOnePercentBackgroundCorrection* is enabled (the default), the top 1% of
 the background events are removed before background subtraction, to reduce
 sensitivity to intensity spikes from nearby peaks.
 
+Integration method
+###################
+
+By default (*ProfileFit* = False) each peak is integrated by counting raw
+or weighted events inside the peak ellipsoid, and subtracting a background
+estimate from the ellipsoidal shell, the same approach used by
+:ref:`algm-IntegrateEllipsoidsTwoStep`.
+
+If *ProfileFit* is enabled, each peak is instead integrated by directly
+maximizing the (weighted) Poisson log-likelihood of an unbinned point
+process, fitting a Gaussian peak amplitude and a flat background rate
+against the raw events within *RegionRadius* of the peak. In this mode the
+peak radii are interpreted as the Gaussian's standard deviations (1-sigma)
+along its principal axes rather than as hard integration boundaries, and
+the background radii are not used since the background rate is fit
+directly instead. This can make better use of the available events for weak
+peaks than a simple ellipsoidal count, at the cost of assuming the peak
+profile is well described by a Gaussian and that essentially all of its
+intensity falls within *RegionRadius*.
+
+Any scaling or mosaic-broadening correction to a peak's shape (e.g. derived
+from a resolution model, or refined per-sample) is expected to be applied
+by the caller before running this algorithm, by writing the corrected
+radii directly into the *PeaksWorkspace*'s stored shapes -- this algorithm
+always uses the shape it is given exactly as supplied, with no adjustment
+of its own.
+
+By default the peak center used is always the peak's own stored Q-vector;
+neither integration method refines or re-centers it, matching
+:ref:`algm-IntegrateEllipsoidsTwoStep`, which also never adjusts a peak's
+center (weak peaks borrow a strong peak's *shape*, but stay centered at
+their own stored Q). If *ProfileFit* and *AdjustCenter* are both enabled,
+the center is additionally refined by a bounded Gauss-Newton correction as
+part of the same fit, capped at one standard deviation of shift from the
+peak's stored Q -- a slight correction, not a free centroid search. This
+correction is only used for this integration; it is not written back to
+the peak's stored position.
+
 Usage
 -----
 

--- a/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
@@ -1,0 +1,56 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm integrates single crystal Bragg peaks by reusing the
+ellipsoidal peak shape already stored on each peak in the input
+*PeaksWorkspace*, instead of fitting a new shape from the events around each
+peak. It sums the raw or weighted events inside that fixed ellipsoid and
+subtracts a background estimate from the ellipsoidal shell already defined by
+the shape's *BackgroundInnerSize* and *BackgroundOuterSize*.
+
+The *PeaksWorkspace* must already have an ellipsoidal shape set on every peak
+to be integrated, for example from a previous run of
+:ref:`algm-IntegrateEllipsoids` or :ref:`algm-IntegrateEllipsoidsTwoStep`.
+This makes the algorithm useful for re-integrating the same or a different
+event workspace (e.g. a rebinned, background-subtracted, or otherwise
+corrected dataset) without re-deriving the peak shapes each time, or for
+comparing intensities obtained with a shape held fixed across multiple
+datasets.
+
+Peaks must be indexed with integral HKL values, in the same way as for
+:ref:`algm-IntegrateEllipsoidsTwoStep`: the indexed peaks are used to
+determine a :ref:`UB matrix <Lattice>`, whose inverse is used to assign each
+event to the nearest peak in reciprocal space. Only events within
+*RegionRadius* of a peak's Q-vector are considered; this should be at least as
+large as the largest background outer radius among the peaks being
+integrated, or the background shell will be truncated.
+
+If *UseOnePercentBackgroundCorrection* is enabled (the default), the top 1% of
+the background events are removed before background subtraction, to reduce
+sensitivity to intensity spikes from nearby peaks.
+
+Usage
+-----
+
+.. code-block:: python
+   :linenos:
+
+   # PeaksWorkspace already integrated once, so every peak has a shape
+   IntegrateEllipsoids(InputWorkspace='TOPAZ_3132_event', PeaksWorkspace='TOPAZ_3132_peaks',
+                       OutputWorkspace='TOPAZ_3132_peaks')
+
+   # Reuse those shapes to integrate again, e.g. after correcting the events
+   IntegratePeaksShapeMD(InputWorkspace='TOPAZ_3132_event', PeaksWorkspace='TOPAZ_3132_peaks',
+                         RegionRadius='0.25', OutputWorkspace='TOPAZ_3132_peaks_reintegrated')
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
@@ -14,7 +14,13 @@ ellipsoidal peak shape already stored on each peak in the input
 *PeaksWorkspace*, instead of fitting a new shape from the events around each
 peak. It sums the raw or weighted events inside that fixed ellipsoid and
 subtracts a background estimate from the ellipsoidal shell already defined by
-the shape's *BackgroundInnerSize* and *BackgroundOuterSize*.
+the shape's own background inner and outer radii -- unlike
+:ref:`algm-IntegrateEllipsoidsTwoStep`, this algorithm has no *PeakSize*,
+*BackgroundInnerSize* or *BackgroundOuterSize* properties of its own; every
+peak's ellipsoid is used exactly as stored. This also differs from
+:ref:`algm-IntegratePeaksMD`, which always integrates with a spherical
+(not ellipsoidal) region computed from user-specified radii rather than a
+shape stored on the peak.
 
 The *PeaksWorkspace* must already have an ellipsoidal shape set on every peak
 to be integrated, for example from a previous run of

--- a/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksShapeMD-v1.rst
@@ -48,8 +48,11 @@ Integration method
 
 By default (*ProfileFit* = False) each peak is integrated by counting raw
 or weighted events inside the peak ellipsoid, and subtracting a background
-estimate from the ellipsoidal shell, the same approach used by
-:ref:`algm-IntegrateEllipsoidsTwoStep`.
+estimate from the ellipsoidal shell, the same background-subtraction method
+:ref:`algm-IntegrateEllipsoidsTwoStep` uses (based on the ILL program Racer
+and Wilkinson, C., et al. "Integration of single-crystal reflections using
+area multidetectors." *Journal of Applied Crystallography* 21.5 (1988):
+471-478) -- applied here to a supplied, rather than fitted, ellipsoid.
 
 If *ProfileFit* is enabled, each peak is instead integrated by directly
 maximizing the (weighted) Poisson log-likelihood of an unbinned point

--- a/docs/source/release/v7.0.0/Diffraction/Single_Crystal/New_features/42122.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Single_Crystal/New_features/42122.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`algm-IntegratePeaksShapeMD` integrates single crystal Bragg peaks by reusing the ellipsoidal peak shape already stored on each peak (e.g. derived from a model of the instrument's resolution), instead of fitting a new shape from the events around each peak.


### PR DESCRIPTION
### Description of work

This algorithm integrate similar to IntegrateEllipsoidTwo step, except that it uses the existing peak shape. The value of this is that the shapes can be set on the peaks workspace based on a model of the instrument resolution. 


### To test:

Run the unit tests
<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

```
"""
Demo/comparison script for IntegratePeaksShapeMD.

IntegratePeaksShapeMD integrates single crystal Bragg peaks by reusing the
ellipsoidal shape already stored on each peak (e.g. from a previous
IntegrateEllipsoids run, or from an instrument resolution model), instead of
fitting a new shape from the events around each peak.

This script:
  1. Finds and indexes peaks in a TOPAZ event dataset (ConvertToMD,
     FindPeaksMD, FindUBUsingFFT, IndexPeaks).
  2. Runs IntegrateEllipsoids to establish an ellipsoidal shape (and a
     baseline intensity) on each indexed peak.
  3. Re-integrates the SAME events with IntegratePeaksShapeMD, reusing those
     stored shapes, in each of its three modes:
       - default: count events inside/outside the ellipsoid, background
         subtracted from the ellipsoidal shell (same method as
         IntegrateEllipsoidsTwoStep, applied to the borrowed shape)
       - ProfileFit: maximize the Poisson log-likelihood of a Gaussian peak
         plus a flat background rate against the raw events
       - ProfileFit + AdjustCenter: as above, but also lets the peak center
         move by a small (<= 1 sigma), bounded correction
  4. Prints a side-by-side comparison so you can sanity-check that
     IntegratePeaksShapeMD reproduces intensities in the same ballpark as
     the IntegrateEllipsoids run its shapes came from.

IMPORTANT -- shape convention: ProfileFit interprets a shape's peak radii
as literal standard deviations (1-sigma), but IntegrateEllipsoids stores a
3-sigma boundary. Feeding IntegrateEllipsoids' shapes straight into
ProfileFit therefore assumes a peak 3x too wide, which on real data can be
wide enough to break ProfileFit's "peak mass stays within RegionRadius"
assumption and collapse the fit toward zero. This script divides the
radii by 3 (rescale_shapes_to_sigma()) before the ProfileFit runs to
correct for this; a shape derived directly from an instrument resolution
model (already expressed in sigma) would not need this step.

Requires "TOPAZ_3132_event.nxs" (also used by the algorithm's own usage
example in the documentation) to be findable on the Mantid data search path
-- available from the Mantid system test data set:
https://github.com/mantidproject/systemtests/tree/master/Data/TOPAZ_3132_event.nxs

Run inside MantidWorkbench, or with mantidpython:
    mantidpython IntegratePeaksShapeMD_demo.py
"""

import json

from mantid.api import mtd
from mantid.dataobjects import PeakShapeEllipsoid
from mantid.kernel import SpecialCoordinateSystem, V3D
from mantid.simpleapi import (
    CloneWorkspace,
    ConvertToMD,
    FindPeaksMD,
    FindUBUsingFFT,
    IndexPeaks,
    IntegrateEllipsoids,
    IntegratePeaksShapeMD,
    Load,
)


def load_and_find_peaks():
    Load(Filename="TOPAZ_3132_event.nxs", OutputWorkspace="TOPAZ_3132_event")

    ConvertToMD(
        InputWorkspace="TOPAZ_3132_event",
        QDimensions="Q3D",
        dEAnalysisMode="Elastic",
        Q3DFrames="Q_sample",
        LorentzCorrection=True,
        OutputWorkspace="TOPAZ_3132_md",
        MinValues="-25,-25,-25",
        MaxValues="25,25,25",
        SplitInto="2",
        SplitThreshold="50",
        MaxRecursionDepth="13",
        MinRecursionDepth="7",
    )
    FindPeaksMD(
        InputWorkspace="TOPAZ_3132_md",
        PeakDistanceThreshold="0.3768",
        MaxPeaks="50",
        DensityThresholdFactor="100",
        OutputWorkspace="TOPAZ_3132_peaks",
    )
    FindUBUsingFFT(PeaksWorkspace="TOPAZ_3132_peaks", MinD="3", MaxD="15", Tolerance="0.12")
    IndexPeaks(PeaksWorkspace="TOPAZ_3132_peaks", Tolerance="0.12")

    return mtd["TOPAZ_3132_event"], mtd["TOPAZ_3132_peaks"]


def run_integrate_ellipsoids():
    """Establish a baseline: fit each peak's own ellipsoidal shape and intensity.

    SpecifySize=False so the stored shape's radii come from the actual
    standard deviations of events near each peak (a fixed multiple of
    sigma), rather than from a single user-specified boundary shared by
    every peak -- see rescale_shapes_to_sigma() for why this matters for
    ProfileFit.
    """
    IntegrateEllipsoids(
        InputWorkspace="TOPAZ_3132_event",
        PeaksWorkspace="TOPAZ_3132_peaks",
        OutputWorkspace="peaks_ellipsoids",
        RegionRadius=0.25,
        SpecifySize=False,
    )
    return mtd["peaks_ellipsoids"]


# IntegrateEllipsoids (SpecifySize=False) sets each peak's major-axis radius
# to 3 standard deviations of the nearby events (see its documentation), and
# scales the other two axes to match -- i.e. every stored radius is 3-sigma,
# not sigma itself. IntegratePeaksShapeMD's default (counting) mode only
# cares that the radii are *some* consistent boundary, so this is fine as
# supplied. ProfileFit, however, interprets the radii as literal standard
# deviations for a Gaussian peak profile: feeding it 3-sigma-sized radii
# directly makes the assumed peak three times too wide, which on real data
# can be wide enough to violate the "peak mass stays within RegionRadius"
# assumption ProfileFit relies on and collapse the fit to ~0. Divide by 3
# first so ProfileFit sees genuine 1-sigma widths.
SIGMA_FROM_THREE_SIGMA_RADIUS = 1.0 / 3.0


def rescale_shapes_to_sigma(peaks_ws, output_name, scale=SIGMA_FROM_THREE_SIGMA_RADIUS):
    rescaled = CloneWorkspace(InputWorkspace=peaks_ws, OutputWorkspace=output_name)

    for i in range(rescaled.getNumberPeaks()):
        peak = rescaled.getPeak(i)
        shape = json.loads(peak.getPeakShape().toJSON())

        directions = [V3D(*(float(x) for x in shape["direction{}".format(j)].split())) for j in range(3)]
        abc_radii = [shape["radius{}".format(j)] * scale for j in range(3)]
        abc_radii_inner = [shape["background_inner_radius{}".format(j)] * scale for j in range(3)]
        abc_radii_outer = [shape["background_outer_radius{}".format(j)] * scale for j in range(3)]

        peak.setPeakShape(
            PeakShapeEllipsoid(directions, abc_radii, abc_radii_inner, abc_radii_outer, SpecialCoordinateSystem.QLab)
        )

    return rescaled


def drop_peaks_without_shape(peaks_ws):
    """Remove peaks IntegrateEllipsoids could not fit (NoShape, zero intensity)
    -- e.g. because too few events were found near them. IntegratePeaksShapeMD
    requires every peak in its input to already have an ellipsoidal shape, so
    these have to be filtered out before reusing them; there's nothing to reuse.
    """
    bad_indices = []
    for i in range(peaks_ws.getNumberPeaks()):
        shape = peaks_ws.getPeak(i).getPeakShape()
        if shape.shapeName() != "ellipsoid":
            bad_indices.append(i)

    if bad_indices:
        print(
            "Dropping {} of {} peaks with no fitted shape (e.g. too few events found "
            "near them): indices {}".format(len(bad_indices), peaks_ws.getNumberPeaks(), bad_indices)
        )
        peaks_ws.removePeaks(bad_indices)

    return peaks_ws


def run_integrate_peaks_shape_md(peaks_workspace_name, output_name, profile_fit=False, adjust_center=False):
    """Re-integrate the same events, reusing the shapes already on peaks_workspace_name."""
    IntegratePeaksShapeMD(
        InputWorkspace="TOPAZ_3132_event",
        PeaksWorkspace=peaks_workspace_name,
        OutputWorkspace=output_name,
        RegionRadius=0.25,
        ProfileFit=profile_fit,
        AdjustCenter=adjust_center,
    )
    return mtd[output_name]


def print_comparison(peaks_ellipsoids, peaks_default, peaks_profile, peaks_profile_adjust):
    header = "{:>10} {:>12} {:>10}   {:>12} {:>10}   {:>12} {:>10}   {:>12} {:>10}".format(
        "HKL",
        "Ellipsoids",
        "I/sig",
        "ShapeMD",
        "I/sig",
        "+ProfileFit",
        "I/sig",
        "+AdjustCtr",
        "I/sig",
    )
    print(header)
    print("-" * len(header))

    n_peaks = peaks_ellipsoids.getNumberPeaks()
    for i in range(n_peaks):
        hkl = peaks_ellipsoids.getPeak(i).getHKL()
        hkl_str = "{:.0f},{:.0f},{:.0f}".format(hkl[0], hkl[1], hkl[2])

        rows = []
        for peaks_ws in (peaks_ellipsoids, peaks_default, peaks_profile, peaks_profile_adjust):
            peak = peaks_ws.getPeak(i)
            inti = peak.getIntensity()
            sigi = peak.getSigmaIntensity()
            isig = inti / sigi if sigi > 0 else float("nan")
            rows.append((inti, isig))

        print(
            "{:>10} {:>12.1f} {:>10.2f}   {:>12.1f} {:>10.2f}   {:>12.1f} {:>10.2f}   {:>12.1f} {:>10.2f}".format(
                hkl_str,
                rows[0][0],
                rows[0][1],
                rows[1][0],
                rows[1][1],
                rows[2][0],
                rows[2][1],
                rows[3][0],
                rows[3][1],
            )
        )


if __name__ == "__main__":
    load_and_find_peaks()

    peaks_ellipsoids = drop_peaks_without_shape(run_integrate_ellipsoids())
    peaks_ellipsoids_sigma = rescale_shapes_to_sigma(peaks_ellipsoids, "peaks_ellipsoids_sigma")

    peaks_default = run_integrate_peaks_shape_md("peaks_ellipsoids", "peaks_shape_md")
    peaks_profile = run_integrate_peaks_shape_md("peaks_ellipsoids_sigma", "peaks_shape_md_profile", profile_fit=True)
    peaks_profile_adjust = run_integrate_peaks_shape_md(
        "peaks_ellipsoids_sigma", "peaks_shape_md_profile_adjust", profile_fit=True, adjust_center=True
    )

    print_comparison(peaks_ellipsoids, peaks_default, peaks_profile, peaks_profile_adjust)
```

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
