### PR TITLE
Add normalization options and error propagation to HFIRGoniometerInde…

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -10,7 +10,6 @@ from mantid.kernel import Direction, FloatBoundedValidator, IntBoundedValidator,
 from mantid.simpleapi import CloneWorkspace
 
 import numpy as np
-import scipy.ndimage
 
 
 class HFIRGoniometerIndependentBackground(PythonAlgorithm):
@@ -49,6 +48,18 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
             validator=StringListValidator(["nearest", "wrap"]),
             doc="Mode should be 'nearest' if the rotation is incomplete or 'wrap' if complete within a reasonable tolerance",
         )
+        self.declareProperty(
+            name="NormalizeBy",
+            defaultValue="None",
+            validator=StringListValidator(["None", "Time", "Monitor"]),
+            doc="Normalize the input by per-rotation duration or monitor count before calculating the background.",
+        )
+        self.declareProperty(
+            name="NormalizeOutput",
+            defaultValue=False,
+            doc="Keep the output normalized when True; otherwise multiply the calculated normalized "
+            "background by the duration or monitor count of each rotation",
+        )
         self.declareProperty(WorkspaceProperty(name="OutputWorkspace", defaultValue="", direction=Direction.Output))
 
     def validateInputs(self):
@@ -61,23 +72,85 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
 
         return issues
 
+    @staticmethod
+    def _get_normalization_factors(data_ws, normalize_by, n_rotations):
+        if normalize_by == "None":
+            return np.ones(n_rotations)
+
+        log_name = {"Time": "duration", "Monitor": "monitor_count"}[normalize_by]
+        factors = np.asarray(data_ws.getExperimentInfo(0).run().getProperty(log_name).value, dtype=float)
+        if factors.size != n_rotations:
+            raise ValueError(f"The {log_name} log has {factors.size} values, but the workspace has {n_rotations} rotations.")
+        return factors
+
+    @staticmethod
+    def _global_percentile(signal, error_squared, percentile):
+        """Return a percentile and its paired error variance along the rotation axis."""
+        order = np.argsort(signal, axis=2)
+        sorted_signal = np.take_along_axis(signal, order, axis=2)
+        sorted_error_squared = np.take_along_axis(error_squared, order, axis=2)
+
+        position = (signal.shape[2] - 1) * percentile / 100.0
+        lower = int(np.floor(position))
+        upper = int(np.ceil(position))
+        weight = position - lower
+
+        value = (1.0 - weight) * sorted_signal[:, :, lower] + weight * sorted_signal[:, :, upper]
+        error = (1.0 - weight) * sorted_error_squared[:, :, lower] + weight * sorted_error_squared[:, :, upper]
+        return value, error
+
+    @staticmethod
+    def _windowed_percentile(signal, error_squared, percentile, window_size, filter_mode):
+        """Return windowed percentiles and paired error variances along the rotation axis."""
+        pad_before = window_size // 2
+        pad_after = window_size - 1 - pad_before
+        mode = "edge" if filter_mode == "nearest" else "wrap"
+        # scipy.ndimage.percentile_filter selects a ranked value rather than linearly interpolating it.
+        rank = min(int(window_size * percentile / 100.0), window_size - 1)
+        selected = np.empty_like(signal)
+        selected_error = np.empty_like(error_squared)
+
+        # Process one detector row at a time to avoid materializing all detector/window combinations.
+        for row in range(signal.shape[0]):
+            padded_signal = np.pad(signal[row], ((0, 0), (pad_before, pad_after)), mode=mode)
+            padded_error_squared = np.pad(error_squared[row], ((0, 0), (pad_before, pad_after)), mode=mode)
+            windows = np.lib.stride_tricks.sliding_window_view(padded_signal, window_size, axis=1)
+            error_windows = np.lib.stride_tricks.sliding_window_view(padded_error_squared, window_size, axis=1)
+            order = np.argsort(windows, axis=2)
+            selected[row] = np.take_along_axis(windows, order[:, :, rank : rank + 1], axis=2)[..., 0]
+            selected_error[row] = np.take_along_axis(error_windows, order[:, :, rank : rank + 1], axis=2)[..., 0]
+        return selected, selected_error
+
     def PyExec(self):
         data_ws = self.getProperty("InputWorkspace").value
         signal = data_ws.getSignalArray().copy()
+        error_squared = data_ws.getErrorSquaredArray().copy()
 
         bkg_level = self.getProperty("BackgroundLevel").value
         bkg_size = self.getProperty("BackgroundWindowSize").value
         filter_mode = self.getProperty("FilterMode").value
+        normalize_by = self.getProperty("NormalizeBy").value
+        normalize_output = self.getProperty("NormalizeOutput").value
+        factors = self._get_normalization_factors(data_ws, normalize_by, signal.shape[2])
+
+        signal /= factors[np.newaxis, np.newaxis, :]
+        error_squared /= factors[np.newaxis, np.newaxis, :] ** 2
 
         if bkg_size == Property.EMPTY_INT:
-            percent = np.percentile(signal, bkg_level, axis=2)
+            percent, percent_error_squared = self._global_percentile(signal, error_squared, bkg_level)
             bkg = np.repeat(percent[:, :, np.newaxis], signal.shape[2], axis=2)
+            bkg_error_squared = np.repeat(percent_error_squared[:, :, np.newaxis], signal.shape[2], axis=2)
         else:
-            bkg = scipy.ndimage.percentile_filter(signal, bkg_level, size=(1, 1, bkg_size), mode=filter_mode)
+            bkg, bkg_error_squared = self._windowed_percentile(signal, error_squared, bkg_level, bkg_size, filter_mode)
+
+        if not normalize_output:
+            bkg *= factors[np.newaxis, np.newaxis, :]
+            bkg_error_squared *= factors[np.newaxis, np.newaxis, :] ** 2
 
         outputWS = self.getPropertyValue("OutputWorkspace")
         outputWS = CloneWorkspace(InputWorkspace=data_ws, OutputWorkspace=outputWS)
         outputWS.setSignalArray(bkg)
