### PR TITLE
Removed checkbox for MultipleScattering in CylinderAbsorptionCW

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
@@ -368,7 +368,6 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             doc="Method to calculate absorption correction.",
             validator=StringListValidator(["Sears", "Sabine"]),
         )
-        self.declareProperty("MultipleScattering", True, doc="Calculate multiple scattering in addition to absorption correction.")
         self.declareProperty(
             WorkspaceProperty("AbsorptionWorkspace", "", direction=Direction.Output), doc="Absorption correction output workspace name"
         )
@@ -396,9 +395,6 @@ class CylinderAbsorptionCW(PythonAlgorithm):
                         "Input workspace sample shape is not a cylinder. Please provide radius and height properties "
                         "or use a workspace with a cylinder sample shape."
                     )
-        elif not self.getProperty("MultipleScattering").value:
-            if self.getProperty("Radius").isDefault:
-                issues["Radius"] = "Radius is required, either provide it or use a workspace with a cylinder sample shape."
         elif self.getProperty("Radius").isDefault or self.getProperty("Height").isDefault:
             issues["Radius"] = "Radius is required, either provide it or use a workspace with a cylinder sample shape."
             issues["Height"] = "Height is required, either provide it or use a workspace with a cylinder sample shape."
@@ -438,7 +434,6 @@ class CylinderAbsorptionCW(PythonAlgorithm):
 
         wavelength = self.getProperty("Wavelength").value
         method = self.getProperty("AbsorptionCorrectionMethod").value