+        outputWS.setErrorSquaredArray(bkg_error_squared)
 
         self.setProperty("OutputWorkspace", outputWS)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -113,27 +113,40 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
     @staticmethod
     def _global_percentile(signal, error_squared, percentile):
         """Return a percentile and the error variance of the value it selected."""
-        order = np.argsort(signal, axis=2)
-        sorted_signal = np.take_along_axis(signal, order, axis=2)
-        sorted_error_squared = np.take_along_axis(error_squared, order, axis=2)
-
         position = (signal.shape[2] - 1) * percentile / 100.0
         lower = int(np.floor(position))
         upper = int(np.ceil(position))
         weight = position - lower
 
-        value = (1.0 - weight) * sorted_signal[:, :, lower] + weight * sorted_signal[:, :, upper]
-        error = (1.0 - weight) * sorted_error_squared[:, :, lower] + weight * sorted_error_squared[:, :, upper]
+        value = np.empty(signal.shape[:2], dtype=signal.dtype)
+        error = np.empty(error_squared.shape[:2], dtype=error_squared.dtype)
+
+        # Process one detector row at a time, and rank only the two values the percentile interpolates
+        # between, to avoid sorting the whole rotation axis of every detector at once.
+        for row in range(signal.shape[0]):
+            order = np.argpartition(signal[row], (lower, upper), axis=-1)[:, [lower, upper]]
+            ranked_signal = np.take_along_axis(signal[row], order, axis=-1)
+            ranked_error_squared = np.take_along_axis(error_squared[row], order, axis=-1)
+            value[row] = (1.0 - weight) * ranked_signal[:, 0] + weight * ranked_signal[:, 1]
+            error[row] = (1.0 - weight) * ranked_error_squared[:, 0] + weight * ranked_error_squared[:, 1]
         return value, error
 
     @staticmethod
-    def _windowed_percentile(signal, error_squared, percentile, window_size, filter_mode):
+    def _window_rank(percentile, window_size):
+        """Return the rank a percentile selects within a window.
+
+        scipy.ndimage.percentile_filter selects a ranked value rather than linearly interpolating it, so the
+        windowed branch reports the value at this rank rather than the requested percentile itself.
+        """
+        return min(int(window_size * percentile / 100.0), window_size - 1)
+
+    @classmethod
+    def _windowed_percentile(cls, signal, error_squared, percentile, window_size, filter_mode):
         """Return windowed percentiles and the error variance of each value they selected."""
         pad_before = window_size // 2
         pad_after = window_size - 1 - pad_before
         mode = "edge" if filter_mode == "nearest" else "wrap"
-        # scipy.ndimage.percentile_filter selects a ranked value rather than linearly interpolating it.
-        rank = min(int(window_size * percentile / 100.0), window_size - 1)
+        rank = cls._window_rank(percentile, window_size)
         selected = np.empty_like(signal)
         selected_error = np.empty_like(error_squared)
 
@@ -149,7 +162,7 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         return selected, selected_error
 
     @staticmethod
-    def _estimator_variance_scale(percentile, n_samples):
+    def _estimator_variance_scale(percentile, n_samples, rank=None):
         """Return the factor converting a selected value's variance into the percentile estimator's variance.
 
         The percentile is not a measurement but an estimator built from ``n_samples`` rotation steps, so it is
@@ -158,9 +171,17 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         ``p (1 - p) / phi(z_p)**2 * sigma**2 / n_samples``, where ``z_p`` is the standard normal quantile at
         ``p`` and ``phi`` its density. The leading factor is pi/2 for the median.
 
+        ``rank`` is the position selected within a window of ``n_samples`` values, and is given for the
+        windowed branch only. That branch reports the value at a fixed rank instead of interpolating at the
+        requested percentile, so the estimator's precision follows the percentile that rank represents.
+
         The asymptotic result does not hold for the smallest or largest value, or for a single sample, so those
         cases fall back to the variance of the selected value itself, which is a conservative upper bound.
         """
+        if rank is not None:
+            if rank == 0 or rank == n_samples - 1:
+                return 1.0
+            percentile = 100.0 * (rank + 0.5) / n_samples
         p = percentile / 100.0
         if not 0.0 < p < 1.0 or n_samples < 2:
             return 1.0
@@ -187,18 +208,20 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
 
         if bkg_size == Property.EMPTY_INT:
             n_samples = signal.shape[2]
+            rank = None
             percent, percent_error_squared = self._global_percentile(signal, error_squared, bkg_level)
             bkg = np.repeat(percent[:, :, np.newaxis], n_samples, axis=2)
             bkg_error_squared = np.repeat(percent_error_squared[:, :, np.newaxis], n_samples, axis=2)
         else:
             n_samples = bkg_size
+            rank = self._window_rank(bkg_level, bkg_size)
             bkg, bkg_error_squared = self._windowed_percentile(signal, error_squared, bkg_level, bkg_size, filter_mode)
 
         # The selected value's variance is the uncertainty of a single measurement. Rescale it to the
         # uncertainty of the percentile estimator, which averages over n_samples rotation steps. Taking the
         # single-measurement variance at the percentile rather than across the whole window keeps the estimate
         # free of the Bragg peaks that the percentile is chosen to reject.
-        bkg_error_squared *= self._estimator_variance_scale(bkg_level, n_samples)
+        bkg_error_squared *= self._estimator_variance_scale(bkg_level, n_samples, rank)
 
         if not normalize_output:
             bkg *= factors[np.newaxis, np.newaxis, :]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -14,6 +14,13 @@ from scipy.stats import norm
 
 
 class HFIRGoniometerIndependentBackground(PythonAlgorithm):
+    _NORMALIZATION_LOGS = {
+        "WAND": {"Time": "duration", "Monitor": "monitor_count"},
+        "HB2C": {"Time": "duration", "Monitor": "monitor_count"},
+        "HB3A": {"Time": "time", "Monitor": "monitor"},
+        "DEMAND": {"Time": "time", "Monitor": "monitor"},
+    }
+
     def category(self):
         return "Diffraction\\Reduction;Diffraction\\Utility"
 
@@ -32,15 +39,15 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
             name="BackgroundLevel",
             defaultValue=50.0,
             direction=Direction.Input,
-            doc="Backgound level defines percentile range, (default 50, median filter)",
-            validator=FloatBoundedValidator(-100.0, 100.0),
+            doc="Percentile in the range 0 to 100 defining the background level (default 50, median filter)",
+            validator=FloatBoundedValidator(0.0, 100.0),
         )
         self.declareProperty(
             name="BackgroundWindowSize",
             defaultValue=Property.EMPTY_INT,
             direction=Direction.Input,
-            doc="Background Window Size, only applies to the rotation axis, assumes the detectors are already \
-              grouped. Integer value or -1 for All values",
+            doc="Background window size, only applies to the rotation axis, assumes the detectors are already \
+              grouped. Leave unset to use every value along the rotation axis",
             validator=IntBoundedValidator(lower=1),
         )
         self.declareProperty(
@@ -73,12 +80,20 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
 
         return issues
 
-    @staticmethod
-    def _get_normalization_factors(data_ws, normalize_by, n_rotations):
+    @classmethod
+    def _get_normalization_factors(cls, data_ws, normalize_by, n_rotations):
         if normalize_by == "None":
             return np.ones(n_rotations)
 
-        log_name = {"Time": "duration", "Monitor": "monitor_count"}[normalize_by]
+        instrument_name = data_ws.getExperimentInfo(0).getInstrumentName()
+        try:
+            log_name = cls._NORMALIZATION_LOGS[instrument_name][normalize_by]
+        except KeyError:
+            raise ValueError(
+                f"Normalization by {normalize_by} is not supported for instrument {instrument_name}. "
+                "Supported instruments are WAND/HB2C and DEMAND/HB3A."
+            ) from None
+
         factors = np.asarray(data_ws.getExperimentInfo(0).run().getProperty(log_name).value, dtype=float)
         if factors.size != n_rotations:
             raise ValueError(f"The {log_name} log has {factors.size} values, but the workspace has {n_rotations} rotations.")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -98,7 +98,12 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
                 "Supported instruments are WAND/HB2C and DEMAND/HB3A."
             ) from None
 
-        factors = np.asarray(data_ws.getExperimentInfo(0).run().getProperty(log_name).value, dtype=float)
+        try:
+            factors = np.asarray(data_ws.getExperimentInfo(0).run().getProperty(log_name).value, dtype=float)
+        except RuntimeError as error:
+            raise ValueError(
+                f"Required normalization log '{log_name}' for {normalize_by} normalization is missing from instrument {instrument_name}."
+            ) from error
         if factors.size != n_rotations:
             raise ValueError(f"The {log_name} log has {factors.size} values, but the workspace has {n_rotations} rotations.")
         if np.any(~np.isfinite(factors)) or np.any(factors <= 0):
@@ -160,7 +165,10 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         if not 0.0 < p < 1.0 or n_samples < 2:
             return 1.0
         density = norm.pdf(norm.ppf(p))
-        return p * (1.0 - p) / density**2 / n_samples
+        density_squared = density**2
+        if density_squared == 0.0:
+            return 1.0
+        return p * (1.0 - p) / density_squared / n_samples
 
     def PyExec(self):
         data_ws = self.getProperty("InputWorkspace").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -78,6 +78,10 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         if inWS.getNumDims() != 3:
             issues["InputWorkspace"] = "InputWorkspace has wrong number of dimensions, need 3"
 
+        bkg_size = self.getProperty("BackgroundWindowSize").value
+        if inWS.getNumDims() == 3 and bkg_size != Property.EMPTY_INT and bkg_size > inWS.getSignalArray().shape[2]:
+            issues["BackgroundWindowSize"] = "BackgroundWindowSize cannot be larger than the number of rotations in InputWorkspace"
+
         return issues
 
     @classmethod
@@ -97,6 +101,8 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         factors = np.asarray(data_ws.getExperimentInfo(0).run().getProperty(log_name).value, dtype=float)
         if factors.size != n_rotations:
             raise ValueError(f"The {log_name} log has {factors.size} values, but the workspace has {n_rotations} rotations.")
+        if np.any(~np.isfinite(factors)) or np.any(factors <= 0):
+            raise ValueError(f"The {log_name} log must contain finite, positive normalization factors.")
         return factors
 
     @staticmethod

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackground.py
@@ -10,6 +10,7 @@ from mantid.kernel import Direction, FloatBoundedValidator, IntBoundedValidator,
 from mantid.simpleapi import CloneWorkspace
 
 import numpy as np
+from scipy.stats import norm
 
 
 class HFIRGoniometerIndependentBackground(PythonAlgorithm):
@@ -85,7 +86,7 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
 
     @staticmethod
     def _global_percentile(signal, error_squared, percentile):
-        """Return a percentile and its paired error variance along the rotation axis."""
+        """Return a percentile and the error variance of the value it selected."""
         order = np.argsort(signal, axis=2)
         sorted_signal = np.take_along_axis(signal, order, axis=2)
         sorted_error_squared = np.take_along_axis(error_squared, order, axis=2)
@@ -101,7 +102,7 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
 
     @staticmethod
     def _windowed_percentile(signal, error_squared, percentile, window_size, filter_mode):
-        """Return windowed percentiles and paired error variances along the rotation axis."""
+        """Return windowed percentiles and the error variance of each value they selected."""
         pad_before = window_size // 2
         pad_after = window_size - 1 - pad_before
         mode = "edge" if filter_mode == "nearest" else "wrap"
@@ -121,6 +122,25 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
             selected_error[row] = np.take_along_axis(error_windows, order[:, :, rank : rank + 1], axis=2)[..., 0]
         return selected, selected_error
 