-        multiple_scattering = self.getProperty("MultipleScattering").value
 
         if (
             self.getProperty("AttenuationXSection").isDefault
@@ -513,26 +508,20 @@ class CylinderAbsorptionCW(PythonAlgorithm):
 
         self.setProperty("AbsorptionWorkspace", output_abs_ws)
 
-        multiple_scattering_delta = 0
-
-        if multiple_scattering:
-            R_over_h_grid = np.array(
-                [0.10, 0.12, 0.14, 0.16, 0.18, 0.20, 0.22, 0.24, 0.26, 0.28, 0.30, 0.40, 0.50, 1.00, 2.00, 3.00, 4.00, 5.00]
-            )
-            μR_grid = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-
-            R_over_h = radius / height
-
-            try:
-                δ = bilinear_interpolate(R_over_h, μR, R_over_h_grid, μR_grid, δ_grid)
-            except ValueError:
-                self.log().error("Multiple scattering correction out of lookup range for this sample and set to zero")
-                δ = 0
-
-            multiple_scattering_delta = δ * totalScatterXSection / totalXSection
-            self.log().information(
-                f"Calculated multiple scattering delta: {multiple_scattering_delta:.4f} using R/h {R_over_h:.4f} and μR {μR:.4f}"
-            )
+        R_over_h_grid = np.array(
+            [0.10, 0.12, 0.14, 0.16, 0.18, 0.20, 0.22, 0.24, 0.26, 0.28, 0.30, 0.40, 0.50, 1.00, 2.00, 3.00, 4.00, 5.00]
+        )
+        μR_grid = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+        R_over_h = radius / height
+        try:
+            δ = bilinear_interpolate(R_over_h, μR, R_over_h_grid, μR_grid, δ_grid)
+        except ValueError:
+            self.log().error("Multiple scattering correction out of lookup range for this sample and set to zero")
+            δ = 0
+        multiple_scattering_delta = δ * totalScatterXSection / totalXSection
+        self.log().information(
+            f"Calculated multiple scattering delta: {multiple_scattering_delta:.4f} using R/h {R_over_h:.4f} and μR {μR:.4f}"
+        )
 
         output_ms_ws = CreateSingleValuedWorkspace(
             DataValue=multiple_scattering_delta, OutputWorkspace=self.getProperty("MultipleScatteringWorkspace").value, EnableLogging=False

--- a/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderAbsorptionCW.py
@@ -345,10 +345,10 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             "the workspace sample shape if it is a cylinder.",
         )
         self.declareProperty(
-            "AttenuationXSection",
+            "AbsorptionXSection",
             Property.EMPTY_DBL,
             float_greater_than_zero_validator,
-            doc="Attenuation cross-section in barn at 1.7982 Å. If not provided, it will be inferred from the workspace sample material.",
+            doc="Absorption cross-section in barn at 1.7982 Å. If not provided, it will be inferred from the workspace sample material.",
         )
         self.declareProperty(
             "ScatteringXSection",
@@ -400,7 +400,7 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             issues["Height"] = "Height is required, either provide it or use a workspace with a cylinder sample shape."
 
         if (
-            self.getProperty("AttenuationXSection").isDefault
+            self.getProperty("AbsorptionXSection").isDefault
             and self.getProperty("ScatteringXSection").isDefault
             and self.getProperty("SampleNumberDensity").isDefault
         ):
@@ -415,17 +415,17 @@ class CylinderAbsorptionCW(PythonAlgorithm):
                     "the workspace sample material. Please provide these properties or ensure the sample material has valid values."
                 )
                 issues["InputWorkspace"] = msg
-                issues["AttenuationXSection"] = msg
+                issues["AbsorptionXSection"] = msg
                 issues["ScatteringXSection"] = msg
                 issues["SampleNumberDensity"] = msg
         elif (
-            self.getProperty("AttenuationXSection").isDefault
+            self.getProperty("AbsorptionXSection").isDefault
             or self.getProperty("ScatteringXSection").isDefault
             or self.getProperty("SampleNumberDensity").isDefault
         ):
-            issues["AttenuationXSection"] = "Attenuation and scattering cross-section properties must be provided together."
-            issues["ScatteringXSection"] = "Attenuation and scattering cross-section properties must be provided together."
-            issues["SampleNumberDensity"] = "Attenuation and scattering cross-section properties must be provided together."
+            issues["AbsorptionXSection"] = "Absorption and scattering cross-section properties must be provided together."
+            issues["ScatteringXSection"] = "Absorption and scattering cross-section properties must be provided together."
+            issues["SampleNumberDensity"] = "Absorption and scattering cross-section properties must be provided together."
 
         return issues
 
@@ -436,7 +436,7 @@ class CylinderAbsorptionCW(PythonAlgorithm):
         method = self.getProperty("AbsorptionCorrectionMethod").value
 
         if (
-            self.getProperty("AttenuationXSection").isDefault
+            self.getProperty("AbsorptionXSection").isDefault
             and self.getProperty("ScatteringXSection").isDefault
             and self.getProperty("SampleNumberDensity").isDefault
         ):
@@ -446,9 +446,9 @@ class CylinderAbsorptionCW(PythonAlgorithm):
             totalXSection = absorbXSection + totalScatterXSection
             numberDensity = material.numberDensity
         else:
-            # AttenuationXSection is given at REFERENCE_LAMBDA, so scale it linearly to the
+            # AbsorptionXSection is given at REFERENCE_LAMBDA, so scale it linearly to the
             # requested wavelength exactly as Material::absorbXSection does.
-            absorbXSection = self.getProperty("AttenuationXSection").value * wavelength / REFERENCE_LAMBDA
+            absorbXSection = self.getProperty("AbsorptionXSection").value * wavelength / REFERENCE_LAMBDA
             totalScatterXSection = self.getProperty("ScatteringXSection").value
             totalXSection = absorbXSection + totalScatterXSection
             numberDensity = self.getProperty("SampleNumberDensity").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReduction.py
@@ -141,11 +141,6 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
             doc="If True, apply sample attenuation (absorption) correction using CylinderAbsorptionCW",
         )
         self.declareProperty(
-            "DoMultipleScatteringCorrection",
-            False,
-            doc="If True, calculate and apply multiple scattering correction for the sample",
-        )
-        self.declareProperty(
             "AbsoluteIntensityUnits",
             False,
             doc="If True, output in absolute intensity units (mb/sr/f.u.)",
@@ -755,12 +750,8 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
 
         # Validate sample absorption correction properties
         doAttenuation = self.getProperty("DoAttenuationCorrection").value
-        doMS = self.getProperty("DoMultipleScatteringCorrection").value
         absoluteUnits = self.getProperty("AbsoluteIntensityUnits").value
         sampleHeight = self.getProperty("SampleHeight").value
-
-        if doMS and sampleHeight <= 0:
-            issues["SampleHeight"] = "SampleHeight must be provided when DoMultipleScatteringCorrection is True"
 
         if absoluteUnits:
             if vanadiumDiameter == Property.EMPTY_DBL or vanadiumDiameter <= 0:
@@ -1285,7 +1276,6 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
         needs detector 2theta angles from the instrument geometry.
         """
         fB = self.getProperty("SampleBackgroundScaleFactor").value
-        do_ms = self.getProperty("DoMultipleScatteringCorrection").value
         wavelength = self.getProperty("Wavelength").value
         sample_formula = self.getProperty("SampleChemicalFormula").value
         crystal_density = self.getProperty("SampleCrystalDensity").value
@@ -1330,13 +1320,12 @@ class HFIRPowderReduction(DataProcessorAlgorithm):
                 Radius=sample_radius,
                 Height=sample_height if sample_height > 0 else 3.0,
                 Wavelength=wavelength,
-                MultipleScattering=do_ms,
                 AbsorptionCorrectionMethod="Sabine",
                 AbsorptionWorkspace="__sample_absorption",
                 MultipleScatteringWorkspace="__sample_ms",
             )
 
-            delta_S = mtd["__sample_ms"].extractY()[0][0] if do_ms else 0.0
+            delta_S = mtd["__sample_ms"].extractY()[0][0]
 
             logger.information(f"Sample absorption correction for {ws_name}: ΔS = {delta_S:.6f}")
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
@@ -175,14 +175,10 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             AbsorptionCorrectionMethod="Sabine",
             AbsorptionWorkspace="Absorption",
             MultipleScatteringWorkspace="MultipleScattering",
-            MultipleScattering=False,
         )
 
         # Check absorption
         np.testing.assert_allclose(result.AbsorptionWorkspace.extractY()[:, 0], [0.54520177, 0.55782039, 0.570439, 0.55782039])
-
-        # Check multiple scattering, should be 0 since we set MultipleScattering=False
-        self.assertEqual(result.MultipleScatteringWorkspace.extractY()[0][0], 0)
 
     def testSabineLargeZ(self):
         """When z is large, the algorithm should use the asymptotic expansion of I_n(z) - L_n(z) to avoid numerical overflow."""
@@ -200,7 +196,6 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             AbsorptionCorrectionMethod="Sabine",
             AbsorptionWorkspace="Absorption",
             MultipleScatteringWorkspace="MultipleScattering",
-            MultipleScattering=False,
         )
 
         # Check absorption
@@ -227,7 +222,6 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             AbsorptionCorrectionMethod="Sabine",
             AbsorptionWorkspace="Absorption",
             MultipleScatteringWorkspace="MultipleScattering",
-            MultipleScattering=False,
         )
 
         spectrum_info = ws.spectrumInfo()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CylinderAbsorptionCWTest.py
@@ -36,7 +36,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             Radius=0.5,  # cm
             Height=1.0,  # cm
             Wavelength=1.7982,  # Å
-            AttenuationXSection=5.08,  # barn at 1.798 Å
+            AbsorptionXSection=5.08,  # barn at 1.798 Å
             ScatteringXSection=5.1,  # barn
             SampleNumberDensity=0.0723,  # atoms/Å^3
             AbsorptionCorrectionMethod="Sears",
@@ -61,7 +61,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
                 Radius=5,  # cm
                 Height=10,  # cm
                 Wavelength=1.7982,  # Å
-                AttenuationXSection=5.08,  # barn at 1.798 Å
+                AbsorptionXSection=5.08,  # barn at 1.798 Å
                 ScatteringXSection=5.1,  # barn
                 SampleNumberDensity=0.0723,  # atoms/Å^3
                 AbsorptionCorrectionMethod="Sears",
@@ -141,7 +141,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
                 Radius=0.5,  # cm
                 Height=1.0,  # cm
                 Wavelength=wavelength,
-                AttenuationXSection=material.absorbXSection(PhysicalConstants.ReferenceLambda),  # barn at 1.7982 Å
+                AbsorptionXSection=material.absorbXSection(PhysicalConstants.ReferenceLambda),  # barn at 1.7982 Å
                 ScatteringXSection=material.totalScatterXSection(),  # barn
                 SampleNumberDensity=material.numberDensity,  # atoms/Å^3
                 AbsorptionCorrectionMethod="Sears",
@@ -169,7 +169,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             Radius=0.5,  # cm
             Height=1.0,  # cm
             Wavelength=1.7982,  # Å
-            AttenuationXSection=5.08,  # barn at 1.798 Å
+            AbsorptionXSection=5.08,  # barn at 1.798 Å
             ScatteringXSection=5.1,  # barn
             SampleNumberDensity=0.0723,  # atoms/Å^3
             AbsorptionCorrectionMethod="Sabine",
@@ -190,7 +190,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             Radius=2,  # cm
             Height=10,  # cm
             Wavelength=1.7982,  # Å
-            AttenuationXSection=100,  # barn at 1.798 Å
+            AbsorptionXSection=100,  # barn at 1.798 Å
             ScatteringXSection=5.1,  # barn
             SampleNumberDensity=0.0723,  # atoms/Å^3
             AbsorptionCorrectionMethod="Sabine",
@@ -207,7 +207,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
 
         # Choose parameters that gives z = 17 so A_B (2z > 32) uses the asymptotic branch to compare to direct evaluation.
         radius = 2.0  # cm
-        attenuation_xs = 80  # barn at 1.7982 A
+        absorption_xs = 80  # barn at 1.7982 A
         scattering_xs = 5  # barn
         number_density = 0.05  # atoms/A^3
 
@@ -216,7 +216,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             Radius=radius,
             Height=10.0,  # cm
             Wavelength=1.7982,  # A
-            AttenuationXSection=attenuation_xs,
+            AbsorptionXSection=absorption_xs,
             ScatteringXSection=scattering_xs,
             SampleNumberDensity=number_density,
             AbsorptionCorrectionMethod="Sabine",
@@ -227,7 +227,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
         spectrum_info = ws.spectrumInfo()
         thetas = np.array([spectrum_info.twoTheta(i) for i in range(spectrum_info.size())]) / 2.0
 
-        z = 2.0 * number_density * (attenuation_xs + scattering_xs) * radius  # equals 17
+        z = 2.0 * number_density * (absorption_xs + scattering_xs) * radius  # equals 17
 
         a_l_direct = 2.0 * ((i0(z) - modstruve(0, z)) - (i1(z) - modstruve(1, z)) / z)
         a_b_direct = (i1(2.0 * z) - modstruve(1, 2.0 * z)) / z
@@ -243,7 +243,7 @@ class CylinderAbsorptionCWTest(unittest.TestCase):
             CylinderAbsorptionCW(
                 InputWorkspace=ws,
                 Wavelength=1.7982,  # Å
-                AttenuationXSection=5.08,  # barn at 1.798 Å
+                AbsorptionXSection=5.08,  # barn at 1.798 Å
                 ScatteringXSection=5.1,  # barn
                 SampleNumberDensity=0.0723,  # atoms/Å^3
                 AbsorptionWorkspace="Absorption",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/HFIRPowderReductionTest.py
@@ -1938,22 +1938,6 @@ class SampleAbsorptionCorrectionTests(unittest.TestCase):
             if mtd.doesExist(name):
                 mtd.remove(name)
 
-    def test_validate_do_ms_requires_sample_height(self):
-        """DoMultipleScatteringCorrection=True requires SampleHeight > 0."""
-        algo = _create_algo(
-            Instrument="WAND^2",
-            Wavelength=1.7982,
-            VanadiumDiameter=0.5,
-            DoAttenuationCorrection=True,
-            DoMultipleScatteringCorrection=True,
-            SampleChemicalFormula="Fe2 O3",
-            SampleCrystalDensity=5.24,
-            SampleDiameter=0.8,
-            SampleHeight=0.0,
-        )
-        issues = algo.validateInputs()
-        self.assertIn("SampleHeight", issues)
-
     def test_validate_absolute_units_requires_vanadium_and_height(self):
         """AbsoluteIntensityUnits=True requires VanadiumDiameter>0, VanadiumHeight>0, SampleHeight>0."""
         algo = _create_algo(
@@ -2094,57 +2078,6 @@ class SampleAbsorptionCorrectionTests(unittest.TestCase):
         for i in range(ws.getNumberHistograms()):
             self.assertGreater(ws.y(i)[0], 90.0)
 
-    def test_no_multiple_scattering_when_disabled(self):
-        """When DoMultipleScatteringCorrection=False, ΔS=0."""
-        self._create_workspace("sample_ws", counts=100.0, monitor=200.0)
-
-        algo = _create_algo(
-            Instrument="WAND^2",
-            Wavelength=1.7982,
-            VanadiumDiameter=0.5,
-            VanadiumHeight=3.0,
-            DoAttenuationCorrection=True,
-            DoMultipleScatteringCorrection=False,
-            SampleChemicalFormula="V",
-            SampleCrystalDensity=6.1172,
-            SamplePackingFraction=1.0,
-            SampleDiameter=1.0,
-            SampleHeight=3.0,
-            NormaliseBy="None",
-        )
-        algo.vanadium_ws = None
-        algo.vanadium_background_ws = None
-        algo.sample_background_ws = None
-
-        algo._apply_sample_corrections_pre_conversion(["sample_ws"])
-        val_no_ms = mtd["sample_ws"].y(0)[0]
-
-        # Now with MS
-        self._create_workspace("sample_ws2", counts=100.0, monitor=200.0)
-        algo2 = _create_algo(
-            Instrument="WAND^2",
-            Wavelength=1.7982,
-            VanadiumDiameter=0.5,
-            VanadiumHeight=3.0,
-            DoAttenuationCorrection=True,
-            DoMultipleScatteringCorrection=True,
-            SampleChemicalFormula="V",
-            SampleCrystalDensity=6.1172,
-            SamplePackingFraction=1.0,
-            SampleDiameter=1.0,
-            SampleHeight=3.0,
-            NormaliseBy="None",
-        )
-        algo2.vanadium_ws = None
-        algo2.vanadium_background_ws = None
-        algo2.sample_background_ws = None
-
-        algo2._apply_sample_corrections_pre_conversion(["sample_ws2"])
-        val_with_ms = mtd["sample_ws2"].y(0)[0]
-
-        # With MS correction (Δ > 0), (1-Δ) < 1, so result should be smaller
-        self.assertGreater(val_no_ms, val_with_ms)
-
     def test_sample_correction_per_spectrum_varies(self):
         """Per-spectrum absorption values differ for different 2theta angles."""
         self._create_workspace("sample_ws", counts=100.0, monitor=200.0)
@@ -2182,7 +2115,6 @@ class SampleAbsorptionCorrectionTests(unittest.TestCase):
         """Test that new properties have correct defaults."""
         algo = _create_algo(Instrument="WAND^2")
         self.assertFalse(algo.getProperty("DoAttenuationCorrection").value)
-        self.assertFalse(algo.getProperty("DoMultipleScatteringCorrection").value)
         self.assertFalse(algo.getProperty("AbsoluteIntensityUnits").value)
         self.assertEqual(algo.getProperty("SamplePackingFraction").value, 0.5)
         self.assertEqual(algo.getProperty("SampleHeight").value, 0.0)

--- a/docs/source/algorithms/CylinderAbsorptionCW-v1.rst
+++ b/docs/source/algorithms/CylinderAbsorptionCW-v1.rst
@@ -17,8 +17,8 @@ Two methods are available for calculating the absorption correction: Using Equat
 Multiple scattering is calculated using Equation 16 and Table 1 from Blech and Averbach [3]_, using a bilinear interpolation of the tabulated values. Equation 16 gives :math:`\sigma_m` but the output from this algorithm is the multiple scattering factor, :math:`\delta` = :math:`\sigma_m/(\sigma_s + \sigma_m)`.
 
 The cross-sections and number density are either taken from the sample material of the input workspace, as set by
-:ref:`algm-SetSample` or :ref:`algm-SetSampleMaterial`, or provided directly through the ``AttenuationXSection``,
-``ScatteringXSection`` and ``SampleNumberDensity`` properties. As with the sample material, ``AttenuationXSection`` is
+:ref:`algm-SetSample` or :ref:`algm-SetSampleMaterial`, or provided directly through the ``AbsorptionXSection``,
+``ScatteringXSection`` and ``SampleNumberDensity`` properties. As with the sample material, ``AbsorptionXSection`` is
 the value tabulated at the reference wavelength of 1.7982 Å and is scaled linearly to ``Wavelength``,
 :math:`\sigma_a(\lambda) = \sigma_a(1.7982\,\text{Å}) \times \lambda / 1.7982\,\text{Å}`.
 
@@ -36,7 +36,7 @@ Usage
             Radius=0.5,  # cm
             Height=4.0,  # cm
             Wavelength=1.7982,
-            AttenuationXSection=5.08,  # barn at 1.798 Å
+            AbsorptionXSection=5.08,  # barn at 1.798 Å
             ScatteringXSection=5.1,  # barn
             SampleNumberDensity=0.0723,  # atoms/Å^3
             AbsorptionWorkspace="Absorption",

--- a/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42134.rst
+++ b/docs/source/release/v7.0.0/Framework/Algorithms/Bugfixes/42134.rst
@@ -1,0 +1,1 @@
+- Removed ``MultipleScattering`` checkbox from :ref:`algm-CylinderAbsorptionCW`, and renamed ``AttenuationXSection`` to ``AbsorptionXSection``


### PR DESCRIPTION
### Description of work

The check box for `MultipleScattering` was removed in `CylinderAbsorptionCW` since the user is required to supply `MultipleScatteringWorkspace` anyway. Since this is removed, the check box for `DoMultipleScattering` in `HFIRPowderReduction` can also be removed. Also renamed `AttenuationXSection` to `AbsorptionXSection` in `CylinderAbsorptionCW`

Closes EWM item [17561](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17561)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Just open `CylinderAbsorptionCW` and `HFIRPowderReduction` algorithms and make sure the related check boxes are now gone. Make sure `AttenuationXSection` has been renamed to `AbsorptionXSection` in `CylinderAbsorptionCW`

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