+    @staticmethod
+    def _estimator_variance_scale(percentile, n_samples):
+        """Return the factor converting a selected value's variance into the percentile estimator's variance.
+
+        The percentile is not a measurement but an estimator built from ``n_samples`` rotation steps, so it is
+        more precise than the single value it selects. For samples of standard deviation ``sigma`` drawn from a
+        distribution that is locally normal around the percentile, the estimator's variance is
+        ``p (1 - p) / phi(z_p)**2 * sigma**2 / n_samples``, where ``z_p`` is the standard normal quantile at
+        ``p`` and ``phi`` its density. The leading factor is pi/2 for the median.
+
+        The asymptotic result does not hold for the smallest or largest value, or for a single sample, so those
+        cases fall back to the variance of the selected value itself, which is a conservative upper bound.
+        """
+        p = percentile / 100.0
+        if not 0.0 < p < 1.0 or n_samples < 2:
+            return 1.0
+        density = norm.pdf(norm.ppf(p))
+        return p * (1.0 - p) / density**2 / n_samples
+
     def PyExec(self):
         data_ws = self.getProperty("InputWorkspace").value
         signal = data_ws.getSignalArray().copy()
@@ -137,11 +157,19 @@ class HFIRGoniometerIndependentBackground(PythonAlgorithm):
         error_squared /= factors[np.newaxis, np.newaxis, :] ** 2
 
         if bkg_size == Property.EMPTY_INT:
+            n_samples = signal.shape[2]
             percent, percent_error_squared = self._global_percentile(signal, error_squared, bkg_level)
-            bkg = np.repeat(percent[:, :, np.newaxis], signal.shape[2], axis=2)
-            bkg_error_squared = np.repeat(percent_error_squared[:, :, np.newaxis], signal.shape[2], axis=2)
+            bkg = np.repeat(percent[:, :, np.newaxis], n_samples, axis=2)
+            bkg_error_squared = np.repeat(percent_error_squared[:, :, np.newaxis], n_samples, axis=2)
         else:
+            n_samples = bkg_size
             bkg, bkg_error_squared = self._windowed_percentile(signal, error_squared, bkg_level, bkg_size, filter_mode)
+
+        # The selected value's variance is the uncertainty of a single measurement. Rescale it to the
+        # uncertainty of the percentile estimator, which averages over n_samples rotation steps. Taking the
+        # single-measurement variance at the percentile rather than across the whole window keeps the estimate
+        # free of the Bragg peaks that the percentile is chosen to reject.
+        bkg_error_squared *= self._estimator_variance_scale(bkg_level, n_samples)
 
         if not normalize_output:
             bkg *= factors[np.newaxis, np.newaxis, :]

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -14,6 +14,7 @@ from mantid.simpleapi import (
 )
 import numpy as np
 import scipy.ndimage
+import scipy.stats
 
 
 class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
@@ -88,7 +89,8 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         error_squared = self.workspace.getErrorSquaredArray().copy()
         normalized_signal = signal / self.monitor_count[np.newaxis, np.newaxis, :]
         normalized_errors = error_squared / self.monitor_count[np.newaxis, np.newaxis, :] ** 2
-        _, expected_error = self._global_percentile(normalized_signal, normalized_errors, 50)
+        expected_error = self._selected_error_squared(normalized_signal, normalized_errors, 50)
+        expected_error = expected_error * self._estimator_scale(50, signal.shape[2])
         expected_error = np.repeat(expected_error[:, :, np.newaxis], signal.shape[2], axis=2)
 
         outputWS = HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy="Monitor", NormalizeOutput=True)
@@ -99,15 +101,63 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         expected_error *= self.monitor_count[np.newaxis, np.newaxis, :] ** 2
         np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected_error)
 
+    def test_error_is_the_estimator_uncertainty_not_the_selected_value(self):
+        """Verify the output variance is the percentile estimator's, not that of the value it selected."""
+        counts = np.array([12.0, 9.0, 14.0, 11.0, 350.0])
+        workspace = CreateMDHistoWorkspace(
+            SignalInput=counts,
+            ErrorInput=np.sqrt(counts),
+            Dimensionality=3,
+            Extents="0,1,0,1,0,5",
+            Names="x,y,z",
+            NumberOfBins="1,1,5",
+            Units="number,number,number",
+            OutputWorkspace="single_pixel",
+        )
+
+        outputWS = HFIRGoniometerIndependentBackground(workspace)
+
+        # Sorted counts are 9, 11, 12, 14, 350, so the median is 12 and the peak at 350 is rejected.
+        np.testing.assert_allclose(outputWS.getSignalArray(), np.full((1, 1, 5), 12.0))
+        # The selected value carries a Poisson variance of 12, reduced by pi/2 / 5 for a median of 5 rotations.
+        np.testing.assert_allclose(outputWS.getErrorSquaredArray(), np.full((1, 1, 5), 12.0 * np.pi / 2 / 5))
+        DeleteWorkspace(workspace)
+
+    def test_windowed_error_uses_the_window_size_as_the_sample_count(self):
+        """Verify the windowed branch averages over the window, not over the whole rotation axis."""
+        window_size = 25
+
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=50, BackgroundWindowSize=window_size)
+
+        # Every input variance is unity, so the output variance is the estimator scale factor alone.
+        expected = np.full_like(self.workspace.getErrorSquaredArray(), self._estimator_scale(50, window_size))
+        np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
+    def test_extreme_percentiles_keep_the_selected_value_variance(self):
+        """Verify the smallest and largest values fall back to the selected variance, where the estimator has no limit."""
+        for background_level in (0.0, 100.0):
+            outputWS = HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=background_level)
+
+            expected = np.ones_like(self.workspace.getErrorSquaredArray())
+            np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
     @staticmethod
-    def _global_percentile(signal, error_squared, percentile):
+    def _selected_error_squared(signal, error_squared, percentile):
+        """Return the error variance of the single value the percentile selects along the rotation axis."""
         order = np.argsort(signal, axis=2)
         sorted_errors = np.take_along_axis(error_squared, order, axis=2)
         position = (signal.shape[2] - 1) * percentile / 100.0
         lower = int(np.floor(position))
         upper = int(np.ceil(position))
         weight = position - lower
-        return None, (1.0 - weight) * sorted_errors[:, :, lower] + weight * sorted_errors[:, :, upper]
+        return (1.0 - weight) * sorted_errors[:, :, lower] + weight * sorted_errors[:, :, upper]
+
+    @staticmethod
+    def _estimator_scale(percentile, n_samples):
+        """Return the independently derived factor from a selected value's variance to the estimator's."""
+        p = percentile / 100.0
+        density = scipy.stats.norm.pdf(scipy.stats.norm.ppf(p))
+        return p * (1.0 - p) / density**2 / n_samples
 
     def test_generate_background_np(self):
         signal = self.workspace.getSignalArray().copy()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -223,6 +223,68 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         expected = np.full_like(self.workspace.getErrorSquaredArray(), self._estimator_scale(50, window_size))
         np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
 
+    def test_windowed_error_follows_the_percentile_of_the_selected_rank(self):
+        """Verify an even window scales by the percentile its rank represents, not the requested one."""
+        window_size = 4
+
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=50, BackgroundWindowSize=window_size)
+
+        # A median of 4 values selects the third, so the estimator's precision is that of the 62.5th percentile.
+        expected = np.full_like(self.workspace.getErrorSquaredArray(), self._estimator_scale(62.5, window_size))
+        np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
+    def test_windowed_error_keeps_the_selected_value_variance_at_the_window_extremes(self):
+        """Verify a rank at either end of the window falls back to the selected value's variance."""
+        window_size = 10
+
+        # A 5th percentile selects the window minimum and a 90th the window maximum. Both are extreme order
+        # statistics, for which the estimator carries no precision gain over the value it selected.
+        for background_level in (5.0, 90.0):
+            outputWS = HFIRGoniometerIndependentBackground(
+                self.workspace, BackgroundLevel=background_level, BackgroundWindowSize=window_size
+            )
+
+            expected = np.ones_like(self.workspace.getErrorSquaredArray())
+            np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
+    def test_filter_mode_matches_the_reference_edge_treatment(self):
+        """Verify the rotation-axis padding reproduces scipy's percentile_filter for both edge treatments."""
+        signal = self.workspace.getSignalArray().copy()
+
+        # An even window makes the two modes disagree at both ends of the rotation axis.
+        for filter_mode in ("nearest", "wrap"):
+            expected = scipy.ndimage.percentile_filter(signal, 50, size=(1, 1, 4), mode=filter_mode)
+
+            outputWS = HFIRGoniometerIndependentBackground(
+                self.workspace, BackgroundLevel=50, BackgroundWindowSize=4, FilterMode=filter_mode
+            )
+
+            np.testing.assert_array_equal(outputWS.getSignalArray(), expected)
+
+    def test_wrap_filter_mode_reaches_across_the_rotation_axis_ends(self):
+        """Verify 'wrap' closes the rotation axis where 'nearest' repeats its edge values."""
+        counts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        workspace = CreateMDHistoWorkspace(
+            SignalInput=counts,
+            ErrorInput=np.sqrt(counts),
+            Dimensionality=3,
+            Extents="0,1,0,1,0,5",
+            Names="x,y,z",
+            NumberOfBins="1,1,5",
+            Units="number,number,number",
+            OutputWorkspace="ramp",
+        )
+
+        # With a window of 3 the median of an unpadded interior triple is the value itself. At the first
+        # rotation 'nearest' pads with 1 and keeps 1, while 'wrap' pads with 5 and returns 2.
+        nearestWS = HFIRGoniometerIndependentBackground(workspace, BackgroundLevel=50, BackgroundWindowSize=3, FilterMode="nearest")
+        np.testing.assert_allclose(nearestWS.getSignalArray().ravel(), [1.0, 2.0, 3.0, 4.0, 5.0])
+
+        wrapWS = HFIRGoniometerIndependentBackground(workspace, BackgroundLevel=50, BackgroundWindowSize=3, FilterMode="wrap")
+        np.testing.assert_allclose(wrapWS.getSignalArray().ravel(), [2.0, 2.0, 3.0, 4.0, 4.0])
+
+        DeleteWorkspace(workspace)
+
     def test_extreme_percentiles_keep_the_selected_value_variance(self):
         """Verify the smallest and largest values fall back to the selected variance, where the estimator has no limit."""
         for background_level in (0.0, 100.0):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -81,13 +81,19 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         """Verify that rotation durations normalize the data before windowed percentile filtering."""
         signal = self.workspace.getSignalArray().copy()
         normalized_signal = signal / self.duration[np.newaxis, np.newaxis, :]
-        expected = scipy.ndimage.percentile_filter(normalized_signal, 50, size=(1, 1, 25), mode="nearest")
+        for background_level in (10, 50, 90):
+            with self.subTest(background_level=background_level):
+                expected = scipy.ndimage.percentile_filter(normalized_signal, background_level, size=(1, 1, 25), mode="nearest")
 
-        outputWS = HFIRGoniometerIndependentBackground(
-            self.workspace, BackgroundLevel=50, BackgroundWindowSize=25, NormalizeBy="Time", NormalizeOutput=True
-        )
+                outputWS = HFIRGoniometerIndependentBackground(
+                    self.workspace,
+                    BackgroundLevel=background_level,
+                    BackgroundWindowSize=25,
+                    NormalizeBy="Time",
+                    NormalizeOutput=True,
+                )
 
-        np.testing.assert_array_equal(outputWS.getSignalArray(), expected)
+                np.testing.assert_array_equal(outputWS.getSignalArray(), expected)
 
     def test_monitor_normalization_can_be_restored_per_rotation(self):
         """Verify that monitor-normalized global backgrounds can be restored to each rotation's scale."""
@@ -134,6 +140,24 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
             HFIRGoniometerIndependentBackground(workspace, NormalizeBy="Time", OutputWorkspace="unsupported_output")
         DeleteWorkspace(workspace)
         DeleteWorkspace("unsupported_instrument")
+
+    def test_missing_normalization_log_is_reported(self):
+        workspace = CreateMDHistoWorkspace(
+            SignalInput=np.ones((1, 1, 1)),
+            ErrorInput=np.ones((1, 1, 1)),
+            Dimensionality=3,
+            Extents="0,1,0,1,0,1",
+            Names="x,y,z",
+            NumberOfBins="1,1,1",
+            Units="number,number,number",
+            OutputWorkspace="missing_log_input",
+        )
+        missing_instrument = LoadEmptyInstrument(InstrumentName="HB2C", OutputWorkspace="missing_log_instrument")
+        workspace.addExperimentInfo(missing_instrument)
+        with self.assertRaisesRegex(RuntimeError, "Required normalization log 'duration'.*instrument (WAND|HB2C)"):
+            HFIRGoniometerIndependentBackground(workspace, NormalizeBy="Time", OutputWorkspace="missing_log_output")
+        DeleteWorkspace(workspace)
+        DeleteWorkspace(missing_instrument)
 
     def test_invalid_normalization_factors_are_rejected(self):
         for normalize_by, log_name in (("Time", "duration"), ("Monitor", "monitor_count")):
@@ -206,6 +230,11 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
 
             expected = np.ones_like(self.workspace.getErrorSquaredArray())
             np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
+    def test_percentile_variance_scale_handles_underflow_near_zero(self):
+        background_level = np.nextafter(0.0, 1.0) * 100.0
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=background_level)
+        np.testing.assert_array_equal(outputWS.getErrorSquaredArray(), np.ones_like(self.workspace.getErrorSquaredArray()))
 
     def test_negative_background_level_is_rejected(self):
         """Verify a negative percentile is refused rather than silently selecting the wrong value."""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -135,6 +135,20 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         DeleteWorkspace(workspace)
         DeleteWorkspace("unsupported_instrument")
 
+    def test_invalid_normalization_factors_are_rejected(self):
+        for normalize_by, log_name in (("Time", "duration"), ("Monitor", "monitor_count")):
+            for invalid_factor in (0.0, -1.0, np.nan, np.inf):
+                factors = np.ones_like(self.duration)
+                factors[0] = invalid_factor
+                self.workspace.getExperimentInfo(0).run().addProperty(log_name, factors.tolist(), True)
+
+                with self.assertRaisesRegex(RuntimeError, "must contain finite, positive normalization factors"):
+                    HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy=normalize_by, OutputWorkspace="invalid_factors_output")
+
+    def test_window_larger_than_rotation_axis_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "Some invalid Properties found"):
+            HFIRGoniometerIndependentBackground(self.workspace, BackgroundWindowSize=self.signal.shape[2] + 1)
+
     def test_normalized_output_error_is_selected_and_scaled(self):
         """Verify percentile-associated errors are retained when normalized and rescaled correctly."""
         signal = self.workspace.getSignalArray().copy()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -6,14 +6,27 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import unittest
-from mantid.simpleapi import DeleteWorkspace, HFIRGoniometerIndependentBackground, CreateMDHistoWorkspace
+from mantid.simpleapi import (
+    CreateMDHistoWorkspace,
+    DeleteWorkspace,
+    HFIRGoniometerIndependentBackground,
+    LoadEmptyInstrument,
+)
 import numpy as np
 import scipy.ndimage
 
 
 class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.instrument = LoadEmptyInstrument(InstrumentName="HB2C", OutputWorkspace="instrument")
+
+    @classmethod
+    def tearDownClass(cls):
+        DeleteWorkspace(cls.instrument)
+
     def setUp(self):
-        self.signal = np.random.random((100, 100, 100))
+        self.signal = np.random.default_rng(12345).random((100, 100, 100))
         _max = self.signal.max()
         _min = self.signal.min()
 
@@ -27,6 +40,12 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
             Units="number,number,number",
             OutputWorkspace="input",
         )
+        self.duration = np.arange(1.0, 101.0)
+        self.monitor_count = np.arange(101.0, 201.0)
+        self.workspace.addExperimentInfo(self.instrument)
+        run = self.workspace.getExperimentInfo(0).run()
+        run.addProperty("duration", self.duration.tolist(), True)
+        run.addProperty("monitor_count", self.monitor_count.tolist(), True)
 
     def tearDown(self):
         DeleteWorkspace(self.workspace)
@@ -38,6 +57,57 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         outputWS = HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=50, BackgroundWindowSize=25)
         result = outputWS.getSignalArray().copy()
         self.assertTrue(np.array_equal(expected, result))
+
+    def test_time_normalization_is_applied_before_windowed_percentile(self):
+        """Verify that rotation durations normalize the data before windowed percentile filtering."""
+        signal = self.workspace.getSignalArray().copy()
+        normalized_signal = signal / self.duration[np.newaxis, np.newaxis, :]
+        expected = scipy.ndimage.percentile_filter(normalized_signal, 50, size=(1, 1, 25), mode="nearest")
+
+        outputWS = HFIRGoniometerIndependentBackground(
+            self.workspace, BackgroundLevel=50, BackgroundWindowSize=25, NormalizeBy="Time", NormalizeOutput=True
+        )
+
+        np.testing.assert_array_equal(outputWS.getSignalArray(), expected)
+
+    def test_monitor_normalization_can_be_restored_per_rotation(self):
+        """Verify that monitor-normalized global backgrounds can be restored to each rotation's scale."""
+        signal = self.workspace.getSignalArray().copy()
+        normalized_signal = signal / self.monitor_count[np.newaxis, np.newaxis, :]
+        normalized_expected = np.percentile(normalized_signal, 50, axis=2)
+        expected = np.repeat(normalized_expected[:, :, np.newaxis], signal.shape[2], axis=2)
+        expected *= self.monitor_count[np.newaxis, np.newaxis, :]
+
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy="Monitor", NormalizeOutput=False)
+
+        np.testing.assert_allclose(outputWS.getSignalArray(), expected)
+
+    def test_normalized_output_error_is_selected_and_scaled(self):
+        """Verify percentile-associated errors are retained when normalized and rescaled correctly."""
+        signal = self.workspace.getSignalArray().copy()
+        error_squared = self.workspace.getErrorSquaredArray().copy()
+        normalized_signal = signal / self.monitor_count[np.newaxis, np.newaxis, :]
+        normalized_errors = error_squared / self.monitor_count[np.newaxis, np.newaxis, :] ** 2
+        _, expected_error = self._global_percentile(normalized_signal, normalized_errors, 50)
+        expected_error = np.repeat(expected_error[:, :, np.newaxis], signal.shape[2], axis=2)
+
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy="Monitor", NormalizeOutput=True)
+
+        np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected_error)
+
+        outputWS = HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy="Monitor", NormalizeOutput=False)
+        expected_error *= self.monitor_count[np.newaxis, np.newaxis, :] ** 2
+        np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected_error)
+
+    @staticmethod
+    def _global_percentile(signal, error_squared, percentile):
+        order = np.argsort(signal, axis=2)
+        sorted_errors = np.take_along_axis(error_squared, order, axis=2)
+        position = (signal.shape[2] - 1) * percentile / 100.0
+        lower = int(np.floor(position))
+        upper = int(np.ceil(position))
+        weight = position - lower
+        return None, (1.0 - weight) * sorted_errors[:, :, lower] + weight * sorted_errors[:, :, upper]
 
     def test_generate_background_np(self):
         signal = self.workspace.getSignalArray().copy()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRGoniometerIndependentBackgroundTest.py
@@ -48,8 +48,26 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         run.addProperty("duration", self.duration.tolist(), True)
         run.addProperty("monitor_count", self.monitor_count.tolist(), True)
 
+        self.demand_workspace = CreateMDHistoWorkspace(
+            SignalInput=self.signal,
+            ErrorInput=np.ones_like(self.signal),
+            Dimensionality=3,
+            Extents=f"{_min},{_max},{_min},{_max},{_min},{_max}",
+            Names="x,y,z",
+            NumberOfBins="100,100,100",
+            Units="number,number,number",
+            OutputWorkspace="demand_input",
+        )
+        demand_instrument = LoadEmptyInstrument(InstrumentName="HB3A", OutputWorkspace="demand_instrument")
+        self.demand_workspace.addExperimentInfo(demand_instrument)
+        demand_run = self.demand_workspace.getExperimentInfo(0).run()
+        demand_run.addProperty("time", self.duration.tolist(), True)
+        demand_run.addProperty("monitor", self.monitor_count.tolist(), True)
+
     def tearDown(self):
         DeleteWorkspace(self.workspace)
+        DeleteWorkspace(self.demand_workspace)
+        DeleteWorkspace("demand_instrument")
 
     def test_generate_background_pf(self):
         signal = self.workspace.getSignalArray().copy()
@@ -82,6 +100,40 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
         outputWS = HFIRGoniometerIndependentBackground(self.workspace, NormalizeBy="Monitor", NormalizeOutput=False)
 
         np.testing.assert_allclose(outputWS.getSignalArray(), expected)
+
+    def test_demand_time_log_is_used_for_time_normalization(self):
+        outputWS = HFIRGoniometerIndependentBackground(self.demand_workspace, NormalizeBy="Time", NormalizeOutput=True)
+
+        signal = self.demand_workspace.getSignalArray()
+        expected = np.percentile(signal / self.duration[np.newaxis, np.newaxis, :], 50, axis=2)
+        expected = np.repeat(expected[:, :, np.newaxis], signal.shape[2], axis=2)
+        np.testing.assert_allclose(outputWS.getSignalArray(), expected)
+
+    def test_demand_monitor_log_is_used_for_monitor_normalization(self):
+        outputWS = HFIRGoniometerIndependentBackground(self.demand_workspace, NormalizeBy="Monitor", NormalizeOutput=True)
+
+        signal = self.demand_workspace.getSignalArray()
+        expected = np.percentile(signal / self.monitor_count[np.newaxis, np.newaxis, :], 50, axis=2)
+        expected = np.repeat(expected[:, :, np.newaxis], signal.shape[2], axis=2)
+        np.testing.assert_allclose(outputWS.getSignalArray(), expected)
+
+    def test_normalization_is_rejected_for_unsupported_instrument(self):
+        workspace = CreateMDHistoWorkspace(
+            SignalInput=[1.0],
+            ErrorInput=[1.0],
+            Dimensionality=3,
+            Extents="0,1,0,1,0,1",
+            Names="x,y,z",
+            NumberOfBins="1,1,1",
+            Units="number,number,number",
+            OutputWorkspace="unsupported_input",
+        )
+        unsupported_instrument = LoadEmptyInstrument(InstrumentName="HB2A", OutputWorkspace="unsupported_instrument")
+        workspace.addExperimentInfo(unsupported_instrument)
+        with self.assertRaisesRegex(RuntimeError, "not supported for instrument HB2A"):
+            HFIRGoniometerIndependentBackground(workspace, NormalizeBy="Time", OutputWorkspace="unsupported_output")
+        DeleteWorkspace(workspace)
+        DeleteWorkspace("unsupported_instrument")
 
     def test_normalized_output_error_is_selected_and_scaled(self):
         """Verify percentile-associated errors are retained when normalized and rescaled correctly."""
@@ -140,6 +192,12 @@ class HFIRGoniometerIndependentBackgroundTest(unittest.TestCase):
 
             expected = np.ones_like(self.workspace.getErrorSquaredArray())
             np.testing.assert_allclose(outputWS.getErrorSquaredArray(), expected)
+
+    def test_negative_background_level_is_rejected(self):
+        """Verify a negative percentile is refused rather than silently selecting the wrong value."""
+        for extra in ({}, {"BackgroundWindowSize": 25}):
+            with self.assertRaises(ValueError):
+                HFIRGoniometerIndependentBackground(self.workspace, BackgroundLevel=-20.0, **extra)
 
     @staticmethod
     def _selected_error_squared(signal, error_squared, percentile):

--- a/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
+++ b/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
@@ -15,6 +15,13 @@ to generate the background for the input workspace. In the case that BackgroundW
 `Numpy.percentile <https://numpy.org/doc/stable/reference/generated/numpy.percentile.html>`_ is used to generate the background as
 it is much faster.
 
+The optional ``NormalizeBy`` property can be set to ``Time`` or ``Monitor`` to divide each rotation
+by its duration or monitor count before calculating the percentile. ``None`` does no normalization.
+``NormalizeOutput`` controls the units of the result. When it is ``True``, the output background
+remains normalized when the user chooses ``Time`` or ``Monitor``.
+When it is ``False`` (the default), the result is multiplied by time duration or monitor count of each rotation.
+The corresponding error variances are scaled consistently.
+
 
 
 Usage

--- a/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
+++ b/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
@@ -9,11 +9,22 @@
 Description
 -----------
 
-This algorithm is used to generate a background for HFIR monochromatic diffraction data. This algorithm wraps
-`Scipy.ndimage.percentile_filter <https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.percentile_filter.html>`_
-to generate the background for the input workspace. In the case that BackgroundWindowSize is -1,
-`Numpy.percentile <https://numpy.org/doc/stable/reference/generated/numpy.percentile.html>`_ is used to generate the background as
-it is much faster.
+This algorithm is used to generate a background for HFIR monochromatic diffraction data. For every
+detector pixel it takes a percentile of the intensities recorded along the rotation axis. Bragg
+scattering illuminates a pixel for only part of the scan while the background persists, so a
+percentile rejects the peaks and retains the goniometer-independent level.
+
+When ``BackgroundWindowSize`` is set, the percentile is taken over a sliding window of that many
+rotation steps, allowing the background to vary slowly with rotation angle. It selects a ranked value
+in the same way as
+`Scipy.ndimage.percentile_filter <https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.percentile_filter.html>`_.
+When the property is left unset, the percentile is taken over the whole rotation axis and the
+background is constant in rotation for each pixel; the value is interpolated linearly between
+order statistics, as
+`Numpy.percentile <https://numpy.org/doc/stable/reference/generated/numpy.percentile.html>`_ does.
+
+``BackgroundLevel`` is a percentile and must lie between 0 and 100. It defaults to 50, which
+takes the median along the rotation axis.
 
 The optional ``NormalizeBy`` property can be set to ``Time`` or ``Monitor`` to divide each rotation
 by its duration or monitor count before calculating the percentile. ``None`` does no normalization.
@@ -21,6 +32,10 @@ by its duration or monitor count before calculating the percentile. ``None`` doe
 remains normalized when the user chooses ``Time`` or ``Monitor``.
 When it is ``False`` (the default), the result is multiplied by time duration or monitor count of each rotation.
 The corresponding error variances are scaled consistently.
+
+For WAND (HB2C), the ``duration`` and ``monitor_count`` sample logs are used. For DEMAND (HB3A),
+the corresponding logs are named ``time`` and ``monitor``. Normalization is not supported for
+other instruments.
 
 Uncertainties
 -------------

--- a/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
+++ b/docs/source/algorithms/HFIRGoniometerIndependentBackground-v1.rst
@@ -22,6 +22,36 @@ remains normalized when the user chooses ``Time`` or ``Monitor``.
 When it is ``False`` (the default), the result is multiplied by time duration or monitor count of each rotation.
 The corresponding error variances are scaled consistently.
 
+Uncertainties
+-------------
+
+The percentile is an estimator built from the rotation steps that contribute to it, not a single
+measurement, so it is more precise than the value it selects. For :math:`n` contributing rotations
+whose values have standard deviation :math:`\sigma`, the output variance is
+
+.. math::
+
+   \mathrm{Var}(\hat{q}_p) = \frac{p(1-p)}{\phi(z_p)^2} \frac{\sigma^2}{n}
+
+where :math:`p` is ``BackgroundLevel`` expressed as a fraction, :math:`z_p` is the standard normal
+quantile at :math:`p` and :math:`\phi` its density. The leading factor is :math:`\pi/2` for the
+median, giving the familiar :math:`1.2533\,\sigma/\sqrt{n}`. Here :math:`n` is the length of the
+rotation axis when ``BackgroundWindowSize`` is unset, and ``BackgroundWindowSize`` otherwise, while
+:math:`\sigma^2` is the input variance of the value the percentile selected. Taking :math:`\sigma`
+at the percentile rather than across all contributing rotations keeps the estimate free of the Bragg
+peaks that the percentile is chosen to reject.
+
+A ``BackgroundLevel`` of 0 or 100 selects the smallest or largest value, for which this limit does not
+apply; those cases keep the variance of the selected value, which is a conservative upper bound.
+
+Two limitations are worth noting. Where the sliding window is padded at the ends of an incomplete
+rotation, it repeats values, so fewer than ``BackgroundWindowSize`` independent rotations contribute
+and the variance is slightly underestimated. More importantly, the output uncertainties are strongly
+correlated - completely so across the rotation axis when ``BackgroundWindowSize`` is unset, and
+between neighbouring rotations otherwise, since their windows overlap. A ``MDHistoWorkspace`` cannot
+represent that correlation, so any subsequent operation that combines these values along the rotation
+axis will underestimate the resulting uncertainty.
+
 
 
 Usage

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42124.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42124.rst
@@ -1,4 +1,7 @@
 - Added optional duration- and monitor-count normalization to
   :ref:`algm-HFIRGoniometerIndependentBackground`. Backgrounds can now be calculated from
   exposure-normalized rotations and either retained in normalized units or restored to the
-  per-rotation exposure scale.
+  per-rotation exposure scale. WAND (HB2C) and DEMAND (HB3A) sample-log naming conventions
+  are supported.
+- :ref:`algm-HFIRGoniometerIndependentBackground` no longer accepts a negative ``BackgroundLevel``.
+  The property is a percentile and must be between 0 and 100.

--- a/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42124.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/New_features/42124.rst
@@ -1,0 +1,4 @@
+- Added optional duration- and monitor-count normalization to
+  :ref:`algm-HFIRGoniometerIndependentBackground`. Backgrounds can now be calculated from
+  exposure-normalized rotations and either retained in normalized units or restored to the
+  per-rotation exposure scale.


### PR DESCRIPTION
### Description of work

Adds normalization options and improved uncertainty handling to `HFIRGoniometerIndependentBackground`, along with updated documentation and expanded unit tests to cover the new behavior.

**Changes:**
- Added `NormalizeBy`/`NormalizeOutput` options with instrument-specific log mapping for time/monitor normalization.
- Implemented background error propagation using percentile-estimator uncertainty scaling (global and windowed modes).
- Updated algorithm and release documentation; expanded tests to validate normalization, supported instruments, and error behavior.

Implements EMW [17691](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17691)

### To test:
Fancy script to run in the workbench: [test_PR_42124.py](https://github.com/user-attachments/files/31602342/test_PR_42124.py)


<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
