### PR TITLE
Texture UI Walkthrough Tutorial + Infrastructure

### DIFF
--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -18,9 +18,7 @@ the user watches a real workflow run rather than reading about one.
 caption, and then waits. The action runs when the user presses *Show me*, so they are reading the
 explanation of a control at the moment they watch it being used.
 
-The tour never advances on its own either: the user presses *Next* when they have finished, because
-there is no interval that is right for everyone — a step someone already understands is a wait, and
-a step they do not is a race. *Next* performs the step's action first if *Show me* was not pressed,
+*Next* performs the step's action first if *Show me* was not pressed,
 since chapters are cumulative and a skipped action would leave every later step describing an
 interface that never reached the state it assumes.
 
@@ -45,8 +43,7 @@ Consequences of this:
 * Jumping to a chapter is a *rebuild*, not an undo. There is no need for a step to know how to
   reverse itself.
 * Your interface must be safe to instantiate twice. In practice that means workspace names must be
-  unique per instance, and closing the window must clean up after itself. The Texture Planner
-  already did both.
+  unique per instance, and closing the window must clean up after itself.
 
 A sandbox is any object with a ``window`` attribute and a ``teardown()`` method. It is also passed
 to every step as the *context*, so put on it whatever the steps need to reach:
@@ -73,8 +70,8 @@ Two traps of this pattern:
 
 * **Usage reporting.** If the view registers a feature usage in its constructor, the sandbox will
   double-count every real launch. Give the view a flag to skip it.
-* **Recursion.** If the presenter offers a tutorial, the sandbox's presenter will offer one too —
-  and on a first-ever open, launch it. Give the presenter a flag to suppress it.
+* **Recursion.** Any method the presenter has of starting the tutorial, the sandbox's presenter also has.
+  Give the presenter a flag to suppress it, these methods so tutorials can't be launched by tutorials.
 
 Writing steps
 #############
@@ -109,8 +106,7 @@ chapter is replayed against a freshly built interface whenever the user jumps to
 
 ``await_`` is polled after the action until it holds — this is how a step waits for slow work
 without blocking, and the step is not reported as done until it does. Give it an explicit
-``await_timeout_s``: how long is reasonable depends entirely on what is being waited for, and a
-default would only ever be wrong in the direction that hides a hang.
+``await_timeout_s``: how long is reasonable depends entirely on what is being waited for.
 
 A step's target is opened up *before* its action runs — the containing tab selected, a collapsed
 group box expanded, including the target itself when it is one. A value set inside a shut section
@@ -153,14 +149,6 @@ own controls until the user closes something they did not ask for. And mind what
 writes: a settings dialog that saves to Mantid's shared ``QSettings`` is *not* isolated by the
 sandbox, so such a tour must dismiss it rather than accept it - Ok or Apply would change the real
 interface's saved settings on the user's behalf.
-
-Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
-actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
-before it leave behind - and it is only possible because the tour drives a throwaway interface.
-Clicking the tab already showing restarts that chapter, which is the framework's answer to "undo":
-rebuilding reaches a known state exactly, where a per-step inverse would have to re-implement the
-interface's own logic backwards and could not be written at all for steps that load a file or run
-an algorithm.
 
 Give a step an action only when it *does* something the user can watch. ``Show me`` is offered
 whenever a step has one, so an action whose effect is invisible - re-expanding a section the reveal

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -147,11 +147,12 @@ dimming its window would put the scrim over the chapter tabs and the navigation 
 user needs to drive the tour. Everything else is annotated on its own window, which is what reaches
 a dialog.
 
-A dialog the tour opens must be **non-modal**, or it blocks the tutorial's own controls until the
-user closes something they did not ask for. Make it non-modal in the sandbox, never in the
-interface itself. And be careful what a dialog writes: the Texture Planner's settings dialog saves
-to Mantid's shared ``QSettings``, so the tour opens it, explains it, and *rejects* it - pressing Ok
-or Apply would change the real interface's saved settings on the user's behalf.
+Two things to check before a tour opens a dialog. It must be made **non-modal**, in the sandbox
+and never in the interface itself, or it blocks the tutorial's own controls until the user closes
+something they did not ask for. And mind what applying it writes: a settings dialog that saves to
+Mantid's shared ``QSettings`` is *not* isolated by the sandbox, so such a tour must dismiss it
+rather than accept it - Ok or Apply would change the real interface's saved settings on the user's
+behalf.
 
 Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
 actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
@@ -164,6 +165,24 @@ an algorithm.
 Give a step an action only when it *does* something the user can watch. ``Show me`` is offered
 whenever a step has one, so an action whose effect is invisible - re-expanding a section the reveal
 has already opened, say - puts a button on screen that appears to do nothing when pressed.
+
+Where a step's effect shows up somewhere other than the control it points at, name that somewhere
+in ``avoid``. The caption is placed clear of it as well as of the spotlight, so a step that ticks a
+check box while the values it changes are displayed elsewhere does not end up explaining the change
+from on top of the evidence:
+
+.. code-block:: python
+
+    TutorialStep(
+        title="Seeing them in the lab frame",
+        text="The fields go read-only, because these values are derived.",
+        target=lambda sandbox: sandbox.view.chkLabDirs,
+        avoid=lambda sandbox: sandbox.view.groupBox_textureVectors,
+        action=lambda sandbox: set_check_state(sandbox.view.chkLabDirs, True),
+    )
+
+``avoid`` takes one widget or a sequence of them, and a miss is ignored - keeping out of the way is
+a courtesy, not something worth interrupting the tour over.
 
 Navigation is refused while a step is settling or working (``busy_changed``). Without that, Next
 pressed mid-calculation would run the following step's action against an interface that had not

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -14,9 +14,15 @@ Overview
 spotlights one widget at a time, explains what it does, and **performs the interaction itself** so
 the user watches a real workflow run rather than reading about one.
 
-The tour never advances on its own. The user presses Next when they have finished reading, because
-there is no interval that is right for everyone: a step someone already understands is a wait, and
-a step they do not is a race.
+**Explain first, act second.** A step opens whatever it points at, spotlights it and shows its
+caption, and then waits. The action runs when the user presses *Show me*, so they are reading the
+explanation of a control at the moment they watch it being used.
+
+The tour never advances on its own either: the user presses *Next* when they have finished, because
+there is no interval that is right for everyone — a step someone already understands is a wait, and
+a step they do not is a race. *Next* performs the step's action first if *Show me* was not pressed,
+since chapters are cumulative and a skipped action would leave every later step describing an
+interface that never reached the state it assumes.
 
 An interface supplies two things — a factory that builds a copy of itself, and a list of steps.
 Everything else is handled by the framework.
@@ -101,19 +107,26 @@ and both bite: the interesting widgets often do not exist when the tour is writt
 canvas injected into a placeholder, a table cell widget that appears once there are rows), and a
 chapter is replayed against a freshly built interface whenever the user jumps to it.
 
-``await_`` is polled until it holds before the step is narrated — this is how a step waits for slow
-work without blocking. Give it an explicit ``await_timeout_s``: how long is reasonable depends
-entirely on what is being waited for, and a default would only ever be wrong in the direction that
-hides a hang.
+``await_`` is polled after the action until it holds — this is how a step waits for slow work
+without blocking, and the step is not reported as done until it does. Give it an explicit
+``await_timeout_s``: how long is reasonable depends entirely on what is being waited for, and a
+default would only ever be wrong in the direction that hides a hang.
+
+A step's target is opened up *before* its action runs — the containing tab selected, a collapsed
+group box expanded, including the target itself when it is one. A value set inside a shut section
+changes nothing the user can see. A target that does not exist until the action has run is
+allowed: it is simply not highlighted while the step is being explained, and is only reported as
+missing if it is still absent afterwards.
 
 Where the controls live
 #######################
 
 Two pieces of chrome, and the split between them matters:
 
-* ``TutorialShell`` wraps the interface. Chapter tabs along the top, ``Back`` / ``Next`` / ``End
-  tutorial`` and a step counter along the bottom, with the interface reparented in between. It
-  does not move.
+* ``TutorialShell`` wraps the interface. Chapter tabs along the top, ``Back`` / ``Show me`` /
+  ``Next`` / ``End tutorial`` and a step counter along the bottom, with the interface reparented in
+  between. It does not move. ``Show me`` is hidden for a step that only explains something, and
+  disabled once the step has been performed.
 * ``TutorialBubble`` is the caption beside the highlight, and carries **no controls at all**. It
   chases whatever is being spotlighted, so a button on it would be somewhere different on every
   step - the one control the user has to press would be the one they had to hunt for.
@@ -125,10 +138,10 @@ Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the ea
 actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
 before it leave behind - and it is only possible because the tour drives a throwaway interface.
 
-Navigation is refused while a step is settling or waiting on the interface (``busy_changed``).
-Without that, Next pressed mid-search would run the following step's action against an interface
-that had not finished reacting to this one - and Next pressed during the settle would skip the
-step's caption while its action had already run.
+Navigation is refused while a step is settling or working (``busy_changed``). Without that, Next
+pressed mid-calculation would run the following step's action against an interface that had not
+finished reacting to this one - and Next pressed during the settle would skip the step's caption
+while its action had already run.
 
 Never block
 ###########

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -134,6 +134,25 @@ Two pieces of chrome, and the split between them matters:
 Because the interface becomes a child of the shell, the dimming overlay covers only the interface:
 the tabs and buttons stay bright and usable while everything they act on is dimmed.
 
+**Pointing into another window.** An interface is rarely one window, and a tour that explains a
+settings dialog has to annotate something the interface's own overlay cannot reach into.
+``TutorialAnnotator`` handles that: it owns an overlay and a caption *per window*, builds them as
+they are needed, and shows only the pair belonging to whatever is currently spotlighted. The player
+is given the annotator in place of an overlay and a bubble and never learns how many windows are
+involved.
+
+One rule inside it is worth knowing before changing it: anything inside the primary widget is
+annotated on the **primary itself**, not on its window. The interface is a child of the shell, so
+dimming its window would put the scrim over the chapter tabs and the navigation - the controls the
+user needs to drive the tour. Everything else is annotated on its own window, which is what reaches
+a dialog.
+
+A dialog the tour opens must be **non-modal**, or it blocks the tutorial's own controls until the
+user closes something they did not ask for. Make it non-modal in the sandbox, never in the
+interface itself. And be careful what a dialog writes: the Texture Planner's settings dialog saves
+to Mantid's shared ``QSettings``, so the tour opens it, explains it, and *rejects* it - pressing Ok
+or Apply would change the real interface's saved settings on the user's behalf.
+
 Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
 actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
 before it leave behind - and it is only possible because the tour drives a throwaway interface.

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -38,7 +38,7 @@ A tour that typed into the interface the user had open would be unusable — it 
 half-finished setup, and could not be offered on startup without risking someone's work. So the
 tour builds and drives **a second, throwaway instance** of the interface, and closes it at the end.
 
-This is what makes the rest of the design possible, and it has consequences worth knowing:
+Consequences of this:
 
 * The tour can perform genuinely destructive-looking actions — loading files, running algorithms,
   writing exports — because none of it touches anything the user owns.
@@ -69,7 +69,7 @@ to every step as the *context*, so put on it whatever the steps need to reach:
             self.view.deleteLater()
             self.data.cleanup()
 
-Two traps that both instances of this pattern have hit:
+Two traps of this pattern:
 
 * **Usage reporting.** If the view registers a feature usage in its constructor, the sandbox will
   double-count every real launch. Give the view a flag to skip it.
@@ -102,8 +102,8 @@ A tour is a sequence of ``TutorialChapter``, each a sequence of ``TutorialStep``
         ],
     )
 
-``target`` and ``action`` are **callables taking the sandbox**, never captured widgets. Two reasons,
-and both bite: the interesting widgets often do not exist when the tour is written (a matplotlib
+``target`` and ``action`` are **callables taking the sandbox**, never captured widgets. There are
+two good reasons for this: some widgets do not exist for access when the tour is written (a matplotlib
 canvas injected into a placeholder, a table cell widget that appears once there are rows), and a
 chapter is replayed against a freshly built interface whenever the user jumps to it.
 
@@ -121,7 +121,7 @@ missing if it is still absent afterwards.
 Where the controls live
 #######################
 
-Two pieces of chrome, and the split between them matters:
+Two main interface components:
 
 * ``TutorialShell`` wraps the interface. Chapter tabs along the top, ``Back`` / ``Show me`` /
   ``Next`` / ``End tutorial`` and a step counter along the bottom, with the interface reparented in
@@ -129,7 +129,7 @@ Two pieces of chrome, and the split between them matters:
   disabled once the step has been performed.
 * ``TutorialBubble`` is the caption beside the highlight, and carries **no controls at all**. It
   chases whatever is being spotlighted, so a button on it would be somewhere different on every
-  step - the one control the user has to press would be the one they had to hunt for.
+  step.
 
 Because the interface becomes a child of the shell, the dimming overlay covers only the interface:
 the tabs and buttons stay bright and usable while everything they act on is dimmed.
@@ -143,7 +143,7 @@ involved.
 
 One rule inside it is worth knowing before changing it: anything inside the primary widget is
 annotated on the **primary itself**, not on its window. The interface is a child of the shell, so
-dimming its window would put the scrim over the chapter tabs and the navigation - the controls the
+dimming its window would put the dimmer over the chapter tabs and the navigation - the controls the
 user needs to drive the tour. Everything else is annotated on its own window, which is what reaches
 a dialog.
 
@@ -166,10 +166,10 @@ Give a step an action only when it *does* something the user can watch. ``Show m
 whenever a step has one, so an action whose effect is invisible - re-expanding a section the reveal
 has already opened, say - puts a button on screen that appears to do nothing when pressed.
 
-Where a step's effect shows up somewhere other than the control it points at, name that somewhere
+Where a step's effect shows up somewhere other than where the annotation is pointing, name that somewhere
 in ``avoid``. The caption is placed clear of it as well as of the spotlight, so a step that ticks a
-check box while the values it changes are displayed elsewhere does not end up explaining the change
-from on top of the evidence:
+check box while the values it changes are displayed elsewhere does not end up explaining a change that
+is blocked from view:
 
 .. code-block:: python
 

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -10,9 +10,13 @@ GUI Tutorial Framework
 Overview
 ########
 
-``mantidqt.widgets.tutorial`` runs a guided, automated walkthrough of a Qt interface: it dims the
-window, spotlights one widget at a time, explains what it does, and **performs the interaction
-itself** so the user watches a real workflow run rather than reading about one.
+``mantidqt.widgets.tutorial`` runs a guided walkthrough of a Qt interface: it dims the window,
+spotlights one widget at a time, explains what it does, and **performs the interaction itself** so
+the user watches a real workflow run rather than reading about one.
+
+The tour never advances on its own. The user presses Next when they have finished reading, because
+there is no interval that is right for everyone: a step someone already understands is a wait, and
+a step they do not is a race.
 
 An interface supplies two things — a factory that builds a copy of itself, and a list of steps.
 Everything else is handled by the framework.
@@ -88,7 +92,6 @@ A tour is a sequence of ``TutorialChapter``, each a sequence of ``TutorialStep``
                 await_=lambda sandbox: not sandbox.view.finder_xml.isSearching(),
                 await_timeout_s=60.0,
                 await_text="Looking for the sample file…",
-                dwell_ms=4500,
             ),
         ],
     )
@@ -102,6 +105,30 @@ chapter is replayed against a freshly built interface whenever the user jumps to
 work without blocking. Give it an explicit ``await_timeout_s``: how long is reasonable depends
 entirely on what is being waited for, and a default would only ever be wrong in the direction that
 hides a hang.
+
+Where the controls live
+#######################
+
+Two pieces of chrome, and the split between them matters:
+
+* ``TutorialShell`` wraps the interface. Chapter tabs along the top, ``Back`` / ``Next`` / ``End
+  tutorial`` and a step counter along the bottom, with the interface reparented in between. It
+  does not move.
+* ``TutorialBubble`` is the caption beside the highlight, and carries **no controls at all**. It
+  chases whatever is being spotlighted, so a button on it would be somewhere different on every
+  step - the one control the user has to press would be the one they had to hunt for.
+
+Because the interface becomes a child of the shell, the dimming overlay covers only the interface:
+the tabs and buttons stay bright and usable while everything they act on is dimmed.
+
+Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
+actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
+before it leave behind - and it is only possible because the tour drives a throwaway interface.
+
+Navigation is refused while a step is settling or waiting on the interface (``busy_changed``).
+Without that, Next pressed mid-search would run the following step's action against an interface
+that had not finished reacting to this one - and Next pressed during the settle would skip the
+step's caption while its action had already run.
 
 Never block
 ###########
@@ -182,8 +209,8 @@ Testing a tour
 
 A tour is written against widget names and presenter methods, so it drifts the moment either is
 renamed — silently, because nothing else imports it. Write a test that plays every chapter against
-a real interface, overriding the delays so it runs at full speed, and assert that no step failed
-and that every step found what it points at. See
+a real interface, pressing Next as each step becomes ready and cutting ``settle_ms`` to the
+minimum, and assert that no step failed and that every step found what it points at. See
 ``mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py``.
 
 Put each step's observation in its own ``subTest`` so one broken step does not hide the rest, and

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -147,12 +147,12 @@ dimming its window would put the scrim over the chapter tabs and the navigation 
 user needs to drive the tour. Everything else is annotated on its own window, which is what reaches
 a dialog.
 
-Two things to check before a tour opens a dialog. It must be made **non-modal**, in the sandbox
-and never in the interface itself, or it blocks the tutorial's own controls until the user closes
-something they did not ask for. And mind what applying it writes: a settings dialog that saves to
-Mantid's shared ``QSettings`` is *not* isolated by the sandbox, so such a tour must dismiss it
-rather than accept it - Ok or Apply would change the real interface's saved settings on the user's
-behalf.
+No shipped tour points into a dialog yet. Two things to check before one does. The dialog must be
+made **non-modal**, in the sandbox and never in the interface itself, or it blocks the tutorial's
+own controls until the user closes something they did not ask for. And mind what applying it
+writes: a settings dialog that saves to Mantid's shared ``QSettings`` is *not* isolated by the
+sandbox, so such a tour must dismiss it rather than accept it - Ok or Apply would change the real
+interface's saved settings on the user's behalf.
 
 Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
 actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
@@ -267,10 +267,15 @@ Testing a tour
 ##############
 
 A tour is written against widget names and presenter methods, so it drifts the moment either is
-renamed — silently, because nothing else imports it. Write a test that plays every chapter against
-a real interface, pressing Next as each step becomes ready and cutting ``settle_ms`` to the
-minimum, and assert that no step failed and that every step found what it points at. See
+renamed — silently, because nothing else imports it. Write a test that plays the tour against a real
+interface, pressing Next as each step becomes ready and cutting ``settle_ms`` to the minimum, and
+assert that no step failed and that every step found what it points at. See
 ``mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py``.
 
 Put each step's observation in its own ``subTest`` so one broken step does not hide the rest, and
-assert that the sandbox leaves no workspaces behind once it is closed.
+assert that the sandbox leaves no workspaces behind once it is closed. Playing the tour runs the
+interface for real, so play it as few times as its distinct paths require - once through, and once
+per chapter entered by itself, since a chapter jump reaches its starting state by fast-forwarding
+rather than by walking - and assert everything else against what that recorded. Build the hurried
+copy of the tour with ``dataclasses.replace`` rather than by listing the fields, or the test will
+quietly stop matching the real steps the next time ``TutorialStep`` gains one.

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -1,0 +1,190 @@
+.. _GuiTutorialFramework:
+
+======================
+GUI Tutorial Framework
+======================
+
+.. contents::
+  :local:
+
+Overview
+########
+
+``mantidqt.widgets.tutorial`` runs a guided, automated walkthrough of a Qt interface: it dims the
+window, spotlights one widget at a time, explains what it does, and **performs the interaction
+itself** so the user watches a real workflow run rather than reading about one.
+
+An interface supplies two things — a factory that builds a copy of itself, and a list of steps.
+Everything else is handled by the framework.
+
+The first user of it is the :ref:`Texture Planner <Texture_Planner-ref>`
+(``mantidqtinterfaces/TexturePlanner/tutorial/``), which is the working example to read alongside
+this page.
+
+The sandbox: why the tour never drives the user's window
+########################################################
+
+A tour that typed into the interface the user had open would be unusable — it would overwrite a
+half-finished setup, and could not be offered on startup without risking someone's work. So the
+tour builds and drives **a second, throwaway instance** of the interface, and closes it at the end.
+
+This is what makes the rest of the design possible, and it has consequences worth knowing:
+
+* The tour can perform genuinely destructive-looking actions — loading files, running algorithms,
+  writing exports — because none of it touches anything the user owns.
+* Jumping to a chapter is a *rebuild*, not an undo. There is no need for a step to know how to
+  reverse itself.
+* Your interface must be safe to instantiate twice. In practice that means workspace names must be
+  unique per instance, and closing the window must clean up after itself. The Texture Planner
+  already did both.
+
+A sandbox is any object with a ``window`` attribute and a ``teardown()`` method. It is also passed
+to every step as the *context*, so put on it whatever the steps need to reach:
+
+.. code-block:: python
+
+    class TutorialSandbox:
+        def __init__(self, parent=None):
+            self.data = DemoData()                       # generated demo files
+            self.model = MyModel()
+            self.view = MyView(parent=parent, register_usage=False)
+            self.presenter = MyPresenter(self.model, self.view, offer_tutorial=False)
+
+        @property
+        def window(self):
+            return self.view
+
+        def teardown(self):
+            self.view.close()                            # cleans up via closeEvent
+            self.view.deleteLater()
+            self.data.cleanup()
+
+Two traps that both instances of this pattern have hit:
+
+* **Usage reporting.** If the view registers a feature usage in its constructor, the sandbox will
+  double-count every real launch. Give the view a flag to skip it.
+* **Recursion.** If the presenter offers a tutorial, the sandbox's presenter will offer one too —
+  and on a first-ever open, launch it. Give the presenter a flag to suppress it.
+
+Writing steps
+#############
+
+A tour is a sequence of ``TutorialChapter``, each a sequence of ``TutorialStep``:
+
+.. code-block:: python
+
+    from mantidqt.widgets.tutorial.interaction import click, select_combo
+    from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
+
+    SETUP = TutorialChapter(
+        name="Sample setup",
+        description="Load a sample and give it a material.",
+        steps=[
+            TutorialStep(
+                title="Load a sample shape",
+                text="The shape comes from an <b>STL mesh</b> or a <b>CSG description</b>.",
+                target=lambda sandbox: sandbox.view.finder_xml,
+                action=lambda sandbox: set_finder(sandbox.view.finder_xml, sandbox.data.path),
+                await_=lambda sandbox: not sandbox.view.finder_xml.isSearching(),
+                await_timeout_s=60.0,
+                await_text="Looking for the sample file…",
+                dwell_ms=4500,
+            ),
+        ],
+    )
+
+``target`` and ``action`` are **callables taking the sandbox**, never captured widgets. Two reasons,
+and both bite: the interesting widgets often do not exist when the tour is written (a matplotlib
+canvas injected into a placeholder, a table cell widget that appears once there are rows), and a
+chapter is replayed against a freshly built interface whenever the user jumps to it.
+
+``await_`` is polled until it holds before the step is narrated — this is how a step waits for slow
+work without blocking. Give it an explicit ``await_timeout_s``: how long is reasonable depends
+entirely on what is being waited for, and a default would only ever be wrong in the direction that
+hides a hang.
+
+Never block
+###########
+
+Everything the tour shows — the spotlight, the caption, the interface reacting — is painted by the
+event loop, so a tour that waits by blocking freezes the demonstration it is giving. Two rules
+follow:
+
+* Wait with ``interaction.wait_for(predicate, on_ready, timeout_s)``, which polls on a ``QTimer``
+  and calls back. Never ``time.sleep``, ``QTest.qWait``, or a spin loop around ``processEvents``.
+* Actions must **finish before they return**. ``interaction.click`` deliberately does not use
+  ``animateClick`` for this reason: that releases the button from a timer ~100 ms later, so the
+  press can still be pending after the tour has moved on — or after the tour has ended and the
+  interface it belonged to has been torn down, at which point the handler runs against workspaces
+  that no longer exist.
+
+Driving widgets
+###############
+
+``mantidqt.widgets.tutorial.interaction`` holds the helpers, which exist because the naive Qt call
+usually does not do what you want:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Helper
+    - Why not the obvious call
+  * - ``set_text``
+    - ``setText`` emits none of ``textEdited`` / ``editingFinished`` / ``returnPressed``, so the
+      interface never notices the value.
+  * - ``select_combo``
+    - ``setCurrentText`` on a non-editable combo silently does nothing when the text is absent.
+  * - ``select_tab``
+    - By title, not index — indices move when tabs are added conditionally.
+  * - ``set_spin_box``
+    - Spin boxes clamp and round silently.
+  * - ``set_check_state``
+    - Synchronous, unlike ``click``, because the caller asked for a *state*.
+  * - ``ensure_visible``
+    - Selects the containing tab, expands a collapsed group box, and scrolls the widget into view.
+      A target that is not on screen has a geometry that is meaningless to point at.
+
+These overlap with ``Testing/AutomatedUITests/qt_interaction_helpers.py``, which solves the same
+problems for tests. They are deliberately *not* shared: the test helpers raise ``AssertionError``
+(right for a test, wrong for production) and wait by blocking (right for a test, fatal here).
+
+Launching it
+############
+
+.. code-block:: python
+
+    from mantidqt.widgets.tutorial.launcher import run_tutorial, should_show_on_startup
+
+    def open_tutorial(self, mark_as_seen=False):
+        self._tutorial_session = run_tutorial(
+            sandbox_factory=make_sandbox_factory(parent=self.view),
+            chapters=CHAPTERS,
+            parent=self.view,
+            settings_key="MyInterface",
+            mark_as_seen=mark_as_seen,
+        )
+
+Keep the returned session alive for as long as the tour runs — it owns the sandbox window.
+
+``should_show_on_startup(key)`` / ``mark_seen(key)`` store a flag under
+``CustomInterfaces/<key>/tutorial_seen``. The flag is set when the tutorial is *offered*, not when
+it is completed: someone who closes it immediately has made their decision, and the toolbar button
+keeps it available. Offer it from the event loop rather than from the presenter's constructor, or
+the window it should appear over has not been laid out yet:
+
+.. code-block:: python
+
+    if should_show_on_startup("MyInterface"):
+        QTimer.singleShot(0, lambda: self.open_tutorial(mark_as_seen=True))
+
+Testing a tour
+##############
+
+A tour is written against widget names and presenter methods, so it drifts the moment either is
+renamed — silently, because nothing else imports it. Write a test that plays every chapter against
+a real interface, overriding the delays so it runs at full speed, and assert that no step failed
+and that every step found what it points at. See
+``mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py``.
+
+Put each step's observation in its own ``subTest`` so one broken step does not hide the rest, and
+assert that the sandbox leaves no workspaces behind once it is closed.

--- a/dev-docs/source/GuiTutorialFramework.rst
+++ b/dev-docs/source/GuiTutorialFramework.rst
@@ -137,6 +137,14 @@ the tabs and buttons stay bright and usable while everything they act on is dimm
 Choosing a chapter tab **rebuilds the sandbox** and fast-forwards through the earlier chapters'
 actions. That is what lets a chapter be entered at all - its steps assume the state the chapters
 before it leave behind - and it is only possible because the tour drives a throwaway interface.
+Clicking the tab already showing restarts that chapter, which is the framework's answer to "undo":
+rebuilding reaches a known state exactly, where a per-step inverse would have to re-implement the
+interface's own logic backwards and could not be written at all for steps that load a file or run
+an algorithm.
+
+Give a step an action only when it *does* something the user can watch. ``Show me`` is offered
+whenever a step has one, so an action whose effect is invisible - re-expanding a section the reveal
+has already opened, say - puts a button on screen that appears to do nothing when pressed.
 
 Navigation is refused while a step is settling or working (``busy_changed``). Without that, Next
 pressed mid-calculation would run the following step's action against an interface that had not

--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -239,6 +239,7 @@ GUI Development
    MVPDesign
    MVPTutorial/index
    QtDesignerForPython
+   GuiTutorialFramework
    BalsamiqWireframes
    MantidUsedIconsTable
    ISISReflectometryInterface
@@ -252,6 +253,9 @@ GUI Development
 
 :doc:`QtDesignerForPython`
    Describes how to use the Qt designer to produce GUI views.
+
+:doc:`GuiTutorialFramework`
+   How to add a guided, automated tutorial that walks a user through a Qt interface.
 
 :doc:`BalsamiqWireframes`
    An introduction to mockups with Balsamiq Wireframes.

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -58,10 +58,9 @@ Settings
 Tutorial
     The mortarboard icon beside the cog runs a guided tutorial, which walks
     through the whole workflow — loading a sample, setting up the instrument and
-    goniometer, reading the pole figure, exporting the result, and what each entry
-    in the settings menu does — highlighting each control and using it as it goes.
-    It appears automatically the first time the interface is opened, and can be
-    re-run from the button at any time.
+    goniometer, reading the pole figure, and exporting the result — highlighting
+    each control and using it as it goes. It appears automatically the first time
+    the interface is opened, and can be re-run from the button at any time.
 
     The tutorial runs in a **separate window containing its own copy of the
     interface**, loaded with a small demo sample. Nothing it does affects the

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -75,7 +75,8 @@ Tutorial
 
     The tabs along the top jump to a chapter — the interface is rebuilt and
     brought up to that point, so a chapter always starts from the state it
-    expects.
+    expects. Clicking the tab you are already on starts that chapter again from
+    a fresh interface, which is the way to undo anything the tutorial has done.
 
 .. _Texture_Planner_sample-setup-ref:
 

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -67,10 +67,15 @@ Tutorial
     session you are working in, and everything it creates is removed when its
     window is closed.
 
-    Nothing moves on its own: press *Next* at the bottom of the window when you
-    have finished reading a step, or *Back* to re-read the previous one. The tabs
-    along the top jump to a chapter — the interface is rebuilt and brought up to
-    that point, so a chapter always starts from the state it expects.
+    Nothing happens on its own. Each step explains a control first; press
+    *Show me* to watch the tutorial use it, then *Next* to move on. *Next* on a
+    step you have not shown performs it for you, so the tutorial never skips a
+    change that later steps depend on. *Back* re-reads the previous step without
+    repeating anything.
+
+    The tabs along the top jump to a chapter — the interface is rebuilt and
+    brought up to that point, so a chapter always starts from the state it
+    expects.
 
 .. _Texture_Planner_sample-setup-ref:
 

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -58,9 +58,10 @@ Settings
 Tutorial
     The mortarboard icon beside the cog runs a guided tutorial, which walks
     through the whole workflow — loading a sample, setting up the instrument and
-    goniometer, reading the pole figure, and exporting the result — highlighting
-    each control and using it as it goes. It appears automatically the first time
-    the interface is opened, and can be re-run from the button at any time.
+    goniometer, reading the pole figure, exporting the result, and what each entry
+    in the settings menu does — highlighting each control and using it as it goes.
+    It appears automatically the first time the interface is opened, and can be
+    re-run from the button at any time.
 
     The tutorial runs in a **separate window containing its own copy of the
     interface**, loaded with a small demo sample. Nothing it does affects the

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -55,6 +55,19 @@ Settings
     interface behaviour that might otherwise clutter the main window. See
     :ref:`Settings Menu <Texture_Planner_settings-ref>` for the full set of options.
 
+Tutorial
+    The mortarboard icon beside the cog runs a guided tutorial, which walks
+    through the whole workflow — loading a sample, setting up the instrument and
+    goniometer, reading the pole figure, and exporting the result — highlighting
+    each control and using it as it goes. It appears automatically the first time
+    the interface is opened, and can be re-run from the button at any time.
+
+    The tutorial runs in a **separate window containing its own copy of the
+    interface**, loaded with a small demo sample. Nothing it does affects the
+    session you are working in, and everything it creates is removed when its
+    window is closed. Use *Pause* to stop and look around, *Back* to re-read a
+    step, and *Chapters…* to jump to a particular part of the workflow.
+
 .. _Texture_Planner_sample-setup-ref:
 
 Sample Setup Options

--- a/docs/source/interfaces/diffraction/Texture Planner.rst
+++ b/docs/source/interfaces/diffraction/Texture Planner.rst
@@ -65,8 +65,12 @@ Tutorial
     The tutorial runs in a **separate window containing its own copy of the
     interface**, loaded with a small demo sample. Nothing it does affects the
     session you are working in, and everything it creates is removed when its
-    window is closed. Use *Pause* to stop and look around, *Back* to re-read a
-    step, and *Chapters…* to jump to a particular part of the workflow.
+    window is closed.
+
+    Nothing moves on its own: press *Next* at the bottom of the window when you
+    have finished reading a step, or *Back* to re-read the previous one. The tabs
+    along the top jump to a chapter — the interface is rebuilt and brought up to
+    that point, so a chapter always starts from the state it expects.
 
 .. _Texture_Planner_sample-setup-ref:
 

--- a/docs/source/release/v7.0.0/Diffraction/Engineering/New_features/42111.rst
+++ b/docs/source/release/v7.0.0/Diffraction/Engineering/New_features/42111.rst
@@ -1,0 +1,1 @@
+- The :ref:`Texture Planning User Interface <Texture_Planner-ref>` now has a guided tutorial. It appears the first time the interface is opened and can be re-run at any time from the mortarboard button on the bottom toolbar. The tutorial drives a separate, temporary copy of the interface, so it never affects the session you are working in.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -198,6 +198,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+    mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py
 )
 

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -202,9 +202,9 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/tutorial/test/test_bubble.py
     mantidqt/widgets/tutorial/test/test_interaction.py
     mantidqt/widgets/tutorial/test/test_launcher.py
+    mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_player.py
     mantidqt/widgets/tutorial/test/test_shell.py
-    mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py
 )

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -198,6 +198,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+    mantidqt/widgets/tutorial/test/test_bubble.py
     mantidqt/widgets/tutorial/test/test_interaction.py
     mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_step.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -202,6 +202,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/tutorial/test/test_interaction.py
     mantidqt/widgets/tutorial/test/test_launcher.py
     mantidqt/widgets/tutorial/test/test_player.py
+    mantidqt/widgets/tutorial/test/test_shell.py
     mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -200,6 +200,8 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
     mantidqt/widgets/tutorial/test/test_bubble.py
     mantidqt/widgets/tutorial/test/test_interaction.py
+    mantidqt/widgets/tutorial/test/test_launcher.py
+    mantidqt/widgets/tutorial/test/test_player.py
     mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -198,6 +198,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+    mantidqt/widgets/tutorial/test/test_interaction.py
     mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py
 )

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -199,6 +199,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
     mantidqt/widgets/tutorial/test/test_interaction.py
+    mantidqt/widgets/tutorial/test/test_overlay.py
     mantidqt/widgets/tutorial/test/test_step.py
     mantidqt/icons/test/test_icons.py
 )

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -198,6 +198,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
     mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+    mantidqt/widgets/tutorial/test/test_annotator.py
     mantidqt/widgets/tutorial/test/test_bubble.py
     mantidqt/widgets/tutorial/test/test_interaction.py
     mantidqt/widgets/tutorial/test/test_launcher.py

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/__init__.py
@@ -1,0 +1,7 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
@@ -1,0 +1,143 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""Puts the spotlight and the caption on whichever window the tour is pointing into.
+
+An interface is rarely one window. The moment a tour wants to explain a settings dialog it has to
+annotate something that is not the window it started in, and an overlay is tied to the widget it
+dims - it cannot reach across into another top-level window.
+
+So this owns one overlay and one caption *per window*, creates them as they are needed, and shows
+only the pair belonging to whatever is currently spotlighted. It exposes exactly the surface the
+player uses, so the player neither knows nor cares how many windows are involved.
+"""
+
+from qtpy.QtCore import QObject
+
+from mantidqt.widgets.tutorial.bubble import TutorialBubble
+from mantidqt.widgets.tutorial.overlay import TutorialOverlay
+
+
+class TutorialAnnotator(QObject):
+    """Overlay and caption for the tour, following the target from window to window.
+
+    :param primary: the window the tour belongs to. Used whenever there is nothing to point at, so
+        a step that only narrates appears over the interface rather than wherever the last target
+        happened to live.
+    """
+
+    def __init__(self, primary, parent=None):
+        super().__init__(parent)
+        self._primary = primary
+        self._panels = {}  # window -> (overlay, bubble)
+        self._active = None
+        # the caption is re-shown when the tour moves between windows, so the last one is kept
+        self._text = ""
+        self._title = ""
+
+    # ------------------------------------------------------------------ the player's surface
+
+    def set_target(self, widget):
+        self._activate(self._host_for(widget))
+        overlay, _bubble = self._active
+        overlay.set_target(widget)
+
+    def _host_for(self, widget):
+        """Which widget should carry the scrim for ``widget``.
+
+        Anything inside the primary is annotated on the primary itself, *not* on its window. The
+        interface being toured is a child of the tutorial shell, and dimming the whole window would
+        put the scrim over the chapter tabs and the navigation buttons - the controls the user needs
+        to drive the tour, and the reason the shell holds them outside the interface in the first
+        place. Anything else is annotated on its own window, which is how a dialog gets reached.
+        """
+        if widget is None:
+            return self._primary
+        if widget is self._primary or self._primary.isAncestorOf(widget):
+            return self._primary
+        return widget.window()
+
+    def target_rect(self):
+        if self._active is None:
+            return None
+        overlay, _bubble = self._active
+        return overlay.target_rect()
+
+    def show_step(self, text, title=""):
+        self._text, self._title = text, title
+        self._activate(self._primary if self._active is None else None)
+        _overlay, bubble = self._active
+        bubble.show_step(text=text, title=title)
+
+    def show_waiting(self, message):
+        self._activate(self._primary if self._active is None else None)
+        _overlay, bubble = self._active
+        bubble.show_waiting(message)
+
+    def place_beside(self, spotlight):
+        if self._active is None:
+            return
+        _overlay, bubble = self._active
+        bubble.place_beside(spotlight)
+
+    def show(self):
+        self._activate(self._primary)
+
+    def hide(self):
+        for overlay, bubble in self._panels.values():
+            overlay.hide()
+            bubble.hide()
+        self._active = None
+
+    def detach(self):
+        for overlay, bubble in self._panels.values():
+            overlay.detach()
+            bubble.hide()
+            bubble.setParent(None)
+            bubble.deleteLater()
+            overlay.setParent(None)
+            overlay.deleteLater()
+        self._panels.clear()
+        self._active = None
+        self._primary = None
+
+    # ------------------------------------------------------------------ per-window panels
+
+    def active_window(self):
+        for window, panel in self._panels.items():
+            if panel is self._active:
+                return window
+        return None
+
+    def active_bubble(self):
+        return None if self._active is None else self._active[1]
+
+    def _activate(self, window):
+        """Make ``window``'s panel the one on screen, building it if this is the first visit."""
+        if window is None:
+            return
+        panel = self._panels.get(window)
+        if panel is None:
+            panel = (TutorialOverlay(window), TutorialBubble(window))
+            self._panels[window] = panel
+        if panel is self._active:
+            return
+
+        # only one window is annotated at a time: leaving the previous overlay up would dim a
+        # window the tour has moved on from, with a caption on it that no longer applies
+        if self._active is not None:
+            previous_overlay, previous_bubble = self._active
+            previous_overlay.set_target(None)
+            previous_overlay.hide()
+            previous_bubble.hide()
+
+        self._active = panel
+        overlay, bubble = panel
+        overlay.show()
+        bubble.show_step(text=self._text, title=self._title)
+        bubble.show()
+        bubble.raise_()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
@@ -11,15 +11,47 @@ An interface is rarely one window. The moment a tour wants to explain a settings
 annotate something that is not the window it started in, and an overlay is tied to the widget it
 dims - it cannot reach across into another top-level window.
 
-So this owns one overlay and one caption *per window*, creates them as they are needed, and shows
-only the pair belonging to whatever is currently spotlighted. It exposes exactly the surface the
-player uses, so the player neither knows nor cares how many windows are involved.
+So this owns a *panel* - one overlay and one caption - per window, creates them as they are needed,
+and shows only the panel belonging to whatever is currently spotlighted. It exposes exactly the
+surface the player uses, so the player neither knows nor cares how many windows are involved.
 """
 
 from qtpy.QtCore import QObject
 
 from mantidqt.widgets.tutorial.bubble import TutorialBubble
 from mantidqt.widgets.tutorial.overlay import TutorialOverlay
+
+
+class _Panel:
+    """The overlay and the caption annotating one window.
+
+    They are built, shown, hidden and discarded together and are never addressed apart, which is
+    what makes them one thing here rather than two lookups kept in step by hand.
+    """
+
+    def __init__(self, window):
+        self.window = window
+        self.overlay = TutorialOverlay(window)
+        self.bubble = TutorialBubble(window)
+
+    def show(self, text, title):
+        self.overlay.show()
+        # the caption is put on rather than assumed to be there: a panel built when the tour
+        # reaches a new window has never been given one
+        self.bubble.show_step(text=text, title=title)
+        self.bubble.show()
+        self.bubble.raise_()
+
+    def hide(self):
+        self.overlay.hide()
+        self.bubble.hide()
+
+    def dispose(self):
+        self.overlay.detach()
+        self.bubble.hide()
+        for widget in (self.bubble, self.overlay):
+            widget.setParent(None)
+            widget.deleteLater()
 
 
 class TutorialAnnotator(QObject):
@@ -33,18 +65,71 @@ class TutorialAnnotator(QObject):
     def __init__(self, primary, parent=None):
         super().__init__(parent)
         self._primary = primary
-        self._panels = {}  # window -> (overlay, bubble)
+        self._panels = {}  # window -> _Panel
         self._active = None
-        # the caption is re-shown when the tour moves between windows, so the last one is kept
         self._text = ""
         self._title = ""
 
-    # ------------------------------------------------------------------ the player's surface
+    # ------------------------------------------------------------------ pointing
 
     def set_target(self, widget):
-        self._activate(self._host_for(widget))
-        overlay, _bubble = self._active
-        overlay.set_target(widget)
+        panel = self._activate(self._panel_for(self._host_for(widget)))
+        if panel is not None:
+            panel.overlay.set_target(widget)
+
+    def target_rect(self):
+        return None if self._active is None else self._active.overlay.target_rect()
+
+    def rect_of(self, widget):
+        """Where ``widget`` is, in the coordinates of the window currently being annotated."""
+        return None if self._active is None else self._active.overlay.rect_of(widget)
+
+    # ------------------------------------------------------------------ narrating
+
+    def show_step(self, text, title=""):
+        # kept because the tour can move to a window whose panel does not exist yet, and that panel
+        # has to open showing the caption that is current rather than a blank box
+        self._text, self._title = text, title
+        panel = self._narration_panel()
+        if panel is not None:
+            panel.bubble.show_step(text=text, title=title)
+
+    def show_waiting(self, message):
+        panel = self._narration_panel()
+        if panel is not None:
+            panel.bubble.show_waiting(message)
+
+    def place_beside(self, spotlight, keep_clear=()):
+        if self._active is not None:
+            self._active.bubble.place_beside(spotlight, keep_clear)
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def show(self):
+        self._activate(self._panel_for(self._primary))
+
+    def hide(self):
+        for panel in self._panels.values():
+            panel.hide()
+        self._active = None
+
+    def detach(self):
+        """Discard every panel. Safe to call more than once, and leaves the annotator inert."""
+        for panel in self._panels.values():
+            panel.dispose()
+        self._panels.clear()
+        self._active = None
+        self._primary = None
+
+    # ------------------------------------------------------------------ where it is pointing
+
+    def active_window(self):
+        return None if self._active is None else self._active.window
+
+    def active_bubble(self):
+        return None if self._active is None else self._active.bubble
+
+    # ------------------------------------------------------------------ panels
 
     def _host_for(self, widget):
         """Which widget should carry the scrim for ``widget``.
@@ -54,97 +139,45 @@ class TutorialAnnotator(QObject):
         put the scrim over the chapter tabs and the navigation buttons - the controls the user needs
         to drive the tour, and the reason the shell holds them outside the interface in the first
         place. Anything else is annotated on its own window, which is how a dialog gets reached.
+
+        None once ``detach`` has run - there is no longer anywhere to put a scrim.
         """
-        if widget is None:
+        if widget is None or self._primary is None:
             return self._primary
         if widget is self._primary or self._primary.isAncestorOf(widget):
             return self._primary
         return widget.window()
 
-    def target_rect(self):
-        if self._active is None:
-            return None
-        overlay, _bubble = self._active
-        return overlay.target_rect()
+    def _panel_for(self, window):
+        """The panel annotating ``window``, built the first time it is visited.
 
-    def show_step(self, text, title=""):
-        self._text, self._title = text, title
-        self._activate(self._primary if self._active is None else None)
-        _overlay, bubble = self._active
-        bubble.show_step(text=text, title=title)
-
-    def show_waiting(self, message):
-        self._activate(self._primary if self._active is None else None)
-        _overlay, bubble = self._active
-        bubble.show_waiting(message)
-
-    def place_beside(self, spotlight, keep_clear=()):
-        if self._active is None:
-            return
-        _overlay, bubble = self._active
-        bubble.place_beside(spotlight, keep_clear)
-
-    def rect_of(self, widget):
-        """Where ``widget`` is, in the coordinates of the window currently being annotated."""
-        if self._active is None:
-            return None
-        overlay, _bubble = self._active
-        return overlay.rect_of(widget)
-
-    def show(self):
-        self._activate(self._primary)
-
-    def hide(self):
-        for overlay, bubble in self._panels.values():
-            overlay.hide()
-            bubble.hide()
-        self._active = None
-
-    def detach(self):
-        for overlay, bubble in self._panels.values():
-            overlay.detach()
-            bubble.hide()
-            bubble.setParent(None)
-            bubble.deleteLater()
-            overlay.setParent(None)
-            overlay.deleteLater()
-        self._panels.clear()
-        self._active = None
-        self._primary = None
-
-    # ------------------------------------------------------------------ per-window panels
-
-    def active_window(self):
-        for window, panel in self._panels.items():
-            if panel is self._active:
-                return window
-        return None
-
-    def active_bubble(self):
-        return None if self._active is None else self._active[1]
-
-    def _activate(self, window):
-        """Make ``window``'s panel the one on screen, building it if this is the first visit."""
+        None once ``detach`` has run: there is no primary left to fall back to, and every method
+        that can be reached afterwards treats that as nothing to annotate.
+        """
         if window is None:
-            return
-        panel = self._panels.get(window)
-        if panel is None:
-            panel = (TutorialOverlay(window), TutorialBubble(window))
-            self._panels[window] = panel
-        if panel is self._active:
-            return
+            return None
+        if window not in self._panels:
+            self._panels[window] = _Panel(window)
+        return self._panels[window]
+
+    def _narration_panel(self):
+        """The panel a caption belongs on: wherever the tour is pointing, or the interface itself
+        before it has pointed anywhere."""
+        if self._active is None:
+            return self._activate(self._panel_for(self._primary))
+        return self._active
+
+    def _activate(self, panel):
+        """Bring ``panel`` on screen and take down whichever was there before. Returns it."""
+        if panel is None or panel is self._active:
+            return panel
 
         # only one window is annotated at a time: leaving the previous overlay up would dim a
         # window the tour has moved on from, with a caption on it that no longer applies
         if self._active is not None:
-            previous_overlay, previous_bubble = self._active
-            previous_overlay.set_target(None)
-            previous_overlay.hide()
-            previous_bubble.hide()
+            self._active.overlay.set_target(None)
+            self._active.hide()
 
         self._active = panel
-        overlay, bubble = panel
-        overlay.show()
-        bubble.show_step(text=self._text, title=self._title)
-        bubble.show()
-        bubble.raise_()
+        panel.show(self._text, self._title)
+        return panel

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/annotator.py
@@ -78,11 +78,18 @@ class TutorialAnnotator(QObject):
         _overlay, bubble = self._active
         bubble.show_waiting(message)
 
-    def place_beside(self, spotlight):
+    def place_beside(self, spotlight, keep_clear=()):
         if self._active is None:
             return
         _overlay, bubble = self._active
-        bubble.place_beside(spotlight)
+        bubble.place_beside(spotlight, keep_clear)
+
+    def rect_of(self, widget):
+        """Where ``widget`` is, in the coordinates of the window currently being annotated."""
+        if self._active is None:
+            return None
+        overlay, _bubble = self._active
+        return overlay.rect_of(widget)
 
     def show(self):
         self._activate(self._primary)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -180,7 +180,3 @@ class TutorialBubble(QFrame):
         x = max(host_rect.left() + GAP, min(top_left.x(), host_rect.right() - size.width() - GAP))
         y = max(host_rect.top() + GAP, min(top_left.y(), host_rect.bottom() - size.height() - GAP))
         return QPoint(x, y)
-
-    def geometry_in_host(self):
-        """Where the bubble is, for a caller that needs to keep something clear of it."""
-        return QRect(self.pos(), self.size())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -1,0 +1,186 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""What the tutorial says, and the controls for driving it.
+
+A child of the window being toured rather than of the overlay: the overlay refuses mouse events
+so that clicks reach the interface, and buttons inside something transparent to the mouse would
+be unclickable. Being a sibling of the overlay also means it can be raised above it, so the
+caption is never dimmed by the scrim it sits on.
+
+It positions itself out of the way of whatever is being spotlighted - below it if there is room,
+otherwise above, otherwise beside - and always inside the window, because a caption half off the
+edge of the screen is worse than one in an awkward place.
+"""
+
+from qtpy.QtCore import QPoint, QRect, Qt, Signal
+from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QVBoxLayout
+
+# the caption is a fixed width so that text does not reflow as the tour moves between steps, which
+# is distracting to read
+WIDTH = 380
+
+# kept this far from the spotlight and from the window's edges
+GAP = 12
+
+
+class TutorialBubble(QFrame):
+    """The tutorial's caption panel, with its navigation buttons.
+
+    Emits a signal per control and holds no tour state of its own - the player decides what
+    ``Next`` means and tells the bubble what to display.
+    """
+
+    back_requested = Signal()
+    next_requested = Signal()
+    chapters_requested = Signal()
+    close_requested = Signal()
+    pause_toggled = Signal(bool)
+
+    def __init__(self, host):
+        super().__init__(host)
+        self._host = host
+
+        self.setObjectName("tutorial_bubble")
+        self.setFrameShape(QFrame.StyledPanel)
+        self.setAutoFillBackground(True)
+        self.setFixedWidth(WIDTH)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+
+        self._chapter_label = QLabel()
+        self._chapter_label.setObjectName("tutorial_bubble_chapter")
+        self._title_label = QLabel()
+        self._title_label.setObjectName("tutorial_bubble_title")
+        self._title_label.setWordWrap(True)
+        title_font = self._title_label.font()
+        title_font.setBold(True)
+        self._title_label.setFont(title_font)
+
+        self._text_label = QLabel()
+        self._text_label.setObjectName("tutorial_bubble_text")
+        self._text_label.setWordWrap(True)
+        self._text_label.setTextFormat(Qt.RichText)
+        # steps explain what a control does, and some of that explanation lives in the docs
+        self._text_label.setOpenExternalLinks(True)
+        self._text_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
+
+        self.btn_chapters = QPushButton("Chapters…")
+        self.btn_back = QPushButton("Back")
+        self.btn_pause = QPushButton("Pause")
+        self.btn_pause.setCheckable(True)
+        self.btn_next = QPushButton("Next")
+        self.btn_close = QPushButton("End tour")
+
+        buttons = QHBoxLayout()
+        buttons.addWidget(self.btn_chapters)
+        buttons.addWidget(self.btn_close)
+        buttons.addStretch(1)
+        buttons.addWidget(self.btn_back)
+        buttons.addWidget(self.btn_pause)
+        buttons.addWidget(self.btn_next)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 12, 14, 12)
+        layout.setSpacing(6)
+        layout.addWidget(self._chapter_label)
+        layout.addWidget(self._title_label)
+        layout.addWidget(self._text_label)
+        layout.addSpacing(4)
+        layout.addLayout(buttons)
+
+        self.btn_chapters.clicked.connect(self.chapters_requested)
+        self.btn_back.clicked.connect(self.back_requested)
+        self.btn_next.clicked.connect(self.next_requested)
+        self.btn_close.clicked.connect(self.close_requested)
+        self.btn_pause.toggled.connect(self._on_pause_toggled)
+
+    # ------------------------------------------------------------------ content
+
+    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
+        """Display one step. ``step_number`` is 1-based; pass 0 for either count to hide the
+        progress line (a status message that is not a step of its own)."""
+        self._title_label.setText(title)
+        self._title_label.setVisible(bool(title))
+        self._text_label.setText(text)
+        if chapter_name and step_number and step_count:
+            self._chapter_label.setText(f"{chapter_name} — step {step_number} of {step_count}")
+        else:
+            self._chapter_label.setText(chapter_name)
+        self._chapter_label.setVisible(bool(self._chapter_label.text()))
+        self.adjustSize()
+
+    def show_waiting(self, message):
+        """Replace the caption with a note that the tour is waiting on the interface.
+
+        Without this a step that runs a real calculation looks like the tour having frozen, which
+        is the moment a user gives up on it.
+        """
+        self._text_label.setText(message)
+        self.adjustSize()
+
+    def set_navigation_enabled(self, back=True, next_=True):
+        self.btn_back.setEnabled(back)
+        self.btn_next.setEnabled(next_)
+
+    def set_paused(self, paused):
+        """Reflect the player's state without emitting ``pause_toggled`` back at it."""
+        was_blocked = self.btn_pause.blockSignals(True)
+        self.btn_pause.setChecked(paused)
+        self.btn_pause.setText("Resume" if paused else "Pause")
+        self.btn_pause.blockSignals(was_blocked)
+
+    def _on_pause_toggled(self, paused):
+        self.btn_pause.setText("Resume" if paused else "Pause")
+        self.pause_toggled.emit(paused)
+
+    # ------------------------------------------------------------------ placement
+
+    def place_beside(self, spotlight):
+        """Move next to ``spotlight`` (in host coordinates), or to the centre when it is empty.
+
+        Below the spotlight is preferred because that is where the eye goes next; above is the
+        fallback, and beside is the last resort for a target that spans the height of the window.
+        Whatever is chosen is then clamped inside the host - the caption being readable matters
+        more than it being perfectly placed.
+        """
+        self.adjustSize()
+        size = self.size()
+        host_rect = self._host.rect()
+
+        if spotlight is None or spotlight.isEmpty():
+            centred = QPoint(
+                host_rect.center().x() - size.width() // 2,
+                host_rect.center().y() - size.height() // 2,
+            )
+            self.move(self._clamped(centred, size, host_rect))
+            self.raise_()
+            return
+
+        below = spotlight.bottom() + GAP
+        above = spotlight.top() - GAP - size.height()
+        if below + size.height() <= host_rect.bottom():
+            top_left = QPoint(spotlight.center().x() - size.width() // 2, below)
+        elif above >= host_rect.top():
+            top_left = QPoint(spotlight.center().x() - size.width() // 2, above)
+        else:
+            right = spotlight.right() + GAP
+            fits_right = right + size.width() <= host_rect.right()
+            x = right if fits_right else spotlight.left() - GAP - size.width()
+            top_left = QPoint(x, spotlight.center().y() - size.height() // 2)
+
+        self.move(self._clamped(top_left, size, host_rect))
+        self.raise_()
+
+    @staticmethod
+    def _clamped(top_left, size, host_rect):
+        x = max(host_rect.left() + GAP, min(top_left.x(), host_rect.right() - size.width() - GAP))
+        y = max(host_rect.top() + GAP, min(top_left.y(), host_rect.bottom() - size.height() - GAP))
+        return QPoint(x, y)
+
+    def geometry_in_host(self):
+        """Where the bubble is, for a caller that needs to keep something clear of it."""
+        return QRect(self.pos(), self.size())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -43,24 +43,27 @@ class TutorialBubble(QFrame):
 
         self._title_label = QLabel()
         self._title_label.setObjectName("tutorial_bubble_title")
-        self._title_label.setWordWrap(True)
         title_font = self._title_label.font()
         title_font.setBold(True)
         self._title_label.setFont(title_font)
 
         self._text_label = QLabel()
         self._text_label.setObjectName("tutorial_bubble_text")
-        self._text_label.setWordWrap(True)
         self._text_label.setTextFormat(Qt.RichText)
         # steps explain what a control does, and some of that explanation lives in the docs
         self._text_label.setOpenExternalLinks(True)
         self._text_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
 
-        # Both labels sit at the top of whatever height they are given, and each takes only the
-        # height its text needs. Without this a wrapped QLabel is centred in its slice of the box
+        # the heading and the caption, in the order they are stacked. Named because everything
+        # below treats them as one thing: they are laid out, measured and hidden together
+        self._labels = (self._title_label, self._text_label)
+
+        # Both labels wrap, sit at the top of whatever height they are given, and take only the
+        # height their text needs. Without this a wrapped QLabel is centred in its slice of the box
         # and any spare height is split between the two, which reads as uneven padding above and
         # below the caption - and pushes the heading away from the top edge.
-        for label in (self._title_label, self._text_label):
+        for label in self._labels:
+            label.setWordWrap(True)
             label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
             policy = label.sizePolicy()
             policy.setVerticalPolicy(QSizePolicy.Minimum)
@@ -97,29 +100,36 @@ class TutorialBubble(QFrame):
     def _fit_to_contents(self):
         """Make the box exactly as tall as its text, at the fixed width.
 
-        Added up from the labels rather than taken from ``adjustSize``: a word-wrapped ``QLabel``
-        reports a size hint that assumes a single line, so the box comes out a different height
-        from the text it holds - and the leftover is what shows up as uneven padding around the
-        caption. ``heightForWidth`` is the number that accounts for the wrapping, and asking each
-        label for its own is exact where asking the layout is not.
+        Added up from the labels rather than taken from ``adjustSize``, which measures them the way
+        the layout would - and the layout is what gets this wrong (see ``_height_of``). Asking each
+        label for its own height is exact where asking the layout is not.
         """
         layout = self.layout()
         margins = layout.contentsMargins()
         # the styled panel's border eats into the width the text wraps in and the height it is
         # given. Left out of either, the box comes up a line short and clips the last one.
         border = 2 * self.frameWidth()
-        available = WIDTH - margins.left() - margins.right() - border
+        wrap_width = WIDTH - margins.left() - margins.right() - border
 
-        height = margins.top() + margins.bottom() + border
-        showing = [label for label in (self._title_label, self._text_label) if label.isVisibleTo(self)]
-        for label in showing:
-            height += label.heightForWidth(available) if label.hasHeightForWidth() else label.sizeHint().height()
-        height += layout.spacing() * max(len(showing) - 1, 0)
+        showing = [label for label in self._labels if label.isVisibleTo(self)]
+        chrome = margins.top() + margins.bottom() + border
+        text_height = sum(self._height_of(label, wrap_width) for label in showing)
+        gaps = layout.spacing() * max(len(showing) - 1, 0)
 
         # fixed rather than resized: a word-wrapped label's minimumSizeHint is its *unwrapped*
         # height, which is taller than the text actually needs, and a plain resize cannot go below
         # it - leaving exactly the unused strip this method exists to remove
-        self.setFixedHeight(height)
+        self.setFixedHeight(chrome + text_height + gaps)
+
+    @staticmethod
+    def _height_of(label, width):
+        """How tall ``label`` really is at ``width``, which is not what its size hint claims.
+
+        A word-wrapped ``QLabel`` reports a size hint that assumes a single line, and that hint is
+        exactly what makes a box sized from it come out a different height from the text it holds.
+        ``heightForWidth`` is the number that accounts for the wrapping.
+        """
+        return label.heightForWidth(width) if label.hasHeightForWidth() else label.sizeHint().height()
 
     # ------------------------------------------------------------------ placement
 
@@ -137,31 +147,39 @@ class TutorialBubble(QFrame):
         better than one off the edge of the window.
         """
         self._fit_to_contents()
-        size = self.size()
-        host_rect = self._host.rect()
-        blocked = [rect for rect in keep_clear if rect is not None and not rect.isEmpty()]
-
-        if spotlight is None or spotlight.isEmpty():
-            centred = QPoint(
-                host_rect.center().x() - size.width() // 2,
-                host_rect.center().y() - size.height() // 2,
-            )
-            self.move(self._clamped(centred, size, host_rect))
-            self.raise_()
-            return
-
-        placed = None
-        for candidate in self._candidates(spotlight, size, host_rect):
-            position = self._clamped(candidate, size, host_rect)
-            rect = QRect(position, size)
-            if placed is None:
-                placed = position  # the preferred position, used if nothing is clean
-            if not rect.intersects(spotlight) and not any(rect.intersects(other) for other in blocked):
-                placed = position
-                break
-
-        self.move(placed)
+        self.move(self._position_for(spotlight, keep_clear))
         self.raise_()
+
+    def _position_for(self, spotlight, keep_clear):
+        """Where the caption should sit, in host coordinates. Moves nothing.
+
+        Every candidate is clamped into the window before it is judged, so what is checked for
+        overlap is where the caption would actually end up rather than where it was first put.
+        """
+        size, host_rect = self.size(), self._host.rect()
+        if spotlight is None or spotlight.isEmpty():
+            return self._clamped(self._centred(size, host_rect), size, host_rect)
+
+        blocked = [rect for rect in keep_clear if rect is not None and not rect.isEmpty()]
+        positions = [self._clamped(point, size, host_rect) for point in self._candidates(spotlight, size, host_rect)]
+        for position in positions:
+            if self._is_clear(QRect(position, size), spotlight, blocked):
+                return position
+        # nothing was clean: fall back to the preferred position, because a caption slightly in the
+        # way is better than one off the edge of the window
+        return positions[0]
+
+    @staticmethod
+    def _is_clear(rect, spotlight, blocked):
+        """Whether the caption at ``rect`` covers neither the spotlight nor anything to avoid."""
+        return not rect.intersects(spotlight) and not any(rect.intersects(other) for other in blocked)
+
+    @staticmethod
+    def _centred(size, host_rect):
+        return QPoint(
+            host_rect.center().x() - size.width() // 2,
+            host_rect.center().y() - size.height() // 2,
+        )
 
     @staticmethod
     def _candidates(spotlight, size, host_rect):

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -5,23 +5,23 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
-"""What the tutorial says, and the controls for driving it.
+"""The caption that sits beside whatever is being spotlighted.
 
-A child of the window being toured rather than of the overlay: the overlay refuses mouse events
-so that clicks reach the interface, and buttons inside something transparent to the mouse would
-be unclickable. Being a sibling of the overlay also means it can be raised above it, so the
-caption is never dimmed by the scrim it sits on.
+Only a caption. It says what the highlighted widget is and nothing else: the controls for driving
+the tour live in the shell around the interface (see ``shell.py``), which stays still. A panel that
+carried the buttons *and* moved to follow the highlight would put Next somewhere different on every
+step, so the one thing the user has to click would be the one thing they had to hunt for.
 
-It positions itself out of the way of whatever is being spotlighted - below it if there is room,
-otherwise above, otherwise beside - and always inside the window, because a caption half off the
-edge of the screen is worse than one in an awkward place.
+A child of the window being toured rather than of the overlay, because the overlay refuses mouse
+events so clicks reach the interface, and it is raised above it so the caption is never dimmed by
+the scrim it sits on.
 """
 
-from qtpy.QtCore import QPoint, QRect, Qt, Signal
-from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QVBoxLayout
+from qtpy.QtCore import QPoint, QRect, Qt
+from qtpy.QtWidgets import QFrame, QLabel, QSizePolicy, QVBoxLayout
 
-# the caption is a fixed width so that text does not reflow as the tour moves between steps, which
-# is distracting to read
+# a fixed width so the text does not reflow as the tour moves between steps, which is distracting
+# to read
 WIDTH = 380
 
 # kept this far from the spotlight and from the window's edges
@@ -29,17 +29,7 @@ GAP = 12
 
 
 class TutorialBubble(QFrame):
-    """The tutorial's caption panel, with its navigation buttons.
-
-    Emits a signal per control and holds no tour state of its own - the player decides what
-    ``Next`` means and tells the bubble what to display.
-    """
-
-    back_requested = Signal()
-    next_requested = Signal()
-    chapters_requested = Signal()
-    close_requested = Signal()
-    pause_toggled = Signal(bool)
+    """Shows one step's title and explanation, positioned clear of the spotlight."""
 
     def __init__(self, host):
         super().__init__(host)
@@ -51,8 +41,6 @@ class TutorialBubble(QFrame):
         self.setFixedWidth(WIDTH)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
 
-        self._chapter_label = QLabel()
-        self._chapter_label.setObjectName("tutorial_bubble_chapter")
         self._title_label = QLabel()
         self._title_label.setObjectName("tutorial_bubble_title")
         self._title_label.setWordWrap(True)
@@ -68,49 +56,18 @@ class TutorialBubble(QFrame):
         self._text_label.setOpenExternalLinks(True)
         self._text_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
 
-        self.btn_chapters = QPushButton("Chapters…")
-        self.btn_back = QPushButton("Back")
-        self.btn_pause = QPushButton("Pause")
-        self.btn_pause.setCheckable(True)
-        self.btn_next = QPushButton("Next")
-        self.btn_close = QPushButton("End tour")
-
-        buttons = QHBoxLayout()
-        buttons.addWidget(self.btn_chapters)
-        buttons.addWidget(self.btn_close)
-        buttons.addStretch(1)
-        buttons.addWidget(self.btn_back)
-        buttons.addWidget(self.btn_pause)
-        buttons.addWidget(self.btn_next)
-
         layout = QVBoxLayout(self)
         layout.setContentsMargins(14, 12, 14, 12)
         layout.setSpacing(6)
-        layout.addWidget(self._chapter_label)
         layout.addWidget(self._title_label)
         layout.addWidget(self._text_label)
-        layout.addSpacing(4)
-        layout.addLayout(buttons)
-
-        self.btn_chapters.clicked.connect(self.chapters_requested)
-        self.btn_back.clicked.connect(self.back_requested)
-        self.btn_next.clicked.connect(self.next_requested)
-        self.btn_close.clicked.connect(self.close_requested)
-        self.btn_pause.toggled.connect(self._on_pause_toggled)
 
     # ------------------------------------------------------------------ content
 
-    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
-        """Display one step. ``step_number`` is 1-based; pass 0 for either count to hide the
-        progress line (a status message that is not a step of its own)."""
+    def show_step(self, text, title=""):
         self._title_label.setText(title)
         self._title_label.setVisible(bool(title))
         self._text_label.setText(text)
-        if chapter_name and step_number and step_count:
-            self._chapter_label.setText(f"{chapter_name} — step {step_number} of {step_count}")
-        else:
-            self._chapter_label.setText(chapter_name)
-        self._chapter_label.setVisible(bool(self._chapter_label.text()))
         self.adjustSize()
 
     def show_waiting(self, message):
@@ -121,21 +78,6 @@ class TutorialBubble(QFrame):
         """
         self._text_label.setText(message)
         self.adjustSize()
-
-    def set_navigation_enabled(self, back=True, next_=True):
-        self.btn_back.setEnabled(back)
-        self.btn_next.setEnabled(next_)
-
-    def set_paused(self, paused):
-        """Reflect the player's state without emitting ``pause_toggled`` back at it."""
-        was_blocked = self.btn_pause.blockSignals(True)
-        self.btn_pause.setChecked(paused)
-        self.btn_pause.setText("Resume" if paused else "Pause")
-        self.btn_pause.blockSignals(was_blocked)
-
-    def _on_pause_toggled(self, paused):
-        self.btn_pause.setText("Resume" if paused else "Pause")
-        self.pause_toggled.emit(paused)
 
     # ------------------------------------------------------------------ placement
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -105,9 +105,12 @@ class TutorialBubble(QFrame):
         """
         layout = self.layout()
         margins = layout.contentsMargins()
-        available = WIDTH - margins.left() - margins.right()
+        # the styled panel's border eats into the width the text wraps in and the height it is
+        # given. Left out of either, the box comes up a line short and clips the last one.
+        border = 2 * self.frameWidth()
+        available = WIDTH - margins.left() - margins.right() - border
 
-        height = margins.top() + margins.bottom()
+        height = margins.top() + margins.bottom() + border
         showing = [label for label in (self._title_label, self._text_label) if label.isVisibleTo(self)]
         for label in showing:
             height += label.heightForWidth(available) if label.hasHeightForWidth() else label.sizeHint().height()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/bubble.py
@@ -56,11 +56,26 @@ class TutorialBubble(QFrame):
         self._text_label.setOpenExternalLinks(True)
         self._text_label.setTextInteractionFlags(Qt.TextBrowserInteraction)
 
+        # Both labels sit at the top of whatever height they are given, and each takes only the
+        # height its text needs. Without this a wrapped QLabel is centred in its slice of the box
+        # and any spare height is split between the two, which reads as uneven padding above and
+        # below the caption - and pushes the heading away from the top edge.
+        for label in (self._title_label, self._text_label):
+            label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+            policy = label.sizePolicy()
+            policy.setVerticalPolicy(QSizePolicy.Minimum)
+            # kept, not replaced: clearing this flag is what makes a layout size a wrapped label
+            # for a single line and hand the rest of the height to the stretch below it
+            policy.setHeightForWidth(True)
+            label.setSizePolicy(policy)
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(14, 12, 14, 12)
         layout.setSpacing(6)
         layout.addWidget(self._title_label)
         layout.addWidget(self._text_label)
+        # spare height goes here rather than between the labels, so the heading stays put
+        layout.addStretch(1)
 
     # ------------------------------------------------------------------ content
 
@@ -68,7 +83,7 @@ class TutorialBubble(QFrame):
         self._title_label.setText(title)
         self._title_label.setVisible(bool(title))
         self._text_label.setText(text)
-        self.adjustSize()
+        self._fit_to_contents()
 
     def show_waiting(self, message):
         """Replace the caption with a note that the tour is waiting on the interface.
@@ -77,21 +92,51 @@ class TutorialBubble(QFrame):
         is the moment a user gives up on it.
         """
         self._text_label.setText(message)
-        self.adjustSize()
+        self._fit_to_contents()
+
+    def _fit_to_contents(self):
+        """Make the box exactly as tall as its text, at the fixed width.
+
+        Added up from the labels rather than taken from ``adjustSize``: a word-wrapped ``QLabel``
+        reports a size hint that assumes a single line, so the box comes out a different height
+        from the text it holds - and the leftover is what shows up as uneven padding around the
+        caption. ``heightForWidth`` is the number that accounts for the wrapping, and asking each
+        label for its own is exact where asking the layout is not.
+        """
+        layout = self.layout()
+        margins = layout.contentsMargins()
+        available = WIDTH - margins.left() - margins.right()
+
+        height = margins.top() + margins.bottom()
+        showing = [label for label in (self._title_label, self._text_label) if label.isVisibleTo(self)]
+        for label in showing:
+            height += label.heightForWidth(available) if label.hasHeightForWidth() else label.sizeHint().height()
+        height += layout.spacing() * max(len(showing) - 1, 0)
+
+        # fixed rather than resized: a word-wrapped label's minimumSizeHint is its *unwrapped*
+        # height, which is taller than the text actually needs, and a plain resize cannot go below
+        # it - leaving exactly the unused strip this method exists to remove
+        self.setFixedHeight(height)
 
     # ------------------------------------------------------------------ placement
 
-    def place_beside(self, spotlight):
+    def place_beside(self, spotlight, keep_clear=()):
         """Move next to ``spotlight`` (in host coordinates), or to the centre when it is empty.
 
-        Below the spotlight is preferred because that is where the eye goes next; above is the
-        fallback, and beside is the last resort for a target that spans the height of the window.
-        Whatever is chosen is then clamped inside the host - the caption being readable matters
-        more than it being perfectly placed.
+        Below the spotlight is preferred because that is where the eye goes next; above, then
+        beside, are the fallbacks for a target with no room under it.
+
+        ``keep_clear`` are further rectangles the caption must not cover - whatever the step is
+        asking the user to watch. A step that ticks a check box while the change it causes appears
+        somewhere else entirely would otherwise be explained by a caption sitting on top of the
+        evidence. Each candidate position is tried in turn and the first that fouls nothing wins;
+        if none is clean the preferred one is used anyway, because a caption slightly in the way is
+        better than one off the edge of the window.
         """
-        self.adjustSize()
+        self._fit_to_contents()
         size = self.size()
         host_rect = self._host.rect()
+        blocked = [rect for rect in keep_clear if rect is not None and not rect.isEmpty()]
 
         if spotlight is None or spotlight.isEmpty():
             centred = QPoint(
@@ -102,20 +147,30 @@ class TutorialBubble(QFrame):
             self.raise_()
             return
 
-        below = spotlight.bottom() + GAP
-        above = spotlight.top() - GAP - size.height()
-        if below + size.height() <= host_rect.bottom():
-            top_left = QPoint(spotlight.center().x() - size.width() // 2, below)
-        elif above >= host_rect.top():
-            top_left = QPoint(spotlight.center().x() - size.width() // 2, above)
-        else:
-            right = spotlight.right() + GAP
-            fits_right = right + size.width() <= host_rect.right()
-            x = right if fits_right else spotlight.left() - GAP - size.width()
-            top_left = QPoint(x, spotlight.center().y() - size.height() // 2)
+        placed = None
+        for candidate in self._candidates(spotlight, size, host_rect):
+            position = self._clamped(candidate, size, host_rect)
+            rect = QRect(position, size)
+            if placed is None:
+                placed = position  # the preferred position, used if nothing is clean
+            if not rect.intersects(spotlight) and not any(rect.intersects(other) for other in blocked):
+                placed = position
+                break
 
-        self.move(self._clamped(top_left, size, host_rect))
+        self.move(placed)
         self.raise_()
+
+    @staticmethod
+    def _candidates(spotlight, size, host_rect):
+        """Where the caption could go, best first: below, above, right, left."""
+        centred_x = spotlight.center().x() - size.width() // 2
+        centred_y = spotlight.center().y() - size.height() // 2
+        return (
+            QPoint(centred_x, spotlight.bottom() + GAP),
+            QPoint(centred_x, spotlight.top() - GAP - size.height()),
+            QPoint(spotlight.right() + GAP, centred_y),
+            QPoint(spotlight.left() - GAP - size.width(), centred_y),
+        )
 
     @staticmethod
     def _clamped(top_left, size, host_rect):

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
@@ -38,7 +38,6 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QStackedWidget,
     QTabWidget,
-    QWidget,
 )
 
 # how often ``wait_for`` re-runs its predicate. The event loop keeps running throughout, so this
@@ -299,24 +298,3 @@ def set_spin_box(spin_box, value):
             f"its range is {spin_box.minimum()} to {spin_box.maximum()}"
         )
     return spin_box.value()
-
-
-def widget_of_type(parent, widget_type, name=""):
-    """One child widget, found by type and optionally object name.
-
-    For the widgets a tutorial wants to point at that are built in code rather than named in a
-    ``.ui`` file - a matplotlib canvas dropped into a placeholder, a toolbar's buttons.
-    """
-    found = parent.findChildren(widget_type, name) if name else parent.findChildren(widget_type)
-    if not found:
-        raise ValueError(f"no {widget_type.__name__}{f' named {name!r}' if name else ''} under {parent.objectName() or parent}")
-    return found[0]
-
-
-def is_shown(widget):
-    """Whether a widget is really on screen, not merely constructed.
-
-    ``isVisible`` is False for everything while the window itself is hidden, so this is the check a
-    tutorial wants when deciding whether it can point at something.
-    """
-    return isinstance(widget, QWidget) and widget.isVisible() and not widget.visibleRegion().isEmpty()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
@@ -1,0 +1,313 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""Driving a live interface from code, for a guided tutorial.
+
+Most of this exists because the naive Qt call does not do what you want:
+
+* ``setText`` on a ``QLineEdit`` emits none of the signals typing into it does, so an interface
+  that reacts to ``editingFinished`` never notices the value,
+* ``setCurrentText`` on a non-editable combo silently does nothing when the text is not there,
+* a spin box clamps to its range and rounds to its decimals without saying so, and
+* a widget on an unselected tab, inside a collapsed group box, or scrolled out of view has a
+  geometry that is meaningless to point at.
+
+``Testing/AutomatedUITests/qt_interaction_helpers.py`` solves the same problems for tests and is
+where most of this came from. What is *not* shared with it is the waiting: those helpers wait by
+blocking (``QTest.qWait``), which is right for a test and wrong here. A tutorial that blocks stops
+repainting, so the overlay it is drawing freezes along with everything else. ``wait_for`` below is
+the non-blocking equivalent, and it is the only way this package should ever wait.
+
+Nothing here imports ``QtTest``. Driving a widget through its own API is enough for a tutorial,
+which - unlike a test - does not need to prove that a real mouse press would have worked.
+"""
+
+import time
+
+from qtpy.QtCore import QEventLoop, QTimer
+from qtpy.QtWidgets import (
+    QAbstractButton,
+    QAbstractScrollArea,
+    QApplication,
+    QGroupBox,
+    QLineEdit,
+    QScrollArea,
+    QStackedWidget,
+    QTabWidget,
+    QWidget,
+)
+
+# how often ``wait_for`` re-runs its predicate. The event loop keeps running throughout, so this
+# only sets the polling granularity, not the responsiveness of the interface.
+POLL_INTERVAL_MS = 100
+
+
+# --------------------------------------------------------------------------------------------
+# waiting
+# --------------------------------------------------------------------------------------------
+
+
+def wait_for(predicate, on_ready, timeout_s, on_timeout=None, interval_ms=POLL_INTERVAL_MS, parent=None):
+    """Call ``on_ready`` once ``predicate()`` holds, without blocking.
+
+    The point of this over a wait loop: everything a tutorial shows - the spotlight, the caption,
+    the interface reacting - is painted by the event loop, so the tutorial must return to it
+    between checks rather than sit in a loop pumping it by hand.
+
+    ``timeout_s`` has no default on purpose. How long a step may wait depends entirely on what it
+    is waiting for, and a default would only ever be wrong in the direction that hides a hang.
+    ``on_timeout`` decides what that means: it raises by default, and a caller that would rather
+    carry on (the player, which moves the tour along rather than stranding the user) passes its
+    own.
+
+    Returns the ``QTimer`` doing the polling, so a caller that may be torn down mid-wait can stop
+    it. Keep a reference to it: an unparented timer with no Python reference can be collected, and
+    the wait would then simply never finish. Passing ``parent`` avoids that.
+    """
+    if timeout_s <= 0:
+        raise ValueError(f"timeout_s must be positive, got {timeout_s}")
+
+    if predicate():
+        on_ready()
+        return None
+
+    timer = QTimer(parent)
+    timer.setInterval(interval_ms)
+    deadline = time.monotonic() + timeout_s
+
+    def poll():
+        try:
+            ready = predicate()
+        except Exception:
+            timer.stop()
+            raise
+        if ready:
+            timer.stop()
+            on_ready()
+        elif time.monotonic() > deadline:
+            timer.stop()
+            if on_timeout is None:
+                raise RuntimeError(f"timed out after {timeout_s}s waiting for {getattr(predicate, '__doc__', None) or predicate}")
+            on_timeout()
+
+    timer.timeout.connect(poll)
+    timer.start()
+    return timer
+
+
+# --------------------------------------------------------------------------------------------
+# making a widget worth pointing at
+# --------------------------------------------------------------------------------------------
+
+
+def ancestors(widget):
+    """Every widget above ``widget``, innermost first."""
+    found = []
+    parent = widget.parentWidget()
+    while parent is not None:
+        found.append(parent)
+        parent = parent.parentWidget()
+    return found
+
+
+def ensure_visible(widget):
+    """Do whatever it takes to bring ``widget`` into view, and report whether it worked.
+
+    A tutorial points at things, so a target that is on an unselected tab, inside a collapsed
+    group box, or scrolled past is not merely awkward - its geometry is stale or empty, and the
+    spotlight would be drawn somewhere meaningless. This reveals it the way a user would: select
+    the tab it is on, expand the section it is in, scroll to it.
+
+    Revealing runs outermost-first, because an inner tab bar does not have a usable geometry until
+    the outer tab holding it has been selected. Scrolling is left until last for the same reason:
+    where a widget sits inside a scroll area is only known once everything around it is shown.
+    """
+    chain = list(reversed(ancestors(widget)))
+    scroll_areas = []
+
+    for ancestor in chain:
+        if isinstance(ancestor, QTabWidget):
+            _select_page_containing(ancestor, widget, ancestor.setCurrentIndex)
+        elif isinstance(ancestor, QStackedWidget):
+            _select_page_containing(ancestor, widget, ancestor.setCurrentIndex)
+        elif isinstance(ancestor, QGroupBox) and ancestor.isCheckable() and not ancestor.isChecked():
+            # collapsible sections are built this way throughout Mantid's interfaces: the group box
+            # is checkable and its contents are hidden while it is unchecked
+            ancestor.setChecked(True)
+        elif isinstance(ancestor, QAbstractScrollArea):
+            scroll_areas.append(ancestor)
+
+    process_events()
+
+    for area in scroll_areas:
+        if isinstance(area, QScrollArea):
+            area.ensureWidgetVisible(widget)
+    process_events()
+
+    return widget.isVisible()
+
+
+def _select_page_containing(container, widget, select):
+    for index in range(container.count()):
+        page = container.widget(index)
+        if page is widget or page.isAncestorOf(widget):
+            select(index)
+            return True
+    return False
+
+
+def process_events(rounds=1):
+    """Drain the Qt event queue.
+
+    Several rounds are sometimes needed because handlers post further events - a queued signal
+    whose slot emits another queued signal. Use this to let a layout catch up before measuring it;
+    use ``wait_for`` for anything that takes real time.
+    """
+    for _ in range(rounds):
+        QApplication.processEvents(QEventLoop.AllEvents, 20)
+
+
+# --------------------------------------------------------------------------------------------
+# driving widgets
+# --------------------------------------------------------------------------------------------
+
+
+def click(button):
+    """Press a button, visibly. **Completes asynchronously.**
+
+    ``animateClick`` rather than ``click`` because a tutorial is watched: it draws the button held
+    down for about 100 ms, so the user sees *which* button the tour pressed rather than only its
+    consequences. The cost is that ``clicked`` is emitted at the end of that animation, so nothing
+    the press causes has happened when this returns. Steps absorb that in ``settle_ms``; anything
+    that must observe the result should go through ``wait_for``.
+
+    Use ``set_check_state`` for a button whose *state* matters - it cannot afford this delay.
+    """
+    if not isinstance(button, QAbstractButton):
+        raise TypeError(f"click expects a button, got {type(button).__name__}")
+    if not button.isEnabled():
+        raise RuntimeError(f"'{button.objectName() or button.text()}' is disabled, so the tutorial cannot press it")
+    button.animateClick()
+    process_events()
+
+
+def set_check_state(button, checked):
+    """Put a check box, radio button or checkable group box into a known state.
+
+    Synchronous, unlike ``click``: the caller asked for a state rather than for a press, so the
+    state has to hold by the time this returns - both for the caller's next line and for the
+    assertion below, which is what turns "the interface ignored us" into an error here rather than
+    a puzzling absence of output several steps later. The visible press is given up to get that.
+    """
+    if button.isChecked() == checked:
+        return button.isChecked()
+    if isinstance(button, QGroupBox):
+        # a group box's indicator is a sub-control of its frame with no dependable hot spot, and
+        # handlers watch ``toggled``, which setChecked emits
+        button.setChecked(checked)
+    else:
+        # click() rather than setChecked() so that handlers connected to ``clicked`` - not only
+        # those on ``toggled`` - run, as they would for a user
+        button.click()
+    process_events()
+    if button.isChecked() != checked:
+        raise RuntimeError(f"'{button.objectName() or _button_text(button)}' is {button.isChecked()} after asking for {checked}")
+    return button.isChecked()
+
+
+def _button_text(button):
+    return button.title() if isinstance(button, QGroupBox) else button.text()
+
+
+def select_combo(combo, text):
+    """Select a combo entry by the text the user reads.
+
+    ``setCurrentText`` on a non-editable combo leaves the selection untouched when the text is not
+    among the items, which would leave the tutorial narrating a choice it never made.
+    """
+    index = combo.findText(text)
+    if index < 0:
+        raise ValueError(f"'{text}' is not in the combo box; available: {combo_items(combo)}")
+    combo.setCurrentIndex(index)
+    process_events()
+    return index
+
+
+def combo_items(combo):
+    return [combo.itemText(index) for index in range(combo.count())]
+
+
+def select_tab(tab_widget, title):
+    """Make a tab current by its title.
+
+    By title rather than index because indices move: interfaces add tabs conditionally, and a
+    tutorial written against index 2 would quietly start describing the wrong page.
+    """
+    for index in range(tab_widget.count()):
+        if tab_widget.tabText(index) == title:
+            tab_widget.setCurrentIndex(index)
+            process_events()
+            return tab_widget.widget(index)
+    available = [tab_widget.tabText(index) for index in range(tab_widget.count())]
+    raise ValueError(f"no tab titled '{title}'; found {available}")
+
+
+def set_text(line_edit, text):
+    """Put text into a line edit as though it had been typed.
+
+    ``setText`` emits ``textChanged`` and nothing else, so an interface that reacts to
+    ``textEdited``, ``editingFinished`` or ``returnPressed`` - and Mantid's interfaces react to all
+    three - would not notice. Emitting them explicitly is what makes the interface respond as it
+    would for a user, without replaying keystrokes through ``QtTest``.
+    """
+    if not isinstance(line_edit, QLineEdit):
+        raise TypeError(f"set_text expects a QLineEdit, got {type(line_edit).__name__}")
+    text = str(text)
+    line_edit.setText(text)
+    line_edit.textEdited.emit(text)
+    line_edit.editingFinished.emit()
+    line_edit.returnPressed.emit()
+    process_events()
+    return line_edit.text()
+
+
+def set_spin_box(spin_box, value):
+    """Set a spin box, checking the value survived.
+
+    Spin boxes clamp to their range and round to their number of decimals silently, so a tutorial
+    that asked for an out-of-range value would go on to describe a result the interface never
+    produced.
+    """
+    spin_box.setValue(value)
+    process_events()
+    if spin_box.value() != value:
+        raise ValueError(
+            f"spin box '{spin_box.objectName() or spin_box}' holds {spin_box.value()} after asking for {value}; "
+            f"its range is {spin_box.minimum()} to {spin_box.maximum()}"
+        )
+    return spin_box.value()
+
+
+def widget_of_type(parent, widget_type, name=""):
+    """One child widget, found by type and optionally object name.
+
+    For the widgets a tutorial wants to point at that are built in code rather than named in a
+    ``.ui`` file - a matplotlib canvas dropped into a placeholder, a toolbar's buttons.
+    """
+    found = parent.findChildren(widget_type, name) if name else parent.findChildren(widget_type)
+    if not found:
+        raise ValueError(f"no {widget_type.__name__}{f' named {name!r}' if name else ''} under {parent.objectName() or parent}")
+    return found[0]
+
+
+def is_shown(widget):
+    """Whether a widget is really on screen, not merely constructed.
+
+    ``isVisible`` is False for everything while the window itself is hidden, so this is the check a
+    tutorial wants when deciding whether it can point at something.
+    """
+    return isinstance(widget, QWidget) and widget.isVisible() and not widget.visibleRegion().isEmpty()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
@@ -46,8 +46,23 @@ POLL_INTERVAL_MS = 100
 
 
 # --------------------------------------------------------------------------------------------
-# waiting
+# the event loop
+#
+# Nothing else in this module works without these two: every helper below drains the queue after
+# it touches a widget, because what a tutorial does next is measured against a layout that has to
+# have caught up first.
 # --------------------------------------------------------------------------------------------
+
+
+def process_events(rounds=1):
+    """Drain the Qt event queue.
+
+    Several rounds are sometimes needed because handlers post further events - a queued signal
+    whose slot emits another queued signal. Use this to let a layout catch up before measuring it;
+    use ``wait_for`` for anything that takes real time.
+    """
+    for _ in range(rounds):
+        QApplication.processEvents(QEventLoop.AllEvents, 20)
 
 
 def wait_for(predicate, on_ready, timeout_s, on_timeout=None, interval_ms=POLL_INTERVAL_MS, parent=None):
@@ -133,15 +148,18 @@ def ensure_visible(widget):
     scroll_areas = []
 
     for node in chain:
-        if node is not widget and isinstance(node, (QTabWidget, QStackedWidget)):
-            # only for ancestors: switching the page of a tab widget the step is pointing *at*
-            # would move the interface for a step that is describing the tab bar itself
-            _select_page_containing(node, widget, node.setCurrentIndex)
+        # a container is only opened up when the target is *inside* it. Doing it to the target
+        # itself would move the interface out from under a step that is describing that very
+        # container - switching the page of the tab widget it is pointing at, say. The one
+        # exception is a collapsed group box, which has to be opened to show anything at all.
+        is_ancestor = node is not widget
+        if is_ancestor and isinstance(node, (QTabWidget, QStackedWidget)):
+            _select_page_containing(node, widget)
         elif isinstance(node, QGroupBox) and node.isCheckable() and not node.isChecked():
             # collapsible sections are built this way throughout Mantid's interfaces: the group box
             # is checkable and its contents are hidden while it is unchecked
             node.setChecked(True)
-        elif node is not widget and isinstance(node, QAbstractScrollArea):
+        elif is_ancestor and isinstance(node, QAbstractScrollArea):
             scroll_areas.append(node)
 
     process_events()
@@ -154,24 +172,13 @@ def ensure_visible(widget):
     return widget.isVisible()
 
 
-def _select_page_containing(container, widget, select):
+def _select_page_containing(container, widget):
+    """Bring the page holding ``widget`` to the front of a tab or stacked widget."""
     for index in range(container.count()):
         page = container.widget(index)
         if page is widget or page.isAncestorOf(widget):
-            select(index)
-            return True
-    return False
-
-
-def process_events(rounds=1):
-    """Drain the Qt event queue.
-
-    Several rounds are sometimes needed because handlers post further events - a queued signal
-    whose slot emits another queued signal. Use this to let a layout catch up before measuring it;
-    use ``wait_for`` for anything that takes real time.
-    """
-    for _ in range(rounds):
-        QApplication.processEvents(QEventLoop.AllEvents, 20)
+            container.setCurrentIndex(index)
+            return
 
 
 # --------------------------------------------------------------------------------------------

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
@@ -115,31 +115,35 @@ def ancestors(widget):
 
 
 def ensure_visible(widget):
-    """Do whatever it takes to bring ``widget`` into view, and report whether it worked.
+    """Do whatever it takes to bring ``widget`` and its contents into view.
 
     A tutorial points at things, so a target that is on an unselected tab, inside a collapsed
     group box, or scrolled past is not merely awkward - its geometry is stale or empty, and the
     spotlight would be drawn somewhere meaningless. This reveals it the way a user would: select
     the tab it is on, expand the section it is in, scroll to it.
 
+    A target that is *itself* a collapsed section is opened too. Pointing at a closed group box
+    while describing what is inside it - or while setting one of the values inside it - shows the
+    user a shut box and nothing else.
+
     Revealing runs outermost-first, because an inner tab bar does not have a usable geometry until
     the outer tab holding it has been selected. Scrolling is left until last for the same reason:
     where a widget sits inside a scroll area is only known once everything around it is shown.
     """
-    chain = list(reversed(ancestors(widget)))
+    chain = list(reversed(ancestors(widget))) + [widget]
     scroll_areas = []
 
-    for ancestor in chain:
-        if isinstance(ancestor, QTabWidget):
-            _select_page_containing(ancestor, widget, ancestor.setCurrentIndex)
-        elif isinstance(ancestor, QStackedWidget):
-            _select_page_containing(ancestor, widget, ancestor.setCurrentIndex)
-        elif isinstance(ancestor, QGroupBox) and ancestor.isCheckable() and not ancestor.isChecked():
+    for node in chain:
+        if node is not widget and isinstance(node, (QTabWidget, QStackedWidget)):
+            # only for ancestors: switching the page of a tab widget the step is pointing *at*
+            # would move the interface for a step that is describing the tab bar itself
+            _select_page_containing(node, widget, node.setCurrentIndex)
+        elif isinstance(node, QGroupBox) and node.isCheckable() and not node.isChecked():
             # collapsible sections are built this way throughout Mantid's interfaces: the group box
             # is checkable and its contents are hidden while it is unchecked
-            ancestor.setChecked(True)
-        elif isinstance(ancestor, QAbstractScrollArea):
-            scroll_areas.append(ancestor)
+            node.setChecked(True)
+        elif node is not widget and isinstance(node, QAbstractScrollArea):
+            scroll_areas.append(node)
 
     process_events()
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/interaction.py
@@ -177,21 +177,26 @@ def process_events(rounds=1):
 
 
 def click(button):
-    """Press a button, visibly. **Completes asynchronously.**
+    """Press a button, visibly, and synchronously.
 
-    ``animateClick`` rather than ``click`` because a tutorial is watched: it draws the button held
-    down for about 100 ms, so the user sees *which* button the tour pressed rather than only its
-    consequences. The cost is that ``clicked`` is emitted at the end of that animation, so nothing
-    the press causes has happened when this returns. Steps absorb that in ``settle_ms``; anything
-    that must observe the result should go through ``wait_for``.
+    The button is drawn held down and the display flushed before the click is delivered, so the
+    user sees *which* button the tour pressed rather than only its consequences.
 
-    Use ``set_check_state`` for a button whose *state* matters - it cannot afford this delay.
+    Deliberately not ``animateClick``, which looks better and is not safe here: it releases the
+    button from a timer about 100 ms later, so the press can still be pending after the tour has
+    moved on - or after the tour has ended and the interface it belonged to has been torn down.
+    The handler then runs against workspaces that no longer exist. Everything the tour does has to
+    have finished happening by the time the step is over, and a deferred click does not.
     """
     if not isinstance(button, QAbstractButton):
         raise TypeError(f"click expects a button, got {type(button).__name__}")
     if not button.isEnabled():
         raise RuntimeError(f"'{button.objectName() or button.text()}' is disabled, so the tutorial cannot press it")
-    button.animateClick()
+    button.setDown(True)
+    button.repaint()
+    process_events()
+    button.setDown(False)
+    button.click()
     process_events()
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -18,13 +18,13 @@ makes starting a chapter partway through possible - the interface is rebuilt and
 than unwound.
 """
 
-from qtpy.QtCore import QObject, QSettings, Qt, Signal
-from qtpy.QtWidgets import QDialog, QDialogButtonBox, QLabel, QListWidget, QListWidgetItem, QVBoxLayout
+from qtpy.QtCore import QObject, QSettings, Signal
 
 from mantidqt.utils.qt.qsettings_change_aware import QSettingsChangeAware
 from mantidqt.widgets.tutorial.bubble import TutorialBubble
 from mantidqt.widgets.tutorial.overlay import TutorialOverlay
 from mantidqt.widgets.tutorial.player import TutorialPlayer
+from mantidqt.widgets.tutorial.shell import TutorialShell
 
 # tutorial preferences live beside the interfaces' own settings, under their own key, so an
 # interface's tutorial state is stored the same way as the rest of its state
@@ -73,43 +73,6 @@ def mark_seen(settings_key, settings=None):
 
 
 # ------------------------------------------------------------------------------------------------
-# chapter picker
-# ------------------------------------------------------------------------------------------------
-
-
-class ChapterPicker(QDialog):
-    """Lets the user choose where to start. Modal, because the tour behind it is about to be
-    rebuilt underneath whatever they pick."""
-
-    def __init__(self, chapters, parent=None, current=0):
-        super().__init__(parent)
-        self.setWindowTitle("Tutorial chapters")
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
-        self.setModal(True)
-
-        self._list = QListWidget()
-        for chapter in chapters:
-            item = QListWidgetItem(chapter.name)
-            if chapter.description:
-                item.setToolTip(chapter.description)
-            self._list.addItem(item)
-        self._list.setCurrentRow(max(0, min(current, len(chapters) - 1)))
-        self._list.itemDoubleClicked.connect(lambda _item: self.accept())
-
-        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-
-        layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Start the tutorial from:"))
-        layout.addWidget(self._list)
-        layout.addWidget(buttons)
-
-    def chosen_chapter(self):
-        return self._list.currentRow()
-
-
-# ------------------------------------------------------------------------------------------------
 # the session
 # ------------------------------------------------------------------------------------------------
 
@@ -124,14 +87,16 @@ class TutorialSession(QObject):
 
     finished = Signal()
 
-    def __init__(self, sandbox_factory, chapters, parent=None, settings_key=None):
+    def __init__(self, sandbox_factory, chapters, parent=None, settings_key=None, title=""):
         super().__init__(parent)
         self._factory = sandbox_factory
         self._chapters = tuple(chapters)
         self._parent = parent
         self._settings_key = settings_key
+        self._title = title
 
         self._sandbox = None
+        self._shell = None
         self._overlay = None
         self._bubble = None
         self._player = None
@@ -149,7 +114,13 @@ class TutorialSession(QObject):
         return self._player
 
     @property
+    def shell(self):
+        """The tutorial window: the interface framed by the chapter tabs and navigation."""
+        return self._shell
+
+    @property
     def window(self):
+        """The interface being toured. Its window is the shell around it - see ``shell``."""
         return None if self._sandbox is None else self._sandbox.window
 
     def start(self, chapter_index=0):
@@ -158,14 +129,23 @@ class TutorialSession(QObject):
     # ------------------------------------------------------------------ building and tearing down
 
     def _build(self, chapter_index, fast_forward):
+        geometry = self._shell.geometry() if self._shell is not None else None
         self._tear_down_sandbox()
 
         self._sandbox = self._factory()
-        window = self._sandbox.window
-        window.show()
+        interface = self._sandbox.window
 
-        self._overlay = TutorialOverlay(window)
-        self._bubble = TutorialBubble(window)
+        # the shell takes the interface as a child, so it must be built before anything is shown -
+        # the overlay measures against an interface that is already in its final place
+        self._shell = TutorialShell(self._chapters, interface, parent=self._parent, title=self._title)
+        if geometry is not None:
+            # a chapter jump rebuilds everything; reusing the geometry keeps the window where the
+            # user put it instead of snapping back on every tab click
+            self._shell.setGeometry(geometry)
+        self._shell.show()
+
+        self._overlay = TutorialOverlay(interface)
+        self._bubble = TutorialBubble(interface)
         self._overlay.show()
         self._bubble.show()
         self._bubble.raise_()
@@ -173,17 +153,18 @@ class TutorialSession(QObject):
         self._player = TutorialPlayer(self._chapters, self._sandbox, self._overlay, self._bubble, parent=self)
         self._player.finished.connect(self._on_player_finished)
         self._player.step_failed.connect(self._on_step_failed)
+        self._player.step_changed.connect(self._on_step_changed)
+        self._player.busy_changed.connect(self._on_busy_changed)
 
-        self._bubble.next_requested.connect(self._player.next_step)
-        self._bubble.back_requested.connect(self._player.back_step)
-        self._bubble.pause_toggled.connect(self._player.set_paused)
-        self._bubble.chapters_requested.connect(self._choose_chapter)
-        self._bubble.close_requested.connect(self.close)
+        self._shell.next_requested.connect(self._player.next_step)
+        self._shell.back_requested.connect(self._player.back_step)
+        self._shell.chapter_selected.connect(self._on_chapter_selected)
+        self._shell.close_requested.connect(self.close)
 
-        # the user closing the sandbox window is the same as ending the tour: there would be
-        # nothing left to point at
-        window.destroyed.connect(self._on_window_destroyed)
+        # the user closing the tutorial window is the same as ending the tour
+        self._shell.destroyed.connect(self._on_window_destroyed)
 
+        self._shell.set_current_chapter(chapter_index)
         self._player.start(chapter_index, fast_forward=fast_forward)
 
     def _tear_down_sandbox(self):
@@ -198,26 +179,30 @@ class TutorialSession(QObject):
                 decoration.setParent(None)
                 decoration.deleteLater()
         self._overlay = self._bubble = None
+        if self._shell is not None:
+            shell, self._shell = self._shell, None
+            # stop listening to the shell being discarded before discarding it. Deletion is
+            # deferred, so on a chapter jump the old shell's ``destroyed`` would arrive *after* the
+            # replacement was built and would tear the whole session down again
+            try:
+                shell.destroyed.disconnect(self._on_window_destroyed)
+            except (RuntimeError, TypeError):
+                pass  # already disconnected, or the shell is gone
+            # hand the interface back before the shell goes, or destroying the shell would take its
+            # child with it and the closeEvent that cleans the interface up would never run
+            shell.release_interface()
+            shell.close()
+            shell.deleteLater()
         if self._sandbox is not None:
             sandbox, self._sandbox = self._sandbox, None
             sandbox.teardown()
 
     # ------------------------------------------------------------------ user actions
 
-    def _choose_chapter(self):
-        if self._player is not None:
-            self._player.set_paused(True)
-            self._bubble.set_paused(True)
-        picker = ChapterPicker(self._chapters, parent=self.window, current=self._player.position[0])
-        if picker.exec_() != QDialog.Accepted:
-            if self._player is not None:
-                self._player.set_paused(False)
-                self._bubble.set_paused(False)
-            return
-        chosen = picker.chosen_chapter()
+    def _on_chapter_selected(self, chapter_index):
         # always rebuilt, even going forwards: a chapter's steps assume the state the chapters
         # before it leave behind, and only a fresh run produces that reliably
-        self._build(chosen, fast_forward=chosen > 0)
+        self._build(chapter_index, fast_forward=chapter_index > 0)
 
     def close(self):
         """End the tour and close the interface it was touring."""
@@ -229,27 +214,44 @@ class TutorialSession(QObject):
 
     # ------------------------------------------------------------------ player callbacks
 
+    def _on_step_changed(self, chapter_index, step_index):
+        if self._shell is None:
+            return
+        chapter = self._chapters[chapter_index]
+        self._shell.show_position(chapter_index, step_index + 1, len(chapter))
+        self._shell.set_navigation_enabled(
+            back=not self._player.at_start(),
+            next_=True,
+        )
+
+    def _on_busy_changed(self, busy, message):
+        if self._shell is not None:
+            self._shell.set_busy(busy, message)
+
     def _on_player_finished(self):
         if self._bubble is not None:
             self._bubble.show_step(
-                "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it.",
+                "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it. "
+                "Use the tabs above to revisit a chapter.",
                 title="Finished",
             )
             self._bubble.place_beside(None)
-            self._bubble.set_navigation_enabled(back=True, next_=False)
         if self._overlay is not None:
             self._overlay.set_target(None)
+        if self._shell is not None:
+            self._shell.show_finished()
 
     def _on_step_failed(self, label, reason):
         self._failures.append((label, reason))
 
     def _on_window_destroyed(self, *_args):
         # the window has already gone, so there is nothing left to tear down but the bookkeeping
+        self._shell = None
         self._sandbox = None
         self.close()
 
 
-def run_tutorial(sandbox_factory, chapters, parent=None, settings_key=None, mark_as_seen=False):
+def run_tutorial(sandbox_factory, chapters, parent=None, settings_key=None, mark_as_seen=False, title=""):
     """Start a tutorial and return its session.
 
     :param sandbox_factory: called with no arguments; must return an object with a ``window``
@@ -261,12 +263,13 @@ def run_tutorial(sandbox_factory, chapters, parent=None, settings_key=None, mark
     :param settings_key: the interface's settings key, e.g. ``"TexturePlanner"``.
     :param mark_as_seen: record that the tutorial has now been offered. True when it appeared by
         itself on startup; False when the user asked for it, which should not change anything.
+    :param title: window title for the tutorial.
 
     Keep the returned session alive for as long as the tour runs - it owns the sandbox window, and
     letting it be collected would take the tour down with it.
     """
     if mark_as_seen and settings_key:
         mark_seen(settings_key)
-    session = TutorialSession(sandbox_factory, chapters, parent=parent, settings_key=settings_key)
+    session = TutorialSession(sandbox_factory, chapters, parent=parent, settings_key=settings_key, title=title)
     session.start()
     return session

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -154,10 +154,12 @@ class TutorialSession(QObject):
         self._player.finished.connect(self._on_player_finished)
         self._player.step_failed.connect(self._on_step_failed)
         self._player.step_changed.connect(self._on_step_changed)
+        self._player.step_applied.connect(self._on_step_applied)
         self._player.busy_changed.connect(self._on_busy_changed)
 
         self._shell.next_requested.connect(self._player.next_step)
         self._shell.back_requested.connect(self._player.back_step)
+        self._shell.apply_requested.connect(self._player.apply_step)
         self._shell.chapter_selected.connect(self._on_chapter_selected)
         self._shell.close_requested.connect(self.close)
 
@@ -223,6 +225,11 @@ class TutorialSession(QObject):
             back=not self._player.at_start(),
             next_=True,
         )
+        self._shell.set_action_available(self._player.current_step_has_action(), self._player.is_applied())
+
+    def _on_step_applied(self):
+        if self._shell is not None:
+            self._shell.set_action_available(self._player.current_step_has_action(), self._player.is_applied())
 
     def _on_busy_changed(self, busy, message):
         if self._shell is not None:

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -29,6 +29,14 @@ from mantidqt.widgets.tutorial.shell import TutorialShell
 # interface's tutorial state is stored the same way as the rest of its state
 SETTINGS_GROUP = "CustomInterfaces"
 
+# what the caption says once the last step has been shown. Here rather than inline because it is
+# the one piece of user-facing prose the framework supplies itself - every other word in a tour
+# comes from the interface being toured.
+FINISHED_TEXT = (
+    "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it. "
+    "Use the tabs above to revisit a chapter."
+)
+
 
 # ------------------------------------------------------------------------------------------------
 # "have they seen it?"
@@ -152,6 +160,17 @@ class TutorialSession(QObject):
         self._annotator.show()
 
         self._player = TutorialPlayer(self._chapters, self._sandbox, self._annotator, parent=self)
+        self._wire_up()
+
+        self._shell.set_current_chapter(chapter_index)
+        self._player.start(chapter_index, fast_forward=fast_forward)
+
+    def _wire_up(self):
+        """Connect the shell and the player to each other, through this session.
+
+        They never speak directly: the shell reports what the user pressed, the player reports what
+        the tour did, and everything either of them means for the other is decided here.
+        """
         self._player.finished.connect(self._on_player_finished)
         self._player.step_failed.connect(self._on_step_failed)
         self._player.step_changed.connect(self._on_step_changed)
@@ -164,11 +183,8 @@ class TutorialSession(QObject):
         self._shell.chapter_selected.connect(self._on_chapter_selected)
         self._shell.close_requested.connect(self.close)
 
-        # the user closing the tutorial window is the same as ending the tour
+        # the user closing or destroying the tutorial window is the same as ending the tour
         self._shell.destroyed.connect(self._on_window_destroyed)
-
-        self._shell.set_current_chapter(chapter_index)
-        self._player.start(chapter_index, fast_forward=fast_forward)
 
     def _tear_down_sandbox(self):
         if self._player is not None:
@@ -238,11 +254,7 @@ class TutorialSession(QObject):
     def _on_player_finished(self):
         if self._annotator is not None:
             self._annotator.set_target(None)
-            self._annotator.show_step(
-                "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it. "
-                "Use the tabs above to revisit a chapter.",
-                title="Finished",
-            )
+            self._annotator.show_step(FINISHED_TEXT, title="Finished")
             self._annotator.place_beside(None)
         if self._shell is not None:
             self._shell.show_finished()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -21,8 +21,7 @@ than unwound.
 from qtpy.QtCore import QObject, QSettings, Signal
 
 from mantidqt.utils.qt.qsettings_change_aware import QSettingsChangeAware
-from mantidqt.widgets.tutorial.bubble import TutorialBubble
-from mantidqt.widgets.tutorial.overlay import TutorialOverlay
+from mantidqt.widgets.tutorial.annotator import TutorialAnnotator
 from mantidqt.widgets.tutorial.player import TutorialPlayer
 from mantidqt.widgets.tutorial.shell import TutorialShell
 
@@ -97,8 +96,7 @@ class TutorialSession(QObject):
 
         self._sandbox = None
         self._shell = None
-        self._overlay = None
-        self._bubble = None
+        self._annotator = None
         self._player = None
         self._failures = []
         self._closing = False
@@ -112,6 +110,11 @@ class TutorialSession(QObject):
     @property
     def player(self):
         return self._player
+
+    @property
+    def annotator(self):
+        """The spotlight and caption, wherever the tour is currently pointing."""
+        return self._annotator
 
     @property
     def shell(self):
@@ -144,13 +147,12 @@ class TutorialSession(QObject):
             self._shell.setGeometry(geometry)
         self._shell.show()
 
-        self._overlay = TutorialOverlay(interface)
-        self._bubble = TutorialBubble(interface)
-        self._overlay.show()
-        self._bubble.show()
-        self._bubble.raise_()
+        # one annotator, however many windows the tour ends up pointing into - a settings dialog
+        # is a window of its own, and its widgets cannot be spotlighted from the interface's overlay
+        self._annotator = TutorialAnnotator(interface, parent=self)
+        self._annotator.show()
 
-        self._player = TutorialPlayer(self._chapters, self._sandbox, self._overlay, self._bubble, parent=self)
+        self._player = TutorialPlayer(self._chapters, self._sandbox, self._annotator, self._annotator, parent=self)
         self._player.finished.connect(self._on_player_finished)
         self._player.step_failed.connect(self._on_step_failed)
         self._player.step_changed.connect(self._on_step_changed)
@@ -174,13 +176,10 @@ class TutorialSession(QObject):
             self._player.stop()
             self._player.deleteLater()
             self._player = None
-        for decoration in (self._overlay, self._bubble):
-            if decoration is not None:
-                if hasattr(decoration, "detach"):
-                    decoration.detach()
-                decoration.setParent(None)
-                decoration.deleteLater()
-        self._overlay = self._bubble = None
+        if self._annotator is not None:
+            self._annotator.detach()
+            self._annotator.deleteLater()
+            self._annotator = None
         if self._shell is not None:
             shell, self._shell = self._shell, None
             # stop listening to the shell being discarded before discarding it. Deletion is
@@ -236,15 +235,14 @@ class TutorialSession(QObject):
             self._shell.set_busy(busy, message)
 
     def _on_player_finished(self):
-        if self._bubble is not None:
-            self._bubble.show_step(
+        if self._annotator is not None:
+            self._annotator.set_target(None)
+            self._annotator.show_step(
                 "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it. "
                 "Use the tabs above to revisit a chapter.",
                 title="Finished",
             )
-            self._bubble.place_beside(None)
-        if self._overlay is not None:
-            self._overlay.set_target(None)
+            self._annotator.place_beside(None)
         if self._shell is not None:
             self._shell.show_finished()
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -182,9 +182,11 @@ class TutorialSession(QObject):
             self._annotator = None
         if self._shell is not None:
             shell, self._shell = self._shell, None
-            # stop listening to the shell being discarded before discarding it. Deletion is
-            # deferred, so on a chapter jump the old shell's ``destroyed`` would arrive *after* the
-            # replacement was built and would tear the whole session down again
+            # stop listening to the shell before discarding it. It reports both being closed and
+            # being destroyed as the end of the tour, and on a chapter jump - which tears the old
+            # shell down to build a new one - either would arrive after the replacement exists and
+            # take the whole session down with it
+            shell.blockSignals(True)
             try:
                 shell.destroyed.disconnect(self._on_window_destroyed)
             except (RuntimeError, TypeError):

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -86,12 +86,11 @@ class TutorialSession(QObject):
 
     finished = Signal()
 
-    def __init__(self, sandbox_factory, chapters, parent=None, settings_key=None, title=""):
+    def __init__(self, sandbox_factory, chapters, parent=None, title=""):
         super().__init__(parent)
         self._factory = sandbox_factory
         self._chapters = tuple(chapters)
         self._parent = parent
-        self._settings_key = settings_key
         self._title = title
 
         self._sandbox = None
@@ -277,6 +276,6 @@ def run_tutorial(sandbox_factory, chapters, parent=None, settings_key=None, mark
     """
     if mark_as_seen and settings_key:
         mark_seen(settings_key)
-    session = TutorialSession(sandbox_factory, chapters, parent=parent, settings_key=settings_key, title=title)
+    session = TutorialSession(sandbox_factory, chapters, parent=parent, title=title)
     session.start()
     return session

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -152,7 +152,7 @@ class TutorialSession(QObject):
         self._annotator = TutorialAnnotator(interface, parent=self)
         self._annotator.show()
 
-        self._player = TutorialPlayer(self._chapters, self._sandbox, self._annotator, self._annotator, parent=self)
+        self._player = TutorialPlayer(self._chapters, self._sandbox, self._annotator, parent=self)
         self._player.finished.connect(self._on_player_finished)
         self._player.step_failed.connect(self._on_step_failed)
         self._player.step_changed.connect(self._on_step_changed)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/launcher.py
@@ -1,0 +1,272 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""Starting and owning a tutorial - the part an interface actually calls.
+
+An interface adds a tour with ``run_tutorial``, giving it a factory for the window to tour and a
+list of chapters. Everything else - the overlay, the caption, the sequencing, cleaning up
+afterwards - is handled here.
+
+**The tour drives its own copy of the interface, never the user's.** The factory builds a fresh
+window, and the session closes it at the end. That is what makes a tour safe to run at any moment:
+it cannot type into a form the user was halfway through, and it cannot delete their data. It also
+makes starting a chapter partway through possible - the interface is rebuilt and caught up rather
+than unwound.
+"""
+
+from qtpy.QtCore import QObject, QSettings, Qt, Signal
+from qtpy.QtWidgets import QDialog, QDialogButtonBox, QLabel, QListWidget, QListWidgetItem, QVBoxLayout
+
+from mantidqt.utils.qt.qsettings_change_aware import QSettingsChangeAware
+from mantidqt.widgets.tutorial.bubble import TutorialBubble
+from mantidqt.widgets.tutorial.overlay import TutorialOverlay
+from mantidqt.widgets.tutorial.player import TutorialPlayer
+
+# tutorial preferences live beside the interfaces' own settings, under their own key, so an
+# interface's tutorial state is stored the same way as the rest of its state
+SETTINGS_GROUP = "CustomInterfaces"
+
+
+# ------------------------------------------------------------------------------------------------
+# "have they seen it?"
+# ------------------------------------------------------------------------------------------------
+
+
+def _seen_key(settings_key):
+    return f"{settings_key}/tutorial_seen"
+
+
+def should_show_on_startup(settings_key, settings=None):
+    """Whether the tutorial has yet to be shown automatically for ``settings_key``.
+
+    QSettings coerces a value it cannot parse to False rather than raising, which for this flag
+    would mean showing the tour again to someone who has already seen it. Reading it as a string
+    and comparing explicitly avoids trusting that coercion.
+    """
+    settings = QSettings() if settings is None else settings
+    settings.beginGroup(SETTINGS_GROUP)
+    try:
+        stored = settings.value(_seen_key(settings_key), defaultValue="", type=str)
+    finally:
+        settings.endGroup()
+    return str(stored).lower() != "true"
+
+
+def mark_seen(settings_key, settings=None):
+    """Record that the tutorial has been shown, so it does not appear unbidden again.
+
+    Called when the tour is *offered*, not when it is completed: a user who closes it immediately
+    has made their decision, and a tour that kept coming back until finished would be a nuisance.
+    The toolbar button is what makes that safe - the tour stays available, it just stops
+    interrupting.
+    """
+    settings = QSettings() if settings is None else settings
+    settings.beginGroup(SETTINGS_GROUP)
+    try:
+        QSettingsChangeAware(settings).setValue(_seen_key(settings_key), "true")
+    finally:
+        settings.endGroup()
+
+
+# ------------------------------------------------------------------------------------------------
+# chapter picker
+# ------------------------------------------------------------------------------------------------
+
+
+class ChapterPicker(QDialog):
+    """Lets the user choose where to start. Modal, because the tour behind it is about to be
+    rebuilt underneath whatever they pick."""
+
+    def __init__(self, chapters, parent=None, current=0):
+        super().__init__(parent)
+        self.setWindowTitle("Tutorial chapters")
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.setModal(True)
+
+        self._list = QListWidget()
+        for chapter in chapters:
+            item = QListWidgetItem(chapter.name)
+            if chapter.description:
+                item.setToolTip(chapter.description)
+            self._list.addItem(item)
+        self._list.setCurrentRow(max(0, min(current, len(chapters) - 1)))
+        self._list.itemDoubleClicked.connect(lambda _item: self.accept())
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Start the tutorial from:"))
+        layout.addWidget(self._list)
+        layout.addWidget(buttons)
+
+    def chosen_chapter(self):
+        return self._list.currentRow()
+
+
+# ------------------------------------------------------------------------------------------------
+# the session
+# ------------------------------------------------------------------------------------------------
+
+
+class TutorialSession(QObject):
+    """One run of a tutorial: the sandbox interface, its decoration, and the player driving it.
+
+    Owns the lifecycle the player deliberately does not. Jumping to a chapter rebuilds the sandbox
+    from scratch and fast-forwards to it, which is the only way to reach a chapter's starting state
+    without asking every step to know how to undo itself.
+    """
+
+    finished = Signal()
+
+    def __init__(self, sandbox_factory, chapters, parent=None, settings_key=None):
+        super().__init__(parent)
+        self._factory = sandbox_factory
+        self._chapters = tuple(chapters)
+        self._parent = parent
+        self._settings_key = settings_key
+
+        self._sandbox = None
+        self._overlay = None
+        self._bubble = None
+        self._player = None
+        self._failures = []
+        self._closing = False
+
+    @property
+    def failures(self):
+        """``(step label, reason)`` for every step that could not be performed. A tour that
+        reports none of these is one that still matches the interface."""
+        return list(self._failures)
+
+    @property
+    def player(self):
+        return self._player
+
+    @property
+    def window(self):
+        return None if self._sandbox is None else self._sandbox.window
+
+    def start(self, chapter_index=0):
+        self._build(chapter_index, fast_forward=chapter_index > 0)
+
+    # ------------------------------------------------------------------ building and tearing down
+
+    def _build(self, chapter_index, fast_forward):
+        self._tear_down_sandbox()
+
+        self._sandbox = self._factory()
+        window = self._sandbox.window
+        window.show()
+
+        self._overlay = TutorialOverlay(window)
+        self._bubble = TutorialBubble(window)
+        self._overlay.show()
+        self._bubble.show()
+        self._bubble.raise_()
+
+        self._player = TutorialPlayer(self._chapters, self._sandbox, self._overlay, self._bubble, parent=self)
+        self._player.finished.connect(self._on_player_finished)
+        self._player.step_failed.connect(self._on_step_failed)
+
+        self._bubble.next_requested.connect(self._player.next_step)
+        self._bubble.back_requested.connect(self._player.back_step)
+        self._bubble.pause_toggled.connect(self._player.set_paused)
+        self._bubble.chapters_requested.connect(self._choose_chapter)
+        self._bubble.close_requested.connect(self.close)
+
+        # the user closing the sandbox window is the same as ending the tour: there would be
+        # nothing left to point at
+        window.destroyed.connect(self._on_window_destroyed)
+
+        self._player.start(chapter_index, fast_forward=fast_forward)
+
+    def _tear_down_sandbox(self):
+        if self._player is not None:
+            self._player.stop()
+            self._player.deleteLater()
+            self._player = None
+        for decoration in (self._overlay, self._bubble):
+            if decoration is not None:
+                if hasattr(decoration, "detach"):
+                    decoration.detach()
+                decoration.setParent(None)
+                decoration.deleteLater()
+        self._overlay = self._bubble = None
+        if self._sandbox is not None:
+            sandbox, self._sandbox = self._sandbox, None
+            sandbox.teardown()
+
+    # ------------------------------------------------------------------ user actions
+
+    def _choose_chapter(self):
+        if self._player is not None:
+            self._player.set_paused(True)
+            self._bubble.set_paused(True)
+        picker = ChapterPicker(self._chapters, parent=self.window, current=self._player.position[0])
+        if picker.exec_() != QDialog.Accepted:
+            if self._player is not None:
+                self._player.set_paused(False)
+                self._bubble.set_paused(False)
+            return
+        chosen = picker.chosen_chapter()
+        # always rebuilt, even going forwards: a chapter's steps assume the state the chapters
+        # before it leave behind, and only a fresh run produces that reliably
+        self._build(chosen, fast_forward=chosen > 0)
+
+    def close(self):
+        """End the tour and close the interface it was touring."""
+        if self._closing:
+            return
+        self._closing = True
+        self._tear_down_sandbox()
+        self.finished.emit()
+
+    # ------------------------------------------------------------------ player callbacks
+
+    def _on_player_finished(self):
+        if self._bubble is not None:
+            self._bubble.show_step(
+                "That is the end of the tutorial. Close this window to return to your own session — nothing done here has touched it.",
+                title="Finished",
+            )
+            self._bubble.place_beside(None)
+            self._bubble.set_navigation_enabled(back=True, next_=False)
+        if self._overlay is not None:
+            self._overlay.set_target(None)
+
+    def _on_step_failed(self, label, reason):
+        self._failures.append((label, reason))
+
+    def _on_window_destroyed(self, *_args):
+        # the window has already gone, so there is nothing left to tear down but the bookkeeping
+        self._sandbox = None
+        self.close()
+
+
+def run_tutorial(sandbox_factory, chapters, parent=None, settings_key=None, mark_as_seen=False):
+    """Start a tutorial and return its session.
+
+    :param sandbox_factory: called with no arguments; must return an object with a ``window``
+        attribute (the interface to tour, not yet shown) and a ``teardown()`` method. It is also
+        the context every step receives, so put whatever the steps need to reach - the presenter,
+        the model, a temporary directory - on it.
+    :param chapters: the ``TutorialChapter`` list to play.
+    :param parent: the widget the tour belongs to, usually the user's own interface window.
+    :param settings_key: the interface's settings key, e.g. ``"TexturePlanner"``.
+    :param mark_as_seen: record that the tutorial has now been offered. True when it appeared by
+        itself on startup; False when the user asked for it, which should not change anything.
+
+    Keep the returned session alive for as long as the tour runs - it owns the sandbox window, and
+    letting it be collected would take the tour down with it.
+    """
+    if mark_as_seen and settings_key:
+        mark_seen(settings_key)
+    session = TutorialSession(sandbox_factory, chapters, parent=parent, settings_key=settings_key)
+    session.start()
+    return session

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
@@ -28,6 +28,13 @@ CORNER_RADIUS = 6
 # around the widget rather than clipping its edge
 PADDING = 4
 
+# how opaque the dimming is, out of 255. Dark enough to push the rest of the interface back
+# without hiding it - the user should still see the context the highlighted widget sits in.
+SCRIM_ALPHA = 130
+
+# how opaque the border around the spotlight is
+HIGHLIGHT_ALPHA = 230
+
 # how often the target's position is re-checked. A target moves for reasons no single event filter
 # catches - an ancestor's layout settling, a scroll area scrolling, a tab animating in - so the
 # rectangle is re-measured rather than only recomputed when something says it changed. It is a
@@ -142,31 +149,35 @@ class TutorialOverlay(QWidget):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing, True)
 
+        spotlight = self._target_rect
+        self._paint_scrim(painter, spotlight)
+        if not spotlight.isEmpty():
+            self._paint_highlight(painter, spotlight)
+
+    def _paint_scrim(self, painter, spotlight):
+        """Dim everything except the spotlight."""
         scrim = QPainterPath()
         scrim.addRect(QRectF(self.rect()))
-
-        spotlight = self._target_rect
         if not spotlight.isEmpty():
             cut_out = QPainterPath()
             cut_out.addRoundedRect(QRectF(spotlight), CORNER_RADIUS, CORNER_RADIUS)
             # subtracting rather than painting the scrim in four strips around the target: this
             # gives one path, so the rounded corners stay clean and there are no seams
             scrim = scrim.subtracted(cut_out)
-
         painter.fillPath(scrim, self._scrim_colour())
 
-        if not spotlight.isEmpty():
-            painter.setPen(QPen(self._highlight_colour(), 2))
-            painter.setBrush(Qt.NoBrush)
-            painter.drawRoundedRect(QRectF(spotlight), CORNER_RADIUS, CORNER_RADIUS)
+    def _paint_highlight(self, painter, spotlight):
+        """Draw the border that picks the spotlight out of the hole in the scrim."""
+        painter.setPen(QPen(self._highlight_colour(), 2))
+        painter.setBrush(Qt.NoBrush)
+        painter.drawRoundedRect(QRectF(spotlight), CORNER_RADIUS, CORNER_RADIUS)
 
-    def _scrim_colour(self):
-        # dark enough to push the rest of the interface back without hiding it - the user should
-        # still see the context the highlighted widget sits in
-        return QColor(0, 0, 0, 130)
+    @staticmethod
+    def _scrim_colour():
+        return QColor(0, 0, 0, SCRIM_ALPHA)
 
     def _highlight_colour(self):
         # the palette's highlight, so the spotlight matches whatever theme the user is running
         colour = QColor(self.palette().highlight().color())
-        colour.setAlpha(230)
+        colour.setAlpha(HIGHLIGHT_ALPHA)
         return colour

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
@@ -83,12 +83,22 @@ class TutorialOverlay(QWidget):
         """Where the spotlight currently is, in overlay coordinates. Empty when there is none."""
         return QRect(self._target_rect)
 
-    def _measure(self):
-        target = self._target
-        if target is None or not target.isVisible():
+    def rect_of(self, widget):
+        """Where ``widget`` sits in this overlay's coordinates, or an empty rect.
+
+        Public because the caption needs the same mapping for the widgets it has been asked to keep
+        clear of, and they are not the spotlight.
+        """
+        if widget is None or self._host is None or not widget.isVisible():
             return QRect()
-        top_left = target.mapTo(self._host, target.rect().topLeft())
-        return QRect(top_left, target.size()).adjusted(-PADDING, -PADDING, PADDING, PADDING)
+        if widget is not self._host and not self._host.isAncestorOf(widget):
+            return QRect()
+        top_left = widget.mapTo(self._host, widget.rect().topLeft())
+        return QRect(top_left, widget.size())
+
+    def _measure(self):
+        rect = self.rect_of(self._target)
+        return rect if rect.isEmpty() else rect.adjusted(-PADDING, -PADDING, PADDING, PADDING)
 
     def _retrack(self):
         measured = self._measure()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
@@ -17,7 +17,7 @@ interface underneath, so the overlay cannot swallow one and the tour cannot dead
 own decoration.
 """
 
-from qtpy.QtCore import QEvent, QObject, QRect, QRectF, Qt, QTimer
+from qtpy.QtCore import QEvent, QRect, QRectF, Qt, QTimer
 from qtpy.QtGui import QColor, QPainter, QPainterPath, QPen
 from qtpy.QtWidgets import QWidget
 
@@ -170,20 +170,3 @@ class TutorialOverlay(QWidget):
         colour = QColor(self.palette().highlight().color())
         colour.setAlpha(230)
         return colour
-
-
-class _NullOverlay(QObject):
-    """Does nothing, for callers that want the tour's structure without the decoration (a test
-    playing every step headless, say). Keeps the player free of ``if overlay is not None``."""
-
-    def set_target(self, widget):
-        pass
-
-    def show(self):
-        pass
-
-    def hide(self):
-        pass
-
-    def detach(self):
-        pass

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/overlay.py
@@ -1,0 +1,179 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""The dimming layer that puts one widget in the spotlight.
+
+A transparent child of the window being toured, covering all of it, painting everything except the
+current target under a scrim. It is a sibling of the widgets it dims rather than a separate
+window, which is what keeps it aligned when the window is moved, resized or restacked - there is
+no second window to keep in step.
+
+It never takes input. ``WA_TransparentForMouseEvents`` means every click passes through to the
+interface underneath, so the overlay cannot swallow one and the tour cannot deadlock behind its
+own decoration.
+"""
+
+from qtpy.QtCore import QEvent, QObject, QRect, QRectF, Qt, QTimer
+from qtpy.QtGui import QColor, QPainter, QPainterPath, QPen
+from qtpy.QtWidgets import QWidget
+
+# how rounded the spotlight is, in pixels
+CORNER_RADIUS = 6
+
+# the spotlight is opened this much wider than the target on each side, so the highlight sits
+# around the widget rather than clipping its edge
+PADDING = 4
+
+# how often the target's position is re-checked. A target moves for reasons no single event filter
+# catches - an ancestor's layout settling, a scroll area scrolling, a tab animating in - so the
+# rectangle is re-measured rather than only recomputed when something says it changed. It is a
+# cheap comparison, and repainting only happens when it actually differs.
+TRACK_INTERVAL_MS = 50
+
+
+class TutorialOverlay(QWidget):
+    """Dims ``host`` except for one widget.
+
+    :param host: the window being toured. The overlay makes itself a child of it and covers it.
+    """
+
+    def __init__(self, host):
+        super().__init__(host)
+        self._host = host
+        self._target = None
+        self._target_rect = QRect()
+
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WA_NoSystemBackground, True)
+        self.setFocusPolicy(Qt.NoFocus)
+        self.setGeometry(host.rect())
+
+        host.installEventFilter(self)
+
+        self._tracker = QTimer(self)
+        self._tracker.setInterval(TRACK_INTERVAL_MS)
+        self._tracker.timeout.connect(self._retrack)
+
+    # ------------------------------------------------------------------ target
+
+    def set_target(self, widget):
+        """Spotlight ``widget``, or dim the whole window when it is None.
+
+        A target that is not a descendant of the host is refused rather than silently ignored: it
+        would be mapped into coordinates that mean nothing here, and the spotlight would land in an
+        arbitrary place - which looks like the tour pointing confidently at the wrong thing.
+        """
+        if widget is not None and not self._host.isAncestorOf(widget):
+            raise ValueError(f"{widget.objectName() or widget} is not inside the window being toured")
+        self._target = widget
+        self._retrack()
+        if widget is None:
+            self._tracker.stop()
+        else:
+            self._tracker.start()
+
+    def target(self):
+        return self._target
+
+    def target_rect(self):
+        """Where the spotlight currently is, in overlay coordinates. Empty when there is none."""
+        return QRect(self._target_rect)
+
+    def _measure(self):
+        target = self._target
+        if target is None or not target.isVisible():
+            return QRect()
+        top_left = target.mapTo(self._host, target.rect().topLeft())
+        return QRect(top_left, target.size()).adjusted(-PADDING, -PADDING, PADDING, PADDING)
+
+    def _retrack(self):
+        measured = self._measure()
+        if measured != self._target_rect:
+            self._target_rect = measured
+            self.update()
+
+    # ------------------------------------------------------------------ staying in place
+
+    def eventFilter(self, watched, event):
+        if watched is self._host and event.type() in (QEvent.Resize, QEvent.Show):
+            self.setGeometry(self._host.rect())
+            self._retrack()
+        return super().eventFilter(watched, event)
+
+    def show(self):
+        # the overlay is created before the widgets it dims, and Qt stacks later siblings on top,
+        # so it has to be raised every time it is shown or it would be painted under them
+        self.setGeometry(self._host.rect())
+        super().show()
+        self.raise_()
+        if self._target is not None:
+            self._tracker.start()
+
+    def hide(self):
+        self._tracker.stop()
+        super().hide()
+
+    def detach(self):
+        """Stop tracking and let go of the host. Safe to call more than once."""
+        self._tracker.stop()
+        if self._host is not None:
+            self._host.removeEventFilter(self)
+            self._host = None
+        self._target = None
+        self.hide()
+
+    # ------------------------------------------------------------------ painting
+
+    def paintEvent(self, _event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, True)
+
+        scrim = QPainterPath()
+        scrim.addRect(QRectF(self.rect()))
+
+        spotlight = self._target_rect
+        if not spotlight.isEmpty():
+            cut_out = QPainterPath()
+            cut_out.addRoundedRect(QRectF(spotlight), CORNER_RADIUS, CORNER_RADIUS)
+            # subtracting rather than painting the scrim in four strips around the target: this
+            # gives one path, so the rounded corners stay clean and there are no seams
+            scrim = scrim.subtracted(cut_out)
+
+        painter.fillPath(scrim, self._scrim_colour())
+
+        if not spotlight.isEmpty():
+            painter.setPen(QPen(self._highlight_colour(), 2))
+            painter.setBrush(Qt.NoBrush)
+            painter.drawRoundedRect(QRectF(spotlight), CORNER_RADIUS, CORNER_RADIUS)
+
+    def _scrim_colour(self):
+        # dark enough to push the rest of the interface back without hiding it - the user should
+        # still see the context the highlighted widget sits in
+        return QColor(0, 0, 0, 130)
+
+    def _highlight_colour(self):
+        # the palette's highlight, so the spotlight matches whatever theme the user is running
+        colour = QColor(self.palette().highlight().color())
+        colour.setAlpha(230)
+        return colour
+
+
+class _NullOverlay(QObject):
+    """Does nothing, for callers that want the tour's structure without the decoration (a test
+    playing every step headless, say). Keeps the player free of ``if overlay is not None``."""
+
+    def set_target(self, widget):
+        pass
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def detach(self):
+        pass

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -41,6 +41,70 @@ from mantidqt.widgets.tutorial.step import walk
 FAST_FORWARD_SETTLE_MS = 30
 
 
+class _Cursor:
+    """Where the tour has got to, and the rules for moving through it.
+
+    Separate from the player because they answer different questions: this one knows only what
+    comes next, and the player knows *when* it should happen. Keeping the index arithmetic here is
+    what lets the player be read as a sequence of timers and signals.
+    """
+
+    def __init__(self, chapters):
+        self._chapters = chapters
+        self._chapter_index = 0
+        self._step_index = 0
+
+    @property
+    def position(self):
+        """The pair identifying the current step, used to key what has already been performed."""
+        return self._chapter_index, self._step_index
+
+    @property
+    def chapter_index(self):
+        return self._chapter_index
+
+    def chapter(self):
+        return self._chapters[self._chapter_index]
+
+    def step(self):
+        return self.chapter()[self._step_index]
+
+    def at_start(self):
+        return self.position == (0, 0)
+
+    def at_end(self):
+        return self._chapter_index == len(self._chapters) - 1 and self._step_index == len(self.chapter()) - 1
+
+    def go_to(self, chapter_index):
+        """Jump to the first step of a chapter."""
+        if not 0 <= chapter_index < len(self._chapters):
+            raise IndexError(f"no chapter {chapter_index}; the tour has {len(self._chapters)}")
+        self._chapter_index = chapter_index
+        self._step_index = 0
+
+    def advance(self):
+        """Move to the next step. False when the tour has been walked to its end."""
+        if self._step_index + 1 < len(self.chapter()):
+            self._step_index += 1
+        elif self._chapter_index + 1 < len(self._chapters):
+            self._chapter_index += 1
+            self._step_index = 0
+        else:
+            return False
+        return True
+
+    def retreat(self):
+        """Move back a step, crossing into the previous chapter's last. False at the very start."""
+        if self._step_index > 0:
+            self._step_index -= 1
+        elif self._chapter_index > 0:
+            self._chapter_index -= 1
+            self._step_index = len(self.chapter()) - 1
+        else:
+            return False
+        return True
+
+
 class TutorialPlayer(QObject):
     """Plays ``chapters`` against ``context``, pointing and narrating through ``annotator``.
 
@@ -68,8 +132,7 @@ class TutorialPlayer(QObject):
         self._context = context
         self._annotator = annotator
 
-        self._chapter_index = 0
-        self._step_index = 0
+        self._cursor = _Cursor(self._chapters)
         self._running = False
         self._busy = False
         self._busy_message = ""
@@ -83,7 +146,7 @@ class TutorialPlayer(QObject):
 
     @property
     def position(self):
-        return self._chapter_index, self._step_index
+        return self._cursor.position
 
     @property
     def is_running(self):
@@ -96,10 +159,10 @@ class TutorialPlayer(QObject):
         return self._busy
 
     def current_chapter(self):
-        return self._chapters[self._chapter_index]
+        return self._cursor.chapter()
 
     def current_step(self):
-        return self.current_chapter()[self._step_index]
+        return self._cursor.step()
 
     def current_step_has_action(self):
         return self.current_step().action is not None
@@ -109,10 +172,10 @@ class TutorialPlayer(QObject):
         return not self.current_step_has_action() or self.position in self._applied
 
     def at_start(self):
-        return self._chapter_index == 0 and self._step_index == 0
+        return self._cursor.at_start()
 
     def at_end(self):
-        return self._chapter_index == len(self._chapters) - 1 and self._step_index == len(self.current_chapter()) - 1
+        return self._cursor.at_end()
 
     # ------------------------------------------------------------------ running
 
@@ -123,11 +186,8 @@ class TutorialPlayer(QObject):
         to catch the interface up to the state the chapter assumes. It is only sound on a freshly
         built interface, which is why the session rebuilds before asking for it.
         """
-        if not 0 <= chapter_index < len(self._chapters):
-            raise IndexError(f"no chapter {chapter_index}; the tour has {len(self._chapters)}")
+        self._cursor.go_to(chapter_index)
         self._running = True
-        self._chapter_index = chapter_index
-        self._step_index = 0
 
         if fast_forward and chapter_index > 0:
             self._fast_forward_to(chapter_index)
@@ -163,14 +223,8 @@ class TutorialPlayer(QObject):
         if self._busy:
             return
         self._cancel_pending()
-        if self._step_index > 0:
-            self._step_index -= 1
-        elif self._chapter_index > 0:
-            self._chapter_index -= 1
-            self._step_index = len(self.current_chapter()) - 1
-        else:
-            return  # already at the very start
-        self._present_current_step()
+        if self._cursor.retreat():
+            self._present_current_step()
 
     # ------------------------------------------------------------------ presenting
 
@@ -192,7 +246,7 @@ class TutorialPlayer(QObject):
         # worth reporting once the action has run
         self._point_at(step, report=self.is_applied())
         self._set_busy(False)
-        self.step_changed.emit(self._chapter_index, self._step_index)
+        self.step_changed.emit(*self.position)
 
     def _point_at(self, step, report=True):
         """Spotlight what the step points at and put its caption beside it."""
@@ -228,10 +282,8 @@ class TutorialPlayer(QObject):
         yet, which is legitimate. ``_locate`` resolves it again when the step is shown and reports
         it properly if it is still missing.
         """
-        if step.target is None:
-            return
         try:
-            target = step.target(self._context)
+            target = step.resolve_target(self._context)
             if target is not None:
                 ensure_visible(target)
         except Exception:
@@ -299,12 +351,7 @@ class TutorialPlayer(QObject):
     def _advance(self):
         if not self._running:
             return
-        if self._step_index + 1 < len(self.current_chapter()):
-            self._step_index += 1
-        elif self._chapter_index + 1 < len(self._chapters):
-            self._chapter_index += 1
-            self._step_index = 0
-        else:
+        if not self._cursor.advance():
             self._running = False
             self._set_busy(False)
             self.finished.emit()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -343,6 +343,10 @@ class TutorialPlayer(QObject):
         # marked applied even when it fails, so a Back into this chapter does not try it again
         self._applied.add(position)
         if step.action is not None:
+            # revealed here as well as when playing: an action that presses a button inside a
+            # collapsed section would find it disabled, so a fast-forward has to open the interface
+            # up exactly as walking through the steps would
+            self._reveal(step)
             try:
                 step.action(self._context)
             except Exception as error:

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -42,7 +42,7 @@ FAST_FORWARD_SETTLE_MS = 30
 
 
 class TutorialPlayer(QObject):
-    """Plays ``chapters`` against ``context``, drawing on ``overlay`` and ``bubble``.
+    """Plays ``chapters`` against ``context``, pointing and narrating through ``annotator``.
 
     The player owns sequencing and nothing else. It does not build or tear down the interface it is
     touring, and it does not decide what the controls mean - a session does both, and calls
@@ -60,14 +60,13 @@ class TutorialPlayer(QObject):
     #: the tour is working and should not be driven; carries a message
     busy_changed = Signal(bool, str)
 
-    def __init__(self, chapters, context, overlay, bubble, parent=None):
+    def __init__(self, chapters, context, annotator, parent=None):
         super().__init__(parent)
         if not chapters:
             raise ValueError("a tutorial needs at least one chapter")
         self._chapters = tuple(chapters)
         self._context = context
-        self._overlay = overlay
-        self._bubble = bubble
+        self._annotator = annotator
 
         self._chapter_index = 0
         self._step_index = 0
@@ -140,8 +139,8 @@ class TutorialPlayer(QObject):
         self._running = False
         self._set_busy(False)
         self._cancel_pending()
-        self._overlay.set_target(None)
-        self._overlay.hide()
+        self._annotator.set_target(None)
+        self._annotator.hide()
 
     def apply_step(self):
         """Perform the current step's action, leaving its explanation on screen to be watched."""
@@ -191,11 +190,15 @@ class TutorialPlayer(QObject):
             return
         # a target the step's own action creates does not exist yet, which is why a miss is only
         # worth reporting once the action has run
-        self._overlay.set_target(self._locate(step, report=self.is_applied()))
-        self._bubble.show_step(text=step.text, title=step.title)
-        self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
+        self._point_at(step, report=self.is_applied())
         self._set_busy(False)
         self.step_changed.emit(self._chapter_index, self._step_index)
+
+    def _point_at(self, step, report=True):
+        """Spotlight what the step points at and put its caption beside it."""
+        self._annotator.set_target(self._locate(step, report=report))
+        self._annotator.show_step(text=step.text, title=step.title)
+        self._annotator.place_beside(self._annotator.target_rect(), self._keep_clear(step))
 
     def _locate(self, step, report=True):
         """The widget to spotlight, or None.
@@ -257,8 +260,8 @@ class TutorialPlayer(QObject):
 
         if step.await_ is not None:
             self._set_busy(True, step.await_text)
-            self._bubble.show_waiting(step.await_text)
-            self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
+            self._annotator.show_waiting(step.await_text)
+            self._annotator.place_beside(self._annotator.target_rect(), self._keep_clear(step))
             self._waiter = wait_for(
                 predicate=lambda: self._await_holds(step),
                 on_ready=lambda: self._schedule(lambda: self._finish_perform(step, advance_after), step.settle_ms),
@@ -278,9 +281,7 @@ class TutorialPlayer(QObject):
             return
         # the caption stays; the highlight is re-measured because the action may have moved,
         # revealed or resized what it points at
-        self._overlay.set_target(self._locate(step))
-        self._bubble.show_step(text=step.text, title=step.title)
-        self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
+        self._point_at(step)
         self._set_busy(False)
         self.step_applied.emit()
 
@@ -321,8 +322,8 @@ class TutorialPlayer(QObject):
         """
         message = "Setting the interface up for this chapter…"
         self._set_busy(True, message)
-        self._bubble.show_waiting(message)
-        self._bubble.place_beside(None)
+        self._annotator.show_waiting(message)
+        self._annotator.place_beside(None)
         preceding = [
             ((chapter_number, step_number), step)
             for chapter_number, step_number, _chapter, step in walk(self._chapters)
@@ -377,17 +378,10 @@ class TutorialPlayer(QObject):
         """Rectangles the caption must not cover: whatever the step asked to stay clear of.
 
         Measured in the coordinates of the window being annotated, which is why it goes through the
-        overlay rather than reading widget geometry directly.
+        annotator rather than reading widget geometry directly.
         """
-        rect_of = getattr(self._overlay, "rect_of", None)
-        if not callable(rect_of):
-            return ()
-        rects = [rect_of(widget) for widget in step.resolve_avoid(self._context)]
+        rects = [self._annotator.rect_of(widget) for widget in step.resolve_avoid(self._context)]
         return tuple(rect for rect in rects if rect is not None and not rect.isEmpty())
-
-    def _spotlight_rect(self):
-        target_rect = getattr(self._overlay, "target_rect", None)
-        return target_rect() if callable(target_rect) else None
 
     def _schedule(self, call, delay_ms):
         """Do something after a delay, keeping the timer so it can be cancelled.

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -5,21 +5,24 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
-"""Runs a tour: performs each step, points at it, says what it is, moves on.
+"""Runs a tour: performs each step, points at it, says what it is, and waits.
 
-Every delay is a timer rather than a wait. A step's action runs, the interface is given
-``settle_ms`` to catch up, the spotlight and caption are placed, and ``dwell_ms`` later the next
-step begins - and between each of those the player returns to the event loop, so the interface
-keeps painting and its buttons keep working. A player that waited instead would freeze the very
+**The tour advances only when the user asks it to.** There is no timer counting down behind the
+caption, because there is no interval that is right: a step someone already understands is a wait,
+and a step they do not is a race. They press Next when they have finished reading.
+
+What is still on a timer is the interface catching up. A step's action runs, the interface is given
+``settle_ms`` to lay out before the spotlight is measured, and a step that waits on real work polls
+for it - and between each of those the player returns to the event loop, so the interface keeps
+painting and its controls keep working. A player that waited by blocking would freeze the
 demonstration it is giving.
 
 Two things follow from the tour driving a real interface:
 
 * **Back does not undo.** It re-shows the previous step's caption and spotlight without re-running
-  its action. Replaying an action would double it - pressing "Add orientation" twice adds two -
-  and unwinding one is not something a step can be asked to describe. So Back is for re-reading,
-  and starting a chapter over is done by rebuilding the interface (which the session, not the
-  player, owns).
+  its action. Replaying an action would double it - pressing "Add orientation" twice adds two - and
+  unwinding one is not something a step can be asked to describe. So Back is for re-reading, and
+  starting a chapter over is done by rebuilding the interface, which the session owns.
 * **A step that fails does not kill the tour.** The interface has moved under it, which is worth
   reporting, but stranding the user mid-tour with a dead window helps nobody. The step is skipped
   and its failure emitted.
@@ -38,9 +41,9 @@ FAST_FORWARD_SETTLE_MS = 30
 class TutorialPlayer(QObject):
     """Plays ``chapters`` against ``context``, drawing on ``overlay`` and ``bubble``.
 
-    The player owns sequencing and nothing else. It does not build or tear down the interface it
-    is touring, and it does not decide what the buttons mean - a session does both, and calls
-    ``next_step`` / ``back_step`` / ``set_paused`` in response.
+    The player owns sequencing and nothing else. It does not build or tear down the interface it is
+    touring, and it does not decide what the controls mean - a session does both, and calls
+    ``next_step`` / ``back_step`` in response.
     """
 
     #: the whole tour reached its end
@@ -49,6 +52,8 @@ class TutorialPlayer(QObject):
     step_changed = Signal(int, int)
     #: a step could not be performed; carries the step's label and the reason
     step_failed = Signal(str, str)
+    #: the tour is waiting on the interface and should not be advanced; carries a message
+    busy_changed = Signal(bool, str)
 
     def __init__(self, chapters, context, overlay, bubble, parent=None):
         super().__init__(parent)
@@ -61,8 +66,9 @@ class TutorialPlayer(QObject):
 
         self._chapter_index = 0
         self._step_index = 0
-        self._paused = False
         self._running = False
+        self._busy = False
+        self._busy_message = ""
         self._pending = None  # the QTimer for whatever happens next, so it can be cancelled
         self._waiter = None  # the QTimer polling a step's await_, likewise
 
@@ -77,8 +83,10 @@ class TutorialPlayer(QObject):
         return self._running
 
     @property
-    def is_paused(self):
-        return self._paused
+    def is_busy(self):
+        """True while a step is waiting on the interface, when advancing would run the next step's
+        action against something that has not finished reacting to this one."""
+        return self._busy
 
     def current_chapter(self):
         return self._chapters[self._chapter_index]
@@ -86,16 +94,21 @@ class TutorialPlayer(QObject):
     def current_step(self):
         return self.current_chapter()[self._step_index]
 
+    def at_start(self):
+        return self._chapter_index == 0 and self._step_index == 0
+
+    def at_end(self):
+        return self._chapter_index == len(self._chapters) - 1 and self._step_index == len(self.current_chapter()) - 1
+
     # ------------------------------------------------------------------ running
 
     def start(self, chapter_index=0, fast_forward=False):
         """Begin at ``chapter_index``.
 
-        With ``fast_forward``, the actions of every earlier chapter are performed first, silently
-        and without dwelling. Chapters are cumulative - there is nothing to add an orientation to
-        until a sample has been loaded - so starting partway through means catching the interface
-        up first. It is only sound on a freshly built interface, which is why the session rebuilds
-        before asking for it.
+        With ``fast_forward``, the actions of every earlier chapter are performed first, silently.
+        Chapters are cumulative - there is nothing to add an orientation to until a sample has been
+        loaded - so starting partway through means catching the interface up first. It is only
+        sound on a freshly built interface, which is why the session rebuilds before asking for it.
         """
         if not 0 <= chapter_index < len(self._chapters):
             raise IndexError(f"no chapter {chapter_index}; the tour has {len(self._chapters)}")
@@ -112,26 +125,22 @@ class TutorialPlayer(QObject):
         """End the tour without emitting ``finished``. Safe to call at any point, including from
         inside a step."""
         self._running = False
+        self._set_busy(False)
         self._cancel_pending()
         self._overlay.set_target(None)
         self._overlay.hide()
 
-    def set_paused(self, paused):
-        """Stop or resume automatic advancing. Pausing leaves the current step on screen; the
-        navigation buttons keep working throughout."""
-        self._paused = bool(paused)
-        if self._paused:
-            self._cancel_pending()
-        elif self._running:
-            self._schedule(self._advance, self.current_step().dwell_ms)
-
     def next_step(self):
-        """Move on now, whether or not the current step has finished dwelling."""
+        """Move to the next step. Ignored while the tour is waiting on the interface."""
+        if self._busy:
+            return
         self._cancel_pending()
         self._advance()
 
     def back_step(self):
         """Re-show the previous step. Does not undo anything - see the module docstring."""
+        if self._busy:
+            return
         self._cancel_pending()
         if self._step_index > 0:
             self._step_index -= 1
@@ -149,6 +158,12 @@ class TutorialPlayer(QObject):
             return
         step = self.current_step()
 
+        # busy from the moment the action starts until the step is on screen. Without this, Next
+        # pressed during the settle would cancel the pending narration and move on, so the step's
+        # action would have run but its caption would never have been shown. No message: this lasts
+        # a couple of hundred milliseconds and should not flash text into the controls.
+        self._set_busy(True)
+
         if step.action is not None:
             try:
                 step.action(self._context)
@@ -156,10 +171,11 @@ class TutorialPlayer(QObject):
                 # the interface has moved under the tour. Worth reporting, not worth stranding the
                 # user in a half-run tour for
                 self.step_failed.emit(step.label, str(error))
-                self._schedule(self._advance, 0)
+                self._narrate(step)
                 return
 
         if step.await_ is not None:
+            self._set_busy(True, step.await_text)
             self._bubble.show_waiting(step.await_text)
             self._bubble.place_beside(self._spotlight_rect())
             self._waiter = wait_for(
@@ -184,7 +200,7 @@ class TutorialPlayer(QObject):
         self._narrate(step)
 
     def _narrate(self, step):
-        """Point at the step's target and say what it is.
+        """Point at the step's target and say what it is, then wait for the user.
 
         Deliberately separate from running the action: Back comes straight here, which is the whole
         of what makes Back safe to press.
@@ -202,20 +218,10 @@ class TutorialPlayer(QObject):
             target = None
 
         self._overlay.set_target(target)
-        chapter = self.current_chapter()
-        self._bubble.show_step(
-            text=step.text,
-            title=step.title,
-            chapter_name=chapter.name,
-            step_number=self._step_index + 1,
-            step_count=len(chapter),
-        )
+        self._bubble.show_step(text=step.text, title=step.title)
         self._bubble.place_beside(self._spotlight_rect())
-        self._bubble.set_navigation_enabled(back=not self._at_start(), next_=True)
+        self._set_busy(False)
         self.step_changed.emit(self._chapter_index, self._step_index)
-
-        if not self._paused:
-            self._schedule(self._advance, step.dwell_ms)
 
     def _advance(self):
         if not self._running:
@@ -234,26 +240,25 @@ class TutorialPlayer(QObject):
     # ------------------------------------------------------------------ fast forward
 
     def _fast_forward_to(self, chapter_index):
-        """Run every action before ``chapter_index`` with no narration and no dwelling.
+        """Run every action before ``chapter_index`` with no narration.
 
         Deliberately synchronous over the actions but never over a wait: a step that awaits
         something is awaited through ``wait_for`` and the rest of the fast-forward continues from
         its callback, so even this stays off the blocking path.
         """
-        self._bubble.show_waiting("Setting the interface up for this chapter…")
+        message = "Setting the interface up for this chapter…"
+        self._set_busy(True, message)
+        self._bubble.show_waiting(message)
         self._bubble.place_beside(None)
-        preceding = [
-            (chapter_number, step)
-            for chapter_number, _step_number, _chapter, step in walk(self._chapters)
-            if chapter_number < chapter_index
-        ]
-        self._replay(iter([step for _chapter_number, step in preceding]))
+        preceding = [step for chapter_number, _step_number, _chapter, step in walk(self._chapters) if chapter_number < chapter_index]
+        self._replay(iter(preceding))
 
     def _replay(self, steps):
         if not self._running:
             return
         step = next(steps, None)
         if step is None:
+            self._set_busy(False)
             self._run_current_step()
             return
 
@@ -277,8 +282,12 @@ class TutorialPlayer(QObject):
 
     # ------------------------------------------------------------------ plumbing
 
-    def _at_start(self):
-        return self._chapter_index == 0 and self._step_index == 0
+    def _set_busy(self, busy, message=""):
+        if busy == self._busy and message == self._busy_message:
+            return
+        self._busy = busy
+        self._busy_message = message
+        self.busy_changed.emit(busy, message)
 
     def _spotlight_rect(self):
         target_rect = getattr(self._overlay, "target_rect", None)
@@ -287,8 +296,8 @@ class TutorialPlayer(QObject):
     def _schedule(self, call, delay_ms):
         """Do something after a delay, keeping the timer so it can be cancelled.
 
-        One pending action at a time: scheduling replaces whatever was pending, which is what lets
-        Next interrupt a dwell without the interrupted one firing later and skipping a step.
+        One pending action at a time: scheduling replaces whatever was pending, so an interrupted
+        settle cannot fire later and narrate a step the tour has already left.
         """
         self._cancel_pending()
         timer = QTimer(self)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -1,0 +1,305 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""Runs a tour: performs each step, points at it, says what it is, moves on.
+
+Every delay is a timer rather than a wait. A step's action runs, the interface is given
+``settle_ms`` to catch up, the spotlight and caption are placed, and ``dwell_ms`` later the next
+step begins - and between each of those the player returns to the event loop, so the interface
+keeps painting and its buttons keep working. A player that waited instead would freeze the very
+demonstration it is giving.
+
+Two things follow from the tour driving a real interface:
+
+* **Back does not undo.** It re-shows the previous step's caption and spotlight without re-running
+  its action. Replaying an action would double it - pressing "Add orientation" twice adds two -
+  and unwinding one is not something a step can be asked to describe. So Back is for re-reading,
+  and starting a chapter over is done by rebuilding the interface (which the session, not the
+  player, owns).
+* **A step that fails does not kill the tour.** The interface has moved under it, which is worth
+  reporting, but stranding the user mid-tour with a dead window helps nobody. The step is skipped
+  and its failure emitted.
+"""
+
+from qtpy.QtCore import QObject, QTimer, Signal
+
+from mantidqt.widgets.tutorial.interaction import ensure_visible, process_events, wait_for
+from mantidqt.widgets.tutorial.step import walk
+
+# how long a fast-forwarded step is given to settle. Shorter than a played one because nothing is
+# being read - this is only getting the interface into the state a later chapter starts from.
+FAST_FORWARD_SETTLE_MS = 30
+
+
+class TutorialPlayer(QObject):
+    """Plays ``chapters`` against ``context``, drawing on ``overlay`` and ``bubble``.
+
+    The player owns sequencing and nothing else. It does not build or tear down the interface it
+    is touring, and it does not decide what the buttons mean - a session does both, and calls
+    ``next_step`` / ``back_step`` / ``set_paused`` in response.
+    """
+
+    #: the whole tour reached its end
+    finished = Signal()
+    #: now showing (chapter index, step index)
+    step_changed = Signal(int, int)
+    #: a step could not be performed; carries the step's label and the reason
+    step_failed = Signal(str, str)
+
+    def __init__(self, chapters, context, overlay, bubble, parent=None):
+        super().__init__(parent)
+        if not chapters:
+            raise ValueError("a tutorial needs at least one chapter")
+        self._chapters = tuple(chapters)
+        self._context = context
+        self._overlay = overlay
+        self._bubble = bubble
+
+        self._chapter_index = 0
+        self._step_index = 0
+        self._paused = False
+        self._running = False
+        self._pending = None  # the QTimer for whatever happens next, so it can be cancelled
+        self._waiter = None  # the QTimer polling a step's await_, likewise
+
+    # ------------------------------------------------------------------ state
+
+    @property
+    def position(self):
+        return self._chapter_index, self._step_index
+
+    @property
+    def is_running(self):
+        return self._running
+
+    @property
+    def is_paused(self):
+        return self._paused
+
+    def current_chapter(self):
+        return self._chapters[self._chapter_index]
+
+    def current_step(self):
+        return self.current_chapter()[self._step_index]
+
+    # ------------------------------------------------------------------ running
+
+    def start(self, chapter_index=0, fast_forward=False):
+        """Begin at ``chapter_index``.
+
+        With ``fast_forward``, the actions of every earlier chapter are performed first, silently
+        and without dwelling. Chapters are cumulative - there is nothing to add an orientation to
+        until a sample has been loaded - so starting partway through means catching the interface
+        up first. It is only sound on a freshly built interface, which is why the session rebuilds
+        before asking for it.
+        """
+        if not 0 <= chapter_index < len(self._chapters):
+            raise IndexError(f"no chapter {chapter_index}; the tour has {len(self._chapters)}")
+        self._running = True
+        self._chapter_index = chapter_index
+        self._step_index = 0
+
+        if fast_forward and chapter_index > 0:
+            self._fast_forward_to(chapter_index)
+        else:
+            self._run_current_step()
+
+    def stop(self):
+        """End the tour without emitting ``finished``. Safe to call at any point, including from
+        inside a step."""
+        self._running = False
+        self._cancel_pending()
+        self._overlay.set_target(None)
+        self._overlay.hide()
+
+    def set_paused(self, paused):
+        """Stop or resume automatic advancing. Pausing leaves the current step on screen; the
+        navigation buttons keep working throughout."""
+        self._paused = bool(paused)
+        if self._paused:
+            self._cancel_pending()
+        elif self._running:
+            self._schedule(self._advance, self.current_step().dwell_ms)
+
+    def next_step(self):
+        """Move on now, whether or not the current step has finished dwelling."""
+        self._cancel_pending()
+        self._advance()
+
+    def back_step(self):
+        """Re-show the previous step. Does not undo anything - see the module docstring."""
+        self._cancel_pending()
+        if self._step_index > 0:
+            self._step_index -= 1
+        elif self._chapter_index > 0:
+            self._chapter_index -= 1
+            self._step_index = len(self.current_chapter()) - 1
+        else:
+            return  # already at the very start
+        self._narrate(self.current_step())
+
+    # ------------------------------------------------------------------ the step cycle
+
+    def _run_current_step(self):
+        if not self._running:
+            return
+        step = self.current_step()
+
+        if step.action is not None:
+            try:
+                step.action(self._context)
+            except Exception as error:
+                # the interface has moved under the tour. Worth reporting, not worth stranding the
+                # user in a half-run tour for
+                self.step_failed.emit(step.label, str(error))
+                self._schedule(self._advance, 0)
+                return
+
+        if step.await_ is not None:
+            self._bubble.show_waiting(step.await_text)
+            self._bubble.place_beside(self._spotlight_rect())
+            self._waiter = wait_for(
+                predicate=lambda: self._await_holds(step),
+                on_ready=lambda: self._schedule(lambda: self._narrate(step), step.settle_ms),
+                timeout_s=step.await_timeout_s,
+                on_timeout=lambda: self._on_await_timeout(step),
+                parent=self,
+            )
+        else:
+            self._schedule(lambda: self._narrate(step), step.settle_ms)
+
+    def _await_holds(self, step):
+        try:
+            return step.await_(self._context)
+        except Exception as error:
+            self.step_failed.emit(step.label, f"while waiting: {error}")
+            return True
+
+    def _on_await_timeout(self, step):
+        self.step_failed.emit(step.label, f"still not ready after {step.await_timeout_s}s")
+        self._narrate(step)
+
+    def _narrate(self, step):
+        """Point at the step's target and say what it is.
+
+        Deliberately separate from running the action: Back comes straight here, which is the whole
+        of what makes Back safe to press.
+        """
+        if not self._running:
+            return
+
+        target = None
+        try:
+            target = step.resolve_target(self._context)
+            if target is not None:
+                ensure_visible(target)
+        except Exception as error:
+            self.step_failed.emit(step.label, f"could not find what to highlight: {error}")
+            target = None
+
+        self._overlay.set_target(target)
+        chapter = self.current_chapter()
+        self._bubble.show_step(
+            text=step.text,
+            title=step.title,
+            chapter_name=chapter.name,
+            step_number=self._step_index + 1,
+            step_count=len(chapter),
+        )
+        self._bubble.place_beside(self._spotlight_rect())
+        self._bubble.set_navigation_enabled(back=not self._at_start(), next_=True)
+        self.step_changed.emit(self._chapter_index, self._step_index)
+
+        if not self._paused:
+            self._schedule(self._advance, step.dwell_ms)
+
+    def _advance(self):
+        if not self._running:
+            return
+        if self._step_index + 1 < len(self.current_chapter()):
+            self._step_index += 1
+        elif self._chapter_index + 1 < len(self._chapters):
+            self._chapter_index += 1
+            self._step_index = 0
+        else:
+            self._running = False
+            self.finished.emit()
+            return
+        self._run_current_step()
+
+    # ------------------------------------------------------------------ fast forward
+
+    def _fast_forward_to(self, chapter_index):
+        """Run every action before ``chapter_index`` with no narration and no dwelling.
+
+        Deliberately synchronous over the actions but never over a wait: a step that awaits
+        something is awaited through ``wait_for`` and the rest of the fast-forward continues from
+        its callback, so even this stays off the blocking path.
+        """
+        self._bubble.show_waiting("Setting the interface up for this chapter…")
+        self._bubble.place_beside(None)
+        preceding = [
+            (chapter_number, step)
+            for chapter_number, _step_number, _chapter, step in walk(self._chapters)
+            if chapter_number < chapter_index
+        ]
+        self._replay(iter([step for _chapter_number, step in preceding]))
+
+    def _replay(self, steps):
+        if not self._running:
+            return
+        step = next(steps, None)
+        if step is None:
+            self._run_current_step()
+            return
+
+        if step.action is not None:
+            try:
+                step.action(self._context)
+            except Exception as error:
+                self.step_failed.emit(step.label, f"while setting up: {error}")
+        process_events()
+
+        if step.await_ is not None:
+            self._waiter = wait_for(
+                predicate=lambda: self._await_holds(step),
+                on_ready=lambda: self._replay(steps),
+                timeout_s=step.await_timeout_s,
+                on_timeout=lambda: self._replay(steps),
+                parent=self,
+            )
+        else:
+            self._schedule(lambda: self._replay(steps), FAST_FORWARD_SETTLE_MS)
+
+    # ------------------------------------------------------------------ plumbing
+
+    def _at_start(self):
+        return self._chapter_index == 0 and self._step_index == 0
+
+    def _spotlight_rect(self):
+        target_rect = getattr(self._overlay, "target_rect", None)
+        return target_rect() if callable(target_rect) else None
+
+    def _schedule(self, call, delay_ms):
+        """Do something after a delay, keeping the timer so it can be cancelled.
+
+        One pending action at a time: scheduling replaces whatever was pending, which is what lets
+        Next interrupt a dwell without the interrupted one firing later and skipping a step.
+        """
+        self._cancel_pending()
+        timer = QTimer(self)
+        timer.setSingleShot(True)
+        timer.timeout.connect(call)
+        timer.start(max(0, delay_ms))
+        self._pending = timer
+
+    def _cancel_pending(self):
+        for timer in (self._pending, self._waiter):
+            if timer is not None:
+                timer.stop()
+        self._pending = None
+        self._waiter = None

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -324,25 +324,21 @@ class TutorialPlayer(QObject):
         self._set_busy(True, message)
         self._annotator.show_waiting(message)
         self._annotator.place_beside(None)
-        preceding = [
-            ((chapter_number, step_number), step)
-            for chapter_number, step_number, _chapter, step in walk(self._chapters)
-            if chapter_number < chapter_index
-        ]
+        preceding = [visit for visit in walk(self._chapters) if visit.chapter_index < chapter_index]
         self._replay(iter(preceding))
 
-    def _replay(self, steps):
+    def _replay(self, visits):
         if not self._running:
             return
-        entry = next(steps, None)
-        if entry is None:
+        visit = next(visits, None)
+        if visit is None:
             self._set_busy(False)
             self._present_current_step()
             return
-        position, step = entry
+        step = visit.step
 
         # marked applied even when it fails, so a Back into this chapter does not try it again
-        self._applied.add(position)
+        self._applied.add(visit.position)
         if step.action is not None:
             # revealed here as well as when playing: an action that presses a button inside a
             # collapsed section would find it disabled, so a fast-forward has to open the interface
@@ -357,13 +353,13 @@ class TutorialPlayer(QObject):
         if step.await_ is not None:
             self._waiter = wait_for(
                 predicate=lambda: self._await_holds(step),
-                on_ready=lambda: self._replay(steps),
+                on_ready=lambda: self._replay(visits),
                 timeout_s=step.await_timeout_s,
-                on_timeout=lambda: self._replay(steps),
+                on_timeout=lambda: self._replay(visits),
                 parent=self,
             )
         else:
-            self._schedule(lambda: self._replay(steps), FAST_FORWARD_SETTLE_MS)
+            self._schedule(lambda: self._replay(visits), FAST_FORWARD_SETTLE_MS)
 
     # ------------------------------------------------------------------ plumbing
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -193,7 +193,7 @@ class TutorialPlayer(QObject):
         # worth reporting once the action has run
         self._overlay.set_target(self._locate(step, report=self.is_applied()))
         self._bubble.show_step(text=step.text, title=step.title)
-        self._bubble.place_beside(self._spotlight_rect())
+        self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
         self._set_busy(False)
         self.step_changed.emit(self._chapter_index, self._step_index)
 
@@ -258,7 +258,7 @@ class TutorialPlayer(QObject):
         if step.await_ is not None:
             self._set_busy(True, step.await_text)
             self._bubble.show_waiting(step.await_text)
-            self._bubble.place_beside(self._spotlight_rect())
+            self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
             self._waiter = wait_for(
                 predicate=lambda: self._await_holds(step),
                 on_ready=lambda: self._schedule(lambda: self._finish_perform(step, advance_after), step.settle_ms),
@@ -280,7 +280,7 @@ class TutorialPlayer(QObject):
         # revealed or resized what it points at
         self._overlay.set_target(self._locate(step))
         self._bubble.show_step(text=step.text, title=step.title)
-        self._bubble.place_beside(self._spotlight_rect())
+        self._bubble.place_beside(self._spotlight_rect(), self._keep_clear(step))
         self._set_busy(False)
         self.step_applied.emit()
 
@@ -372,6 +372,18 @@ class TutorialPlayer(QObject):
         self._busy = busy
         self._busy_message = message
         self.busy_changed.emit(busy, message)
+
+    def _keep_clear(self, step):
+        """Rectangles the caption must not cover: whatever the step asked to stay clear of.
+
+        Measured in the coordinates of the window being annotated, which is why it goes through the
+        overlay rather than reading widget geometry directly.
+        """
+        rect_of = getattr(self._overlay, "rect_of", None)
+        if not callable(rect_of):
+            return ()
+        rects = [rect_of(widget) for widget in step.resolve_avoid(self._context)]
+        return tuple(rect for rect in rects if rect is not None and not rect.isEmpty())
 
     def _spotlight_rect(self):
         target_rect = getattr(self._overlay, "target_rect", None)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/player.py
@@ -5,27 +5,30 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
-"""Runs a tour: performs each step, points at it, says what it is, and waits.
+"""Runs a tour: points at something, explains it, and then - when asked - does it.
 
-**The tour advances only when the user asks it to.** There is no timer counting down behind the
-caption, because there is no interval that is right: a step someone already understands is a wait,
-and a step they do not is a race. They press Next when they have finished reading.
+**Explain first, act second.** A step opens whatever it points at, spotlights it and shows its
+caption, and then waits. The action runs when the user presses *Show me*, so they are reading the
+explanation of a control at the moment they watch it being used. Performing it first and narrating
+afterwards means describing a change that already happened while they were looking elsewhere.
 
-What is still on a timer is the interface catching up. A step's action runs, the interface is given
-``settle_ms`` to lay out before the spotlight is measured, and a step that waits on real work polls
-for it - and between each of those the player returns to the event loop, so the interface keeps
-painting and its controls keep working. A player that waited by blocking would freeze the
-demonstration it is giving.
+**The tour advances only when the user asks it to.** No timer counts down behind the caption:
+there is no interval that is right for everyone, since a step someone already understands is a
+wait and a step they do not is a race.
 
-Two things follow from the tour driving a real interface:
+*Next* applies the step's action first if *Show me* has not been pressed. Chapters are cumulative -
+there is nothing to add an orientation to until a sample has been loaded - so a skipped action
+would leave every later step describing an interface that never got into the state it assumes.
 
-* **Back does not undo.** It re-shows the previous step's caption and spotlight without re-running
-  its action. Replaying an action would double it - pressing "Add orientation" twice adds two - and
-  unwinding one is not something a step can be asked to describe. So Back is for re-reading, and
+Two more things follow from the tour driving a real interface:
+
+* **Back does not undo.** It re-shows an earlier step's caption and spotlight without re-running
+  its action. Replaying one would double it - pressing "Add orientation" twice adds two - and
+  unwinding it is not something a step can be asked to describe. So Back is for re-reading, and
   starting a chapter over is done by rebuilding the interface, which the session owns.
 * **A step that fails does not kill the tour.** The interface has moved under it, which is worth
-  reporting, but stranding the user mid-tour with a dead window helps nobody. The step is skipped
-  and its failure emitted.
+  reporting, but stranding the user mid-tour with a dead window helps nobody. The failure is
+  emitted and the step is treated as done.
 """
 
 from qtpy.QtCore import QObject, QTimer, Signal
@@ -43,16 +46,18 @@ class TutorialPlayer(QObject):
 
     The player owns sequencing and nothing else. It does not build or tear down the interface it is
     touring, and it does not decide what the controls mean - a session does both, and calls
-    ``next_step`` / ``back_step`` in response.
+    ``next_step`` / ``back_step`` / ``apply_step`` in response.
     """
 
     #: the whole tour reached its end
     finished = Signal()
     #: now showing (chapter index, step index)
     step_changed = Signal(int, int)
+    #: the current step's action has now been performed
+    step_applied = Signal()
     #: a step could not be performed; carries the step's label and the reason
     step_failed = Signal(str, str)
-    #: the tour is waiting on the interface and should not be advanced; carries a message
+    #: the tour is working and should not be driven; carries a message
     busy_changed = Signal(bool, str)
 
     def __init__(self, chapters, context, overlay, bubble, parent=None):
@@ -69,6 +74,9 @@ class TutorialPlayer(QObject):
         self._running = False
         self._busy = False
         self._busy_message = ""
+        # positions whose action has already run. Kept per position rather than as a single flag
+        # because Back revisits steps, and their actions must not run a second time.
+        self._applied = set()
         self._pending = None  # the QTimer for whatever happens next, so it can be cancelled
         self._waiter = None  # the QTimer polling a step's await_, likewise
 
@@ -84,8 +92,8 @@ class TutorialPlayer(QObject):
 
     @property
     def is_busy(self):
-        """True while a step is waiting on the interface, when advancing would run the next step's
-        action against something that has not finished reacting to this one."""
+        """True while the tour is performing or settling, when driving it would run one step's
+        action against an interface still reacting to another."""
         return self._busy
 
     def current_chapter(self):
@@ -93,6 +101,13 @@ class TutorialPlayer(QObject):
 
     def current_step(self):
         return self.current_chapter()[self._step_index]
+
+    def current_step_has_action(self):
+        return self.current_step().action is not None
+
+    def is_applied(self):
+        """Whether this step's action has run - vacuously true for a step that has none."""
+        return not self.current_step_has_action() or self.position in self._applied
 
     def at_start(self):
         return self._chapter_index == 0 and self._step_index == 0
@@ -105,10 +120,9 @@ class TutorialPlayer(QObject):
     def start(self, chapter_index=0, fast_forward=False):
         """Begin at ``chapter_index``.
 
-        With ``fast_forward``, the actions of every earlier chapter are performed first, silently.
-        Chapters are cumulative - there is nothing to add an orientation to until a sample has been
-        loaded - so starting partway through means catching the interface up first. It is only
-        sound on a freshly built interface, which is why the session rebuilds before asking for it.
+        With ``fast_forward``, the actions of every earlier chapter are performed first, silently,
+        to catch the interface up to the state the chapter assumes. It is only sound on a freshly
+        built interface, which is why the session rebuilds before asking for it.
         """
         if not 0 <= chapter_index < len(self._chapters):
             raise IndexError(f"no chapter {chapter_index}; the tour has {len(self._chapters)}")
@@ -119,20 +133,28 @@ class TutorialPlayer(QObject):
         if fast_forward and chapter_index > 0:
             self._fast_forward_to(chapter_index)
         else:
-            self._run_current_step()
+            self._present_current_step()
 
     def stop(self):
-        """End the tour without emitting ``finished``. Safe to call at any point, including from
-        inside a step."""
+        """End the tour without emitting ``finished``. Safe to call at any point."""
         self._running = False
         self._set_busy(False)
         self._cancel_pending()
         self._overlay.set_target(None)
         self._overlay.hide()
 
-    def next_step(self):
-        """Move to the next step. Ignored while the tour is waiting on the interface."""
+    def apply_step(self):
+        """Perform the current step's action, leaving its explanation on screen to be watched."""
         if self._busy:
+            return
+        self._perform(advance_after=False)
+
+    def next_step(self):
+        """Move on, performing this step's action first if it has not been performed yet."""
+        if self._busy:
+            return
+        if not self.is_applied():
+            self._perform(advance_after=True)
             return
         self._cancel_pending()
         self._advance()
@@ -149,30 +171,89 @@ class TutorialPlayer(QObject):
             self._step_index = len(self.current_chapter()) - 1
         else:
             return  # already at the very start
-        self._narrate(self.current_step())
+        self._present_current_step()
 
-    # ------------------------------------------------------------------ the step cycle
+    # ------------------------------------------------------------------ presenting
 
-    def _run_current_step(self):
+    def _present_current_step(self):
+        """Open up the step's target, spotlight it and show its caption. Runs no action."""
         if not self._running:
             return
         step = self.current_step()
-
-        # busy from the moment the action starts until the step is on screen. Without this, Next
-        # pressed during the settle would cancel the pending narration and move on, so the step's
-        # action would have run but its caption would never have been shown. No message: this lasts
-        # a couple of hundred milliseconds and should not flash text into the controls.
         self._set_busy(True)
+        # revealed before it is measured: a target on an unselected tab or inside a collapsed
+        # section has a geometry that would put the spotlight somewhere meaningless
+        self._reveal(step)
+        self._schedule(lambda: self._narrate(step), step.settle_ms)
 
-        if step.action is not None:
+    def _narrate(self, step):
+        if not self._running:
+            return
+        # a target the step's own action creates does not exist yet, which is why a miss is only
+        # worth reporting once the action has run
+        self._overlay.set_target(self._locate(step, report=self.is_applied()))
+        self._bubble.show_step(text=step.text, title=step.title)
+        self._bubble.place_beside(self._spotlight_rect())
+        self._set_busy(False)
+        self.step_changed.emit(self._chapter_index, self._step_index)
+
+    def _locate(self, step, report=True):
+        """The widget to spotlight, or None.
+
+        ``report`` says whether a target that cannot be found is a failure. It is not while the
+        step is only being explained - some targets are created by the action about to run - but it
+        is once that action has happened, when a missing one means the interface has moved under
+        the tour.
+        """
+        try:
+            target = step.resolve_target(self._context)
+        except Exception as error:
+            if report:
+                self.step_failed.emit(step.label, f"could not find what to highlight: {error}")
+            return None
+        if target is not None:
             try:
-                step.action(self._context)
+                ensure_visible(target)
             except Exception as error:
-                # the interface has moved under the tour. Worth reporting, not worth stranding the
-                # user in a half-run tour for
-                self.step_failed.emit(step.label, str(error))
-                self._narrate(step)
-                return
+                self.step_failed.emit(step.label, f"could not bring the target into view: {error}")
+        return target
+
+    def _reveal(self, step):
+        """Open up the step's target ahead of time, best-effort.
+
+        Failures are swallowed on purpose: a target created *by* the step's action does not exist
+        yet, which is legitimate. ``_locate`` resolves it again when the step is shown and reports
+        it properly if it is still missing.
+        """
+        if step.target is None:
+            return
+        try:
+            target = step.target(self._context)
+            if target is not None:
+                ensure_visible(target)
+        except Exception:
+            return
+
+    # ------------------------------------------------------------------ performing
+
+    def _perform(self, advance_after):
+        step = self.current_step()
+        if self.is_applied():
+            if advance_after:
+                self._advance()
+            return
+
+        self._set_busy(True)
+        self._applied.add(self.position)
+
+        try:
+            step.action(self._context)
+        except Exception as error:
+            # the interface has moved under the tour. Worth reporting, not worth stranding the
+            # user in a half-run tour for
+            self.step_failed.emit(step.label, str(error))
+            self._schedule(lambda: self._finish_perform(step, advance_after), 0)
+            return
 
         if step.await_ is not None:
             self._set_busy(True, step.await_text)
@@ -180,13 +261,28 @@ class TutorialPlayer(QObject):
             self._bubble.place_beside(self._spotlight_rect())
             self._waiter = wait_for(
                 predicate=lambda: self._await_holds(step),
-                on_ready=lambda: self._schedule(lambda: self._narrate(step), step.settle_ms),
+                on_ready=lambda: self._schedule(lambda: self._finish_perform(step, advance_after), step.settle_ms),
                 timeout_s=step.await_timeout_s,
-                on_timeout=lambda: self._on_await_timeout(step),
+                on_timeout=lambda: self._on_await_timeout(step, advance_after),
                 parent=self,
             )
         else:
-            self._schedule(lambda: self._narrate(step), step.settle_ms)
+            self._schedule(lambda: self._finish_perform(step, advance_after), step.settle_ms)
+
+    def _finish_perform(self, step, advance_after):
+        if not self._running:
+            return
+        if advance_after:
+            self._set_busy(False)
+            self._advance()
+            return
+        # the caption stays; the highlight is re-measured because the action may have moved,
+        # revealed or resized what it points at
+        self._overlay.set_target(self._locate(step))
+        self._bubble.show_step(text=step.text, title=step.title)
+        self._bubble.place_beside(self._spotlight_rect())
+        self._set_busy(False)
+        self.step_applied.emit()
 
     def _await_holds(self, step):
         try:
@@ -195,33 +291,9 @@ class TutorialPlayer(QObject):
             self.step_failed.emit(step.label, f"while waiting: {error}")
             return True
 
-    def _on_await_timeout(self, step):
+    def _on_await_timeout(self, step, advance_after):
         self.step_failed.emit(step.label, f"still not ready after {step.await_timeout_s}s")
-        self._narrate(step)
-
-    def _narrate(self, step):
-        """Point at the step's target and say what it is, then wait for the user.
-
-        Deliberately separate from running the action: Back comes straight here, which is the whole
-        of what makes Back safe to press.
-        """
-        if not self._running:
-            return
-
-        target = None
-        try:
-            target = step.resolve_target(self._context)
-            if target is not None:
-                ensure_visible(target)
-        except Exception as error:
-            self.step_failed.emit(step.label, f"could not find what to highlight: {error}")
-            target = None
-
-        self._overlay.set_target(target)
-        self._bubble.show_step(text=step.text, title=step.title)
-        self._bubble.place_beside(self._spotlight_rect())
-        self._set_busy(False)
-        self.step_changed.emit(self._chapter_index, self._step_index)
+        self._finish_perform(step, advance_after)
 
     def _advance(self):
         if not self._running:
@@ -233,14 +305,15 @@ class TutorialPlayer(QObject):
             self._step_index = 0
         else:
             self._running = False
+            self._set_busy(False)
             self.finished.emit()
             return
-        self._run_current_step()
+        self._present_current_step()
 
     # ------------------------------------------------------------------ fast forward
 
     def _fast_forward_to(self, chapter_index):
-        """Run every action before ``chapter_index`` with no narration.
+        """Run every action before ``chapter_index``, with no narration.
 
         Deliberately synchronous over the actions but never over a wait: a step that awaits
         something is awaited through ``wait_for`` and the rest of the fast-forward continues from
@@ -250,18 +323,25 @@ class TutorialPlayer(QObject):
         self._set_busy(True, message)
         self._bubble.show_waiting(message)
         self._bubble.place_beside(None)
-        preceding = [step for chapter_number, _step_number, _chapter, step in walk(self._chapters) if chapter_number < chapter_index]
+        preceding = [
+            ((chapter_number, step_number), step)
+            for chapter_number, step_number, _chapter, step in walk(self._chapters)
+            if chapter_number < chapter_index
+        ]
         self._replay(iter(preceding))
 
     def _replay(self, steps):
         if not self._running:
             return
-        step = next(steps, None)
-        if step is None:
+        entry = next(steps, None)
+        if entry is None:
             self._set_busy(False)
-            self._run_current_step()
+            self._present_current_step()
             return
+        position, step = entry
 
+        # marked applied even when it fails, so a Back into this chapter does not try it again
+        self._applied.add(position)
         if step.action is not None:
             try:
                 step.action(self._context)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -100,6 +100,9 @@ class TutorialShell(QWidget):
         self.btn_apply.setToolTip("Perform this step in the interface")
         self.btn_next = QPushButton("Next")
         self.btn_next.setDefault(True)
+        # whether *Show me* still has something to do, which is what decides if it comes back
+        # enabled when the tour stops being busy. True until a step says otherwise.
+        self._action_pending = True
 
         self._position_label = QLabel()
         self._position_label.setObjectName("tutorial_position")
@@ -173,8 +176,12 @@ class TutorialShell(QWidget):
         the two live ones reads as something being broken. Once used it stays visible but disabled,
         so the row does not reflow under the pointer between pressing it and pressing Next.
         """
+        # remembered rather than read back off the button when it is next needed: the button's text
+        # is a label for the user, not a place to keep state, and reading it back would tie whether
+        # the tour can be driven to the wording on a button
+        self._action_pending = has_action and not applied
         self.btn_apply.setVisible(has_action)
-        self.btn_apply.setEnabled(has_action and not applied)
+        self.btn_apply.setEnabled(self._action_pending)
         self.btn_apply.setText("Done" if has_action and applied else "Show me")
 
     def set_busy(self, busy, message=""):
@@ -189,7 +196,7 @@ class TutorialShell(QWidget):
         """
         self.btn_back.setEnabled(not busy)
         self.btn_next.setEnabled(not busy)
-        self.btn_apply.setEnabled(not busy and self.btn_apply.text() == "Show me")
+        self.btn_apply.setEnabled(not busy and self._action_pending)
         self._tabs.setEnabled(not busy)
         self._position_label.setText(message if busy and message else self._position_text)
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -20,6 +20,11 @@ and buttons stay bright and usable while everything they act on is dimmed.
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QTabBar, QVBoxLayout, QWidget
 
+# a floor for the tutorial window, for an interface whose own size hint is tiny. Below this the
+# chapter tabs and the navigation start competing with the interface for room.
+MIN_WIDTH = 900
+MIN_HEIGHT = 600
+
 
 class TutorialShell(QWidget):
     """Wraps ``interface`` in tutorial chrome.
@@ -30,6 +35,8 @@ class TutorialShell(QWidget):
 
     back_requested = Signal()
     next_requested = Signal()
+    #: perform the current step's action, with its explanation still on screen
+    apply_requested = Signal()
     #: the user picked a chapter from the tab bar
     chapter_selected = Signal(int)
     close_requested = Signal()
@@ -39,8 +46,18 @@ class TutorialShell(QWidget):
         self._interface = interface
         self._chapters = tuple(chapters)
 
+        # Qt.Window is what makes this a window of its own. A QWidget given a parent is otherwise a
+        # *child* of it, and would be drawn as a small panel in the corner of the interface that
+        # launched the tour rather than as the window the tour lives in. Keeping the parent is
+        # still right: it is what keeps the tutorial in front of the window it belongs to and takes
+        # it away with it.
+        self.setWindowFlags(Qt.Window)
         self.setWindowTitle(title or "Tutorial")
         self.setObjectName("tutorial_shell")
+
+        # the interface arrives sized by its own .ui file; the shell has to be at least that big or
+        # the whole point of framing a real interface is lost to scrollbars and clipping
+        interface_size = interface.size()
 
         self._tabs = QTabBar()
         self._tabs.setObjectName("tutorial_chapter_tabs")
@@ -60,6 +77,8 @@ class TutorialShell(QWidget):
 
         self.btn_close = QPushButton("End tutorial")
         self.btn_back = QPushButton("Back")
+        self.btn_apply = QPushButton("Show me")
+        self.btn_apply.setToolTip("Perform this step in the interface")
         self.btn_next = QPushButton("Next")
         self.btn_next.setDefault(True)
 
@@ -76,6 +95,7 @@ class TutorialShell(QWidget):
         controls_layout.addWidget(self._position_label)
         controls_layout.addSpacing(12)
         controls_layout.addWidget(self.btn_back)
+        controls_layout.addWidget(self.btn_apply)
         controls_layout.addWidget(self.btn_next)
 
         layout = QVBoxLayout(self)
@@ -86,8 +106,14 @@ class TutorialShell(QWidget):
         layout.addWidget(controls)
 
         self.btn_back.clicked.connect(self.back_requested)
+        self.btn_apply.clicked.connect(self.apply_requested)
         self.btn_next.clicked.connect(self.next_requested)
         self.btn_close.clicked.connect(self.close_requested)
+
+        self.resize(
+            max(interface_size.width(), MIN_WIDTH),
+            max(interface_size.height() + self._tabs.sizeHint().height() + controls.sizeHint().height(), MIN_HEIGHT),
+        )
 
     # ------------------------------------------------------------------ display
 
@@ -115,6 +141,17 @@ class TutorialShell(QWidget):
         self.btn_back.setEnabled(back)
         self.btn_next.setEnabled(next_)
 
+    def set_action_available(self, has_action, applied):
+        """Offer *Show me* for a step that does something, until it has been done.
+
+        Hidden rather than disabled for a step with no action - a permanently dead button beside
+        the two live ones reads as something being broken. Once used it stays visible but disabled,
+        so the row does not reflow under the pointer between pressing it and pressing Next.
+        """
+        self.btn_apply.setVisible(has_action)
+        self.btn_apply.setEnabled(has_action and not applied)
+        self.btn_apply.setText("Done" if has_action and applied else "Show me")
+
     def set_busy(self, busy, message=""):
         """Disable navigation while a step is waiting on the interface.
 
@@ -123,6 +160,7 @@ class TutorialShell(QWidget):
         """
         self.btn_back.setEnabled(not busy)
         self.btn_next.setEnabled(not busy)
+        self.btn_apply.setEnabled(not busy and self.btn_apply.text() == "Show me")
         self._tabs.setEnabled(not busy)
         if message:
             self._position_label.setText(message)
@@ -130,6 +168,7 @@ class TutorialShell(QWidget):
     def show_finished(self, message="Tutorial complete"):
         self._position_label.setText(message)
         self.btn_next.setEnabled(False)
+        self.btn_apply.setVisible(False)
 
     # ------------------------------------------------------------------ plumbing
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -1,0 +1,148 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""The frame around the interface being toured: chapter tabs above it, navigation below it.
+
+The controls live here rather than in the caption because they must not move. The caption chases
+whatever is being highlighted, and a Next button that moved with it would be somewhere different on
+every step - the one control the user has to click would be the one they had to look for. Here they
+are in the same place all the way through, and the interface sits between them, framed.
+
+The interface is *reparented into* this widget, so it is no longer a window of its own. That is
+what lets the chrome sit outside the dimming: the overlay covers only the interface, and the tabs
+and buttons stay bright and usable while everything they act on is dimmed.
+"""
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QTabBar, QVBoxLayout, QWidget
+
+
+class TutorialShell(QWidget):
+    """Wraps ``interface`` in tutorial chrome.
+
+    Emits a signal per control and holds no tour state: the session decides what Next means and
+    tells the shell what to display.
+    """
+
+    back_requested = Signal()
+    next_requested = Signal()
+    #: the user picked a chapter from the tab bar
+    chapter_selected = Signal(int)
+    close_requested = Signal()
+
+    def __init__(self, chapters, interface, parent=None, title=""):
+        super().__init__(parent)
+        self._interface = interface
+        self._chapters = tuple(chapters)
+
+        self.setWindowTitle(title or "Tutorial")
+        self.setObjectName("tutorial_shell")
+
+        self._tabs = QTabBar()
+        self._tabs.setObjectName("tutorial_chapter_tabs")
+        self._tabs.setExpanding(False)
+        self._tabs.setDrawBase(True)
+        for chapter in self._chapters:
+            index = self._tabs.addTab(chapter.name)
+            if chapter.description:
+                self._tabs.setTabToolTip(index, chapter.description)
+        self._tabs.currentChanged.connect(self._on_tab_changed)
+
+        # the interface becomes an ordinary child widget. A QMainWindow is happy to be one; it
+        # keeps its own toolbars and status bar, it just stops being a top-level window
+        interface.setParent(self)
+        interface.setWindowFlags(Qt.Widget)
+        interface.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        self.btn_close = QPushButton("End tutorial")
+        self.btn_back = QPushButton("Back")
+        self.btn_next = QPushButton("Next")
+        self.btn_next.setDefault(True)
+
+        self._position_label = QLabel()
+        self._position_label.setObjectName("tutorial_position")
+
+        controls = QFrame()
+        controls.setObjectName("tutorial_controls")
+        controls.setFrameShape(QFrame.StyledPanel)
+        controls_layout = QHBoxLayout(controls)
+        controls_layout.setContentsMargins(10, 8, 10, 8)
+        controls_layout.addWidget(self.btn_close)
+        controls_layout.addStretch(1)
+        controls_layout.addWidget(self._position_label)
+        controls_layout.addSpacing(12)
+        controls_layout.addWidget(self.btn_back)
+        controls_layout.addWidget(self.btn_next)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._tabs)
+        layout.addWidget(interface, 1)
+        layout.addWidget(controls)
+
+        self.btn_back.clicked.connect(self.back_requested)
+        self.btn_next.clicked.connect(self.next_requested)
+        self.btn_close.clicked.connect(self.close_requested)
+
+    # ------------------------------------------------------------------ display
+
+    def show_position(self, chapter_index, step_number, step_count):
+        """Reflect where the tour has got to. ``step_number`` is 1-based."""
+        self.set_current_chapter(chapter_index)
+        self._position_label.setText(f"Step {step_number} of {step_count}")
+
+    def set_current_chapter(self, chapter_index):
+        """Move the tab bar without it reporting the move back as a user request.
+
+        The player drives the tab as it crosses into a new chapter, and letting that echo back
+        would rebuild the interface underneath a tour that was running perfectly well.
+        """
+        if not 0 <= chapter_index < self._tabs.count():
+            return
+        was_blocked = self._tabs.blockSignals(True)
+        self._tabs.setCurrentIndex(chapter_index)
+        self._tabs.blockSignals(was_blocked)
+
+    def current_chapter(self):
+        return self._tabs.currentIndex()
+
+    def set_navigation_enabled(self, back=True, next_=True):
+        self.btn_back.setEnabled(back)
+        self.btn_next.setEnabled(next_)
+
+    def set_busy(self, busy, message=""):
+        """Disable navigation while a step is waiting on the interface.
+
+        Pressing Next in the middle of a file search or an absorption calculation would run the
+        following step's action against an interface that had not finished reacting to this one.
+        """
+        self.btn_back.setEnabled(not busy)
+        self.btn_next.setEnabled(not busy)
+        self._tabs.setEnabled(not busy)
+        if message:
+            self._position_label.setText(message)
+
+    def show_finished(self, message="Tutorial complete"):
+        self._position_label.setText(message)
+        self.btn_next.setEnabled(False)
+
+    # ------------------------------------------------------------------ plumbing
+
+    def _on_tab_changed(self, index):
+        self.chapter_selected.emit(index)
+
+    def release_interface(self):
+        """Let go of the toured interface so it can be closed independently.
+
+        Called before teardown: the interface is a child, so destroying the shell first would take
+        it with it and its ``closeEvent`` - which is what removes its workspaces - would never run
+        the way it does for a window the user closes.
+        """
+        if self._interface is not None:
+            self._interface.setParent(None)
+            self._interface = None

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -88,6 +88,9 @@ class TutorialShell(QWidget):
 
         self._position_label = QLabel()
         self._position_label.setObjectName("tutorial_position")
+        # what the label says when nothing is being waited for. Kept because a busy message takes
+        # the label over, and the step the tour is on has to come back when the wait ends
+        self._position_text = ""
 
         controls = QFrame()
         controls.setObjectName("tutorial_controls")
@@ -124,7 +127,11 @@ class TutorialShell(QWidget):
     def show_position(self, chapter_index, step_number, step_count):
         """Reflect where the tour has got to. ``step_number`` is 1-based."""
         self.set_current_chapter(chapter_index)
-        self._position_label.setText(f"Step {step_number} of {step_count}")
+        self._show_position_text(f"Step {step_number} of {step_count}")
+
+    def _show_position_text(self, text):
+        self._position_text = text
+        self._position_label.setText(text)
 
     def set_current_chapter(self, chapter_index):
         """Move the tab bar without it reporting the move back as a user request.
@@ -161,16 +168,19 @@ class TutorialShell(QWidget):
 
         Pressing Next in the middle of a file search or an absorption calculation would run the
         following step's action against an interface that had not finished reacting to this one.
+
+        A message borrows the step counter's label rather than adding a second one, so it has to be
+        given back: a wait that ended would otherwise leave "Working…" sitting where the position
+        belongs until the user moved on.
         """
         self.btn_back.setEnabled(not busy)
         self.btn_next.setEnabled(not busy)
         self.btn_apply.setEnabled(not busy and self.btn_apply.text() == "Show me")
         self._tabs.setEnabled(not busy)
-        if message:
-            self._position_label.setText(message)
+        self._position_label.setText(message if busy and message else self._position_text)
 
     def show_finished(self, message="Tutorial complete"):
-        self._position_label.setText(message)
+        self._show_position_text(message)
         self.btn_next.setEnabled(False)
         self.btn_apply.setVisible(False)
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -65,9 +65,13 @@ class TutorialShell(QWidget):
         self._tabs.setDrawBase(True)
         for chapter in self._chapters:
             index = self._tabs.addTab(chapter.name)
-            if chapter.description:
-                self._tabs.setTabToolTip(index, chapter.description)
+            hint = "Click again to start this chapter over."
+            self._tabs.setTabToolTip(index, f"{chapter.description}\n{hint}" if chapter.description else hint)
         self._tabs.currentChanged.connect(self._on_tab_changed)
+        # clicking the chapter already showing restarts it. ``currentChanged`` does not fire for
+        # the current tab, and a chapter jump is a rebuild - which makes "start this chapter again"
+        # the one form of undo the tour can offer that is always exactly right
+        self._tabs.tabBarClicked.connect(self._on_tab_clicked)
 
         # the interface becomes an ordinary child widget. A QMainWindow is happy to be one; it
         # keeps its own toolbars and status bar, it just stops being a top-level window
@@ -174,6 +178,10 @@ class TutorialShell(QWidget):
 
     def _on_tab_changed(self, index):
         self.chapter_selected.emit(index)
+
+    def _on_tab_clicked(self, index):
+        if index == self._tabs.currentIndex():
+            self.chapter_selected.emit(index)
 
     def release_interface(self):
         """Let go of the toured interface so it can be closed independently.

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -176,6 +176,17 @@ class TutorialShell(QWidget):
 
     # ------------------------------------------------------------------ plumbing
 
+    def closeEvent(self, event):
+        """Closing the window ends the tour, exactly as *End tutorial* does.
+
+        Without this the two are not the same thing at all: ``close`` on a widget hides it rather
+        than destroying it, so the session - which is watching for the window being *destroyed* -
+        would hear nothing, and the interface being toured would be left alive behind a hidden
+        window, with its workspaces still in the ADS.
+        """
+        self.close_requested.emit()
+        super().closeEvent(event)
+
     def _on_tab_changed(self, index):
         self.chapter_selected.emit(index)
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/shell.py
@@ -59,26 +59,41 @@ class TutorialShell(QWidget):
         # the whole point of framing a real interface is lost to scrollbars and clipping
         interface_size = interface.size()
 
-        self._tabs = QTabBar()
-        self._tabs.setObjectName("tutorial_chapter_tabs")
-        self._tabs.setExpanding(False)
-        self._tabs.setDrawBase(True)
+        self._tabs = self._build_tabs()
+        controls = self._build_controls()
+        self._adopt(interface)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._tabs)
+        layout.addWidget(interface, 1)
+        layout.addWidget(controls)
+
+        self.resize(
+            max(interface_size.width(), MIN_WIDTH),
+            max(interface_size.height() + self._tabs.sizeHint().height() + controls.sizeHint().height(), MIN_HEIGHT),
+        )
+
+    def _build_tabs(self):
+        """The chapter tabs along the top."""
+        tabs = QTabBar()
+        tabs.setObjectName("tutorial_chapter_tabs")
+        tabs.setExpanding(False)
+        tabs.setDrawBase(True)
         for chapter in self._chapters:
-            index = self._tabs.addTab(chapter.name)
+            index = tabs.addTab(chapter.name)
             hint = "Click again to start this chapter over."
-            self._tabs.setTabToolTip(index, f"{chapter.description}\n{hint}" if chapter.description else hint)
-        self._tabs.currentChanged.connect(self._on_tab_changed)
+            tabs.setTabToolTip(index, f"{chapter.description}\n{hint}" if chapter.description else hint)
+        tabs.currentChanged.connect(self._on_tab_changed)
         # clicking the chapter already showing restarts it. ``currentChanged`` does not fire for
         # the current tab, and a chapter jump is a rebuild - which makes "start this chapter again"
         # the one form of undo the tour can offer that is always exactly right
-        self._tabs.tabBarClicked.connect(self._on_tab_clicked)
+        tabs.tabBarClicked.connect(self._on_tab_clicked)
+        return tabs
 
-        # the interface becomes an ordinary child widget. A QMainWindow is happy to be one; it
-        # keeps its own toolbars and status bar, it just stops being a top-level window
-        interface.setParent(self)
-        interface.setWindowFlags(Qt.Widget)
-        interface.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
+    def _build_controls(self):
+        """The navigation row along the bottom, and the step counter it shares."""
         self.btn_close = QPushButton("End tutorial")
         self.btn_back = QPushButton("Back")
         self.btn_apply = QPushButton("Show me")
@@ -105,22 +120,21 @@ class TutorialShell(QWidget):
         controls_layout.addWidget(self.btn_apply)
         controls_layout.addWidget(self.btn_next)
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-        layout.addWidget(self._tabs)
-        layout.addWidget(interface, 1)
-        layout.addWidget(controls)
-
         self.btn_back.clicked.connect(self.back_requested)
         self.btn_apply.clicked.connect(self.apply_requested)
         self.btn_next.clicked.connect(self.next_requested)
         self.btn_close.clicked.connect(self.close_requested)
+        return controls
 
-        self.resize(
-            max(interface_size.width(), MIN_WIDTH),
-            max(interface_size.height() + self._tabs.sizeHint().height() + controls.sizeHint().height(), MIN_HEIGHT),
-        )
+    def _adopt(self, interface):
+        """Take the interface in as an ordinary child widget.
+
+        A QMainWindow is happy to be one; it keeps its own toolbars and status bar, it just stops
+        being a top-level window.
+        """
+        interface.setParent(self)
+        interface.setWindowFlags(Qt.Widget)
+        interface.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
     # ------------------------------------------------------------------ display
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -1,0 +1,147 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+"""The units a guided tutorial is written in.
+
+A tour is a list of ``TutorialChapter``, each a list of ``TutorialStep``. A step says what to
+spotlight, what to say about it, and - because these tours drive the interface themselves rather
+than asking the user to - what to do to it.
+
+Everything a step refers to in the interface is a *callable* taking the tutorial context, never a
+widget or an object name. Two reasons, and both bite in practice:
+
+* the interesting widgets often do not exist when the tour is written down. Matplotlib canvases
+  are injected into placeholder widgets after construction, and table cell widgets only appear
+  once the table has rows - which, in an automated tour, is several steps in.
+* a chapter can be replayed from its start (this is what ``Back`` does), and a replay happens
+  against a freshly built interface. A captured widget reference would be dangling by then.
+
+The context object itself belongs to whoever wrote the tour: the framework only passes it through.
+It is whatever the sandbox factory produced, so an interface's steps can reach its presenter and
+model as readily as its widgets.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Sequence, Tuple
+
+# A step with no explicit dwell pauses for this long once its action has run and the spotlight has
+# moved. Long enough to read a sentence or two without the tour feeling stalled.
+DEFAULT_DWELL_MS = 2500
+
+# ``settle`` default. A step's action usually triggers a repaint, a replot or a queued signal, and
+# the spotlight is positioned from the target's geometry - so the geometry has to have caught up
+# before it is measured.
+DEFAULT_SETTLE_MS = 150
+
+
+@dataclass(frozen=True)
+class TutorialStep:
+    """One thing the tour points at and says.
+
+    :param text: what to tell the user. Rich text - the bubble renders it as HTML.
+    :param target: ``context -> widget`` to spotlight, or None to narrate with no highlight
+        (an opening or closing remark, say). Returning None is allowed and means the same.
+    :param action: ``context -> None``, performed *before* the step is narrated, so the user reads
+        the caption while looking at the result. Must not block: see ``await_``.
+    :param title: short heading for the bubble. Falls back to the chapter name when empty.
+    :param dwell_ms: how long to hold this step before advancing while playing.
+    :param settle_ms: how long to let the interface repaint after ``action`` before the target is
+        measured and spotlighted.
+    :param await_: ``context -> bool``, polled after ``action`` until it holds; the step is not
+        narrated until it does. This is how a step waits for slow work (a fit, an absorption
+        calculation) without blocking the event loop and freezing the very repaints the tour is
+        showing off.
+    :param await_timeout_s: how long ``await_`` may take. Deliberately explicit whenever it is
+        long: a tour that waits on something slow should say so here rather than inherit a
+        generous default that would hide a hang.
+    :param await_text: what the bubble says while ``await_`` is pending, so a pause that is doing
+        real work does not read as the tour having frozen.
+    """
+
+    text: str
+    target: Optional[Callable[[Any], Any]] = None
+    action: Optional[Callable[[Any], None]] = None
+    title: str = ""
+    dwell_ms: int = DEFAULT_DWELL_MS
+    settle_ms: int = DEFAULT_SETTLE_MS
+    await_: Optional[Callable[[Any], bool]] = None
+    await_timeout_s: float = 10.0
+    await_text: str = "Working…"
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("a tutorial step must say something; 'text' is empty")
+        if self.dwell_ms < 0 or self.settle_ms < 0:
+            raise ValueError(f"'{self.label}' has a negative delay")
+        if self.await_ is not None and self.await_timeout_s <= 0:
+            raise ValueError(f"'{self.label}' waits on a predicate with a non-positive timeout")
+
+    @property
+    def label(self) -> str:
+        """A name for this step in a log or a test failure. The title if it has one, otherwise the
+        opening of its text, so an untitled step is still identifiable."""
+        if self.title:
+            return self.title
+        flat = " ".join(self.text.split())
+        return flat if len(flat) <= 60 else flat[:57] + "…"
+
+    def resolve_target(self, context: Any) -> Any:
+        """The widget to spotlight, or None for a step that only narrates.
+
+        Failure is not caught here. A target that cannot be resolved means the interface has moved
+        underneath the tour - a renamed ``.ui`` object, a widget built only on some code path - and
+        the tour is now describing something that is not there. That should surface loudly in the
+        chapter test rather than be smoothed over into a step that silently stops highlighting.
+        """
+        if self.target is None:
+            return None
+        return self.target(context)
+
+
+@dataclass(frozen=True)
+class TutorialChapter:
+    """A named run of steps that can be played on its own.
+
+    Chapters are the unit the user picks from and the unit ``Back`` rewinds to: a chapter is
+    replayed from its first step against a freshly built interface, rather than the tour trying to
+    undo actions it has taken. That is only sound if a chapter is self-contained, so a chapter
+    should begin from whatever state the sandbox factory produces and not rely on an earlier
+    chapter having run.
+    """
+
+    name: str
+    steps: Sequence[TutorialStep] = field(default_factory=tuple)
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("a tutorial chapter must be named; it is what the user picks from")
+        if not self.steps:
+            raise ValueError(f"chapter '{self.name}' has no steps")
+        object.__setattr__(self, "steps", tuple(self.steps))
+
+    def __len__(self) -> int:
+        return len(self.steps)
+
+    def __getitem__(self, index: int) -> TutorialStep:
+        return self.steps[index]
+
+
+def total_steps(chapters: Sequence[TutorialChapter]) -> int:
+    return sum(len(chapter) for chapter in chapters)
+
+
+def walk(chapters: Sequence[TutorialChapter]) -> Tuple[Tuple[int, int, TutorialChapter, TutorialStep], ...]:
+    """Every step in play order as ``(chapter_index, step_index, chapter, step)``.
+
+    Used by the chapter test to visit the whole tour, and by the player to validate a position.
+    """
+    return tuple(
+        (chapter_index, step_index, chapter, step)
+        for chapter_index, chapter in enumerate(chapters)
+        for step_index, step in enumerate(chapter.steps)
+    )

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -28,10 +28,6 @@ model as readily as its widgets.
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Sequence, Tuple
 
-# A step with no explicit dwell pauses for this long once its action has run and the spotlight has
-# moved. Long enough to read a sentence or two without the tour feeling stalled.
-DEFAULT_DWELL_MS = 2500
-
 # ``settle`` default. A step's action usually triggers a repaint, a replot or a queued signal, and
 # the spotlight is positioned from the target's geometry - so the geometry has to have caught up
 # before it is measured.
@@ -48,7 +44,6 @@ class TutorialStep:
     :param action: ``context -> None``, performed *before* the step is narrated, so the user reads
         the caption while looking at the result. Must not block: see ``await_``.
     :param title: short heading for the bubble. Falls back to the chapter name when empty.
-    :param dwell_ms: how long to hold this step before advancing while playing.
     :param settle_ms: how long to let the interface repaint after ``action`` before the target is
         measured and spotlighted.
     :param await_: ``context -> bool``, polled after ``action`` until it holds; the step is not
@@ -66,7 +61,6 @@ class TutorialStep:
     target: Optional[Callable[[Any], Any]] = None
     action: Optional[Callable[[Any], None]] = None
     title: str = ""
-    dwell_ms: int = DEFAULT_DWELL_MS
     settle_ms: int = DEFAULT_SETTLE_MS
     await_: Optional[Callable[[Any], bool]] = None
     await_timeout_s: float = 10.0
@@ -75,7 +69,7 @@ class TutorialStep:
     def __post_init__(self) -> None:
         if not self.text.strip():
             raise ValueError("a tutorial step must say something; 'text' is empty")
-        if self.dwell_ms < 0 or self.settle_ms < 0:
+        if self.settle_ms < 0:
             raise ValueError(f"'{self.label}' has a negative delay")
         if self.await_ is not None and self.await_timeout_s <= 0:
             raise ValueError(f"'{self.label}' waits on a predicate with a non-positive timeout")

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -41,19 +41,20 @@ class TutorialStep:
     :param text: what to tell the user. Rich text - the bubble renders it as HTML.
     :param target: ``context -> widget`` to spotlight, or None to narrate with no highlight
         (an opening or closing remark, say). Returning None is allowed and means the same.
-    :param action: ``context -> None``, performed *before* the step is narrated, so the user reads
-        the caption while looking at the result. Must not block: see ``await_``.
+    :param action: ``context -> None``, performed when the user presses *Show me* - that is, only
+        once the step has been narrated, so they read what a control does and then watch it used.
+        Must not block: see ``await_``.
     :param avoid: ``context -> widget`` (or a sequence of them) the caption must not cover.
         For a step whose effect appears somewhere other than the control it points at - ticking a
         check box while the values it changes are displayed elsewhere - so the explanation does not
         end up sitting on top of the evidence.
     :param title: short heading for the bubble. Falls back to the chapter name when empty.
-    :param settle_ms: how long to let the interface repaint after ``action`` before the target is
-        measured and spotlighted.
+    :param settle_ms: how long to let the interface repaint before the target is measured and
+        spotlighted - both when the step is first shown and again once ``action`` has run.
     :param await_: ``context -> bool``, polled after ``action`` until it holds; the step is not
-        narrated until it does. This is how a step waits for slow work (a fit, an absorption
-        calculation) without blocking the event loop and freezing the very repaints the tour is
-        showing off.
+        reported as done until it does, and the bubble shows ``await_text`` meanwhile. This is how
+        a step waits for slow work (a fit, an absorption calculation) without blocking the event
+        loop and freezing the very repaints the tour is showing off.
     :param await_timeout_s: how long ``await_`` may take. Deliberately explicit whenever it is
         long: a tour that waits on something slow should say so here rather than inherit a
         generous default that would hide a hang.

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -43,6 +43,10 @@ class TutorialStep:
         (an opening or closing remark, say). Returning None is allowed and means the same.
     :param action: ``context -> None``, performed *before* the step is narrated, so the user reads
         the caption while looking at the result. Must not block: see ``await_``.
+    :param avoid: ``context -> widget`` (or a sequence of them) the caption must not cover.
+        For a step whose effect appears somewhere other than the control it points at - ticking a
+        check box while the values it changes are displayed elsewhere - so the explanation does not
+        end up sitting on top of the evidence.
     :param title: short heading for the bubble. Falls back to the chapter name when empty.
     :param settle_ms: how long to let the interface repaint after ``action`` before the target is
         measured and spotlighted.
@@ -60,6 +64,7 @@ class TutorialStep:
     text: str
     target: Optional[Callable[[Any], Any]] = None
     action: Optional[Callable[[Any], None]] = None
+    avoid: Optional[Callable[[Any], Any]] = None
     title: str = ""
     settle_ms: int = DEFAULT_SETTLE_MS
     await_: Optional[Callable[[Any], bool]] = None
@@ -82,6 +87,24 @@ class TutorialStep:
             return self.title
         flat = " ".join(self.text.split())
         return flat if len(flat) <= 60 else flat[:57] + "…"
+
+    def resolve_avoid(self, context: Any) -> Tuple[Any, ...]:
+        """Widgets the caption must keep clear of. Empty when the step names none.
+
+        Unlike the target, a miss here is swallowed: keeping out of the way of something is a
+        courtesy, and failing at it is not worth interrupting the tour for.
+        """
+        if self.avoid is None:
+            return ()
+        try:
+            found = self.avoid(context)
+        except Exception:
+            return ()
+        if found is None:
+            return ()
+        if isinstance(found, (list, tuple, set)):
+            return tuple(widget for widget in found if widget is not None)
+        return (found,)
 
     def resolve_target(self, context: Any) -> Any:
         """The widget to spotlight, or None for a step that only narrates.

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -26,7 +26,7 @@ model as readily as its widgets.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Tuple
 
 # ``settle`` default. A step's action usually triggers a repaint, a replot or a queued signal, and
 # the spotlight is positioned from the target's geometry - so the geometry has to have caught up
@@ -148,13 +148,33 @@ class TutorialChapter:
         return self.steps[index]
 
 
-def walk(chapters: Sequence[TutorialChapter]) -> Tuple[Tuple[int, int, TutorialChapter, TutorialStep], ...]:
-    """Every step in play order as ``(chapter_index, step_index, chapter, step)``.
+class Visit(NamedTuple):
+    """One step, and where in the tour it was reached.
 
-    Used by the chapter test to visit the whole tour, and by the player to validate a position.
+    A tuple, so ``chapter_index, step_index, chapter, step = visit`` still works - but naming the
+    fields means a caller that wants two of them does not have to spell out throwaways for the
+    other two.
+    """
+
+    chapter_index: int
+    step_index: int
+    chapter: TutorialChapter
+    step: TutorialStep
+
+    @property
+    def position(self) -> Tuple[int, int]:
+        """What the player calls a position: the pair that identifies this step in the tour."""
+        return self.chapter_index, self.step_index
+
+
+def walk(chapters: Sequence[TutorialChapter]) -> Tuple[Visit, ...]:
+    """Every step in play order.
+
+    Used by the chapter test to visit the whole tour, and by the player to catch an interface up to
+    a chapter that is being jumped to.
     """
     return tuple(
-        (chapter_index, step_index, chapter, step)
+        Visit(chapter_index, step_index, chapter, step)
         for chapter_index, chapter in enumerate(chapters)
         for step_index, step in enumerate(chapter.steps)
     )

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/step.py
@@ -148,10 +148,6 @@ class TutorialChapter:
         return self.steps[index]
 
 
-def total_steps(chapters: Sequence[TutorialChapter]) -> int:
-    return sum(len(chapter) for chapter in chapters)
-
-
 def walk(chapters: Sequence[TutorialChapter]) -> Tuple[Tuple[int, int, TutorialChapter, TutorialStep], ...]:
     """Every step in play order as ``(chapter_index, step_index, chapter, step)``.
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/__init__.py
@@ -1,0 +1,7 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_annotator.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_annotator.py
@@ -1,0 +1,158 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.annotator import TutorialAnnotator
+
+
+@start_qapplication
+class TutorialAnnotatorTest(unittest.TestCase):
+    def setUp(self):
+        self.window = QWidget()
+        layout = QVBoxLayout(self.window)
+        self.button = QPushButton("In the main window")
+        layout.addWidget(self.button)
+        self.window.resize(600, 400)
+        self.window.show()
+
+        # a second top-level window, as a settings dialog is
+        self.dialog = QDialog(self.window)
+        dialog_layout = QVBoxLayout(self.dialog)
+        self.setting = QPushButton("In the dialog")
+        dialog_layout.addWidget(self.setting)
+        self.dialog.resize(400, 300)
+        self.dialog.show()
+
+        interaction.process_events(3)
+        self.annotator = TutorialAnnotator(self.window)
+        self.annotator.show()
+        interaction.process_events(3)
+
+    def tearDown(self):
+        self.annotator.detach()
+        self.dialog.close()
+        self.window.close()
+        self.dialog.deleteLater()
+        self.window.deleteLater()
+        interaction.process_events()
+
+    def _caption_text(self):
+        bubble = self.annotator.active_bubble()
+        return bubble.findChild(QLabel, "tutorial_bubble_text").text()
+
+    # ------------------------------------------------------------------ following the target
+
+    def test_it_annotates_the_window_the_target_is_in(self):
+        self.annotator.set_target(self.button)
+        self.assertIs(self.annotator.active_window(), self.window)
+
+    def test_it_dims_the_primary_itself_not_the_window_around_it(self):
+        # the interface is a child of the tutorial shell, which also holds the chapter tabs and the
+        # navigation. Dimming its *window* would put the scrim over the controls driving the tour.
+        shell = QWidget()
+        self.addCleanup(shell.deleteLater)
+        shell_layout = QVBoxLayout(shell)
+        interface = QWidget()
+        interface_layout = QVBoxLayout(interface)
+        target = QPushButton("deep inside")
+        interface_layout.addWidget(target)
+        shell_layout.addWidget(interface)
+        shell.resize(500, 400)
+        shell.show()
+        interaction.process_events(3)
+
+        annotator = TutorialAnnotator(interface)
+        self.addCleanup(annotator.detach)
+        annotator.set_target(target)
+
+        self.assertIs(annotator.active_window(), interface)
+        self.assertIsNot(annotator.active_window(), shell)
+
+    def test_it_follows_a_target_into_another_window(self):
+        # the whole reason this exists: a settings dialog is a window of its own, and the
+        # interface's overlay cannot reach into it
+        self.annotator.set_target(self.button)
+        self.annotator.set_target(self.setting)
+
+        self.assertIs(self.annotator.active_window(), self.dialog)
+
+    def test_the_caption_moves_with_it(self):
+        self.annotator.show_step("about a setting", title="Settings")
+        self.annotator.set_target(self.setting)
+        interaction.process_events(3)
+
+        self.assertIs(self.annotator.active_bubble().window(), self.dialog)
+        self.assertEqual(self._caption_text(), "about a setting")
+
+    def test_only_one_window_is_annotated_at_a_time(self):
+        # a scrim left on a window the tour has moved off, with a caption that no longer applies
+        self.annotator.set_target(self.button)
+        first_bubble = self.annotator.active_bubble()
+
+        self.annotator.set_target(self.setting)
+        interaction.process_events(3)
+
+        self.assertFalse(first_bubble.isVisible())
+        self.assertTrue(self.annotator.active_bubble().isVisible())
+
+    def test_it_comes_back_to_the_main_window(self):
+        self.annotator.set_target(self.setting)
+        self.annotator.set_target(self.button)
+        self.assertIs(self.annotator.active_window(), self.window)
+
+    def test_a_step_with_no_target_annotates_the_window_the_tour_belongs_to(self):
+        # otherwise a narration-only step would appear over whatever window happened to be last
+        self.annotator.set_target(self.setting)
+        self.annotator.set_target(None)
+        self.assertIs(self.annotator.active_window(), self.window)
+
+    def test_it_reuses_a_windows_panel_rather_than_building_another(self):
+        self.annotator.set_target(self.setting)
+        first = self.annotator.active_bubble()
+        self.annotator.set_target(self.button)
+        self.annotator.set_target(self.setting)
+
+        self.assertIs(self.annotator.active_bubble(), first)
+
+    # ------------------------------------------------------------------ the player's surface
+
+    def test_the_spotlight_rect_comes_from_the_active_window(self):
+        self.annotator.set_target(self.setting)
+        interaction.process_events(3)
+
+        rect = self.annotator.target_rect()
+        self.assertFalse(rect.isEmpty())
+        self.assertTrue(rect.contains(self.setting.geometry()))
+
+    def test_show_waiting_replaces_the_caption_text(self):
+        self.annotator.show_step("a step", title="Step")
+        self.annotator.show_waiting("Calculating…")
+        self.assertEqual(self._caption_text(), "Calculating…")
+
+    def test_hide_takes_every_panel_down(self):
+        self.annotator.set_target(self.setting)
+        self.annotator.set_target(self.button)
+
+        self.annotator.hide()
+        interaction.process_events(3)
+
+        self.assertIsNone(self.annotator.active_bubble())
+
+    def test_detach_is_safe_to_repeat(self):
+        self.annotator.set_target(self.setting)
+        self.annotator.detach()
+        self.annotator.detach()
+        self.assertIsNone(self.annotator.active_window())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_annotator.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_annotator.py
@@ -153,6 +153,22 @@ class TutorialAnnotatorTest(unittest.TestCase):
         self.annotator.detach()
         self.assertIsNone(self.annotator.active_window())
 
+    def test_the_whole_surface_is_inert_once_detached(self):
+        # the session stops the player before detaching, so nothing should arrive after this - but
+        # every method answering the same way is one less thing to check when reading the class
+        self.annotator.set_target(self.setting)
+        self.annotator.detach()
+
+        self.annotator.set_target(self.button)
+        self.annotator.show_step("anything", title="Step")
+        self.annotator.show_waiting("Working…")
+        self.annotator.place_beside(None)
+        self.annotator.show()
+
+        self.assertIsNone(self.annotator.active_window())
+        self.assertIsNone(self.annotator.target_rect())
+        self.assertIsNone(self.annotator.rect_of(self.button))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import QAbstractButton, QWidget
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.tutorial import interaction
-from mantidqt.widgets.tutorial.bubble import GAP, WIDTH, TutorialBubble
+from mantidqt.widgets.tutorial.bubble import GAP, TutorialBubble
 
 
 @start_qapplication
@@ -127,32 +127,24 @@ class TutorialBubbleTest(unittest.TestCase):
 
     # ------------------------------------------------------------------ layout
 
-    def test_the_box_is_no_taller_than_the_text_it_holds(self):
-        # leftover height is what shows up as uneven padding around the caption
-        self.bubble.show_step("A caption long enough that it has to wrap over several lines. " * 3, title="A step")
-        interaction.process_events()
+    # The box sizes itself to its text rather than leaving it to the layout, because a word-wrapped
+    # QLabel reports a size hint for a single line. Get that wrong in one direction and the last
+    # line of the caption is cut off; wrong in the other and there is a strip of dead space under
+    # it. The two tests below are those two failures.
 
-        title = self.window.findChild(QWidget, "tutorial_bubble_title")
-        text = self.window.findChild(QWidget, "tutorial_bubble_text")
-        content_bottom = max(title.geometry().bottom(), text.geometry().bottom())
-        slack = self.bubble.height() - content_bottom
-
-        self.assertGreaterEqual(slack, 0)
-        self.assertLessEqual(slack, 20, f"{slack}px of unused height below the caption")
+    #: captions of the shapes the tour actually uses: one line, a couple, and the long welcome step
+    CAPTIONS = (
+        "Short.",
+        "A caption that runs on for long enough to need wrapping over two lines or so.",
+        "This is a working copy of the interface, loaded with a demo sample. Everything the "
+        "tutorial does happens here — your own session is untouched.<br><br>"
+        "Each step explains a control first. Press <b>Show me</b> to watch the tutorial use it, "
+        "then <b>Next</b> to move on — nothing happens on its own. <b>Back</b> re-reads a step, "
+        "and the tabs above jump to a chapter.",
+    )
 
     def test_no_caption_is_clipped(self):
-        # the box was coming up a line short and cutting off the last one: the frame's border eats
-        # into both the width the text wraps in and the height it is given
-        captions = (
-            "Short.",
-            "A caption that runs on for long enough to need wrapping over two lines or so.",
-            "This is a working copy of the interface, loaded with a demo sample. Everything the "
-            "tutorial does happens here — your own session is untouched.<br><br>"
-            "Each step explains a control first. Press <b>Show me</b> to watch the tutorial use it, "
-            "then <b>Next</b> to move on — nothing happens on its own. <b>Back</b> re-reads a step, "
-            "and the tabs above jump to a chapter.",
-        )
-        for caption in captions:
+        for caption in self.CAPTIONS:
             with self.subTest(caption=caption[:40]):
                 self.bubble.show_step(caption, title="Welcome to the Texture Planner")
                 interaction.process_events()
@@ -162,61 +154,20 @@ class TutorialBubbleTest(unittest.TestCase):
                 self.assertGreaterEqual(text.height(), needed, f"the caption is clipped by {needed - text.height()}px")
                 self.assertLessEqual(text.geometry().bottom(), self.bubble.height(), "the caption runs past the box")
 
-    def test_the_box_leaves_room_for_its_own_border(self):
-        # the frame's border takes from both the width the text wraps in and the height it is
-        # given. Missing from the height, the box lands 2px short of its contents; missing from the
-        # width, the text wraps into a narrower space than was measured and gains a line
-        self.bubble.show_step("A caption that runs on long enough to wrap over a couple of lines. " * 2, title="A step")
-        interaction.process_events()
+    def test_the_box_is_no_taller_than_the_caption_it_holds(self):
+        heights = []
+        for caption in self.CAPTIONS:
+            with self.subTest(caption=caption[:40]):
+                self.bubble.show_step(caption, title="A step")
+                interaction.process_events()
+                heights.append(self.bubble.height())
 
-        title = self.window.findChild(QWidget, "tutorial_bubble_title")
-        text = self.window.findChild(QWidget, "tutorial_bubble_text")
-        margins = self.bubble.layout().contentsMargins()
-        border = 2 * self.bubble.frameWidth()
+                text = self.window.findChild(QWidget, "tutorial_bubble_text")
+                slack = self.bubble.height() - text.geometry().bottom()
+                self.assertGreaterEqual(slack, 0)
+                self.assertLessEqual(slack, 20, f"{slack}px of unused height below the caption")
 
-        expected = border + margins.top() + margins.bottom() + title.height() + self.bubble.layout().spacing() + text.height()
-        self.assertEqual(self.bubble.height(), expected)
-        self.assertEqual(text.width(), WIDTH - margins.left() - margins.right() - border)
-
-    def test_a_short_caption_gets_a_short_box(self):
-        self.bubble.show_step("Short.", title="A step")
-        interaction.process_events()
-        short = self.bubble.height()
-
-        self.bubble.show_step("A much longer caption that will certainly need to wrap. " * 4, title="A step")
-        interaction.process_events()
-
-        self.assertGreater(self.bubble.height(), short, "the box should grow with its text, not stay a fixed size")
-
-    def test_the_heading_sits_against_the_top_margin(self):
-        self.bubble.show_step("short", title="A step")
-        interaction.process_events()
-
-        title = self.window.findChild(QWidget, "tutorial_bubble_title")
-        margin = self.bubble.layout().contentsMargins()
-        # plus the styled frame's own border
-        self.assertEqual(title.geometry().top(), margin.top() + self.bubble.frameWidth())
-
-    def test_the_padding_above_and_below_the_caption_matches(self):
-        # the complaint this fixes: uneven blank space around the text
-        self.bubble.show_step("A caption that runs on long enough to wrap. " * 3, title="A step")
-        interaction.process_events()
-
-        title = self.window.findChild(QWidget, "tutorial_bubble_title")
-        text = self.window.findChild(QWidget, "tutorial_bubble_text")
-        above = title.geometry().top()
-        below = self.bubble.height() - text.geometry().bottom()
-
-        self.assertAlmostEqual(above, below, delta=2, msg=f"{above}px above the caption, {below}px below")
-
-    def test_the_text_follows_the_heading_rather_than_floating(self):
-        self.bubble.show_step("short", title="A step")
-        interaction.process_events()
-
-        title = self.window.findChild(QWidget, "tutorial_bubble_title")
-        text = self.window.findChild(QWidget, "tutorial_bubble_text")
-        gap = text.geometry().top() - title.geometry().bottom()
-        self.assertLessEqual(gap, self.bubble.layout().spacing() + 2, "the two should stay together at the top")
+        self.assertEqual(heights, sorted(heights), "the box should grow with its text, not stay a fixed size")
 
     def test_with_no_spotlight_it_centres_itself(self):
         placed = self._place(QRect())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -8,7 +8,7 @@
 import unittest
 
 from qtpy.QtCore import QRect
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QAbstractButton, QWidget
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.tutorial import interaction
@@ -24,7 +24,7 @@ class TutorialBubbleTest(unittest.TestCase):
         interaction.process_events(3)
 
         self.bubble = TutorialBubble(self.window)
-        self.bubble.show_step("Some explanation of a control.", title="A step", chapter_name="Setup", step_number=2, step_count=5)
+        self.bubble.show_step("Some explanation of a control.", title="A step")
         self.bubble.show()
         interaction.process_events(3)
 
@@ -38,72 +38,24 @@ class TutorialBubbleTest(unittest.TestCase):
 
     # ------------------------------------------------------------------ content
 
-    def test_it_shows_the_step_and_its_position_in_the_chapter(self):
+    def test_it_shows_the_step(self):
         self.assertEqual(self._text_of("tutorial_bubble_title"), "A step")
         self.assertEqual(self._text_of("tutorial_bubble_text"), "Some explanation of a control.")
-        self.assertEqual(self._text_of("tutorial_bubble_chapter"), "Setup — step 2 of 5")
 
     def test_an_untitled_step_hides_the_title_rather_than_leaving_a_gap(self):
-        self.bubble.show_step("Just narrating.", chapter_name="Setup", step_number=1, step_count=3)
+        self.bubble.show_step("Just narrating.")
         interaction.process_events()
         self.assertFalse(self.window.findChild(QWidget, "tutorial_bubble_title").isVisible())
-
-    def test_a_message_with_no_step_number_hides_the_progress_line(self):
-        self.bubble.show_step("A closing remark.")
-        interaction.process_events()
-        self.assertFalse(self.window.findChild(QWidget, "tutorial_bubble_chapter").isVisible())
 
     def test_show_waiting_replaces_only_the_text(self):
         self.bubble.show_waiting("Calculating transmission…")
         self.assertEqual(self._text_of("tutorial_bubble_text"), "Calculating transmission…")
         self.assertEqual(self._text_of("tutorial_bubble_title"), "A step")
 
-    # ------------------------------------------------------------------ controls
-
-    def test_each_button_emits_its_signal(self):
-        for button, signal_name in (
-            (self.bubble.btn_back, "back_requested"),
-            (self.bubble.btn_next, "next_requested"),
-            (self.bubble.btn_chapters, "chapters_requested"),
-            (self.bubble.btn_close, "close_requested"),
-        ):
-            with self.subTest(button=button.text()):
-                fired = []
-                getattr(self.bubble, signal_name).connect(lambda: fired.append(True))
-                button.click()
-                interaction.process_events()
-                self.assertEqual(fired, [True])
-
-    def test_pause_reports_its_new_state_and_renames_itself(self):
-        states = []
-        self.bubble.pause_toggled.connect(states.append)
-
-        self.bubble.btn_pause.click()
-        interaction.process_events()
-        self.assertEqual(states, [True])
-        self.assertEqual(self.bubble.btn_pause.text(), "Resume")
-
-        self.bubble.btn_pause.click()
-        interaction.process_events()
-        self.assertEqual(states, [True, False])
-        self.assertEqual(self.bubble.btn_pause.text(), "Pause")
-
-    def test_set_paused_does_not_echo_back_to_the_player(self):
-        # the player calls this to reflect its own state; emitting would drive it back round
-        states = []
-        self.bubble.pause_toggled.connect(states.append)
-
-        self.bubble.set_paused(True)
-        interaction.process_events()
-
-        self.assertEqual(states, [])
-        self.assertTrue(self.bubble.btn_pause.isChecked())
-        self.assertEqual(self.bubble.btn_pause.text(), "Resume")
-
-    def test_navigation_can_be_disabled_at_the_ends_of_the_tour(self):
-        self.bubble.set_navigation_enabled(back=False, next_=True)
-        self.assertFalse(self.bubble.btn_back.isEnabled())
-        self.assertTrue(self.bubble.btn_next.isEnabled())
+    def test_it_carries_no_controls(self):
+        # the caption moves with the highlight, so a button on it would be somewhere different on
+        # every step. Navigation lives in the shell, which stays put.
+        self.assertEqual(self.bubble.findChildren(QAbstractButton), [])
 
     # ------------------------------------------------------------------ placement
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -1,0 +1,155 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtCore import QRect
+from qtpy.QtWidgets import QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.bubble import GAP, TutorialBubble
+
+
+@start_qapplication
+class TutorialBubbleTest(unittest.TestCase):
+    def setUp(self):
+        self.window = QWidget()
+        self.window.resize(900, 700)
+        self.window.show()
+        interaction.process_events(3)
+
+        self.bubble = TutorialBubble(self.window)
+        self.bubble.show_step("Some explanation of a control.", title="A step", chapter_name="Setup", step_number=2, step_count=5)
+        self.bubble.show()
+        interaction.process_events(3)
+
+    def tearDown(self):
+        self.window.close()
+        self.window.deleteLater()
+        interaction.process_events()
+
+    def _text_of(self, object_name):
+        return self.window.findChild(QWidget, object_name).text()
+
+    # ------------------------------------------------------------------ content
+
+    def test_it_shows_the_step_and_its_position_in_the_chapter(self):
+        self.assertEqual(self._text_of("tutorial_bubble_title"), "A step")
+        self.assertEqual(self._text_of("tutorial_bubble_text"), "Some explanation of a control.")
+        self.assertEqual(self._text_of("tutorial_bubble_chapter"), "Setup — step 2 of 5")
+
+    def test_an_untitled_step_hides_the_title_rather_than_leaving_a_gap(self):
+        self.bubble.show_step("Just narrating.", chapter_name="Setup", step_number=1, step_count=3)
+        interaction.process_events()
+        self.assertFalse(self.window.findChild(QWidget, "tutorial_bubble_title").isVisible())
+
+    def test_a_message_with_no_step_number_hides_the_progress_line(self):
+        self.bubble.show_step("A closing remark.")
+        interaction.process_events()
+        self.assertFalse(self.window.findChild(QWidget, "tutorial_bubble_chapter").isVisible())
+
+    def test_show_waiting_replaces_only_the_text(self):
+        self.bubble.show_waiting("Calculating transmission…")
+        self.assertEqual(self._text_of("tutorial_bubble_text"), "Calculating transmission…")
+        self.assertEqual(self._text_of("tutorial_bubble_title"), "A step")
+
+    # ------------------------------------------------------------------ controls
+
+    def test_each_button_emits_its_signal(self):
+        for button, signal_name in (
+            (self.bubble.btn_back, "back_requested"),
+            (self.bubble.btn_next, "next_requested"),
+            (self.bubble.btn_chapters, "chapters_requested"),
+            (self.bubble.btn_close, "close_requested"),
+        ):
+            with self.subTest(button=button.text()):
+                fired = []
+                getattr(self.bubble, signal_name).connect(lambda: fired.append(True))
+                button.click()
+                interaction.process_events()
+                self.assertEqual(fired, [True])
+
+    def test_pause_reports_its_new_state_and_renames_itself(self):
+        states = []
+        self.bubble.pause_toggled.connect(states.append)
+
+        self.bubble.btn_pause.click()
+        interaction.process_events()
+        self.assertEqual(states, [True])
+        self.assertEqual(self.bubble.btn_pause.text(), "Resume")
+
+        self.bubble.btn_pause.click()
+        interaction.process_events()
+        self.assertEqual(states, [True, False])
+        self.assertEqual(self.bubble.btn_pause.text(), "Pause")
+
+    def test_set_paused_does_not_echo_back_to_the_player(self):
+        # the player calls this to reflect its own state; emitting would drive it back round
+        states = []
+        self.bubble.pause_toggled.connect(states.append)
+
+        self.bubble.set_paused(True)
+        interaction.process_events()
+
+        self.assertEqual(states, [])
+        self.assertTrue(self.bubble.btn_pause.isChecked())
+        self.assertEqual(self.bubble.btn_pause.text(), "Resume")
+
+    def test_navigation_can_be_disabled_at_the_ends_of_the_tour(self):
+        self.bubble.set_navigation_enabled(back=False, next_=True)
+        self.assertFalse(self.bubble.btn_back.isEnabled())
+        self.assertTrue(self.bubble.btn_next.isEnabled())
+
+    # ------------------------------------------------------------------ placement
+
+    def _place(self, spotlight):
+        self.bubble.place_beside(spotlight)
+        interaction.process_events()
+        return self.bubble.geometry_in_host()
+
+    def test_it_sits_below_a_spotlight_near_the_top(self):
+        spotlight = QRect(300, 40, 200, 60)
+        placed = self._place(spotlight)
+        self.assertGreaterEqual(placed.top(), spotlight.bottom())
+        self.assertFalse(placed.intersects(spotlight))
+
+    def test_it_moves_above_a_spotlight_with_no_room_below(self):
+        spotlight = QRect(300, 560, 200, 120)
+        placed = self._place(spotlight)
+        self.assertLessEqual(placed.bottom(), spotlight.top())
+        self.assertFalse(placed.intersects(spotlight))
+
+    def test_it_goes_beside_a_spotlight_that_spans_the_window(self):
+        spotlight = QRect(20, 10, 200, 680)
+        placed = self._place(spotlight)
+        self.assertFalse(placed.intersects(spotlight))
+        self.assertGreaterEqual(placed.left(), spotlight.right())
+
+    def test_it_stays_inside_the_window_whatever_it_is_beside(self):
+        for spotlight in (
+            QRect(0, 0, 10, 10),
+            QRect(880, 680, 10, 10),
+            QRect(-50, 300, 40, 40),
+            QRect(860, -20, 60, 60),
+        ):
+            with self.subTest(spotlight=spotlight):
+                placed = self._place(spotlight)
+                self.assertTrue(
+                    self.window.rect().contains(placed),
+                    f"{placed} is not inside {self.window.rect()}",
+                )
+                self.assertGreaterEqual(placed.left(), GAP)
+
+    def test_with_no_spotlight_it_centres_itself(self):
+        placed = self._place(QRect())
+        self.assertAlmostEqual(placed.center().x(), self.window.rect().center().x(), delta=2)
+        self.assertAlmostEqual(placed.center().y(), self.window.rect().center().y(), delta=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -62,7 +62,8 @@ class TutorialBubbleTest(unittest.TestCase):
     def _place(self, spotlight, keep_clear=()):
         self.bubble.place_beside(spotlight, keep_clear)
         interaction.process_events()
-        return self.bubble.geometry_in_host()
+        # in the host's coordinates, which is what place_beside was given
+        return QRect(self.bubble.pos(), self.bubble.size())
 
     def test_it_sits_below_a_spotlight_near_the_top(self):
         spotlight = QRect(300, 40, 200, 60)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -124,6 +124,8 @@ class TutorialBubbleTest(unittest.TestCase):
         spotlight = QRect(300, 300, 40, 40)
         placed = self._place(spotlight, keep_clear=[self.window.rect()])
         self.assertTrue(self.window.rect().contains(placed))
+        # and it is the *preferred* position it settles on - below - not whichever was tried last
+        self.assertGreaterEqual(placed.top(), spotlight.bottom())
 
     # ------------------------------------------------------------------ layout
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import QAbstractButton, QWidget
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.tutorial import interaction
-from mantidqt.widgets.tutorial.bubble import GAP, TutorialBubble
+from mantidqt.widgets.tutorial.bubble import GAP, WIDTH, TutorialBubble
 
 
 @start_qapplication
@@ -138,6 +138,44 @@ class TutorialBubbleTest(unittest.TestCase):
 
         self.assertGreaterEqual(slack, 0)
         self.assertLessEqual(slack, 20, f"{slack}px of unused height below the caption")
+
+    def test_no_caption_is_clipped(self):
+        # the box was coming up a line short and cutting off the last one: the frame's border eats
+        # into both the width the text wraps in and the height it is given
+        captions = (
+            "Short.",
+            "A caption that runs on for long enough to need wrapping over two lines or so.",
+            "This is a working copy of the interface, loaded with a demo sample. Everything the "
+            "tutorial does happens here — your own session is untouched.<br><br>"
+            "Each step explains a control first. Press <b>Show me</b> to watch the tutorial use it, "
+            "then <b>Next</b> to move on — nothing happens on its own. <b>Back</b> re-reads a step, "
+            "and the tabs above jump to a chapter.",
+        )
+        for caption in captions:
+            with self.subTest(caption=caption[:40]):
+                self.bubble.show_step(caption, title="Welcome to the Texture Planner")
+                interaction.process_events()
+
+                text = self.window.findChild(QWidget, "tutorial_bubble_text")
+                needed = text.heightForWidth(text.width())
+                self.assertGreaterEqual(text.height(), needed, f"the caption is clipped by {needed - text.height()}px")
+                self.assertLessEqual(text.geometry().bottom(), self.bubble.height(), "the caption runs past the box")
+
+    def test_the_box_leaves_room_for_its_own_border(self):
+        # the frame's border takes from both the width the text wraps in and the height it is
+        # given. Missing from the height, the box lands 2px short of its contents; missing from the
+        # width, the text wraps into a narrower space than was measured and gains a line
+        self.bubble.show_step("A caption that runs on long enough to wrap over a couple of lines. " * 2, title="A step")
+        interaction.process_events()
+
+        title = self.window.findChild(QWidget, "tutorial_bubble_title")
+        text = self.window.findChild(QWidget, "tutorial_bubble_text")
+        margins = self.bubble.layout().contentsMargins()
+        border = 2 * self.bubble.frameWidth()
+
+        expected = border + margins.top() + margins.bottom() + title.height() + self.bubble.layout().spacing() + text.height()
+        self.assertEqual(self.bubble.height(), expected)
+        self.assertEqual(text.width(), WIDTH - margins.left() - margins.right() - border)
 
     def test_a_short_caption_gets_a_short_box(self):
         self.bubble.show_step("Short.", title="A step")

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_bubble.py
@@ -59,8 +59,8 @@ class TutorialBubbleTest(unittest.TestCase):
 
     # ------------------------------------------------------------------ placement
 
-    def _place(self, spotlight):
-        self.bubble.place_beside(spotlight)
+    def _place(self, spotlight, keep_clear=()):
+        self.bubble.place_beside(spotlight, keep_clear)
         interaction.process_events()
         return self.bubble.geometry_in_host()
 
@@ -96,6 +96,88 @@ class TutorialBubbleTest(unittest.TestCase):
                     f"{placed} is not inside {self.window.rect()}",
                 )
                 self.assertGreaterEqual(placed.left(), GAP)
+
+    def test_it_keeps_clear_of_what_the_step_is_demonstrating(self):
+        # a step that ticks a check box while the values it changes are displayed elsewhere would
+        # otherwise put the explanation on top of the evidence
+        # the real shape of it: a check box near the top, the fields it changes below and to one
+        # side, leaving the caption room on the other side
+        spotlight = QRect(300, 40, 120, 30)
+        evidence = QRect(60, 120, 300, 200)
+
+        without = self._place(spotlight)
+        self.assertTrue(without.intersects(evidence), "this is the placement the step has to avoid")
+
+        placed = self._place(spotlight, keep_clear=[evidence])
+
+        self.assertFalse(placed.intersects(evidence))
+        self.assertFalse(placed.intersects(spotlight))
+        self.assertTrue(self.window.rect().contains(placed))
+
+    def test_an_empty_keep_clear_rect_is_ignored(self):
+        spotlight = QRect(300, 40, 120, 30)
+        self.assertEqual(self._place(spotlight, keep_clear=[QRect(), None]), self._place(spotlight))
+
+    def test_it_settles_somewhere_even_when_everything_is_blocked(self):
+        # a caption slightly in the way beats one off the edge of the window
+        spotlight = QRect(300, 300, 40, 40)
+        placed = self._place(spotlight, keep_clear=[self.window.rect()])
+        self.assertTrue(self.window.rect().contains(placed))
+
+    # ------------------------------------------------------------------ layout
+
+    def test_the_box_is_no_taller_than_the_text_it_holds(self):
+        # leftover height is what shows up as uneven padding around the caption
+        self.bubble.show_step("A caption long enough that it has to wrap over several lines. " * 3, title="A step")
+        interaction.process_events()
+
+        title = self.window.findChild(QWidget, "tutorial_bubble_title")
+        text = self.window.findChild(QWidget, "tutorial_bubble_text")
+        content_bottom = max(title.geometry().bottom(), text.geometry().bottom())
+        slack = self.bubble.height() - content_bottom
+
+        self.assertGreaterEqual(slack, 0)
+        self.assertLessEqual(slack, 20, f"{slack}px of unused height below the caption")
+
+    def test_a_short_caption_gets_a_short_box(self):
+        self.bubble.show_step("Short.", title="A step")
+        interaction.process_events()
+        short = self.bubble.height()
+
+        self.bubble.show_step("A much longer caption that will certainly need to wrap. " * 4, title="A step")
+        interaction.process_events()
+
+        self.assertGreater(self.bubble.height(), short, "the box should grow with its text, not stay a fixed size")
+
+    def test_the_heading_sits_against_the_top_margin(self):
+        self.bubble.show_step("short", title="A step")
+        interaction.process_events()
+
+        title = self.window.findChild(QWidget, "tutorial_bubble_title")
+        margin = self.bubble.layout().contentsMargins()
+        # plus the styled frame's own border
+        self.assertEqual(title.geometry().top(), margin.top() + self.bubble.frameWidth())
+
+    def test_the_padding_above_and_below_the_caption_matches(self):
+        # the complaint this fixes: uneven blank space around the text
+        self.bubble.show_step("A caption that runs on long enough to wrap. " * 3, title="A step")
+        interaction.process_events()
+
+        title = self.window.findChild(QWidget, "tutorial_bubble_title")
+        text = self.window.findChild(QWidget, "tutorial_bubble_text")
+        above = title.geometry().top()
+        below = self.bubble.height() - text.geometry().bottom()
+
+        self.assertAlmostEqual(above, below, delta=2, msg=f"{above}px above the caption, {below}px below")
+
+    def test_the_text_follows_the_heading_rather_than_floating(self):
+        self.bubble.show_step("short", title="A step")
+        interaction.process_events()
+
+        title = self.window.findChild(QWidget, "tutorial_bubble_title")
+        text = self.window.findChild(QWidget, "tutorial_bubble_text")
+        gap = text.geometry().top() - title.geometry().bottom()
+        self.assertLessEqual(gap, self.bubble.layout().spacing() + 2, "the two should stay together at the top")
 
     def test_with_no_spotlight_it_centres_itself(self):
         placed = self._place(QRect())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
@@ -65,12 +65,11 @@ class InteractionTest(unittest.TestCase):
         button.show()
 
         interaction.click(button)
-        # animateClick holds the button down for ~100ms, so nothing has been emitted yet - this is
-        # the asynchrony the docstring warns callers about
-        self.assertEqual(pressed, [])
 
-        self.assertTrue(self._pump_until(lambda: bool(pressed)))
+        # synchronous on purpose: a press still pending when the tour ends would fire against an
+        # interface that had already been torn down
         self.assertEqual(pressed, [True])
+        self.assertFalse(button.isDown(), "the button must not be left held down")
 
     def test_click_refuses_a_non_button(self):
         self.assertRaises(TypeError, interaction.click, self._keep(QLabel("not a button")))

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
@@ -1,0 +1,280 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+
+
+@start_qapplication
+class InteractionTest(unittest.TestCase):
+    def setUp(self):
+        self.widgets = []
+
+    def tearDown(self):
+        for widget in self.widgets:
+            widget.close()
+            widget.deleteLater()
+        interaction.process_events()
+
+    def _keep(self, widget):
+        self.widgets.append(widget)
+        return widget
+
+    @staticmethod
+    def _pump_until(predicate, timeout_ms=5000):
+        """Let real time pass while the event loop runs, until ``predicate`` holds.
+
+        ``processEvents`` on its own is not enough here: it returns the moment the queue is empty
+        without any wall-clock time passing, so a loop around it never reaches a timer that is due
+        in 100 ms. ``qWait`` sleeps *and* pumps, which is what timer-driven code needs to be
+        observed. It is a test-only tool - the production code under test must never wait this way.
+        """
+        waited = 0
+        while not predicate() and waited < timeout_ms:
+            QTest.qWait(10)
+            waited += 10
+        return predicate()
+
+    # ------------------------------------------------------------------ driving widgets
+
+    def test_click_presses_a_button(self):
+        button = self._keep(QPushButton("Go"))
+        pressed = []
+        button.clicked.connect(lambda: pressed.append(True))
+        button.show()
+
+        interaction.click(button)
+        # animateClick holds the button down for ~100ms, so nothing has been emitted yet - this is
+        # the asynchrony the docstring warns callers about
+        self.assertEqual(pressed, [])
+
+        self.assertTrue(self._pump_until(lambda: bool(pressed)))
+        self.assertEqual(pressed, [True])
+
+    def test_click_refuses_a_non_button(self):
+        self.assertRaises(TypeError, interaction.click, self._keep(QLabel("not a button")))
+
+    def test_click_refuses_a_disabled_button(self):
+        button = self._keep(QPushButton("Go"))
+        button.setEnabled(False)
+        self.assertRaises(RuntimeError, interaction.click, button)
+
+    def test_set_check_state_takes_effect_immediately(self):
+        box = self._keep(QCheckBox("Include"))
+        clicks = []
+        box.clicked.connect(lambda *_: clicks.append(True))
+        box.show()
+
+        # synchronous, unlike click(): the state holds on return, and handlers on ``clicked`` ran
+        self.assertTrue(interaction.set_check_state(box, True))
+        self.assertEqual(len(clicks), 1)
+
+    def test_set_check_state_is_idempotent(self):
+        box = self._keep(QCheckBox("Include"))
+        clicks = []
+        box.clicked.connect(lambda *_: clicks.append(True))
+        box.show()
+
+        self.assertTrue(interaction.set_check_state(box, True))
+        self.assertTrue(interaction.set_check_state(box, True))
+        self.assertEqual(len(clicks), 1, "asking for the state it is already in should not click it again")
+
+    def test_set_check_state_toggles_a_group_box(self):
+        group = self._keep(QGroupBox("Section"))
+        group.setCheckable(True)
+        group.setChecked(False)
+        toggles = []
+        group.toggled.connect(toggles.append)
+
+        interaction.set_check_state(group, True)
+
+        self.assertTrue(group.isChecked())
+        self.assertEqual(toggles, [True])
+
+    def test_select_combo_by_text(self):
+        combo = self._keep(QComboBox())
+        combo.addItems(["ENGINX", "IMAT", "POLDI"])
+        self.assertEqual(interaction.select_combo(combo, "IMAT"), 1)
+        self.assertEqual(combo.currentText(), "IMAT")
+
+    def test_select_combo_reports_what_was_available(self):
+        combo = self._keep(QComboBox())
+        combo.addItems(["ENGINX", "IMAT"])
+        with self.assertRaises(ValueError) as caught:
+            interaction.select_combo(combo, "WISH")
+        self.assertIn("ENGINX", str(caught.exception))
+
+    def test_select_tab_by_title(self):
+        tabs = self._keep(QTabWidget())
+        first, second = QWidget(), QWidget()
+        tabs.addTab(first, "Sample Setup")
+        tabs.addTab(second, "Experimental Setup")
+
+        self.assertIs(interaction.select_tab(tabs, "Experimental Setup"), second)
+        self.assertEqual(tabs.currentIndex(), 1)
+
+    def test_select_tab_reports_what_was_available(self):
+        tabs = self._keep(QTabWidget())
+        tabs.addTab(QWidget(), "Sample Setup")
+        with self.assertRaises(ValueError) as caught:
+            interaction.select_tab(tabs, "Nope")
+        self.assertIn("Sample Setup", str(caught.exception))
+
+    def test_set_text_emits_what_typing_would(self):
+        line_edit = self._keep(QLineEdit())
+        seen = {"edited": [], "finished": 0, "returned": 0}
+        line_edit.textEdited.connect(seen["edited"].append)
+        line_edit.editingFinished.connect(lambda: seen.__setitem__("finished", seen["finished"] + 1))
+        line_edit.returnPressed.connect(lambda: seen.__setitem__("returned", seen["returned"] + 1))
+
+        self.assertEqual(interaction.set_text(line_edit, "0,1,0"), "0,1,0")
+
+        # setText alone emits none of these, which is the whole reason this helper exists
+        self.assertEqual(seen["edited"], ["0,1,0"])
+        self.assertEqual(seen["finished"], 1)
+        self.assertEqual(seen["returned"], 1)
+
+    def test_set_text_refuses_a_non_line_edit(self):
+        self.assertRaises(TypeError, interaction.set_text, self._keep(QLabel()), "x")
+
+    def test_set_spin_box(self):
+        spin = self._keep(QDoubleSpinBox())
+        spin.setRange(-180.0, 180.0)
+        self.assertEqual(interaction.set_spin_box(spin, 45.0), 45.0)
+
+    def test_set_spin_box_rejects_a_clamped_value(self):
+        spin = self._keep(QDoubleSpinBox())
+        spin.setRange(0.0, 10.0)
+        with self.assertRaises(ValueError) as caught:
+            interaction.set_spin_box(spin, 99.0)
+        self.assertIn("range is 0.0 to 10.0", str(caught.exception))
+
+    # ------------------------------------------------------------------ ensure_visible
+
+    def _nested_window(self):
+        """A target buried the way a real interface buries one: on the second tab, inside a
+        collapsed group box, inside a scroll area."""
+        window = self._keep(QWidget())
+        layout = QVBoxLayout(window)
+        tabs = QTabWidget()
+        layout.addWidget(tabs)
+
+        tabs.addTab(QLabel("first page"), "First")
+
+        page = QWidget()
+        page_layout = QVBoxLayout(page)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        page_layout.addWidget(scroll)
+
+        contents = QWidget()
+        contents_layout = QVBoxLayout(contents)
+        # tall filler so the target starts well below the visible part of the scroll area
+        for index in range(30):
+            contents_layout.addWidget(QLabel(f"filler {index}"))
+        group = QGroupBox("Collapsed section")
+        group.setCheckable(True)
+        group.setChecked(False)
+        group_layout = QVBoxLayout(group)
+        target = QPushButton("Target")
+        group_layout.addWidget(target)
+        contents_layout.addWidget(group)
+        scroll.setWidget(contents)
+
+        tabs.addTab(page, "Second")
+        tabs.setCurrentIndex(0)
+
+        window.resize(400, 300)
+        window.show()
+        interaction.process_events(3)
+        return window, tabs, group, target
+
+    def test_ensure_visible_selects_the_tab_expands_the_group_and_scrolls(self):
+        window, tabs, group, target = self._nested_window()
+        self.assertFalse(target.isVisible())
+
+        shown = interaction.ensure_visible(target)
+
+        self.assertEqual(tabs.currentIndex(), 1)
+        self.assertTrue(group.isChecked())
+        self.assertTrue(shown)
+        self.assertTrue(target.isVisible())
+
+    def test_ensure_visible_leaves_an_already_visible_widget_alone(self):
+        button = self._keep(QPushButton("Plain"))
+        button.show()
+        interaction.process_events()
+        self.assertTrue(interaction.ensure_visible(button))
+
+    def test_ancestors_are_innermost_first(self):
+        window, tabs, group, target = self._nested_window()
+        chain = interaction.ancestors(target)
+        self.assertIs(chain[0], group)
+        self.assertIs(chain[-1], window)
+
+    # ------------------------------------------------------------------ wait_for
+
+    def test_wait_for_calls_back_immediately_when_already_true(self):
+        called = []
+        handle = interaction.wait_for(lambda: True, lambda: called.append("ready"), timeout_s=1.0)
+        self.assertEqual(called, ["ready"])
+        self.assertIsNone(handle, "no timer should be started when the predicate already holds")
+
+    def test_wait_for_does_not_block_and_fires_when_the_predicate_turns_true(self):
+        state = {"ready": False}
+        called = []
+        holder = self._keep(QWidget())
+
+        handle = interaction.wait_for(lambda: state["ready"], lambda: called.append("ready"), timeout_s=5.0, interval_ms=10, parent=holder)
+        # control came straight back, which is the point: a blocking wait would have hung here
+        self.assertEqual(called, [])
+        self.assertTrue(handle.isActive())
+
+        state["ready"] = True
+        self.assertTrue(self._pump_until(lambda: bool(called)))
+
+        self.assertEqual(called, ["ready"])
+        self.assertFalse(handle.isActive())
+
+    def test_wait_for_calls_on_timeout_rather_than_on_ready(self):
+        called = []
+        holder = self._keep(QWidget())
+
+        interaction.wait_for(
+            lambda: False,
+            lambda: called.append("ready"),
+            timeout_s=0.05,
+            on_timeout=lambda: called.append("timeout"),
+            interval_ms=10,
+            parent=holder,
+        )
+        self.assertTrue(self._pump_until(lambda: bool(called)))
+        self.assertEqual(called, ["timeout"])
+
+    def test_wait_for_rejects_a_non_positive_timeout(self):
+        self.assertRaises(ValueError, interaction.wait_for, lambda: False, lambda: None, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_interaction.py
@@ -220,6 +220,24 @@ class InteractionTest(unittest.TestCase):
         self.assertTrue(shown)
         self.assertTrue(target.isVisible())
 
+    def test_ensure_visible_opens_a_collapsed_group_box_it_is_pointed_at(self):
+        # pointing at a shut box while describing what is inside it shows the user nothing
+        window, tabs, group, target = self._nested_window()
+
+        interaction.ensure_visible(group)
+
+        self.assertTrue(group.isChecked())
+        self.assertTrue(target.isVisible(), "the contents should be on show, not just the box")
+
+    def test_ensure_visible_does_not_change_the_page_of_a_tab_widget_it_is_pointed_at(self):
+        # a step describing the tab bar itself should not have the interface move under it
+        window, tabs, _group, _target = self._nested_window()
+        self.assertEqual(tabs.currentIndex(), 0)
+
+        interaction.ensure_visible(tabs)
+
+        self.assertEqual(tabs.currentIndex(), 0)
+
     def test_ensure_visible_leaves_an_already_visible_widget_alone(self):
         button = self._keep(QPushButton("Plain"))
         button.show()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
@@ -177,9 +177,9 @@ class TutorialSessionTest(unittest.TestCase):
         session.start(chapter_index=1)
 
         self._wait_ready(session)
-        # the earlier chapter's actions still ran, so the chapter is played against the state it
-        # expects rather than an empty interface
-        self.assertEqual(self.performed, ["load", "material", "plot"])
+        # the earlier chapter's actions still ran, so the chapter is entered against the state it
+        # expects rather than an empty interface. Its own first step is explained, not performed.
+        self.assertEqual(self.performed, ["load", "material"])
 
     def test_the_shell_buttons_drive_the_player(self):
         session = self._session()
@@ -200,6 +200,29 @@ class TutorialSessionTest(unittest.TestCase):
 
         self.assertIs(session.window.parentWidget(), session.shell)
         self.assertTrue(session.shell.isVisible())
+
+    def test_show_me_performs_the_step_without_moving_off_it(self):
+        session = self._session()
+        session.start()
+        self._wait_ready(session)
+        self.assertEqual(self.performed, [], "a step is explained before it is performed")
+        self.assertTrue(session.shell.btn_apply.isEnabled())
+
+        session.shell.btn_apply.click()
+        self._wait_ready(session)
+
+        self.assertEqual(self.performed, ["load"])
+        self.assertEqual(session.player.position, (0, 0))
+        self.assertEqual(session.shell.btn_apply.text(), "Done")
+        self.assertFalse(session.shell.btn_apply.isEnabled())
+
+    def test_show_me_is_hidden_for_a_step_with_nothing_to_do(self):
+        chapters = (TutorialChapter(name="Setup", steps=[TutorialStep(text="just words", settle_ms=1)]),)
+        session = self._session(chapters)
+        session.start()
+        self._wait_ready(session)
+
+        self.assertFalse(session.shell.btn_apply.isVisible())
 
     def test_the_shell_tracks_which_step_the_tour_is_on(self):
         from qtpy.QtWidgets import QLabel
@@ -233,7 +256,7 @@ class TutorialSessionTest(unittest.TestCase):
         self.assertTrue(first_sandbox.torn_down, "the chapter jump should discard the old interface")
         self.assertEqual(session.player.position, (1, 0))
         # the earlier chapter's actions were replayed so the chapter starts from the right state
-        self.assertEqual(self.performed, ["load", "material", "plot"])
+        self.assertEqual(self.performed, ["load", "material"])
 
     def test_a_chapter_jump_keeps_the_window_where_the_user_put_it(self):
         session = self._session()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
@@ -1,0 +1,284 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import tempfile
+import unittest
+
+from qtpy.QtCore import QSettings
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.launcher import ChapterPicker, TutorialSession, mark_seen, run_tutorial, should_show_on_startup
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
+
+
+class FakeSandbox:
+    """Stands in for a real interface: a window with a button, and a record of what the tour did
+    to it."""
+
+    def __init__(self, performed, built):
+        self.window = QWidget()
+        layout = QVBoxLayout(self.window)
+        self.button = QPushButton("Target")
+        layout.addWidget(self.button)
+        self.window.resize(500, 400)
+        self.performed = performed
+        self.torn_down = False
+        built.append(self)
+
+    def teardown(self):
+        self.torn_down = True
+        self.window.close()
+        self.window.deleteLater()
+
+
+@start_qapplication
+class SeenFlagTest(unittest.TestCase):
+    """QSettings is redirected to a temporary ini file so the developer's own settings are never
+    touched by the test - the flag under test is the one an interface really writes."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="tutorial_settings_", ignore_cleanup_errors=True)
+        self.addCleanup(self._tmpdir.cleanup)
+        self.settings = QSettings(f"{self._tmpdir.name}/tutorial.ini", QSettings.IniFormat)
+
+    def test_a_tutorial_that_has_never_been_shown_should_be(self):
+        self.assertTrue(should_show_on_startup("TexturePlanner", self.settings))
+
+    def test_marking_it_seen_stops_it_appearing_again(self):
+        mark_seen("TexturePlanner", self.settings)
+        self.assertFalse(should_show_on_startup("TexturePlanner", self.settings))
+
+    def test_the_flag_is_per_interface(self):
+        mark_seen("TexturePlanner", self.settings)
+        self.assertTrue(should_show_on_startup("SomeOtherInterface", self.settings))
+
+    def test_it_is_stored_beside_the_other_interface_settings(self):
+        mark_seen("TexturePlanner", self.settings)
+        self.settings.sync()
+        self.assertIn("CustomInterfaces/TexturePlanner/tutorial_seen", self.settings.allKeys())
+
+    def test_a_corrupt_value_is_treated_as_not_yet_seen_rather_than_seen(self):
+        # QSettings coerces what it cannot parse; erring towards showing the tour is the harmless
+        # direction to be wrong in
+        self.settings.setValue("CustomInterfaces/TexturePlanner/tutorial_seen", "not a boolean")
+        self.assertTrue(should_show_on_startup("TexturePlanner", self.settings))
+
+
+@start_qapplication
+class TutorialSessionTest(unittest.TestCase):
+    def setUp(self):
+        self.performed = []
+        self.built = []
+        self.sessions = []
+
+    def tearDown(self):
+        for session in self.sessions:
+            session.close()
+        interaction.process_events(3)
+
+    def _factory(self):
+        return FakeSandbox(self.performed, self.built)
+
+    def _chapters(self):
+        def record(name):
+            return lambda sandbox: sandbox.performed.append(name)
+
+        return (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    TutorialStep(text="first", action=record("load"), target=lambda s: s.button, dwell_ms=1, settle_ms=1),
+                    TutorialStep(text="second", action=record("material"), dwell_ms=1, settle_ms=1),
+                ],
+            ),
+            TutorialChapter(
+                name="Results",
+                steps=[TutorialStep(text="third", action=record("plot"), dwell_ms=1, settle_ms=1)],
+            ),
+        )
+
+    def _session(self, chapters=None):
+        session = TutorialSession(self._factory, chapters or self._chapters())
+        self.sessions.append(session)
+        self.finished = []
+        session.finished.connect(lambda: self.finished.append(True))
+        return session
+
+    @staticmethod
+    def _pump_until(predicate, timeout_ms=5000):
+        waited = 0
+        while not predicate() and waited < timeout_ms:
+            QTest.qWait(5)
+            waited += 5
+        return predicate()
+
+    def test_it_builds_and_shows_a_sandbox_rather_than_touching_anything_of_the_users(self):
+        session = self._session()
+        session.start()
+
+        self.assertEqual(len(self.built), 1)
+        self.assertTrue(session.window.isVisible())
+        self.assertIs(session.window, self.built[0].window)
+
+    def test_it_plays_the_tour_through_the_sandbox(self):
+        session = self._session()
+        session.start()
+
+        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+        self.assertEqual(session.failures, [])
+
+    def test_closing_tears_the_sandbox_down(self):
+        session = self._session()
+        session.start()
+        sandbox = self.built[0]
+
+        session.close()
+        interaction.process_events(3)
+
+        self.assertTrue(sandbox.torn_down, "the sandbox window and its workspaces must not outlive the tour")
+        self.assertEqual(self.finished, [True])
+
+    def test_closing_twice_is_harmless(self):
+        session = self._session()
+        session.start()
+        session.close()
+        session.close()
+        self.assertEqual(self.finished, [True], "the tour should report finishing once, not once per call")
+
+    def test_starting_at_a_later_chapter_rebuilds_and_catches_the_interface_up(self):
+        session = self._session()
+        session.start(chapter_index=1)
+
+        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        # the earlier chapter's actions still ran, so the chapter is played against the state it
+        # expects rather than an empty interface
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+
+    def test_the_bubble_buttons_drive_the_player(self):
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    TutorialStep(text="first", dwell_ms=100000, settle_ms=1),
+                    TutorialStep(text="second", dwell_ms=100000, settle_ms=1),
+                ],
+            ),
+        )
+        session = self._session(chapters)
+        session.start()
+        self.assertTrue(self._pump_until(lambda: session.player.position == (0, 0)))
+
+        session._bubble.btn_next.click()
+        self.assertTrue(self._pump_until(lambda: session.player.position == (0, 1)))
+
+        session._bubble.btn_pause.click()
+        interaction.process_events(3)
+        self.assertTrue(session.player.is_paused)
+
+        session._bubble.btn_back.click()
+        interaction.process_events(3)
+        self.assertEqual(session.player.position, (0, 0))
+
+    def test_the_end_of_the_tour_says_the_users_session_was_untouched(self):
+        session = self._session()
+        session.start()
+        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+
+        interaction.process_events(3)
+        text = session._bubble.findChild(QWidget, "tutorial_bubble_text").text()
+        self.assertIn("has touched it", text)
+
+    def test_a_failing_step_is_collected_rather_than_ending_the_tour(self):
+        def explode(_sandbox):
+            raise RuntimeError("gone")
+
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    TutorialStep(text="broken", title="Broken", action=explode, dwell_ms=1, settle_ms=1),
+                    TutorialStep(text="fine", dwell_ms=1, settle_ms=1),
+                ],
+            ),
+        )
+        session = self._session(chapters)
+        session.start()
+
+        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self.assertEqual(session.failures, [("Broken", "gone")])
+
+    def _isolate_default_qsettings(self):
+        """Point the process-wide QSettings at a temporary ini file.
+
+        ``run_tutorial`` writes through a bare ``QSettings()`` - which is the whole point, since
+        that is what an interface will read - so testing it means redirecting the default rather
+        than passing an instance in. On Windows the default format is the registry, which
+        ``setPath`` cannot redirect, hence forcing the ini format first.
+        """
+        from qtpy.QtCore import QCoreApplication
+
+        tmpdir = tempfile.TemporaryDirectory(prefix="tutorial_launcher_", ignore_cleanup_errors=True)
+        self.addCleanup(tmpdir.cleanup)
+        saved = (QSettings.defaultFormat(), QCoreApplication.organizationName(), QCoreApplication.applicationName())
+
+        QSettings.setDefaultFormat(QSettings.IniFormat)
+        QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, tmpdir.name)
+        QCoreApplication.setOrganizationName("mantidproject-tutorial-test")
+        QCoreApplication.setApplicationName("tutorial_launcher_test")
+
+        def restore():
+            QSettings.setDefaultFormat(saved[0])
+            QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, tempfile.gettempdir())
+            QCoreApplication.setOrganizationName(saved[1])
+            QCoreApplication.setApplicationName(saved[2])
+
+        self.addCleanup(restore)
+
+    def test_run_tutorial_marks_it_seen_when_it_appeared_by_itself(self):
+        self._isolate_default_qsettings()
+        self.assertTrue(should_show_on_startup("TexturePlanner"))
+
+        session = run_tutorial(self._factory, self._chapters(), settings_key="TexturePlanner", mark_as_seen=True)
+        self.sessions.append(session)
+
+        self.assertFalse(should_show_on_startup("TexturePlanner"))
+
+    def test_run_tutorial_leaves_the_flag_alone_when_the_user_asked_for_it(self):
+        self._isolate_default_qsettings()
+
+        # opening it from the toolbar button should not change whether it appears on startup
+        session = run_tutorial(self._factory, self._chapters(), settings_key="TexturePlanner", mark_as_seen=False)
+        self.sessions.append(session)
+
+        self.assertTrue(should_show_on_startup("TexturePlanner"))
+
+
+@start_qapplication
+class ChapterPickerTest(unittest.TestCase):
+    def setUp(self):
+        self.chapters = (
+            TutorialChapter(name="Setup", steps=[TutorialStep(text="a")], description="Load a sample"),
+            TutorialChapter(name="Results", steps=[TutorialStep(text="b")]),
+        )
+
+    def test_it_lists_every_chapter_and_starts_on_the_current_one(self):
+        picker = ChapterPicker(self.chapters, current=1)
+        self.addCleanup(picker.deleteLater)
+        self.assertEqual(picker.chosen_chapter(), 1)
+
+    def test_a_current_chapter_out_of_range_is_clamped_rather_than_crashing(self):
+        picker = ChapterPicker(self.chapters, current=99)
+        self.addCleanup(picker.deleteLater)
+        self.assertEqual(picker.chosen_chapter(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.tutorial import interaction
-from mantidqt.widgets.tutorial.launcher import ChapterPicker, TutorialSession, mark_seen, run_tutorial, should_show_on_startup
+from mantidqt.widgets.tutorial.launcher import TutorialSession, mark_seen, run_tutorial, should_show_on_startup
 from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
 
 
@@ -94,13 +94,13 @@ class TutorialSessionTest(unittest.TestCase):
             TutorialChapter(
                 name="Setup",
                 steps=[
-                    TutorialStep(text="first", action=record("load"), target=lambda s: s.button, dwell_ms=1, settle_ms=1),
-                    TutorialStep(text="second", action=record("material"), dwell_ms=1, settle_ms=1),
+                    TutorialStep(text="first", action=record("load"), target=lambda s: s.button, settle_ms=1),
+                    TutorialStep(text="second", action=record("material"), settle_ms=1),
                 ],
             ),
             TutorialChapter(
                 name="Results",
-                steps=[TutorialStep(text="third", action=record("plot"), dwell_ms=1, settle_ms=1)],
+                steps=[TutorialStep(text="third", action=record("plot"), settle_ms=1)],
             ),
         )
 
@@ -119,6 +119,25 @@ class TutorialSessionTest(unittest.TestCase):
             waited += 5
         return predicate()
 
+    def _wait_ready(self, session):
+        """Wait until the tour is showing a step and will accept navigation.
+
+        ``session.player`` is briefly None during a chapter jump, while the old interface has been
+        torn down and the new one not yet built, so this has to tolerate that rather than assume a
+        player is always there.
+        """
+        self.assertTrue(self._pump_until(lambda: session.player is not None and not session.player.is_busy))
+
+    def _play_to_the_end(self, session):
+        """Press Next until the tour finishes. Nothing advances on its own any more, so a test
+        that wants the end of the tour has to walk there like a user."""
+        for _ in range(60):
+            if not session.player.is_running:
+                return True
+            self._wait_ready(session)
+            session.shell.btn_next.click()
+        return not session.player.is_running
+
     def test_it_builds_and_shows_a_sandbox_rather_than_touching_anything_of_the_users(self):
         session = self._session()
         session.start()
@@ -131,7 +150,7 @@ class TutorialSessionTest(unittest.TestCase):
         session = self._session()
         session.start()
 
-        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self.assertTrue(self._play_to_the_end(session))
         self.assertEqual(self.performed, ["load", "material", "plot"])
         self.assertEqual(session.failures, [])
 
@@ -157,44 +176,87 @@ class TutorialSessionTest(unittest.TestCase):
         session = self._session()
         session.start(chapter_index=1)
 
-        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self._wait_ready(session)
         # the earlier chapter's actions still ran, so the chapter is played against the state it
         # expects rather than an empty interface
         self.assertEqual(self.performed, ["load", "material", "plot"])
 
-    def test_the_bubble_buttons_drive_the_player(self):
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[
-                    TutorialStep(text="first", dwell_ms=100000, settle_ms=1),
-                    TutorialStep(text="second", dwell_ms=100000, settle_ms=1),
-                ],
-            ),
-        )
-        session = self._session(chapters)
+    def test_the_shell_buttons_drive_the_player(self):
+        session = self._session()
         session.start()
-        self.assertTrue(self._pump_until(lambda: session.player.position == (0, 0)))
+        self._wait_ready(session)
 
-        session._bubble.btn_next.click()
+        session.shell.btn_next.click()
         self.assertTrue(self._pump_until(lambda: session.player.position == (0, 1)))
 
-        session._bubble.btn_pause.click()
-        interaction.process_events(3)
-        self.assertTrue(session.player.is_paused)
-
-        session._bubble.btn_back.click()
+        self._wait_ready(session)
+        session.shell.btn_back.click()
         interaction.process_events(3)
         self.assertEqual(session.player.position, (0, 0))
+
+    def test_the_shell_frames_the_interface_being_toured(self):
+        session = self._session()
+        session.start()
+
+        self.assertIs(session.window.parentWidget(), session.shell)
+        self.assertTrue(session.shell.isVisible())
+
+    def test_the_shell_tracks_which_step_the_tour_is_on(self):
+        from qtpy.QtWidgets import QLabel
+
+        session = self._session()
+        session.start()
+        self._wait_ready(session)
+
+        position = session.shell.findChild(QLabel, "tutorial_position")
+        self.assertEqual(position.text(), "Step 1 of 2")
+        self.assertFalse(session.shell.btn_back.isEnabled(), "there is nothing before the first step")
+
+        session.shell.btn_next.click()
+        self._wait_ready(session)
+        self.assertEqual(session.player.position, (0, 1))
+        self.assertEqual(position.text(), "Step 2 of 2")
+        self.assertTrue(session.shell.btn_back.isEnabled())
+
+    def test_choosing_a_chapter_tab_rebuilds_the_interface_and_jumps_to_it(self):
+        session = self._session()
+        session.start()
+        self._wait_ready(session)
+        self.assertEqual(len(self.built), 1)
+        first_sandbox = self.built[0]
+        self.performed.clear()
+
+        session.shell._tabs.setCurrentIndex(1)
+        self.assertTrue(self._pump_until(lambda: len(self.built) == 2))
+        self._wait_ready(session)
+
+        self.assertTrue(first_sandbox.torn_down, "the chapter jump should discard the old interface")
+        self.assertEqual(session.player.position, (1, 0))
+        # the earlier chapter's actions were replayed so the chapter starts from the right state
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+
+    def test_a_chapter_jump_keeps_the_window_where_the_user_put_it(self):
+        session = self._session()
+        session.start()
+        self._wait_ready(session)
+        session.shell.resize(1000, 720)
+        interaction.process_events(3)
+        geometry = session.shell.geometry()
+
+        session.shell._tabs.setCurrentIndex(1)
+        self.assertTrue(self._pump_until(lambda: len(self.built) == 2))
+
+        self.assertEqual(session.shell.geometry(), geometry)
 
     def test_the_end_of_the_tour_says_the_users_session_was_untouched(self):
         session = self._session()
         session.start()
-        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self.assertTrue(self._play_to_the_end(session))
 
         interaction.process_events(3)
         text = session._bubble.findChild(QWidget, "tutorial_bubble_text").text()
         self.assertIn("has touched it", text)
+        self.assertFalse(session.shell.btn_next.isEnabled(), "there is nowhere left to go")
 
     def test_a_failing_step_is_collected_rather_than_ending_the_tour(self):
         def explode(_sandbox):
@@ -204,15 +266,15 @@ class TutorialSessionTest(unittest.TestCase):
             TutorialChapter(
                 name="Setup",
                 steps=[
-                    TutorialStep(text="broken", title="Broken", action=explode, dwell_ms=1, settle_ms=1),
-                    TutorialStep(text="fine", dwell_ms=1, settle_ms=1),
+                    TutorialStep(text="broken", title="Broken", action=explode, settle_ms=1),
+                    TutorialStep(text="fine", settle_ms=1),
                 ],
             ),
         )
         session = self._session(chapters)
         session.start()
 
-        self.assertTrue(self._pump_until(lambda: not session.player.is_running))
+        self.assertTrue(self._play_to_the_end(session))
         self.assertEqual(session.failures, [("Broken", "gone")])
 
     def _isolate_default_qsettings(self):
@@ -259,25 +321,6 @@ class TutorialSessionTest(unittest.TestCase):
         self.sessions.append(session)
 
         self.assertTrue(should_show_on_startup("TexturePlanner"))
-
-
-@start_qapplication
-class ChapterPickerTest(unittest.TestCase):
-    def setUp(self):
-        self.chapters = (
-            TutorialChapter(name="Setup", steps=[TutorialStep(text="a")], description="Load a sample"),
-            TutorialChapter(name="Results", steps=[TutorialStep(text="b")]),
-        )
-
-    def test_it_lists_every_chapter_and_starts_on_the_current_one(self):
-        picker = ChapterPicker(self.chapters, current=1)
-        self.addCleanup(picker.deleteLater)
-        self.assertEqual(picker.chosen_chapter(), 1)
-
-    def test_a_current_chapter_out_of_range_is_clamped_rather_than_crashing(self):
-        picker = ChapterPicker(self.chapters, current=99)
-        self.addCleanup(picker.deleteLater)
-        self.assertEqual(picker.chosen_chapter(), 1)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
@@ -277,7 +277,7 @@ class TutorialSessionTest(unittest.TestCase):
         self.assertTrue(self._play_to_the_end(session))
 
         interaction.process_events(3)
-        text = session._bubble.findChild(QWidget, "tutorial_bubble_text").text()
+        text = session.annotator.active_bubble().findChild(QWidget, "tutorial_bubble_text").text()
         self.assertIn("has touched it", text)
         self.assertFalse(session.shell.btn_next.isEnabled(), "there is nowhere left to go")
 

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_launcher.py
@@ -165,6 +165,19 @@ class TutorialSessionTest(unittest.TestCase):
         self.assertTrue(sandbox.torn_down, "the sandbox window and its workspaces must not outlive the tour")
         self.assertEqual(self.finished, [True])
 
+    def test_closing_the_window_tears_the_sandbox_down_as_end_tutorial_does(self):
+        # the title bar's close button is not the End tutorial button, and both have to end the
+        # tour - otherwise the toured interface lives on behind a hidden window, workspaces and all
+        session = self._session()
+        session.start()
+        sandbox = self.built[0]
+
+        session.shell.close()
+        interaction.process_events(3)
+
+        self.assertTrue(sandbox.torn_down)
+        self.assertEqual(self.finished, [True])
+
     def test_closing_twice_is_harmless(self):
         session = self._session()
         session.start()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_overlay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_overlay.py
@@ -1,0 +1,119 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.overlay import PADDING, TutorialOverlay
+
+
+@start_qapplication
+class TutorialOverlayTest(unittest.TestCase):
+    def setUp(self):
+        self.window = QWidget()
+        layout = QVBoxLayout(self.window)
+        self.first = QPushButton("First")
+        self.second = QPushButton("Second")
+        layout.addWidget(self.first)
+        layout.addWidget(self.second)
+        self.window.resize(400, 300)
+        self.window.show()
+        interaction.process_events(3)
+
+        self.overlay = TutorialOverlay(self.window)
+        self.overlay.show()
+        interaction.process_events(3)
+
+    def tearDown(self):
+        self.overlay.detach()
+        self.window.close()
+        self.window.deleteLater()
+        interaction.process_events()
+
+    @staticmethod
+    def _settle(rounds=3, wait_ms=120):
+        # long enough for the overlay's position tracker (50ms) to have ticked at least twice
+        QTest.qWait(wait_ms)
+        interaction.process_events(rounds)
+
+    def test_it_covers_the_whole_host(self):
+        self.assertEqual(self.overlay.geometry(), self.window.rect())
+
+    def test_it_never_takes_input(self):
+        # a tour that could swallow a click would be able to deadlock behind its own decoration
+        self.assertTrue(self.overlay.testAttribute(Qt.WA_TransparentForMouseEvents))
+
+    def test_with_no_target_there_is_no_spotlight(self):
+        self.overlay.set_target(None)
+        self._settle()
+        self.assertTrue(self.overlay.target_rect().isEmpty())
+
+    def test_the_spotlight_surrounds_the_target(self):
+        self.overlay.set_target(self.first)
+        self._settle()
+
+        spotlight = self.overlay.target_rect()
+        expected = self.first.geometry().adjusted(-PADDING, -PADDING, PADDING, PADDING)
+        self.assertEqual(spotlight.size(), expected.size())
+        self.assertTrue(spotlight.contains(self.first.geometry()), "the target should sit inside the spotlight")
+
+    def test_the_spotlight_moves_with_the_target_when_the_host_is_resized(self):
+        self.overlay.set_target(self.second)
+        self._settle()
+        before = self.overlay.target_rect()
+
+        self.window.resize(700, 600)
+        self._settle()
+
+        self.assertEqual(self.overlay.geometry(), self.window.rect())
+        after = self.overlay.target_rect()
+        self.assertNotEqual(before, after, "the button was relaid out, so the spotlight should have followed")
+        self.assertTrue(after.contains(self.second.geometry()))
+
+    def test_the_spotlight_follows_a_target_that_moves_without_a_resize(self):
+        self.overlay.set_target(self.second)
+        self._settle()
+        before = self.overlay.target_rect()
+
+        # the kind of move no single event on the host reports: the widget above it goes away and
+        # the layout shuffles everything up
+        self.first.hide()
+        self._settle()
+
+        self.assertNotEqual(before, self.overlay.target_rect())
+        self.assertTrue(self.overlay.target_rect().contains(self.second.geometry()))
+
+    def test_a_hidden_target_has_no_spotlight_rather_than_a_stale_one(self):
+        self.overlay.set_target(self.second)
+        self._settle()
+        self.assertFalse(self.overlay.target_rect().isEmpty())
+
+        self.second.hide()
+        self._settle()
+
+        self.assertTrue(self.overlay.target_rect().isEmpty())
+
+    def test_a_target_outside_the_host_is_refused(self):
+        stranger = QPushButton("Elsewhere")
+        self.addCleanup(stranger.deleteLater)
+        self.assertRaises(ValueError, self.overlay.set_target, stranger)
+
+    def test_detach_is_safe_to_repeat(self):
+        self.overlay.set_target(self.first)
+        self.overlay.detach()
+        self.overlay.detach()
+        self.assertIsNone(self.overlay.target())
+        self.assertFalse(self.overlay.isVisible())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -50,8 +50,8 @@ class FakeBubble:
     def show_waiting(self, message):
         self.waiting.append(message)
 
-    def place_beside(self, _spotlight):
-        pass
+    def place_beside(self, _spotlight, keep_clear=()):
+        self.kept_clear = keep_clear
 
 
 @start_qapplication

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -43,21 +43,14 @@ class FakeBubble:
     def __init__(self):
         self.shown = []
         self.waiting = []
-        self.navigation = []
 
-    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
-        self.shown.append((chapter_name, step_number, step_count, title, text))
+    def show_step(self, text, title=""):
+        self.shown.append((title, text))
 
     def show_waiting(self, message):
         self.waiting.append(message)
 
     def place_beside(self, _spotlight):
-        pass
-
-    def set_navigation_enabled(self, back=True, next_=True):
-        self.navigation.append((back, next_))
-
-    def set_paused(self, paused):
         pass
 
 
@@ -87,7 +80,6 @@ class TutorialPlayerTest(unittest.TestCase):
     # ------------------------------------------------------------------ helpers
 
     def _step(self, text, **kwargs):
-        kwargs.setdefault("dwell_ms", 1)
         kwargs.setdefault("settle_ms", 1)
         return TutorialStep(text=text, **kwargs)
 
@@ -98,8 +90,10 @@ class TutorialPlayerTest(unittest.TestCase):
         player = TutorialPlayer(chapters, self.context, self.overlay, self.bubble, parent=self.window)
         self.finished = []
         self.failures = []
+        self.busy = []
         player.finished.connect(lambda: self.finished.append(True))
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
+        player.busy_changed.connect(lambda busy, message: self.busy.append((busy, message)))
         return player
 
     @staticmethod
@@ -122,22 +116,97 @@ class TutorialPlayerTest(unittest.TestCase):
             TutorialChapter(name="Results", steps=[self._recording_step("plot")]),
         )
 
-    # ------------------------------------------------------------------ playing
+    def _next(self, player):
+        """Wait until the current step is on screen, then press Next - as a user would.
 
-    def test_it_plays_every_step_of_every_chapter_in_order(self):
+        Pressing it before the step has settled is deliberately ignored by the player, so a test
+        that clicked immediately would be testing that guard rather than what it meant to.
+        """
+        self.assertTrue(self._pump_until(lambda: not player.is_busy))
+        player.next_step()
+
+    def _play_to_the_end(self, player):
+        """Press Next until the tour reports it has finished, as a user would.
+
+        Waits for each step to actually be on screen first - the player refuses to advance until
+        then, so pressing Next early would simply be ignored and the loop would spin.
+        """
+        seen = 0
+        for _ in range(50):
+            if self.finished:
+                return True
+            self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) > seen))
+            seen = len(self.bubble.shown)
+            player.next_step()
+        return bool(self.finished)
+
+    # ------------------------------------------------------------------ user-driven advance
+
+    def test_it_does_not_advance_on_its_own(self):
+        # the whole point of the redesign: no timer is counting down behind the caption
         player = self._player(self._two_chapters())
         player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        QTest.qWait(400)
+
+        self.assertEqual(player.position, (0, 0))
+        self.assertEqual(self.performed, ["load"], "only the first step's action should have run")
+        self.assertEqual(len(self.bubble.shown), 1)
+        self.assertFalse(self.finished)
+
+    def test_next_moves_one_step_at_a_time(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
+        self.assertEqual(player.position, (0, 1))
+        self.assertEqual(self.performed, ["load", "material"])
+
+    def test_next_during_the_settle_is_ignored_rather_than_skipping_the_caption(self):
+        # otherwise a step's action would have run while its explanation was never shown
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[self._recording_step("one", settle_ms=200), self._recording_step("two", settle_ms=200)],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(player.is_busy, "the action has run but the caption is not up yet")
+
+        player.next_step()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self.assertEqual(player.position, (0, 0))
+        self.assertEqual(self.bubble.shown[-1][1], "one")
+        self.assertEqual(self.performed, ["one"])
+
+    def test_next_crosses_into_the_following_chapter(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
         self.assertEqual(self.performed, ["load", "material", "plot"])
-        self.assertEqual([entry[0] for entry in self.bubble.shown], ["Setup", "Setup", "Results"])
-        self.assertEqual([(entry[1], entry[2]) for entry in self.bubble.shown], [(1, 2), (2, 2), (1, 1)])
+
+    def test_next_past_the_last_step_finishes_the_tour(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._play_to_the_end(player))
+
+        self.assertEqual(self.performed, ["load", "material", "plot"])
         self.assertFalse(player.is_running)
 
     def test_it_spotlights_each_step_target(self):
         player = self._player(self._two_chapters())
         player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self._play_to_the_end(player)
 
         self.assertEqual(self.overlay.targets[:2], [self.first, self.second])
 
@@ -145,128 +214,79 @@ class TutorialPlayerTest(unittest.TestCase):
         chapters = (TutorialChapter(name="Only", steps=[self._step("a closing remark")]),)
         player = self._player(chapters)
         player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
 
         self.assertEqual(self.overlay.targets, [None])
 
     def test_it_starts_at_a_named_chapter_without_fast_forwarding(self):
         player = self._player(self._two_chapters())
         player.start(chapter_index=1)
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
         self.assertEqual(self.performed, ["plot"])
 
     def test_starting_beyond_the_last_chapter_is_refused(self):
         player = self._player(self._two_chapters())
         self.assertRaises(IndexError, player.start, 5)
 
-    # ------------------------------------------------------------------ navigation
-
-    def test_next_interrupts_the_dwell_without_skipping_a_step(self):
-        # a long dwell, so nothing advances on its own during this test
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[
-                    self._recording_step("one", dwell_ms=100000),
-                    self._recording_step("two", dwell_ms=100000),
-                ],
-            ),
-        )
-        player = self._player(chapters)
+    def test_it_knows_when_it_is_at_the_ends_of_the_tour(self):
+        player = self._player(self._two_chapters())
         player.start()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self.assertTrue(player.at_start())
+        self.assertFalse(player.at_end())
 
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertFalse(player.at_start())
 
-        self.assertEqual(self.performed, ["one", "two"])
-        self.assertEqual(player.position, (0, 1))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
+        self.assertTrue(player.at_end())
+
+    # ------------------------------------------------------------------ back
 
     def test_back_re_narrates_without_re_running_the_action(self):
         # the crux of Back: pressing "Add orientation" a second time would add a second one
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[
-                    self._recording_step("one", dwell_ms=100000),
-                    self._recording_step("two", dwell_ms=100000),
-                ],
-            ),
-        )
-        player = self._player(chapters)
+        player = self._player(self._two_chapters())
         player.start()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
         player.next_step()
         self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
-        self.assertEqual(self.performed, ["one", "two"])
+        self.assertEqual(self.performed, ["load", "material"])
 
         player.back_step()
         interaction.process_events(3)
 
         self.assertEqual(player.position, (0, 0))
-        self.assertEqual(self.bubble.shown[-1][4], "one")
-        self.assertEqual(self.performed, ["one", "two"], "back must not perform anything again")
+        self.assertEqual(self.bubble.shown[-1][1], "load")
+        self.assertEqual(self.performed, ["load", "material"], "back must not perform anything again")
 
     def test_back_crosses_into_the_previous_chapter(self):
-        chapters = (
-            TutorialChapter(name="Setup", steps=[self._recording_step("one", dwell_ms=100000)]),
-            TutorialChapter(name="Results", steps=[self._recording_step("two", dwell_ms=100000)]),
-        )
-        player = self._player(chapters)
+        player = self._player(self._two_chapters())
         player.start()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: not player.is_busy))
 
         player.back_step()
         interaction.process_events(3)
 
-        self.assertEqual(player.position, (0, 0))
+        self.assertEqual(player.position, (0, 1))
 
     def test_back_at_the_very_start_does_nothing(self):
         player = self._player(self._two_chapters())
         player.start()
         self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        player.set_paused(True)
 
         player.back_step()
         interaction.process_events(3)
 
         self.assertEqual(player.position, (0, 0))
 
-    def test_back_is_disabled_only_on_the_first_step(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
-
-        self.assertEqual([entry[0] for entry in self.bubble.navigation], [False, True, True])
-
-    # ------------------------------------------------------------------ pausing
-
-    def test_pausing_holds_the_current_step(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        player.set_paused(True)
-
-        QTest.qWait(150)
-
-        self.assertTrue(player.is_paused)
-        self.assertEqual(player.position, (0, 0))
-        self.assertFalse(self.finished)
-
-    def test_resuming_carries_on_from_where_it_paused(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        player.set_paused(True)
-        QTest.qWait(50)
-
-        player.set_paused(False)
-
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
-        self.assertEqual(self.performed, ["load", "material", "plot"])
+    # ------------------------------------------------------------------ stopping
 
     def test_stop_ends_the_tour_without_reporting_it_as_finished(self):
         player = self._player(self._two_chapters())
@@ -274,7 +294,7 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
 
         player.stop()
-        QTest.qWait(150)
+        QTest.qWait(100)
 
         self.assertFalse(player.is_running)
         self.assertEqual(self.finished, [], "stopping is not the same as reaching the end")
@@ -302,10 +322,44 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertTrue(self._pump_until(lambda: bool(self.bubble.waiting)))
         self.assertEqual(self.bubble.waiting, ["Calculating…"])
         self.assertEqual(self.bubble.shown, [], "it should not narrate until the wait is over")
+        self.assertTrue(player.is_busy)
+        # busy is raised as soon as the step starts, then re-announced with the wait's own message
+        self.assertEqual(self.busy[0][0], True)
+        self.assertIn((True, "Calculating…"), self.busy)
 
         ready["now"] = True
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
-        self.assertEqual(len(self.bubble.shown), 1)
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self.assertFalse(player.is_busy)
+        self.assertEqual(self.busy[-1][0], False)
+
+    def test_next_is_ignored_while_a_step_is_waiting(self):
+        # advancing mid-wait would run the following action against an interface that had not
+        # finished reacting to this one
+        ready = {"now": False}
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    self._recording_step("slow", await_=lambda _ctx: ready["now"], await_timeout_s=5.0),
+                    self._recording_step("after"),
+                ],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(self._pump_until(lambda: player.is_busy))
+
+        player.next_step()
+        player.back_step()
+        QTest.qWait(100)
+
+        self.assertEqual(player.position, (0, 0))
+        self.assertEqual(self.performed, ["slow"])
+
+        ready["now"] = True
+        self.assertTrue(self._pump_until(lambda: not player.is_busy))
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: self.performed == ["slow", "after"]))
 
     def test_a_wait_that_times_out_reports_it_and_carries_on(self):
         chapters = (
@@ -317,13 +371,14 @@ class TutorialPlayerTest(unittest.TestCase):
         player = self._player(chapters)
         player.start()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
         self.assertEqual(len(self.failures), 1)
         self.assertIn("still not ready", self.failures[0][1])
+        self.assertFalse(player.is_busy, "a timed-out wait must not leave navigation locked")
 
     # ------------------------------------------------------------------ failure
 
-    def test_a_failing_action_is_reported_and_the_tour_carries_on(self):
+    def test_a_failing_action_is_reported_and_the_step_is_still_narrated(self):
         def explode(_context):
             raise RuntimeError("the button went away")
 
@@ -336,9 +391,11 @@ class TutorialPlayerTest(unittest.TestCase):
         player = self._player(chapters)
         player.start()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
         self.assertEqual(self.failures, [("Broken step", "the button went away")])
-        self.assertEqual(self.performed, ["after"], "the rest of the tour should still run")
+
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: self.performed == ["after"]), "the rest of the tour should still run")
 
     def test_an_unresolvable_target_is_reported_and_the_step_is_still_narrated(self):
         chapters = (
@@ -350,10 +407,9 @@ class TutorialPlayerTest(unittest.TestCase):
         player = self._player(chapters)
         player.start()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
         self.assertEqual(len(self.failures), 1)
         self.assertIn("could not find what to highlight", self.failures[0][1])
-        self.assertEqual(len(self.bubble.shown), 1)
         self.assertEqual(self.overlay.targets, [None])
 
     # ------------------------------------------------------------------ fast forward
@@ -362,12 +418,22 @@ class TutorialPlayerTest(unittest.TestCase):
         player = self._player(self._two_chapters())
         player.start(chapter_index=1, fast_forward=True)
 
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
         # every action ran, so the interface is in the right state for the chapter jumped to...
         self.assertEqual(self.performed, ["load", "material", "plot"])
         # ...but only the chapter asked for was narrated
-        self.assertEqual([entry[0] for entry in self.bubble.shown], ["Results"])
+        self.assertEqual(len(self.bubble.shown), 1)
         self.assertIn("Setting the interface up", self.bubble.waiting[0])
+        self.assertFalse(player.is_busy)
+
+    def test_fast_forward_locks_navigation_while_it_catches_up(self):
+        player = self._player(self._two_chapters())
+        player.start(chapter_index=1, fast_forward=True)
+
+        self.assertTrue(self.busy)
+        self.assertEqual(self.busy[0][0], True)
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self.assertEqual(self.busy[-1][0], False)
 
     def test_fast_forward_awaits_an_earlier_chapters_wait(self):
         ready = {"now": False}
@@ -385,8 +451,7 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertEqual(self.performed, ["slow"], "it should be held at the wait, not racing past it")
 
         ready["now"] = True
-        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
-        self.assertEqual(self.performed, ["slow", "after"])
+        self.assertTrue(self._pump_until(lambda: self.performed == ["slow", "after"]))
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -1,0 +1,393 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.player import TutorialPlayer
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
+
+
+class FakeOverlay:
+    """Records what it was asked to spotlight, so a test can check the tour pointed at the right
+    thing without going near painting."""
+
+    def __init__(self):
+        self.targets = []
+
+    def set_target(self, widget):
+        self.targets.append(widget)
+
+    def target_rect(self):
+        return None
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def detach(self):
+        pass
+
+
+class FakeBubble:
+    def __init__(self):
+        self.shown = []
+        self.waiting = []
+        self.navigation = []
+
+    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
+        self.shown.append((chapter_name, step_number, step_count, title, text))
+
+    def show_waiting(self, message):
+        self.waiting.append(message)
+
+    def place_beside(self, _spotlight):
+        pass
+
+    def set_navigation_enabled(self, back=True, next_=True):
+        self.navigation.append((back, next_))
+
+    def set_paused(self, paused):
+        pass
+
+
+@start_qapplication
+class TutorialPlayerTest(unittest.TestCase):
+    def setUp(self):
+        self.window = QWidget()
+        layout = QVBoxLayout(self.window)
+        self.first = QPushButton("First")
+        self.second = QPushButton("Second")
+        layout.addWidget(self.first)
+        layout.addWidget(self.second)
+        self.window.resize(400, 300)
+        self.window.show()
+        interaction.process_events(3)
+
+        self.performed = []
+        self.overlay = FakeOverlay()
+        self.bubble = FakeBubble()
+        self.context = {"window": self.window, "first": self.first, "second": self.second}
+
+    def tearDown(self):
+        self.window.close()
+        self.window.deleteLater()
+        interaction.process_events()
+
+    # ------------------------------------------------------------------ helpers
+
+    def _step(self, text, **kwargs):
+        kwargs.setdefault("dwell_ms", 1)
+        kwargs.setdefault("settle_ms", 1)
+        return TutorialStep(text=text, **kwargs)
+
+    def _recording_step(self, text, **kwargs):
+        return self._step(text, action=lambda _ctx: self.performed.append(text), **kwargs)
+
+    def _player(self, chapters):
+        player = TutorialPlayer(chapters, self.context, self.overlay, self.bubble, parent=self.window)
+        self.finished = []
+        self.failures = []
+        player.finished.connect(lambda: self.finished.append(True))
+        player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
+        return player
+
+    @staticmethod
+    def _pump_until(predicate, timeout_ms=5000):
+        waited = 0
+        while not predicate() and waited < timeout_ms:
+            QTest.qWait(5)
+            waited += 5
+        return predicate()
+
+    def _two_chapters(self):
+        return (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    self._recording_step("load", target=lambda ctx: ctx["first"]),
+                    self._recording_step("material", target=lambda ctx: ctx["second"]),
+                ],
+            ),
+            TutorialChapter(name="Results", steps=[self._recording_step("plot")]),
+        )
+
+    # ------------------------------------------------------------------ playing
+
+    def test_it_plays_every_step_of_every_chapter_in_order(self):
+        player = self._player(self._two_chapters())
+        player.start()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+        self.assertEqual([entry[0] for entry in self.bubble.shown], ["Setup", "Setup", "Results"])
+        self.assertEqual([(entry[1], entry[2]) for entry in self.bubble.shown], [(1, 2), (2, 2), (1, 1)])
+        self.assertFalse(player.is_running)
+
+    def test_it_spotlights_each_step_target(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+
+        self.assertEqual(self.overlay.targets[:2], [self.first, self.second])
+
+    def test_a_step_with_no_target_clears_the_spotlight_rather_than_leaving_the_last_one(self):
+        chapters = (TutorialChapter(name="Only", steps=[self._step("a closing remark")]),)
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+
+        self.assertEqual(self.overlay.targets, [None])
+
+    def test_it_starts_at_a_named_chapter_without_fast_forwarding(self):
+        player = self._player(self._two_chapters())
+        player.start(chapter_index=1)
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(self.performed, ["plot"])
+
+    def test_starting_beyond_the_last_chapter_is_refused(self):
+        player = self._player(self._two_chapters())
+        self.assertRaises(IndexError, player.start, 5)
+
+    # ------------------------------------------------------------------ navigation
+
+    def test_next_interrupts_the_dwell_without_skipping_a_step(self):
+        # a long dwell, so nothing advances on its own during this test
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    self._recording_step("one", dwell_ms=100000),
+                    self._recording_step("two", dwell_ms=100000),
+                ],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
+
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
+
+        self.assertEqual(self.performed, ["one", "two"])
+        self.assertEqual(player.position, (0, 1))
+
+    def test_back_re_narrates_without_re_running_the_action(self):
+        # the crux of Back: pressing "Add orientation" a second time would add a second one
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[
+                    self._recording_step("one", dwell_ms=100000),
+                    self._recording_step("two", dwell_ms=100000),
+                ],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
+        self.assertEqual(self.performed, ["one", "two"])
+
+        player.back_step()
+        interaction.process_events(3)
+
+        self.assertEqual(player.position, (0, 0))
+        self.assertEqual(self.bubble.shown[-1][4], "one")
+        self.assertEqual(self.performed, ["one", "two"], "back must not perform anything again")
+
+    def test_back_crosses_into_the_previous_chapter(self):
+        chapters = (
+            TutorialChapter(name="Setup", steps=[self._recording_step("one", dwell_ms=100000)]),
+            TutorialChapter(name="Results", steps=[self._recording_step("two", dwell_ms=100000)]),
+        )
+        player = self._player(chapters)
+        player.start()
+        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 1))
+        player.next_step()
+        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
+
+        player.back_step()
+        interaction.process_events(3)
+
+        self.assertEqual(player.position, (0, 0))
+
+    def test_back_at_the_very_start_does_nothing(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player.set_paused(True)
+
+        player.back_step()
+        interaction.process_events(3)
+
+        self.assertEqual(player.position, (0, 0))
+
+    def test_back_is_disabled_only_on_the_first_step(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+
+        self.assertEqual([entry[0] for entry in self.bubble.navigation], [False, True, True])
+
+    # ------------------------------------------------------------------ pausing
+
+    def test_pausing_holds_the_current_step(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player.set_paused(True)
+
+        QTest.qWait(150)
+
+        self.assertTrue(player.is_paused)
+        self.assertEqual(player.position, (0, 0))
+        self.assertFalse(self.finished)
+
+    def test_resuming_carries_on_from_where_it_paused(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player.set_paused(True)
+        QTest.qWait(50)
+
+        player.set_paused(False)
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+
+    def test_stop_ends_the_tour_without_reporting_it_as_finished(self):
+        player = self._player(self._two_chapters())
+        player.start()
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+
+        player.stop()
+        QTest.qWait(150)
+
+        self.assertFalse(player.is_running)
+        self.assertEqual(self.finished, [], "stopping is not the same as reaching the end")
+
+    # ------------------------------------------------------------------ waiting
+
+    def test_a_step_waits_for_its_predicate_before_narrating(self):
+        ready = {"now": False}
+        chapters = (
+            TutorialChapter(
+                name="Results",
+                steps=[
+                    self._step(
+                        "the calculation has finished",
+                        await_=lambda _ctx: ready["now"],
+                        await_timeout_s=5.0,
+                        await_text="Calculating…",
+                    )
+                ],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.bubble.waiting)))
+        self.assertEqual(self.bubble.waiting, ["Calculating…"])
+        self.assertEqual(self.bubble.shown, [], "it should not narrate until the wait is over")
+
+        ready["now"] = True
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(len(self.bubble.shown), 1)
+
+    def test_a_wait_that_times_out_reports_it_and_carries_on(self):
+        chapters = (
+            TutorialChapter(
+                name="Results",
+                steps=[self._step("never ready", await_=lambda _ctx: False, await_timeout_s=0.05)],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(len(self.failures), 1)
+        self.assertIn("still not ready", self.failures[0][1])
+
+    # ------------------------------------------------------------------ failure
+
+    def test_a_failing_action_is_reported_and_the_tour_carries_on(self):
+        def explode(_context):
+            raise RuntimeError("the button went away")
+
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[self._step("broken", action=explode, title="Broken step"), self._recording_step("after")],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(self.failures, [("Broken step", "the button went away")])
+        self.assertEqual(self.performed, ["after"], "the rest of the tour should still run")
+
+    def test_an_unresolvable_target_is_reported_and_the_step_is_still_narrated(self):
+        chapters = (
+            TutorialChapter(
+                name="Setup",
+                steps=[self._step("gone", target=lambda ctx: ctx["nope"], title="Missing target")],
+            ),
+        )
+        player = self._player(chapters)
+        player.start()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(len(self.failures), 1)
+        self.assertIn("could not find what to highlight", self.failures[0][1])
+        self.assertEqual(len(self.bubble.shown), 1)
+        self.assertEqual(self.overlay.targets, [None])
+
+    # ------------------------------------------------------------------ fast forward
+
+    def test_fast_forward_runs_earlier_actions_without_narrating_them(self):
+        player = self._player(self._two_chapters())
+        player.start(chapter_index=1, fast_forward=True)
+
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        # every action ran, so the interface is in the right state for the chapter jumped to...
+        self.assertEqual(self.performed, ["load", "material", "plot"])
+        # ...but only the chapter asked for was narrated
+        self.assertEqual([entry[0] for entry in self.bubble.shown], ["Results"])
+        self.assertIn("Setting the interface up", self.bubble.waiting[0])
+
+    def test_fast_forward_awaits_an_earlier_chapters_wait(self):
+        ready = {"now": False}
+        chapters = (
+            TutorialChapter(
+                name="Slow",
+                steps=[self._recording_step("slow", await_=lambda _ctx: ready["now"], await_timeout_s=5.0)],
+            ),
+            TutorialChapter(name="After", steps=[self._recording_step("after")]),
+        )
+        player = self._player(chapters)
+        player.start(chapter_index=1, fast_forward=True)
+
+        QTest.qWait(60)
+        self.assertEqual(self.performed, ["slow"], "it should be held at the wait, not racing past it")
+
+        ready["now"] = True
+        self.assertTrue(self._pump_until(lambda: bool(self.finished)))
+        self.assertEqual(self.performed, ["slow", "after"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -376,7 +376,7 @@ class TutorialPlayerTest(unittest.TestCase):
                             "calculate",
                             await_=lambda _ctx: ready["now"],
                             await_timeout_s=5.0,
-                            await_text="Calculatingâ€¦",
+                            await_text="Calculating…",
                         )
                     ],
                 ),
@@ -386,9 +386,9 @@ class TutorialPlayerTest(unittest.TestCase):
         player.apply_step()
 
         self.assertTrue(self._pump_until(lambda: bool(self.annotator.waiting)))
-        self.assertEqual(self.annotator.waiting, ["Calculatingâ€¦"])
+        self.assertEqual(self.annotator.waiting, ["Calculating…"])
         self.assertTrue(player.is_busy)
-        self.assertIn((True, "Calculatingâ€¦"), self.busy)
+        self.assertIn((True, "Calculating…"), self.busy)
         self.assertEqual(self.applied, [], "not done until the work it started has finished")
 
         ready["now"] = True

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -8,7 +8,7 @@
 import unittest
 
 from qtpy.QtTest import QTest
-from qtpy.QtWidgets import QPushButton, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QGroupBox, QPushButton, QSpinBox, QVBoxLayout, QWidget
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.tutorial import interaction
@@ -91,9 +91,11 @@ class TutorialPlayerTest(unittest.TestCase):
         self.finished = []
         self.failures = []
         self.busy = []
+        self.applied = []
         player.finished.connect(lambda: self.finished.append(True))
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
         player.busy_changed.connect(lambda busy, message: self.busy.append((busy, message)))
+        player.step_applied.connect(lambda: self.applied.append(True))
         return player
 
     @staticmethod
@@ -116,123 +118,137 @@ class TutorialPlayerTest(unittest.TestCase):
             TutorialChapter(name="Results", steps=[self._recording_step("plot")]),
         )
 
-    def _next(self, player):
-        """Wait until the current step is on screen, then press Next - as a user would.
+    def _started(self, chapters=None, **kwargs):
+        """A player showing its first step and ready to be driven."""
+        player = self._player(chapters or self._two_chapters())
+        player.start(**kwargs)
+        self._ready(player)
+        return player
 
-        Pressing it before the step has settled is deliberately ignored by the player, so a test
-        that clicked immediately would be testing that guard rather than what it meant to.
+    def _ready(self, player):
+        """Wait until the tour will accept navigation.
+
+        The player ignores Back/Next/Show me while a step is settling or waiting, so a test that
+        clicked immediately would be testing that guard rather than what it meant to.
         """
         self.assertTrue(self._pump_until(lambda: not player.is_busy))
+
+    def _next(self, player):
+        self._ready(player)
         player.next_step()
 
-    def _play_to_the_end(self, player):
-        """Press Next until the tour reports it has finished, as a user would.
+    def _apply(self, player):
+        self._ready(player)
+        player.apply_step()
+        self._ready(player)
 
-        Waits for each step to actually be on screen first - the player refuses to advance until
-        then, so pressing Next early would simply be ignored and the loop would spin.
-        """
-        seen = 0
+    def _play_to_the_end(self, player):
+        """Press Next until the tour finishes, as a user would."""
         for _ in range(50):
             if self.finished:
                 return True
-            self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) > seen))
-            seen = len(self.bubble.shown)
-            player.next_step()
+            self._next(player)
         return bool(self.finished)
 
-    # ------------------------------------------------------------------ user-driven advance
+    # ------------------------------------------------------------------ explain first, act second
 
-    def test_it_does_not_advance_on_its_own(self):
-        # the whole point of the redesign: no timer is counting down behind the caption
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+    def test_it_explains_a_step_without_doing_anything_to_the_interface(self):
+        player = self._started()
 
-        QTest.qWait(400)
+        QTest.qWait(300)
 
         self.assertEqual(player.position, (0, 0))
-        self.assertEqual(self.performed, ["load"], "only the first step's action should have run")
+        self.assertEqual(self.performed, [], "the step should be explained before it is performed")
+        self.assertFalse(player.is_applied())
         self.assertEqual(len(self.bubble.shown), 1)
         self.assertFalse(self.finished)
 
-    def test_next_moves_one_step_at_a_time(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+    def test_show_me_performs_the_step_and_leaves_its_explanation_up(self):
+        player = self._started()
 
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
-        self.assertEqual(player.position, (0, 1))
-        self.assertEqual(self.performed, ["load", "material"])
+        self._apply(player)
 
-    def test_next_during_the_settle_is_ignored_rather_than_skipping_the_caption(self):
-        # otherwise a step's action would have run while its explanation was never shown
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[self._recording_step("one", settle_ms=200), self._recording_step("two", settle_ms=200)],
-            ),
-        )
-        player = self._player(chapters)
-        player.start()
-        self.assertTrue(player.is_busy, "the action has run but the caption is not up yet")
+        self.assertEqual(self.applied, [True])
+        self.assertEqual(self.performed, ["load"])
+        self.assertEqual(player.position, (0, 0), "performing a step does not move off it")
+        self.assertTrue(player.is_applied())
+        self.assertEqual(self.bubble.shown[-1][1], "load", "the caption stays while the action is watched")
 
-        player.next_step()
+    def test_show_me_twice_does_not_perform_it_twice(self):
+        # pressing "Add orientation" a second time would add a second one
+        player = self._started()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        self.assertEqual(player.position, (0, 0))
-        self.assertEqual(self.bubble.shown[-1][1], "one")
-        self.assertEqual(self.performed, ["one"])
+        self._apply(player)
+        player.apply_step()
+        QTest.qWait(100)
+
+        self.assertEqual(self.performed, ["load"])
+
+    def test_a_step_with_no_action_is_already_applied(self):
+        player = self._started((TutorialChapter(name="Only", steps=[self._step("just narrating")]),))
+        self.assertFalse(player.current_step_has_action())
+        self.assertTrue(player.is_applied())
+
+    # ------------------------------------------------------------------ user-driven advance
+
+    def test_next_performs_a_step_that_was_not_shown_before_moving_on(self):
+        # chapters are cumulative, so a skipped action would break every later step
+        player = self._started()
+
+        self._next(player)
+
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertEqual(self.performed, ["load"])
+
+    def test_next_after_show_me_does_not_perform_it_again(self):
+        player = self._started()
+        self._apply(player)
+
+        self._next(player)
+
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertEqual(self.performed, ["load"])
 
     def test_next_crosses_into_the_following_chapter(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player = self._started()
         self._next(player)
         self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
 
         self._next(player)
+
         self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
-        self.assertEqual(self.performed, ["load", "material", "plot"])
+        self.assertEqual(self.performed, ["load", "material"])
 
     def test_next_past_the_last_step_finishes_the_tour(self):
-        player = self._player(self._two_chapters())
-        player.start()
+        player = self._started()
+
         self.assertTrue(self._play_to_the_end(player))
 
-        self.assertEqual(self.performed, ["load", "material", "plot"])
+        self.assertEqual(self.performed, ["load", "material", "plot"], "every action ran on the way through")
         self.assertFalse(player.is_running)
 
     def test_it_spotlights_each_step_target(self):
-        player = self._player(self._two_chapters())
-        player.start()
+        player = self._started()
         self._play_to_the_end(player)
 
         self.assertEqual(self.overlay.targets[:2], [self.first, self.second])
 
     def test_a_step_with_no_target_clears_the_spotlight_rather_than_leaving_the_last_one(self):
-        chapters = (TutorialChapter(name="Only", steps=[self._step("a closing remark")]),)
-        player = self._player(chapters)
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-
+        self._started((TutorialChapter(name="Only", steps=[self._step("a closing remark")]),))
         self.assertEqual(self.overlay.targets, [None])
 
     def test_it_starts_at_a_named_chapter_without_fast_forwarding(self):
-        player = self._player(self._two_chapters())
-        player.start(chapter_index=1)
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player = self._started(chapter_index=1)
 
-        self.assertEqual(self.performed, ["plot"])
+        self.assertEqual(player.position, (1, 0))
+        self.assertEqual(self.performed, [], "the chapter's own step is explained, not performed")
 
     def test_starting_beyond_the_last_chapter_is_refused(self):
         player = self._player(self._two_chapters())
         self.assertRaises(IndexError, player.start, 5)
 
     def test_it_knows_when_it_is_at_the_ends_of_the_tour(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player = self._started()
         self.assertTrue(player.at_start())
         self.assertFalse(player.at_end())
 
@@ -246,107 +262,157 @@ class TutorialPlayerTest(unittest.TestCase):
 
     # ------------------------------------------------------------------ back
 
-    def test_back_re_narrates_without_re_running_the_action(self):
+    def test_back_re_shows_the_previous_step_without_re_running_its_action(self):
         # the crux of Back: pressing "Add orientation" a second time would add a second one
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: len(self.bubble.shown) == 2))
-        self.assertEqual(self.performed, ["load", "material"])
+        player = self._started()
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertEqual(self.performed, ["load"])
 
+        self._ready(player)
         player.back_step()
-        interaction.process_events(3)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 0)))
+        # the position moves at once but the caption follows after the settle
+        self._ready(player)
 
-        self.assertEqual(player.position, (0, 0))
         self.assertEqual(self.bubble.shown[-1][1], "load")
-        self.assertEqual(self.performed, ["load", "material"], "back must not perform anything again")
+        self.assertEqual(self.performed, ["load"], "back must not perform anything again")
+        self.assertTrue(player.is_applied(), "the step it returned to has already been performed")
+
+    def test_next_after_back_does_not_repeat_the_action(self):
+        player = self._started()
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self._ready(player)
+        player.back_step()
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 0)))
+
+        self._next(player)
+
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertEqual(self.performed, ["load"])
 
     def test_back_crosses_into_the_previous_chapter(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player = self._started()
         self._next(player)
         self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
         self._next(player)
-        self.assertTrue(self._pump_until(lambda: not player.is_busy))
+        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
 
+        self._ready(player)
         player.back_step()
-        interaction.process_events(3)
 
-        self.assertEqual(player.position, (0, 1))
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
 
     def test_back_at_the_very_start_does_nothing(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player = self._started()
 
         player.back_step()
         interaction.process_events(3)
 
         self.assertEqual(player.position, (0, 0))
 
-    # ------------------------------------------------------------------ stopping
+    # ------------------------------------------------------------------ revealing
 
-    def test_stop_ends_the_tour_without_reporting_it_as_finished(self):
-        player = self._player(self._two_chapters())
-        player.start()
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+    def test_the_target_is_opened_up_before_the_action_runs(self):
+        # otherwise the value is set inside a section the user cannot see, and the box only opens
+        # afterwards to explain a change they never watched happen
+        group = QGroupBox("Section", self.window)
+        group.setCheckable(True)
+        group.setChecked(False)
+        group_layout = QVBoxLayout(group)
+        spin = QSpinBox()
+        spin.setRange(0, 100)
+        group_layout.addWidget(spin)
+        self.window.layout().addWidget(group)
+        interaction.process_events(3)
+        # an unchecked checkable group box disables its contents
+        self.assertFalse(spin.isEnabled())
 
-        player.stop()
-        QTest.qWait(100)
+        state_when_the_action_ran = {}
 
-        self.assertFalse(player.is_running)
-        self.assertEqual(self.finished, [], "stopping is not the same as reaching the end")
+        def set_the_value(_ctx):
+            state_when_the_action_ran["enabled"] = spin.isEnabled()
+            spin.setValue(42)
+
+        player = self._started(
+            (TutorialChapter(name="Setup", steps=[self._step("set it", target=lambda _ctx: group, action=set_the_value)]),)
+        )
+        self.assertTrue(group.isChecked(), "the section should be open before the step is even explained")
+
+        self._apply(player)
+
+        self.assertTrue(state_when_the_action_ran["enabled"], "the section must be open before the action runs")
+        self.assertEqual(spin.value(), 42)
+
+    def test_a_target_that_only_appears_after_the_action_is_highlighted_once_it_is_shown(self):
+        made = {}
+
+        def create_it(_ctx):
+            made["button"] = QPushButton("Made", self.window)
+            made["button"].show()
+
+        player = self._started(
+            (TutorialChapter(name="Setup", steps=[self._step("appears", target=lambda _ctx: made["button"], action=create_it)]),)
+        )
+        # nothing to point at while the step is only being explained, and that is not a failure
+        self.assertEqual(self.overlay.targets, [None])
+        self.assertEqual(self.failures, [])
+
+        self._apply(player)
+
+        self.assertEqual(self.overlay.targets[-1], made["button"])
+        self.assertEqual(self.failures, [])
 
     # ------------------------------------------------------------------ waiting
 
-    def test_a_step_waits_for_its_predicate_before_narrating(self):
+    def test_a_step_waits_for_its_action_to_finish_before_reporting_it_done(self):
         ready = {"now": False}
-        chapters = (
-            TutorialChapter(
-                name="Results",
-                steps=[
-                    self._step(
-                        "the calculation has finished",
-                        await_=lambda _ctx: ready["now"],
-                        await_timeout_s=5.0,
-                        await_text="Calculating…",
-                    )
-                ],
-            ),
+        player = self._started(
+            (
+                TutorialChapter(
+                    name="Results",
+                    steps=[
+                        self._recording_step(
+                            "calculate",
+                            await_=lambda _ctx: ready["now"],
+                            await_timeout_s=5.0,
+                            await_text="Calculating…",
+                        )
+                    ],
+                ),
+            )
         )
-        player = self._player(chapters)
-        player.start()
+
+        player.apply_step()
 
         self.assertTrue(self._pump_until(lambda: bool(self.bubble.waiting)))
         self.assertEqual(self.bubble.waiting, ["Calculating…"])
-        self.assertEqual(self.bubble.shown, [], "it should not narrate until the wait is over")
         self.assertTrue(player.is_busy)
-        # busy is raised as soon as the step starts, then re-announced with the wait's own message
-        self.assertEqual(self.busy[0][0], True)
         self.assertIn((True, "Calculating…"), self.busy)
+        self.assertEqual(self.applied, [], "not done until the work it started has finished")
 
         ready["now"] = True
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self.assertTrue(self._pump_until(lambda: bool(self.applied)))
         self.assertFalse(player.is_busy)
-        self.assertEqual(self.busy[-1][0], False)
+        self.assertEqual(self.bubble.shown[-1][1], "calculate", "the caption comes back after the wait")
 
-    def test_next_is_ignored_while_a_step_is_waiting(self):
-        # advancing mid-wait would run the following action against an interface that had not
-        # finished reacting to this one
+    def test_navigation_is_ignored_while_a_step_is_working(self):
+        # advancing mid-calculation would run the next step's action against an interface that had
+        # not finished reacting to this one
         ready = {"now": False}
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[
-                    self._recording_step("slow", await_=lambda _ctx: ready["now"], await_timeout_s=5.0),
-                    self._recording_step("after"),
-                ],
-            ),
+        player = self._started(
+            (
+                TutorialChapter(
+                    name="Setup",
+                    steps=[
+                        self._recording_step("slow", await_=lambda _ctx: ready["now"], await_timeout_s=5.0),
+                        self._recording_step("after"),
+                    ],
+                ),
+            )
         )
-        player = self._player(chapters)
-        player.start()
+        player.apply_step()
         self.assertTrue(self._pump_until(lambda: player.is_busy))
 
         player.next_step()
@@ -357,74 +423,84 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertEqual(self.performed, ["slow"])
 
         ready["now"] = True
-        self.assertTrue(self._pump_until(lambda: not player.is_busy))
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: self.performed == ["slow", "after"]))
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
 
     def test_a_wait_that_times_out_reports_it_and_carries_on(self):
-        chapters = (
-            TutorialChapter(
-                name="Results",
-                steps=[self._step("never ready", await_=lambda _ctx: False, await_timeout_s=0.05)],
-            ),
+        player = self._started(
+            (TutorialChapter(name="Results", steps=[self._recording_step("never ready", await_=lambda _ctx: False, await_timeout_s=0.05)]),)
         )
-        player = self._player(chapters)
-        player.start()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        player.apply_step()
+
+        self.assertTrue(self._pump_until(lambda: bool(self.applied)))
         self.assertEqual(len(self.failures), 1)
         self.assertIn("still not ready", self.failures[0][1])
         self.assertFalse(player.is_busy, "a timed-out wait must not leave navigation locked")
 
     # ------------------------------------------------------------------ failure
 
-    def test_a_failing_action_is_reported_and_the_step_is_still_narrated(self):
+    def test_a_failing_action_is_reported_and_the_tour_carries_on(self):
         def explode(_context):
             raise RuntimeError("the button went away")
 
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[self._step("broken", action=explode, title="Broken step"), self._recording_step("after")],
-            ),
+        player = self._started(
+            (
+                TutorialChapter(
+                    name="Setup",
+                    steps=[self._step("broken", action=explode, title="Broken step"), self._recording_step("after")],
+                ),
+            )
         )
-        player = self._player(chapters)
-        player.start()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self._apply(player)
+
         self.assertEqual(self.failures, [("Broken step", "the button went away")])
+        self.assertTrue(player.is_applied(), "a step that failed is not retried")
 
-        player.next_step()
-        self.assertTrue(self._pump_until(lambda: self.performed == ["after"]), "the rest of the tour should still run")
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
 
-    def test_an_unresolvable_target_is_reported_and_the_step_is_still_narrated(self):
-        chapters = (
-            TutorialChapter(
-                name="Setup",
-                steps=[self._step("gone", target=lambda ctx: ctx["nope"], title="Missing target")],
-            ),
+    def test_a_target_still_missing_after_the_action_is_reported(self):
+        player = self._started(
+            (
+                TutorialChapter(
+                    name="Setup",
+                    steps=[self._step("gone", target=lambda ctx: ctx["nope"], title="Missing target", action=lambda _ctx: None)],
+                ),
+            )
         )
-        player = self._player(chapters)
-        player.start()
+        self.assertEqual(self.failures, [], "not a failure while the step is only being explained")
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self._apply(player)
+
         self.assertEqual(len(self.failures), 1)
         self.assertIn("could not find what to highlight", self.failures[0][1])
-        self.assertEqual(self.overlay.targets, [None])
+
+    # ------------------------------------------------------------------ stopping
+
+    def test_stop_ends_the_tour_without_reporting_it_as_finished(self):
+        player = self._started()
+
+        player.stop()
+        QTest.qWait(100)
+
+        self.assertFalse(player.is_running)
+        self.assertEqual(self.finished, [], "stopping is not the same as reaching the end")
 
     # ------------------------------------------------------------------ fast forward
 
     def test_fast_forward_runs_earlier_actions_without_narrating_them(self):
         player = self._player(self._two_chapters())
         player.start(chapter_index=1, fast_forward=True)
+        self._ready(player)
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
-        # every action ran, so the interface is in the right state for the chapter jumped to...
-        self.assertEqual(self.performed, ["load", "material", "plot"])
-        # ...but only the chapter asked for was narrated
+        # the earlier chapter's actions ran, so the interface is in the state this chapter assumes
+        self.assertEqual(self.performed, ["load", "material"])
+        # ...but only the chapter asked for was narrated, and its own step is not performed yet
         self.assertEqual(len(self.bubble.shown), 1)
+        self.assertFalse(player.is_applied())
         self.assertIn("Setting the interface up", self.bubble.waiting[0])
-        self.assertFalse(player.is_busy)
 
     def test_fast_forward_locks_navigation_while_it_catches_up(self):
         player = self._player(self._two_chapters())
@@ -432,8 +508,22 @@ class TutorialPlayerTest(unittest.TestCase):
 
         self.assertTrue(self.busy)
         self.assertEqual(self.busy[0][0], True)
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.shown)))
+        self._ready(player)
         self.assertEqual(self.busy[-1][0], False)
+
+    def test_back_into_a_fast_forwarded_chapter_does_not_repeat_its_actions(self):
+        player = self._player(self._two_chapters())
+        player.start(chapter_index=1, fast_forward=True)
+        self._ready(player)
+        self.assertEqual(self.performed, ["load", "material"])
+
+        player.back_step()
+        self.assertTrue(self._pump_until(lambda: player.position == (0, 1)))
+        self.assertTrue(player.is_applied())
+
+        self._next(player)
+        self.assertTrue(self._pump_until(lambda: player.position == (1, 0)))
+        self.assertEqual(self.performed, ["load", "material"])
 
     def test_fast_forward_awaits_an_earlier_chapters_wait(self):
         ready = {"now": False}
@@ -449,9 +539,11 @@ class TutorialPlayerTest(unittest.TestCase):
 
         QTest.qWait(60)
         self.assertEqual(self.performed, ["slow"], "it should be held at the wait, not racing past it")
+        self.assertTrue(player.is_busy)
 
         ready["now"] = True
-        self.assertTrue(self._pump_until(lambda: self.performed == ["slow", "after"]))
+        self._ready(player)
+        self.assertEqual(player.position, (1, 0))
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_player.py
@@ -16,12 +16,15 @@ from mantidqt.widgets.tutorial.player import TutorialPlayer
 from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
 
 
-class FakeOverlay:
-    """Records what it was asked to spotlight, so a test can check the tour pointed at the right
-    thing without going near painting."""
+class FakeAnnotator:
+    """Records what the tour pointed at and said, so a test can check both without going near
+    painting. The whole surface the player uses, so nothing has to be probed for."""
 
     def __init__(self):
         self.targets = []
+        self.shown = []
+        self.waiting = []
+        self.kept_clear = ()
 
     def set_target(self, widget):
         self.targets.append(widget)
@@ -29,20 +32,8 @@ class FakeOverlay:
     def target_rect(self):
         return None
 
-    def show(self):
-        pass
-
-    def hide(self):
-        pass
-
-    def detach(self):
-        pass
-
-
-class FakeBubble:
-    def __init__(self):
-        self.shown = []
-        self.waiting = []
+    def rect_of(self, _widget):
+        return None
 
     def show_step(self, text, title=""):
         self.shown.append((title, text))
@@ -52,6 +43,15 @@ class FakeBubble:
 
     def place_beside(self, _spotlight, keep_clear=()):
         self.kept_clear = keep_clear
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def detach(self):
+        pass
 
 
 @start_qapplication
@@ -68,8 +68,7 @@ class TutorialPlayerTest(unittest.TestCase):
         interaction.process_events(3)
 
         self.performed = []
-        self.overlay = FakeOverlay()
-        self.bubble = FakeBubble()
+        self.annotator = FakeAnnotator()
         self.context = {"window": self.window, "first": self.first, "second": self.second}
 
     def tearDown(self):
@@ -87,7 +86,7 @@ class TutorialPlayerTest(unittest.TestCase):
         return self._step(text, action=lambda _ctx: self.performed.append(text), **kwargs)
 
     def _player(self, chapters):
-        player = TutorialPlayer(chapters, self.context, self.overlay, self.bubble, parent=self.window)
+        player = TutorialPlayer(chapters, self.context, self.annotator, parent=self.window)
         self.finished = []
         self.failures = []
         self.busy = []
@@ -160,7 +159,7 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertEqual(player.position, (0, 0))
         self.assertEqual(self.performed, [], "the step should be explained before it is performed")
         self.assertFalse(player.is_applied())
-        self.assertEqual(len(self.bubble.shown), 1)
+        self.assertEqual(len(self.annotator.shown), 1)
         self.assertFalse(self.finished)
 
     def test_show_me_performs_the_step_and_leaves_its_explanation_up(self):
@@ -172,7 +171,7 @@ class TutorialPlayerTest(unittest.TestCase):
         self.assertEqual(self.performed, ["load"])
         self.assertEqual(player.position, (0, 0), "performing a step does not move off it")
         self.assertTrue(player.is_applied())
-        self.assertEqual(self.bubble.shown[-1][1], "load", "the caption stays while the action is watched")
+        self.assertEqual(self.annotator.shown[-1][1], "load", "the caption stays while the action is watched")
 
     def test_show_me_twice_does_not_perform_it_twice(self):
         # pressing "Add orientation" a second time would add a second one
@@ -231,11 +230,11 @@ class TutorialPlayerTest(unittest.TestCase):
         player = self._started()
         self._play_to_the_end(player)
 
-        self.assertEqual(self.overlay.targets[:2], [self.first, self.second])
+        self.assertEqual(self.annotator.targets[:2], [self.first, self.second])
 
     def test_a_step_with_no_target_clears_the_spotlight_rather_than_leaving_the_last_one(self):
         self._started((TutorialChapter(name="Only", steps=[self._step("a closing remark")]),))
-        self.assertEqual(self.overlay.targets, [None])
+        self.assertEqual(self.annotator.targets, [None])
 
     def test_it_starts_at_a_named_chapter_without_fast_forwarding(self):
         player = self._started(chapter_index=1)
@@ -275,7 +274,7 @@ class TutorialPlayerTest(unittest.TestCase):
         # the position moves at once but the caption follows after the settle
         self._ready(player)
 
-        self.assertEqual(self.bubble.shown[-1][1], "load")
+        self.assertEqual(self.annotator.shown[-1][1], "load")
         self.assertEqual(self.performed, ["load"], "back must not perform anything again")
         self.assertTrue(player.is_applied(), "the step it returned to has already been performed")
 
@@ -356,12 +355,12 @@ class TutorialPlayerTest(unittest.TestCase):
             (TutorialChapter(name="Setup", steps=[self._step("appears", target=lambda _ctx: made["button"], action=create_it)]),)
         )
         # nothing to point at while the step is only being explained, and that is not a failure
-        self.assertEqual(self.overlay.targets, [None])
+        self.assertEqual(self.annotator.targets, [None])
         self.assertEqual(self.failures, [])
 
         self._apply(player)
 
-        self.assertEqual(self.overlay.targets[-1], made["button"])
+        self.assertEqual(self.annotator.targets[-1], made["button"])
         self.assertEqual(self.failures, [])
 
     # ------------------------------------------------------------------ waiting
@@ -377,7 +376,7 @@ class TutorialPlayerTest(unittest.TestCase):
                             "calculate",
                             await_=lambda _ctx: ready["now"],
                             await_timeout_s=5.0,
-                            await_text="Calculating…",
+                            await_text="Calculatingâ€¦",
                         )
                     ],
                 ),
@@ -386,16 +385,16 @@ class TutorialPlayerTest(unittest.TestCase):
 
         player.apply_step()
 
-        self.assertTrue(self._pump_until(lambda: bool(self.bubble.waiting)))
-        self.assertEqual(self.bubble.waiting, ["Calculating…"])
+        self.assertTrue(self._pump_until(lambda: bool(self.annotator.waiting)))
+        self.assertEqual(self.annotator.waiting, ["Calculatingâ€¦"])
         self.assertTrue(player.is_busy)
-        self.assertIn((True, "Calculating…"), self.busy)
+        self.assertIn((True, "Calculatingâ€¦"), self.busy)
         self.assertEqual(self.applied, [], "not done until the work it started has finished")
 
         ready["now"] = True
         self.assertTrue(self._pump_until(lambda: bool(self.applied)))
         self.assertFalse(player.is_busy)
-        self.assertEqual(self.bubble.shown[-1][1], "calculate", "the caption comes back after the wait")
+        self.assertEqual(self.annotator.shown[-1][1], "calculate", "the caption comes back after the wait")
 
     def test_navigation_is_ignored_while_a_step_is_working(self):
         # advancing mid-calculation would run the next step's action against an interface that had
@@ -498,9 +497,9 @@ class TutorialPlayerTest(unittest.TestCase):
         # the earlier chapter's actions ran, so the interface is in the state this chapter assumes
         self.assertEqual(self.performed, ["load", "material"])
         # ...but only the chapter asked for was narrated, and its own step is not performed yet
-        self.assertEqual(len(self.bubble.shown), 1)
+        self.assertEqual(len(self.annotator.shown), 1)
         self.assertFalse(player.is_applied())
-        self.assertIn("Setting the interface up", self.bubble.waiting[0])
+        self.assertIn("Setting the interface up", self.annotator.waiting[0])
 
     def test_fast_forward_locks_navigation_while_it_catches_up(self):
         player = self._player(self._two_chapters())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
@@ -93,7 +93,7 @@ class TutorialShellTest(unittest.TestCase):
     def test_it_shows_a_tab_per_chapter(self):
         tabs = self._tab_bar()
         self.assertEqual([tabs.tabText(i) for i in range(tabs.count())], ["Sample setup", "Results", "Exporting"])
-        self.assertEqual(tabs.tabToolTip(0), "Load a sample")
+        self.assertIn("Load a sample", tabs.tabToolTip(0))
 
     # ------------------------------------------------------------------ controls
 
@@ -125,6 +125,29 @@ class TutorialShellTest(unittest.TestCase):
         interaction.process_events()
 
         self.assertEqual(chosen, [2])
+
+    def test_clicking_the_current_chapter_restarts_it(self):
+        # a chapter jump is a rebuild, which makes "start this chapter again" the one form of undo
+        # the tour can offer that is always exactly right
+        chosen = []
+        self.shell.chapter_selected.connect(chosen.append)
+        self.shell.set_current_chapter(1)
+
+        self.shell._tabs.tabBarClicked.emit(1)
+        interaction.process_events()
+
+        self.assertEqual(chosen, [1])
+
+    def test_clicking_a_different_chapter_reports_it_once(self):
+        chosen = []
+        self.shell.chapter_selected.connect(chosen.append)
+
+        tabs = self._tab_bar()
+        tabs.tabBarClicked.emit(2)
+        tabs.setCurrentIndex(2)
+        interaction.process_events()
+
+        self.assertEqual(chosen, [2], "a move to another chapter must not rebuild twice")
 
     def test_the_player_moving_the_tab_does_not_report_it_back(self):
         # otherwise crossing into a new chapter would rebuild the interface underneath a tour that

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
@@ -1,0 +1,158 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from qtpy.QtWidgets import QLabel, QMainWindow, QTabBar, QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial import interaction
+from mantidqt.widgets.tutorial.shell import TutorialShell
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
+
+
+def _chapters():
+    return (
+        TutorialChapter(name="Sample setup", steps=[TutorialStep(text="a"), TutorialStep(text="b")], description="Load a sample"),
+        TutorialChapter(name="Results", steps=[TutorialStep(text="c")]),
+        TutorialChapter(name="Exporting", steps=[TutorialStep(text="d")]),
+    )
+
+
+@start_qapplication
+class TutorialShellTest(unittest.TestCase):
+    def setUp(self):
+        self.chapters = _chapters()
+        # a QMainWindow, because that is what a Mantid interface is and the shell has to adopt one
+        self.interface = QMainWindow()
+        self.interface.setCentralWidget(QLabel("the interface"))
+        self.shell = TutorialShell(self.chapters, self.interface, title="Tutorial")
+        self.shell.resize(800, 600)
+        self.shell.show()
+        interaction.process_events(3)
+
+    def tearDown(self):
+        self.shell.close()
+        self.shell.deleteLater()
+        interaction.process_events()
+
+    def _tab_bar(self):
+        return self.shell.findChild(QTabBar, "tutorial_chapter_tabs")
+
+    # ------------------------------------------------------------------ framing
+
+    def test_it_adopts_the_interface_as_a_child(self):
+        self.assertIs(self.interface.parentWidget(), self.shell)
+        self.assertTrue(self.interface.isVisible())
+
+    def test_the_interface_sits_between_the_tabs_and_the_controls(self):
+        tabs = self._tab_bar()
+        controls = self.shell.findChild(QWidget, "tutorial_controls")
+        interface_top = self.interface.mapTo(self.shell, self.interface.rect().topLeft()).y()
+        interface_bottom = interface_top + self.interface.height()
+
+        self.assertLessEqual(tabs.geometry().bottom(), interface_top)
+        self.assertGreaterEqual(controls.geometry().top(), interface_bottom)
+
+    def test_the_controls_are_outside_the_interface_so_the_scrim_never_covers_them(self):
+        controls = self.shell.findChild(QWidget, "tutorial_controls")
+        self.assertIsNot(controls.parentWidget(), self.interface)
+        self.assertFalse(self.interface.isAncestorOf(controls))
+        self.assertFalse(self.interface.isAncestorOf(self._tab_bar()))
+
+    def test_it_shows_a_tab_per_chapter(self):
+        tabs = self._tab_bar()
+        self.assertEqual([tabs.tabText(i) for i in range(tabs.count())], ["Sample setup", "Results", "Exporting"])
+        self.assertEqual(tabs.tabToolTip(0), "Load a sample")
+
+    # ------------------------------------------------------------------ controls
+
+    def test_back_and_next_emit_their_signals(self):
+        for button, signal_name in ((self.shell.btn_back, "back_requested"), (self.shell.btn_next, "next_requested")):
+            with self.subTest(button=button.text()):
+                fired = []
+                getattr(self.shell, signal_name).connect(lambda: fired.append(True))
+                button.click()
+                interaction.process_events()
+                self.assertEqual(fired, [True])
+
+    def test_ending_the_tutorial_emits_close(self):
+        fired = []
+        self.shell.close_requested.connect(lambda: fired.append(True))
+        self.shell.btn_close.click()
+        interaction.process_events()
+        self.assertEqual(fired, [True])
+
+    def test_choosing_a_tab_reports_the_chapter(self):
+        chosen = []
+        self.shell.chapter_selected.connect(chosen.append)
+
+        self._tab_bar().setCurrentIndex(2)
+        interaction.process_events()
+
+        self.assertEqual(chosen, [2])
+
+    def test_the_player_moving_the_tab_does_not_report_it_back(self):
+        # otherwise crossing into a new chapter would rebuild the interface underneath a tour that
+        # was running perfectly well
+        chosen = []
+        self.shell.chapter_selected.connect(chosen.append)
+
+        self.shell.set_current_chapter(1)
+        interaction.process_events()
+
+        self.assertEqual(chosen, [])
+        self.assertEqual(self.shell.current_chapter(), 1)
+
+    def test_an_out_of_range_chapter_is_ignored_rather_than_crashing(self):
+        self.shell.set_current_chapter(99)
+        self.assertEqual(self.shell.current_chapter(), 0)
+
+    # ------------------------------------------------------------------ display
+
+    def test_it_shows_where_the_tour_has_got_to(self):
+        self.shell.show_position(1, 1, 1)
+        self.assertEqual(self.shell.findChild(QLabel, "tutorial_position").text(), "Step 1 of 1")
+        self.assertEqual(self.shell.current_chapter(), 1)
+
+    def test_navigation_can_be_disabled_at_the_start_of_the_tour(self):
+        self.shell.set_navigation_enabled(back=False, next_=True)
+        self.assertFalse(self.shell.btn_back.isEnabled())
+        self.assertTrue(self.shell.btn_next.isEnabled())
+
+    def test_being_busy_locks_navigation_and_the_tabs(self):
+        # pressing Next during a file search would run the next step against an interface that had
+        # not finished reacting to this one
+        self.shell.set_busy(True, "Looking for the sample file…")
+
+        self.assertFalse(self.shell.btn_next.isEnabled())
+        self.assertFalse(self.shell.btn_back.isEnabled())
+        self.assertFalse(self._tab_bar().isEnabled())
+        self.assertEqual(self.shell.findChild(QLabel, "tutorial_position").text(), "Looking for the sample file…")
+
+        self.shell.set_busy(False)
+        self.assertTrue(self.shell.btn_next.isEnabled())
+        self.assertTrue(self._tab_bar().isEnabled())
+
+    def test_finishing_disables_next_but_leaves_the_tabs(self):
+        self.shell.show_finished()
+        self.assertFalse(self.shell.btn_next.isEnabled())
+        self.assertTrue(self._tab_bar().isEnabled(), "the user should still be able to revisit a chapter")
+
+    # ------------------------------------------------------------------ teardown
+
+    def test_releasing_the_interface_leaves_it_alive_to_be_closed_properly(self):
+        self.shell.release_interface()
+        self.assertIsNone(self.interface.parentWidget())
+        # still a live object, so its own closeEvent can run and clean up after it
+        self.assertEqual(self.interface.centralWidget().text(), "the interface")
+        self.interface.close()
+        self.interface.deleteLater()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
@@ -227,6 +227,16 @@ class TutorialShellTest(unittest.TestCase):
         self.assertTrue(self.shell.btn_next.isEnabled())
         self.assertTrue(self._tab_bar().isEnabled())
 
+    def test_the_step_counter_comes_back_once_the_tour_stops_being_busy(self):
+        # a busy message borrows the counter's label; left there, a finished absorption calculation
+        # reads as the tour still working on it
+        self.shell.show_position(0, 2, 5)
+        self.shell.set_busy(True, "Calculating transmission…")
+
+        self.shell.set_busy(False)
+
+        self.assertEqual(self.shell.findChild(QLabel, "tutorial_position").text(), "Step 2 of 5")
+
     def test_finishing_disables_next_but_leaves_the_tabs(self):
         self.shell.show_finished()
         self.assertFalse(self.shell.btn_next.isEnabled())

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
@@ -30,20 +30,46 @@ class TutorialShellTest(unittest.TestCase):
         # a QMainWindow, because that is what a Mantid interface is and the shell has to adopt one
         self.interface = QMainWindow()
         self.interface.setCentralWidget(QLabel("the interface"))
-        self.shell = TutorialShell(self.chapters, self.interface, title="Tutorial")
-        self.shell.resize(800, 600)
+        self.interface.resize(1200, 800)
+        # a parent, as the real launcher passes: the tutorial belongs to the window that opened it
+        self.owner = QWidget()
+        self.shell = TutorialShell(self.chapters, self.interface, parent=self.owner, title="Tutorial")
         self.shell.show()
         interaction.process_events(3)
 
     def tearDown(self):
         self.shell.close()
         self.shell.deleteLater()
+        self.owner.deleteLater()
         interaction.process_events()
 
     def _tab_bar(self):
         return self.shell.findChild(QTabBar, "tutorial_chapter_tabs")
 
     # ------------------------------------------------------------------ framing
+
+    def test_it_is_a_window_of_its_own_despite_having_a_parent(self):
+        # a QWidget given a parent is a child widget by default, which would draw the whole tutorial
+        # as a small panel in the corner of the window that launched it
+        self.assertTrue(self.shell.isWindow(), "the tutorial must be a window, not a panel inside its parent")
+        self.assertIs(self.shell.parentWidget(), self.owner, "but still owned by the window it belongs to")
+        self.assertEqual(self.shell.windowTitle(), "Tutorial")
+
+    def test_it_opens_big_enough_to_show_the_interface_it_frames(self):
+        # the interface arrives sized by its .ui file; the shell has to be at least that big plus
+        # room for its own chrome, or framing a real interface achieves nothing
+        self.assertGreaterEqual(self.shell.width(), self.interface.width())
+        self.assertGreater(self.shell.height(), self.interface.height())
+
+    def test_a_tiny_interface_still_gets_a_usable_window(self):
+        small = QMainWindow()
+        small.setCentralWidget(QLabel("small"))
+        small.resize(120, 80)
+        shell = TutorialShell(self.chapters, small, title="Tutorial")
+        self.addCleanup(shell.deleteLater)
+
+        self.assertGreaterEqual(shell.width(), 900)
+        self.assertGreaterEqual(shell.height(), 600)
 
     def test_it_adopts_the_interface_as_a_child(self):
         self.assertIs(self.interface.parentWidget(), self.shell)
@@ -72,7 +98,11 @@ class TutorialShellTest(unittest.TestCase):
     # ------------------------------------------------------------------ controls
 
     def test_back_and_next_emit_their_signals(self):
-        for button, signal_name in ((self.shell.btn_back, "back_requested"), (self.shell.btn_next, "next_requested")):
+        for button, signal_name in (
+            (self.shell.btn_back, "back_requested"),
+            (self.shell.btn_next, "next_requested"),
+            (self.shell.btn_apply, "apply_requested"),
+        ):
             with self.subTest(button=button.text()):
                 fired = []
                 getattr(self.shell, signal_name).connect(lambda: fired.append(True))
@@ -124,11 +154,36 @@ class TutorialShellTest(unittest.TestCase):
         self.assertFalse(self.shell.btn_back.isEnabled())
         self.assertTrue(self.shell.btn_next.isEnabled())
 
+    def test_show_me_is_offered_for_a_step_that_does_something(self):
+        self.shell.set_action_available(has_action=True, applied=False)
+        self.assertTrue(self.shell.btn_apply.isVisible())
+        self.assertTrue(self.shell.btn_apply.isEnabled())
+        self.assertEqual(self.shell.btn_apply.text(), "Show me")
+
+    def test_show_me_is_spent_once_the_step_has_been_performed(self):
+        self.shell.set_action_available(has_action=True, applied=True)
+        self.assertTrue(self.shell.btn_apply.isVisible(), "kept visible so the row does not reflow under the pointer")
+        self.assertFalse(self.shell.btn_apply.isEnabled())
+        self.assertEqual(self.shell.btn_apply.text(), "Done")
+
+    def test_show_me_is_hidden_for_a_step_that_only_explains(self):
+        # a permanently dead button beside two live ones reads as something being broken
+        self.shell.set_action_available(has_action=False, applied=True)
+        self.assertFalse(self.shell.btn_apply.isVisible())
+
+    def test_a_spent_show_me_stays_disabled_when_the_tour_stops_being_busy(self):
+        self.shell.set_action_available(has_action=True, applied=True)
+        self.shell.set_busy(True, "working")
+        self.shell.set_busy(False)
+        self.assertFalse(self.shell.btn_apply.isEnabled())
+
     def test_being_busy_locks_navigation_and_the_tabs(self):
         # pressing Next during a file search would run the next step against an interface that had
         # not finished reacting to this one
+        self.shell.set_action_available(has_action=True, applied=False)
         self.shell.set_busy(True, "Looking for the sample file…")
 
+        self.assertFalse(self.shell.btn_apply.isEnabled())
         self.assertFalse(self.shell.btn_next.isEnabled())
         self.assertFalse(self.shell.btn_back.isEnabled())
         self.assertFalse(self._tab_bar().isEnabled())
@@ -141,6 +196,7 @@ class TutorialShellTest(unittest.TestCase):
     def test_finishing_disables_next_but_leaves_the_tabs(self):
         self.shell.show_finished()
         self.assertFalse(self.shell.btn_next.isEnabled())
+        self.assertFalse(self.shell.btn_apply.isVisible(), "there is nothing left to perform")
         self.assertTrue(self._tab_bar().isEnabled(), "the user should still be able to revisit a chapter")
 
     # ------------------------------------------------------------------ teardown

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_shell.py
@@ -117,6 +117,17 @@ class TutorialShellTest(unittest.TestCase):
         interaction.process_events()
         self.assertEqual(fired, [True])
 
+    def test_closing_the_window_emits_close_too(self):
+        # closing a widget hides it rather than destroying it, so without this the session hears
+        # nothing and the interface being toured is left alive behind a hidden window
+        fired = []
+        self.shell.close_requested.connect(lambda: fired.append(True))
+
+        self.shell.close()
+        interaction.process_events()
+
+        self.assertEqual(fired, [True])
+
     def test_choosing_a_tab_reports_the_chapter(self):
         chosen = []
         self.shell.chapter_selected.connect(chosen.append)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
@@ -16,9 +16,11 @@ class TutorialStepTest(unittest.TestCase):
             with self.subTest(text=repr(empty)):
                 self.assertRaises(ValueError, TutorialStep, text=empty)
 
-    def test_negative_delays_are_rejected(self):
-        self.assertRaises(ValueError, TutorialStep, text="hello", dwell_ms=-1)
+    def test_a_negative_settle_is_rejected(self):
         self.assertRaises(ValueError, TutorialStep, text="hello", settle_ms=-1)
+
+    def test_a_step_has_no_dwell_because_the_tour_never_advances_on_its_own(self):
+        self.assertRaises(TypeError, TutorialStep, text="hello", dwell_ms=1000)
 
     def test_awaiting_with_a_non_positive_timeout_is_rejected(self):
         self.assertRaises(ValueError, TutorialStep, text="hello", await_=lambda _ctx: True, await_timeout_s=0)

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantidqt package
 import unittest
 
-from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep, total_steps, walk
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep, walk
 
 
 class TutorialStepTest(unittest.TestCase):
@@ -85,9 +85,6 @@ class TutorialWalkTest(unittest.TestCase):
             TutorialChapter(name="First", steps=[TutorialStep(text="1a"), TutorialStep(text="1b")]),
             TutorialChapter(name="Second", steps=[TutorialStep(text="2a")]),
         )
-
-    def test_total_steps_counts_across_chapters(self):
-        self.assertEqual(total_steps(self.chapters), 3)
 
     def test_walk_visits_every_step_in_play_order(self):
         visited = [(chapter_index, step_index, step.text) for chapter_index, step_index, _chapter, step in walk(self.chapters)]

--- a/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
+++ b/qt/python/mantidqt/mantidqt/widgets/tutorial/test/test_step.py
@@ -1,0 +1,96 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+import unittest
+
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep, total_steps, walk
+
+
+class TutorialStepTest(unittest.TestCase):
+    def test_a_step_must_say_something(self):
+        for empty in ("", "   ", "\n"):
+            with self.subTest(text=repr(empty)):
+                self.assertRaises(ValueError, TutorialStep, text=empty)
+
+    def test_negative_delays_are_rejected(self):
+        self.assertRaises(ValueError, TutorialStep, text="hello", dwell_ms=-1)
+        self.assertRaises(ValueError, TutorialStep, text="hello", settle_ms=-1)
+
+    def test_awaiting_with_a_non_positive_timeout_is_rejected(self):
+        self.assertRaises(ValueError, TutorialStep, text="hello", await_=lambda _ctx: True, await_timeout_s=0)
+
+    def test_label_prefers_the_title(self):
+        self.assertEqual(TutorialStep(text="anything", title="Load the shape").label, "Load the shape")
+
+    def test_label_falls_back_to_flattened_text(self):
+        self.assertEqual(TutorialStep(text="Pick an\n  instrument").label, "Pick an instrument")
+
+    def test_label_truncates_a_long_text(self):
+        label = TutorialStep(text="word " * 40).label
+        self.assertLessEqual(len(label), 60)
+        self.assertTrue(label.startswith("word word"))
+        self.assertTrue(label.endswith("…"))
+
+    def test_label_leaves_a_text_that_already_fits(self):
+        text = "Pick the instrument you are planning for"
+        self.assertEqual(TutorialStep(text=text).label, text)
+
+    def test_target_is_resolved_against_the_context(self):
+        step = TutorialStep(text="there", target=lambda context: context["button"])
+        self.assertEqual(step.resolve_target({"button": "a widget"}), "a widget")
+
+    def test_a_step_with_no_target_resolves_to_none(self):
+        self.assertIsNone(TutorialStep(text="just narrating").resolve_target({}))
+
+    def test_an_unresolvable_target_raises_rather_than_being_swallowed(self):
+        # the interface having moved under the tour must be loud, not a step that quietly stops
+        # highlighting
+        step = TutorialStep(text="there", target=lambda context: context.gone_away)
+        self.assertRaises(AttributeError, step.resolve_target, object())
+
+
+class TutorialChapterTest(unittest.TestCase):
+    @staticmethod
+    def _step(text="a step"):
+        return TutorialStep(text=text)
+
+    def test_a_chapter_must_be_named(self):
+        self.assertRaises(ValueError, TutorialChapter, name=" ", steps=[self._step()])
+
+    def test_a_chapter_must_have_steps(self):
+        self.assertRaises(ValueError, TutorialChapter, name="Setup", steps=[])
+
+    def test_steps_are_frozen_into_a_tuple(self):
+        mutable = [self._step("one")]
+        chapter = TutorialChapter(name="Setup", steps=mutable)
+        mutable.append(self._step("two"))
+        self.assertEqual(len(chapter), 1)
+        self.assertIsInstance(chapter.steps, tuple)
+
+    def test_indexing_and_length(self):
+        chapter = TutorialChapter(name="Setup", steps=[self._step("one"), self._step("two")])
+        self.assertEqual(len(chapter), 2)
+        self.assertEqual(chapter[1].text, "two")
+
+
+class TutorialWalkTest(unittest.TestCase):
+    def setUp(self):
+        self.chapters = (
+            TutorialChapter(name="First", steps=[TutorialStep(text="1a"), TutorialStep(text="1b")]),
+            TutorialChapter(name="Second", steps=[TutorialStep(text="2a")]),
+        )
+
+    def test_total_steps_counts_across_chapters(self):
+        self.assertEqual(total_steps(self.chapters), 3)
+
+    def test_walk_visits_every_step_in_play_order(self):
+        visited = [(chapter_index, step_index, step.text) for chapter_index, step_index, _chapter, step in walk(self.chapters)]
+        self.assertEqual(visited, [(0, 0, "1a"), (0, 1, "1b"), (1, 0, "2a")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_PY_FILES
     test/test_model.py
     test/test_presenter.py
     test/test_view_functional.py
+    tutorial/test/test_chapters.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -61,7 +61,7 @@ class TexturePlannerPresenter(AlgorithmObserver):
         # kept alive for as long as the tour runs: the session owns the sandbox planner it drives
         self._tutorial_session = None
         if offer_tutorial:
-            self.view.set_on_tutorial_clicked(self.open_tutorial)
+            self.view.set_on_tutorial_clicked(self._on_tutorial_clicked)
         else:
             # the tutorial's own planner: the button would start a tutorial inside the tutorial
             self.view.set_tutorial_button_visible(False)
@@ -146,6 +146,15 @@ class TexturePlannerPresenter(AlgorithmObserver):
     # TexturePlanner/tutorial/sandbox.py) so it can load a sample, add orientations and
     # export a file without any of it reaching the window the user is working in.
     # ----------------------------------------------------------------------------------
+
+    def _on_tutorial_clicked(self) -> None:
+        """Open the tutorial because the user asked for it.
+
+        Not ``open_tutorial`` connected directly: ``clicked`` carries a bool, which would land in
+        ``mark_as_seen`` - and asking for the tutorial must not change whether it appears by itself
+        on a first open.
+        """
+        self.open_tutorial()
 
     def open_tutorial(self, mark_as_seen: bool = False) -> None:
         # imported here rather than at module scope: the sandbox builds a presenter, so importing

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -35,6 +35,9 @@ if TYPE_CHECKING:
 # other settings.
 TUTORIAL_SETTINGS_KEY = "TexturePlanner"
 
+# Title of the tutorial window, which frames a throwaway copy of this interface.
+TUTORIAL_WINDOW_TITLE = "Texture Planner — Tutorial"
+
 
 class TexturePlannerPresenter(AlgorithmObserver):
     def __init__(self, model: TexturePlannerModel, view: TexturePlannerView, offer_tutorial: bool = True):
@@ -162,6 +165,7 @@ class TexturePlannerPresenter(AlgorithmObserver):
             parent=self.view,
             settings_key=TUTORIAL_SETTINGS_KEY,
             mark_as_seen=mark_as_seen,
+            title=TUTORIAL_WINDOW_TITLE,
         )
         self._tutorial_session.finished.connect(self._on_tutorial_finished)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -153,12 +153,14 @@ class TexturePlannerPresenter(AlgorithmObserver):
         from mantidqtinterfaces.TexturePlanner.tutorial.sandbox import make_sandbox_factory
 
         if self._tutorial_session is not None:
-            # already running; bring its window forward rather than starting a second one
-            window = self._tutorial_session.window
-            if window is not None:
-                window.raise_()
-                window.activateWindow()
-                return
+            # already running: bring it forward rather than starting a second one. The shell is
+            # what has to be raised - the interface it frames is a child widget of it, and raising
+            # a child does nothing to the window it is in
+            shell = self._tutorial_session.shell
+            if shell is not None:
+                shell.raise_()
+                shell.activateWindow()
+            return
         self._tutorial_session = run_tutorial(
             sandbox_factory=make_sandbox_factory(parent=self.view),
             chapters=CHAPTERS,

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -60,6 +60,9 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self._offer_tutorial = offer_tutorial
         # kept alive for as long as the tour runs: the session owns the sandbox planner it drives
         self._tutorial_session = None
+        # set once this planner has been closed, so the deferred first-open offer below becomes a
+        # no-op rather than building a tour for a window that has already gone
+        self._closed = False
         if offer_tutorial:
             self.view.set_on_tutorial_clicked(self._on_tutorial_clicked)
         else:
@@ -131,6 +134,7 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self._offer_tutorial_on_first_open()
 
     def on_close(self) -> None:
+        self._closed = True
         # the tutorial drives a second planner of its own; closing this one must take that with it,
         # or its window would be left behind with nothing to return to
         if self._tutorial_session is not None:
@@ -161,6 +165,10 @@ class TexturePlannerPresenter(AlgorithmObserver):
         # it from the presenter's own module would be a cycle
         from mantidqtinterfaces.TexturePlanner.tutorial.sandbox import make_sandbox_factory
 
+        if self._closed:
+            # the first-open offer is deferred to the event loop, so it can still arrive after the
+            # planner it belongs to has been closed. There is nothing left to open a tour over.
+            return
         if self._tutorial_session is not None:
             # already running: bring it forward rather than starting a second one. The shell is
             # what has to be raised - the interface it frames is a child widget of it, and raising

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/presenter.py
@@ -6,9 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import annotations
 from typing import TYPE_CHECKING, List, Tuple
+from qtpy.QtCore import QTimer
+
 from mantid.api import AlgorithmObserver
 from mantidqt.interfacemanager import InterfaceManager
+from mantidqt.widgets.tutorial.launcher import run_tutorial, should_show_on_startup
 
+from mantidqtinterfaces.TexturePlanner.tutorial.chapters import CHAPTERS
 from mantidqtinterfaces.TexturePlanner.settings.settings_view import TexturePlannerSettingsView
 from mantidqtinterfaces.TexturePlanner.settings.settings_presenter import TexturePlannerSettingsPresenter
 from mantidqtinterfaces.TexturePlanner.helpers.instrument import CUSTOM_GROUP
@@ -27,9 +31,16 @@ if TYPE_CHECKING:
     from mantidqtinterfaces.TexturePlanner.view import TexturePlannerView
     from numpy import ndarray
 
+# Settings key the tutorial's "already shown once" flag is stored under, beside this interface's
+# other settings.
+TUTORIAL_SETTINGS_KEY = "TexturePlanner"
+
 
 class TexturePlannerPresenter(AlgorithmObserver):
-    def __init__(self, model: TexturePlannerModel, view: TexturePlannerView):
+    def __init__(self, model: TexturePlannerModel, view: TexturePlannerView, offer_tutorial: bool = True):
+        """:param offer_tutorial: whether this planner may show the guided tutorial on a first ever
+        open, and offer it from the toolbar. False for the throwaway planner the tutorial itself
+        drives, which must not offer a tutorial inside a tutorial."""
         super().__init__()
         self.model = model
         self.view = view
@@ -43,6 +54,14 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.settings_presenter.set_on_settings_applied(self.on_settings_applied)
         self.view.set_on_settings_clicked(self.open_settings)
         self.view.set_on_close(self.on_close)
+        self._offer_tutorial = offer_tutorial
+        # kept alive for as long as the tour runs: the session owns the sandbox planner it drives
+        self._tutorial_session = None
+        if offer_tutorial:
+            self.view.set_on_tutorial_clicked(self.open_tutorial)
+        else:
+            # the tutorial's own planner: the button would start a tutorial inside the tutorial
+            self.view.set_tutorial_button_visible(False)
 
         self.set_instrument_options()
         self.set_view_with_default_texture_directions()
@@ -106,12 +125,59 @@ class TexturePlannerPresenter(AlgorithmObserver):
         self.refresh_update_instrument_enabled()
         self.update_material_display()
 
+        self._offer_tutorial_on_first_open()
+
     def on_close(self) -> None:
+        # the tutorial drives a second planner of its own; closing this one must take that with it,
+        # or its window would be left behind with nothing to return to
+        if self._tutorial_session is not None:
+            self._tutorial_session.close()
         # remove this instance's workspaces from the ADS so they don't linger after the window closes
         self.model.workspaces.cleanup()
 
     def open_settings(self) -> None:
         self.settings_presenter.show()
+
+    # ----------------------------------------------------------------------------------
+    # Guided tutorial. The tour runs against a separate, throwaway planner (see
+    # TexturePlanner/tutorial/sandbox.py) so it can load a sample, add orientations and
+    # export a file without any of it reaching the window the user is working in.
+    # ----------------------------------------------------------------------------------
+
+    def open_tutorial(self, mark_as_seen: bool = False) -> None:
+        # imported here rather than at module scope: the sandbox builds a presenter, so importing
+        # it from the presenter's own module would be a cycle
+        from mantidqtinterfaces.TexturePlanner.tutorial.sandbox import make_sandbox_factory
+
+        if self._tutorial_session is not None:
+            # already running; bring its window forward rather than starting a second one
+            window = self._tutorial_session.window
+            if window is not None:
+                window.raise_()
+                window.activateWindow()
+                return
+        self._tutorial_session = run_tutorial(
+            sandbox_factory=make_sandbox_factory(parent=self.view),
+            chapters=CHAPTERS,
+            parent=self.view,
+            settings_key=TUTORIAL_SETTINGS_KEY,
+            mark_as_seen=mark_as_seen,
+        )
+        self._tutorial_session.finished.connect(self._on_tutorial_finished)
+
+    def _on_tutorial_finished(self) -> None:
+        self._tutorial_session = None
+
+    def _offer_tutorial_on_first_open(self) -> None:
+        """Show the tutorial the first time this interface is ever opened.
+
+        Deferred to the event loop rather than run here: this is still the presenter's constructor,
+        so the window it would appear over has not been shown or laid out yet, and the tutorial
+        would have nothing to position itself against.
+        """
+        if not self._offer_tutorial or not should_show_on_startup(TUTORIAL_SETTINGS_KEY):
+            return
+        QTimer.singleShot(0, lambda: self.open_tutorial(mark_as_seen=True))
 
     def set_view_texture_directions(self, names: Tuple[str, str, str], vecs: FlatArrayTuple | ndarray) -> None:
         self.view.set_rd_name(names[0])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
@@ -1074,6 +1074,65 @@ class TestTexturePlannerPresenter_Settings(unittest.TestCase):
         mock_settings_presenter.return_value.show.assert_called_with()
 
 
+@patch(file_path + ".run_tutorial")
+@patch(file_path + ".TexturePlannerSettingsPresenter")
+@patch(file_path + ".TexturePlannerSettingsView")
+class TestTexturePlannerPresenter_Tutorial(unittest.TestCase):
+    """The tutorial builds a whole second planner, so every test here stubs ``run_tutorial`` out.
+    What is under test is when the presenter asks for one, not what the tour then does."""
+
+    def test_opening_it_from_the_toolbar_does_not_mark_it_as_already_seen(
+        self, mock_settings_view, mock_settings_presenter, mock_run_tutorial
+    ):
+        # asking for the tutorial should not change whether it appears on startup
+        presenter = TexturePlannerPresenter(_make_model(), _make_view(), offer_tutorial=False)
+
+        presenter.open_tutorial()
+
+        self.assertFalse(mock_run_tutorial.call_args.kwargs["mark_as_seen"])
+
+    def test_a_second_request_raises_the_running_tutorial_rather_than_starting_another(
+        self, mock_settings_view, mock_settings_presenter, mock_run_tutorial
+    ):
+        presenter = TexturePlannerPresenter(_make_model(), _make_view(), offer_tutorial=False)
+        presenter.open_tutorial()
+
+        presenter.open_tutorial()
+
+        mock_run_tutorial.assert_called_once()
+        # the shell is the window; the sandbox interface inside it is only a child widget
+        mock_run_tutorial.return_value.shell.raise_.assert_called_once_with()
+
+    def test_closing_the_planner_closes_a_tutorial_it_started(self, mock_settings_view, mock_settings_presenter, mock_run_tutorial):
+        # the tour drives a second planner, which would otherwise be left with nothing to return to
+        presenter = TexturePlannerPresenter(_make_model(), _make_view(), offer_tutorial=False)
+        presenter.open_tutorial()
+
+        presenter.on_close()
+
+        mock_run_tutorial.return_value.close.assert_called_once_with()
+
+    @patch(file_path + ".should_show_on_startup", return_value=False)
+    def test_it_is_not_offered_once_it_has_been_seen(
+        self, mock_should_show, mock_settings_view, mock_settings_presenter, mock_run_tutorial
+    ):
+        TexturePlannerPresenter(_make_model(), _make_view())
+
+        mock_run_tutorial.assert_not_called()
+
+    @patch(file_path + ".should_show_on_startup", return_value=True)
+    def test_it_is_not_offered_when_the_planner_is_the_tutorials_own(
+        self, mock_should_show, mock_settings_view, mock_settings_presenter, mock_run_tutorial
+    ):
+        # a tutorial inside a tutorial, recursively, on a first ever open
+        view = _make_view()
+
+        TexturePlannerPresenter(_make_model(), view, offer_tutorial=False)
+
+        mock_run_tutorial.assert_not_called()
+        view.set_tutorial_button_visible.assert_called_once_with(False)
+
+
 @patch(file_path + ".TexturePlannerSettingsPresenter")
 @patch(file_path + ".TexturePlannerSettingsView")
 class TestTexturePlannerPresenter_UpdatePlotsAndTable(unittest.TestCase):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
@@ -1115,6 +1115,19 @@ class TestTexturePlannerPresenter_Tutorial(unittest.TestCase):
 
         mock_run_tutorial.return_value.close.assert_called_once_with()
 
+    @patch(file_path + ".should_show_on_startup", return_value=True)
+    def test_closing_the_planner_before_the_offer_arrives_cancels_it(
+        self, mock_should_show, mock_settings_view, mock_settings_presenter, mock_run_tutorial
+    ):
+        # the first-open offer is deferred to the event loop, so it can arrive after the planner has
+        # been closed - at which point there is no window left to run a tour over
+        presenter = TexturePlannerPresenter(_make_model(), _make_view())
+        presenter.on_close()
+
+        presenter.open_tutorial(mark_as_seen=True)  # what the deferred timer would do
+
+        mock_run_tutorial.assert_not_called()
+
     @patch(file_path + ".should_show_on_startup", return_value=False)
     def test_it_is_not_offered_once_it_has_been_seen(
         self, mock_should_show, mock_settings_view, mock_settings_presenter, mock_run_tutorial

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_presenter.py
@@ -1084,10 +1084,13 @@ class TestTexturePlannerPresenter_Tutorial(unittest.TestCase):
     def test_opening_it_from_the_toolbar_does_not_mark_it_as_already_seen(
         self, mock_settings_view, mock_settings_presenter, mock_run_tutorial
     ):
-        # asking for the tutorial should not change whether it appears on startup
-        presenter = TexturePlannerPresenter(_make_model(), _make_view(), offer_tutorial=False)
+        # asking for the tutorial should not change whether it appears on startup. The slot the
+        # button gets takes no arguments, so ``clicked(bool)`` cannot be what decides that
+        view = _make_view()
+        with patch(file_path + ".should_show_on_startup", return_value=False):
+            TexturePlannerPresenter(_make_model(), view)
 
-        presenter.open_tutorial()
+        view.set_on_tutorial_clicked.call_args.args[0]()
 
         self.assertFalse(mock_run_tutorial.call_args.kwargs["mark_as_seen"])
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/test/test_view_functional.py
@@ -117,7 +117,10 @@ class _FunctionalTestBase(unittest.TestCase):
 
         self.model = TexturePlannerModel()
         self.view = TexturePlannerView()
-        self.presenter = TexturePlannerPresenter(self.model, self.view)
+        # offer_tutorial=False: the first-open offer is scheduled on the event loop, and the
+        # processEvents below would fire it - building a whole second planner in the middle of
+        # every test and writing the "already seen" flag into the developer's real QSettings
+        self.presenter = TexturePlannerPresenter(self.model, self.view, offer_tutorial=False)
         self.view.presenter = self.presenter
 
         self.view.show()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -23,7 +23,7 @@ Two conventions worth knowing before adding a step:
 
 from mantid.simpleapi import SetSampleMaterial
 
-from mantidqt.widgets.tutorial.interaction import click, select_tab, set_check_state, set_spin_box, set_text
+from mantidqt.widgets.tutorial.interaction import click, select_combo, select_tab, set_check_state, set_spin_box, set_text
 from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
 
 # the tour's sample material: deliberately not the interface's default, so the "Current material"
@@ -196,4 +196,172 @@ SAMPLE_SETUP = TutorialChapter(
 )
 
 
-CHAPTERS = (SAMPLE_SETUP,)
+# ------------------------------------------------------------------------------------------------
+# chapter 2 - experimental setup
+# ------------------------------------------------------------------------------------------------
+
+
+# how many orientations the tour builds. Enough to make a pole figure and a table worth looking at,
+# few enough that the per-orientation absorption calculation in the next chapter stays quick.
+DEMO_ORIENTATION_COUNT = 3
+
+DEMO_GROUP = "Texture20"
+DEMO_GAUGE_VOLUME = "4mmCube"
+
+
+def _add_orientations(sandbox):
+    for _ in range(DEMO_ORIENTATION_COUNT):
+        click(sandbox.view.addOrientation)
+
+
+EXPERIMENTAL_SETUP = TutorialChapter(
+    name="Experimental setup",
+    description="Choose the instrument, the gauge volume, and the goniometer moves to measure.",
+    steps=[
+        TutorialStep(
+            title="Now the instrument",
+            text=(
+                "The second tab describes the measurement rather than the sample: which instrument, "
+                "which detector grouping, what part of the sample the beam sees, and how you will "
+                "rotate it."
+            ),
+            target=lambda s: s.view.tabSetup,
+            action=lambda s: select_tab(s.view.tabSetup, "Experimental Setup"),
+            settle_ms=300,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Pick an instrument",
+            text=(
+                "Choosing an instrument loads its detector geometry. Picking <b>Custom</b> instead lets "
+                "you name any instrument definition Mantid can find, and supply your own grouping file."
+            ),
+            target=lambda s: s.view.cmbInstr,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="…and a detector grouping",
+            text=(
+                "Texture measurements group detectors into banks that each look at the sample from a "
+                "different direction — every group becomes one point per orientation on the pole figure. "
+                f"The tutorial is selecting <b>{DEMO_GROUP}</b>."
+            ),
+            target=lambda s: s.view.cmbGroup,
+            action=lambda s: select_combo(s.view.cmbGroup, DEMO_GROUP),
+            settle_ms=300,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="Apply the selection",
+            text=(
+                "Nothing is rebuilt until <b>Update Instrument</b> is pressed — and it stays disabled "
+                "until the instrument and grouping together make sense. That keeps the interface out of "
+                "half-applied states."
+            ),
+            target=lambda s: s.view.btnUpdateInstr,
+            action=lambda s: click(s.view.btnUpdateInstr),
+            settle_ms=800,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="The gauge volume",
+            text=(
+                "The gauge volume is the region where the incident and scattered beams overlap — the "
+                "part of the sample you are actually measuring. It decides the scattering centre, and "
+                "with it the path lengths through the sample."
+            ),
+            target=lambda s: s.view.grpGaugeVol,
+            action=lambda s: set_check_state(s.view.grpGaugeVol, True),
+            settle_ms=400,
+            dwell_ms=5500,
+        ),
+        TutorialStep(
+            title="Choose a preset or your own shape",
+            text=(
+                f"<b>{DEMO_GAUGE_VOLUME}</b> is a preset; <b>Custom Shape</b> takes an XML shape file of "
+                "your own, and <b>No Gauge Volume</b> treats the whole sample as illuminated."
+            ),
+            target=lambda s: s.view.combo_shapeMethod,
+            action=lambda s: select_combo(s.view.combo_shapeMethod, DEMO_GAUGE_VOLUME),
+            settle_ms=300,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="Set it",
+            text="<b>Set Gauge Volume</b> applies it and moves the scattering centre to match.",
+            target=lambda s: s.view.setGV,
+            action=lambda s: click(s.view.setGV),
+            settle_ms=800,
+            dwell_ms=4000,
+        ),
+        TutorialStep(
+            title="Describe your goniometer",
+            text=(
+                "This is how the sample can be moved. Set the number of axes, then give each one a "
+                "rotation vector and a sense — the tutorial is setting up two axes."
+            ),
+            target=lambda s: s.view.grpGoniometer,
+            action=lambda s: set_spin_box(s.view.spnNumAxes, 2),
+            settle_ms=500,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="An axis is a vector and a sense",
+            text=(
+                "The vector is the axis of rotation in the lab frame; the sense says which way a positive "
+                "angle turns. Axes beyond the number you asked for are greyed out."
+            ),
+            target=lambda s: s.view.axis0,
+            action=lambda s: (set_text(s.view.edtVec0, "0,1,0"), select_combo(s.view.cmbSense0, "Counterclockwise")),
+            settle_ms=500,
+            dwell_ms=5500,
+        ),
+        TutorialStep(
+            title="The step size",
+            text=(
+                "The step size sets how far each angle spin box moves per click, so you can walk through "
+                "a scan in even increments rather than typing every angle."
+            ),
+            target=lambda s: s.view.spnStepSize,
+            action=lambda s: set_spin_box(s.view.spnStepSize, 30.0),
+            settle_ms=400,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Dial in an orientation",
+            text=(
+                "Set the angles for each axis and the lab view updates as you go, so you can see where "
+                "the sample ends up before committing to it."
+            ),
+            target=lambda s: s.view.spnAngle0,
+            action=lambda s: set_spin_box(s.view.spnAngle0, 30.0),
+            settle_ms=700,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="Add it to the list",
+            text=(
+                "<b>Add Orientation</b> records the current angles as one measurement position. The "
+                f"tutorial is adding {DEMO_ORIENTATION_COUNT} of them so there is something to look at."
+            ),
+            target=lambda s: s.view.addOrientation,
+            action=_add_orientations,
+            settle_ms=1000,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="Move between them",
+            text=(
+                "The index selector steps through the orientations you have added. Whichever one is "
+                "selected is the one drawn in the lab view and highlighted on the pole figure."
+            ),
+            target=lambda s: s.view.spnIndex,
+            action=lambda s: set_spin_box(s.view.spnIndex, 1),
+            settle_ms=700,
+            dwell_ms=5000,
+        ),
+    ],
+)
+
+
+CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -21,8 +21,6 @@ Two conventions worth knowing before adding a step:
   the tour dead.
 """
 
-from qtpy.QtWidgets import QGroupBox
-
 from mantid.simpleapi import SetSampleMaterial
 
 from mantidqt.widgets.tutorial.interaction import (
@@ -231,6 +229,7 @@ SAMPLE_SETUP = TutorialChapter(
                 "quoted in has rotated with the sample."
             ),
             target=lambda s: s.view.chkTransformDirs,
+            avoid=lambda s: (s.view.groupBox_textureVectors, s.view.grpPoleFigure),
             action=lambda s: set_check_state(s.view.chkTransformDirs, True),
             settle_ms=800,
         ),
@@ -242,6 +241,8 @@ SAMPLE_SETUP = TutorialChapter(
                 "frame is still where you edit them."
             ),
             target=lambda s: s.view.chkLabDirs,
+            # the change this makes shows up in the vector fields, not at the check box
+            avoid=lambda s: s.view.groupBox_textureVectors,
             action=lambda s: set_check_state(s.view.chkLabDirs, True),
             settle_ms=600,
         ),
@@ -249,6 +250,7 @@ SAMPLE_SETUP = TutorialChapter(
             title="Back to the sample frame",
             text=("Untick it to edit the directions again. The tutorial is switching back so the next step can change them."),
             target=lambda s: s.view.chkLabDirs,
+            avoid=lambda s: s.view.groupBox_textureVectors,
             action=lambda s: set_check_state(s.view.chkLabDirs, False),
             settle_ms=600,
         ),
@@ -623,149 +625,27 @@ EXPORT = TutorialChapter(
             settle_ms=800,
         ),
         TutorialStep(
+            title="Everything else is in Settings",
+            text=(
+                "The cog holds the options the tour has skipped: how STL files are scaled and rotated "
+                "on load, which axes Euler angles are written about, the Monte Carlo statistics behind "
+                "the transmission estimate, and the wavelength the attenuation is quoted at — including "
+                "the ring around the current orientation you saw a moment ago. They are remembered "
+                "between sessions."
+            ),
+            target=lambda s: s.view.btn_settings,
+        ),
+        TutorialStep(
             title="That is the whole workflow",
             text=(
                 "Describe the sample, describe the instrument and how you will move it, read the pole "
                 "figure, export the plan.<br><br>"
-                "One chapter left: the settings behind the cog."
-            ),
-        ),
-    ],
-)
-
-
-# ------------------------------------------------------------------------------------------------
-# chapter 5 - the settings menu
-# ------------------------------------------------------------------------------------------------
-
-
-def _open_settings(sandbox):
-    """Open the settings dialog so the chapter can point into it.
-
-    The sandbox has already made this dialog non-modal (see ``sandbox.py``); left modal it would
-    block the tutorial's own controls until the user closed a dialog the tour had opened for them.
-    """
-    sandbox.presenter.open_settings()
-    process_events(3)
-
-
-def _close_settings(sandbox):
-    """Dismiss the dialog *without* applying it.
-
-    Ok and Apply write through to Mantid's shared QSettings, so pressing either here would change
-    the real interface's saved settings on the user's behalf. Rejecting leaves them untouched.
-    """
-    sandbox.settings_view.reject()
-    process_events(3)
-
-
-def _settings_group(widget):
-    """The group box a setting sits in, so a step can spotlight the whole section.
-
-    Found by walking up rather than held as an attribute: the dialog builds its groups locally and
-    only keeps references to the individual fields.
-    """
-    node = widget.parentWidget()
-    while node is not None and not isinstance(node, QGroupBox):
-        node = node.parentWidget()
-    return node if node is not None else widget
-
-
-SETTINGS = TutorialChapter(
-    name="Settings",
-    description="What each option behind the cog does.",
-    steps=[
-        TutorialStep(
-            title="The settings menu",
-            text=(
-                "The cog holds everything the main window would be cluttered by. These settings are "
-                "remembered between sessions, so they are worth setting once for your instrument and "
-                "sample."
-            ),
-            target=lambda s: s.view.btn_settings,
-            action=_open_settings,
-            settle_ms=600,
-        ),
-        TutorialStep(
-            title="Visualisation",
-            text=(
-                "What is drawn in the lab view: the sample direction arrows, the goniometer axes and "
-                "rings, the incident beam, the scattering vectors <b>k</b>, and the scattered beams to "
-                "each detector group.<br><br>"
-                "Turning things off is how you make a busy scene readable — with six goniometer axes "
-                "and twenty detector groups the lab view gets crowded."
-            ),
-            target=lambda s: _settings_group(s.settings_view.show_goniometers),
-        ),
-        TutorialStep(
-            title="STL loading",
-            text=(
-                "STL files carry no units and no agreed orientation. <b>Scale</b> says what the numbers "
-                "in the file mean, and the three <b>degrees</b> fields plus the <b>translation "
-                "vector</b> correct a mesh that was exported in the wrong frame.<br><br>"
-                "These apply as the file is loaded, so they are separate from the initial orientation "
-                "in the main window — that describes how a correct sample sits in the beam, these fix "
-                "a file that was wrong to begin with."
-            ),
-            target=lambda s: _settings_group(s.settings_view.stl_scale_combo),
-        ),
-        TutorialStep(
-            title="Orientation files",
-            text=(
-                "When you load a list of orientations from a file, or export Euler angles, these say "
-                "which <b>axes</b> the angles are about and which <b>sense</b> each one turns in — the "
-                "convention your goniometer control software uses.<br><br>"
-                "Get these wrong and every angle is read or written in the wrong convention, which is "
-                "the sort of mistake that only shows up on the beamline."
-            ),
-            target=lambda s: _settings_group(s.settings_view.orient_axes),
-        ),
-        TutorialStep(
-            title="Monte Carlo absorption",
-            text=(
-                "The statistics behind the transmission estimate. <b>Events per point</b> trades "
-                "accuracy for time — raise it for a final answer, lower it while you are still "
-                "planning. <b>Max scatter point attempts</b> guards against a gauge volume that barely "
-                "intersects the sample.<br><br>"
-                "The tutorial has turned the events right down so its own calculation finishes quickly."
-            ),
-            target=lambda s: _settings_group(s.settings_view.mc_events),
-        ),
-        TutorialStep(
-            title="Attenuation",
-            text=(
-                "How the transmission result is reported. <b>Point</b> and <b>unit</b> pick the "
-                "wavelength or d-spacing the factors are quoted at. <b>Use data range scale</b> "
-                "stretches the colour map over the values actually present rather than fixing it to "
-                "0–1, which brings out small differences.<br><br>"
-                "<b>Highlight current orientation</b> is the grey ring around the current orientation "
-                "you saw on the transmission plot."
-            ),
-            target=lambda s: _settings_group(s.settings_view.att_point),
-        ),
-        TutorialStep(
-            title="Applying them",
-            text=(
-                "<b>Ok</b> and <b>Apply</b> save these and redraw; <b>Cancel</b> discards them. The "
-                "tutorial is cancelling — it has been running on a throwaway copy of the interface all "
-                "along, but the settings themselves are shared with your real session, so it will not "
-                "change them on your behalf."
-            ),
-            target=lambda s: s.settings_view.button_box,
-            action=_close_settings,
-            settle_ms=600,
-        ),
-        TutorialStep(
-            title="That is everything",
-            text=(
-                "Describe the sample, describe the instrument and how you will move it, read the pole "
-                "figure, export the plan — and tune the settings to your instrument.<br><br>"
                 "The full documentation is under <b>Help → Mantid Help</b>. Close this window whenever "
-                "you like; nothing here has touched your own session."
+                "you like — nothing here has touched your own session."
             ),
         ),
     ],
 )
 
 
-CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP, RESULTS, EXPORT, SETTINGS)
+CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP, RESULTS, EXPORT)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -82,10 +82,9 @@ SAMPLE_SETUP = TutorialChapter(
             text=(
                 "This is a working copy of the interface, loaded with a demo sample. Everything the "
                 "tutorial does happens here — your own session is untouched.<br><br>"
-                "Use <b>Pause</b> to stop and look around, <b>Back</b> to re-read a step, or "
-                "<b>Chapters…</b> to skip to a part you care about."
+                "Press <b>Next</b> below when you have finished reading each step; nothing moves on "
+                "its own. <b>Back</b> re-reads a step, and the tabs above jump to a chapter."
             ),
-            dwell_ms=6000,
         ),
         TutorialStep(
             title="Two setup tabs",
@@ -96,7 +95,6 @@ SAMPLE_SETUP = TutorialChapter(
             ),
             target=lambda s: s.view.tabSetup,
             action=lambda s: select_tab(s.view.tabSetup, "Sample Setup"),
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Load a sample shape",
@@ -110,7 +108,6 @@ SAMPLE_SETUP = TutorialChapter(
             await_=lambda s: _finder_ready(s.view.finder_xml),
             await_timeout_s=FINDER_TIMEOUT_S,
             await_text="Looking for the sample file…",
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Load it",
@@ -122,7 +119,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.btnXML,
             action=lambda s: click(s.view.btnXML),
             settle_ms=600,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Give the sample a material",
@@ -134,7 +130,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.btnSetMaterial,
             action=_apply_material,
             settle_ms=400,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="The material is shown here",
@@ -143,7 +138,6 @@ SAMPLE_SETUP = TutorialChapter(
                 "tell at a glance whether the transmission estimates later on mean anything."
             ),
             target=lambda s: s.view.lblCurrentMaterialValue,
-            dwell_ms=4000,
         ),
         TutorialStep(
             title="How the sample sits in its own frame",
@@ -155,7 +149,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.initOrientation,
             action=lambda s: set_spin_box(s.view.spnInitX, 30.0),
             settle_ms=500,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="And where it sits in the beam",
@@ -167,7 +160,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.initPosition,
             action=lambda s: set_spin_box(s.view.spnInitPZ, 0.005),
             settle_ms=500,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="Name your sample directions",
@@ -179,7 +171,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.grpDirectionWidgets,
             action=lambda s: set_check_state(s.view.grpDirectionWidgets, True),
             settle_ms=400,
-            dwell_ms=5500,
         ),
         TutorialStep(
             title="Apply the directions",
@@ -190,7 +181,6 @@ SAMPLE_SETUP = TutorialChapter(
             target=lambda s: s.view.updateDirs,
             action=lambda s: (set_text(s.view.lineedit_RD, "Rolling"), click(s.view.updateDirs)),
             settle_ms=600,
-            dwell_ms=5000,
         ),
     ],
 )
@@ -228,7 +218,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.tabSetup,
             action=lambda s: select_tab(s.view.tabSetup, "Experimental Setup"),
             settle_ms=300,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Pick an instrument",
@@ -237,7 +226,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
                 "you name any instrument definition Mantid can find, and supply your own grouping file."
             ),
             target=lambda s: s.view.cmbInstr,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="…and a detector grouping",
@@ -249,7 +237,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.cmbGroup,
             action=lambda s: select_combo(s.view.cmbGroup, DEMO_GROUP),
             settle_ms=300,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="Apply the selection",
@@ -261,7 +248,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.btnUpdateInstr,
             action=lambda s: click(s.view.btnUpdateInstr),
             settle_ms=800,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="The gauge volume",
@@ -273,7 +259,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.grpGaugeVol,
             action=lambda s: set_check_state(s.view.grpGaugeVol, True),
             settle_ms=400,
-            dwell_ms=5500,
         ),
         TutorialStep(
             title="Choose a preset or your own shape",
@@ -284,7 +269,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.combo_shapeMethod,
             action=lambda s: select_combo(s.view.combo_shapeMethod, DEMO_GAUGE_VOLUME),
             settle_ms=300,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="Set it",
@@ -292,7 +276,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.setGV,
             action=lambda s: click(s.view.setGV),
             settle_ms=800,
-            dwell_ms=4000,
         ),
         TutorialStep(
             title="Describe your goniometer",
@@ -303,7 +286,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.grpGoniometer,
             action=lambda s: set_spin_box(s.view.spnNumAxes, 2),
             settle_ms=500,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="An axis is a vector and a sense",
@@ -314,7 +296,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.axis0,
             action=lambda s: (set_text(s.view.edtVec0, "0,1,0"), select_combo(s.view.cmbSense0, "Counterclockwise")),
             settle_ms=500,
-            dwell_ms=5500,
         ),
         TutorialStep(
             title="The step size",
@@ -325,7 +306,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.spnStepSize,
             action=lambda s: set_spin_box(s.view.spnStepSize, 30.0),
             settle_ms=400,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Dial in an orientation",
@@ -336,7 +316,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.spnAngle0,
             action=lambda s: set_spin_box(s.view.spnAngle0, 30.0),
             settle_ms=700,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="Add it to the list",
@@ -347,7 +326,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.addOrientation,
             action=_add_orientations,
             settle_ms=1000,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="Move between them",
@@ -358,7 +336,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             target=lambda s: s.view.spnIndex,
             action=lambda s: set_spin_box(s.view.spnIndex, 1),
             settle_ms=700,
-            dwell_ms=5000,
         ),
     ],
 )
@@ -381,7 +358,6 @@ RESULTS = TutorialChapter(
                 "really is where you think it is."
             ),
             target=lambda s: s.view.grpSampleFigure,
-            dwell_ms=5500,
         ),
         TutorialStep(
             title="The pole figure",
@@ -391,7 +367,6 @@ RESULTS = TutorialChapter(
                 "whole reason for planning before beam time."
             ),
             target=lambda s: s.view.grpPoleFigure,
-            dwell_ms=6000,
         ),
         TutorialStep(
             title="Transmission",
@@ -401,7 +376,6 @@ RESULTS = TutorialChapter(
                 "slowest thing the interface does — the tutorial has turned the statistics right down."
             ),
             target=lambda s: s.view.chkTransmission,
-            dwell_ms=6000,
         ),
         TutorialStep(
             title="Now with absorption",
@@ -412,7 +386,6 @@ RESULTS = TutorialChapter(
             target=lambda s: s.view.grpPoleFigure,
             action=lambda s: set_check_state(s.view.chkTransmission, True),
             settle_ms=1200,
-            dwell_ms=6000,
         ),
         TutorialStep(
             title="The orientation table",
@@ -421,7 +394,6 @@ RESULTS = TutorialChapter(
                 "controls whether an orientation is exported; <b>Select</b> is for the buttons below."
             ),
             target=lambda s: s.view.grpDynamicTable,
-            dwell_ms=5500,
         ),
         TutorialStep(
             title="Selecting rows",
@@ -433,7 +405,6 @@ RESULTS = TutorialChapter(
             target=lambda s: s.view.selectAll,
             action=lambda s: (click(s.view.selectAll), click(s.view.deselectAll)),
             settle_ms=700,
-            dwell_ms=5500,
         ),
     ],
 )
@@ -464,7 +435,6 @@ EXPORT = TutorialChapter(
             await_timeout_s=FINDER_TIMEOUT_S,
             await_text="Checking the output directory…",
             settle_ms=400,
-            dwell_ms=5000,
         ),
         TutorialStep(
             title="And what to call it",
@@ -472,7 +442,6 @@ EXPORT = TutorialChapter(
             target=lambda s: s.view.saveFileLine,
             action=lambda s: set_text(s.view.saveFileLine, s.data.save_filename),
             settle_ms=400,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Pick a format",
@@ -485,7 +454,6 @@ EXPORT = TutorialChapter(
             target=lambda s: s.view.cmbExportFormat,
             action=lambda s: select_combo(s.view.cmbExportFormat, DEMO_EXPORT_FORMAT),
             settle_ms=400,
-            dwell_ms=6000,
         ),
         TutorialStep(
             title="Write it out",
@@ -493,7 +461,6 @@ EXPORT = TutorialChapter(
             target=lambda s: s.view.btnExport,
             action=lambda s: click(s.view.btnExport),
             settle_ms=800,
-            dwell_ms=4500,
         ),
         TutorialStep(
             title="Everything else is in Settings",
@@ -503,7 +470,6 @@ EXPORT = TutorialChapter(
                 "wavelength the attenuation is quoted at. They are remembered between sessions."
             ),
             target=lambda s: s.view.btn_settings,
-            dwell_ms=6500,
         ),
         TutorialStep(
             title="That is the whole workflow",
@@ -513,7 +479,6 @@ EXPORT = TutorialChapter(
                 "The full documentation is under <b>Help → Mantid Help</b>. Close this window whenever "
                 "you like — nothing here has touched your own session."
             ),
-            dwell_ms=8000,
         ),
     ],
 )

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -21,6 +21,8 @@ Two conventions worth knowing before adding a step:
   the tour dead.
 """
 
+from qtpy.QtWidgets import QGroupBox
+
 from mantid.simpleapi import SetSampleMaterial
 
 from mantidqt.widgets.tutorial.interaction import (
@@ -205,6 +207,50 @@ SAMPLE_SETUP = TutorialChapter(
                 "So which direction you put in the middle row decides which pole you are looking down."
             ),
             target=lambda s: s.view.groupBox_textureVectors,
+        ),
+        TutorialStep(
+            title="Pinning the directions to the shape",
+            text=(
+                "<b>Apply Orientation to Directions</b> is for the common case where the sample "
+                "directions and the shape file are both easy to write down in the <i>sample</i> frame "
+                "and awkward in the lab frame.<br><br>"
+                "Say you know the rolling direction runs along the length of the block. Both the shape "
+                "and the directions are obvious in the sample's own frame — but once the block is "
+                "mounted at some angle in the beam, neither is obvious in the lab frame."
+            ),
+            target=lambda s: s.view.chkTransformDirs,
+        ),
+        TutorialStep(
+            title="One rotation aligns both",
+            text=(
+                "Tick it and the <b>initial orientation</b> from earlier is applied to the sample "
+                "directions as well as to the shape. So you describe both in the frame they are easy "
+                "to describe in, and the single rotation that puts the shape in the beam carries the "
+                "directions with it.<br><br>"
+                "Watch the pole figure: the measurements have not changed, but the frame they are "
+                "quoted in has rotated with the sample."
+            ),
+            target=lambda s: s.view.chkTransformDirs,
+            action=lambda s: set_check_state(s.view.chkTransformDirs, True),
+            settle_ms=800,
+        ),
+        TutorialStep(
+            title="Seeing them in the lab frame",
+            text=(
+                "<b>View in Lab Frame</b> shows what those directions have become in instrument "
+                "coordinates. The fields go read-only, because these values are derived — the sample "
+                "frame is still where you edit them."
+            ),
+            target=lambda s: s.view.chkLabDirs,
+            action=lambda s: set_check_state(s.view.chkLabDirs, True),
+            settle_ms=600,
+        ),
+        TutorialStep(
+            title="Back to the sample frame",
+            text=("Untick it to edit the directions again. The tutorial is switching back so the next step can change them."),
+            target=lambda s: s.view.chkLabDirs,
+            action=lambda s: set_check_state(s.view.chkLabDirs, False),
+            settle_ms=600,
         ),
         TutorialStep(
             title="Permute them and the projection changes",
@@ -428,11 +474,46 @@ RESULTS = TutorialChapter(
             target=lambda s: s.view.grpSampleFigure,
         ),
         TutorialStep(
+            title="The goniometer axes and rings",
+            text=(
+                "Each goniometer is drawn as an <b>arrow</b> along its rotation axis and a <b>ring</b> "
+                "showing the circle it sweeps. The rings nest: an axis is drawn inside the ones it is "
+                "mounted on, so the stack reads outermost-first.<br><br>"
+                "The coloured part of a ring is the angle it has been rotated through; the grey "
+                "remainder is the travel left. The axis you changed most recently is drawn "
+                "<b>solid</b>, the others dashed."
+            ),
+            target=lambda s: s.view.grpSampleFigure,
+        ),
+        TutorialStep(
             title="The pole figure",
             text=(
                 "Every detector group, for every orientation you added, projected into the sample's own "
                 "frame. Gaps here are directions your planned measurement never samples — which is the "
                 "whole reason for planning before beam time."
+            ),
+            target=lambda s: s.view.grpPoleFigure,
+        ),
+        TutorialStep(
+            title="The goniometers appear here too",
+            text=(
+                "Each goniometer axis is projected onto the pole figure as well — as a <b>point</b>, or "
+                "as a <b>line</b> across the figure when the axis lies in its plane.<br><br>"
+                "The fill matches the lab view: the axis you last changed is drawn <b>filled</b> (or "
+                "solid, for a line), the rest hollow and dashed. It is the quickest way to see which "
+                "axis you are currently moving and where it points."
+            ),
+            target=lambda s: s.view.grpPoleFigure,
+        ),
+        TutorialStep(
+            title="Which orientation is which",
+            text=(
+                "The pole figure distinguishes the orientation you have selected from the rest:<br>"
+                "• <b>Filled</b> points — the current orientation, included in the plan.<br>"
+                "• <b>Hollow</b> points — every other included orientation.<br>"
+                "• <b>Faint grey</b> points — the current orientation when it is <i>not</i> included.<br>"
+                "• Orientations that are neither current nor included are not drawn at all.<br><br>"
+                "So stepping the index selector walks the filled points around the figure."
             ),
             target=lambda s: s.view.grpPoleFigure,
         ),
@@ -449,7 +530,11 @@ RESULTS = TutorialChapter(
             title="Now with absorption",
             text=(
                 "Dark points are directions where the beam has a long path through the sample, so they "
-                "will need longer counting times — or a different sample orientation."
+                "will need longer counting times — or a different sample orientation.<br><br>"
+                "With every point coloured by transmission there is no fill left to mark the current "
+                "orientation, so it is <b>ringed</b> with oversized open circles instead. Only included "
+                "orientations are shown at all. The ring can be turned off under "
+                "<i>Attenuation Settings</i> in the settings menu."
             ),
             target=lambda s: s.view.grpPoleFigure,
             action=lambda s: set_check_state(s.view.chkTransmission, True),
@@ -538,25 +623,149 @@ EXPORT = TutorialChapter(
             settle_ms=800,
         ),
         TutorialStep(
-            title="Everything else is in Settings",
-            text=(
-                "The cog holds the options the tour has skipped: how STL files are scaled and rotated on "
-                "load, which axes Euler angles are written about, the Monte Carlo statistics, and the "
-                "wavelength the attenuation is quoted at. They are remembered between sessions."
-            ),
-            target=lambda s: s.view.btn_settings,
-        ),
-        TutorialStep(
             title="That is the whole workflow",
             text=(
                 "Describe the sample, describe the instrument and how you will move it, read the pole "
                 "figure, export the plan.<br><br>"
-                "The full documentation is under <b>Help → Mantid Help</b>. Close this window whenever "
-                "you like — nothing here has touched your own session."
+                "One chapter left: the settings behind the cog."
             ),
         ),
     ],
 )
 
 
-CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP, RESULTS, EXPORT)
+# ------------------------------------------------------------------------------------------------
+# chapter 5 - the settings menu
+# ------------------------------------------------------------------------------------------------
+
+
+def _open_settings(sandbox):
+    """Open the settings dialog so the chapter can point into it.
+
+    The sandbox has already made this dialog non-modal (see ``sandbox.py``); left modal it would
+    block the tutorial's own controls until the user closed a dialog the tour had opened for them.
+    """
+    sandbox.presenter.open_settings()
+    process_events(3)
+
+
+def _close_settings(sandbox):
+    """Dismiss the dialog *without* applying it.
+
+    Ok and Apply write through to Mantid's shared QSettings, so pressing either here would change
+    the real interface's saved settings on the user's behalf. Rejecting leaves them untouched.
+    """
+    sandbox.settings_view.reject()
+    process_events(3)
+
+
+def _settings_group(widget):
+    """The group box a setting sits in, so a step can spotlight the whole section.
+
+    Found by walking up rather than held as an attribute: the dialog builds its groups locally and
+    only keeps references to the individual fields.
+    """
+    node = widget.parentWidget()
+    while node is not None and not isinstance(node, QGroupBox):
+        node = node.parentWidget()
+    return node if node is not None else widget
+
+
+SETTINGS = TutorialChapter(
+    name="Settings",
+    description="What each option behind the cog does.",
+    steps=[
+        TutorialStep(
+            title="The settings menu",
+            text=(
+                "The cog holds everything the main window would be cluttered by. These settings are "
+                "remembered between sessions, so they are worth setting once for your instrument and "
+                "sample."
+            ),
+            target=lambda s: s.view.btn_settings,
+            action=_open_settings,
+            settle_ms=600,
+        ),
+        TutorialStep(
+            title="Visualisation",
+            text=(
+                "What is drawn in the lab view: the sample direction arrows, the goniometer axes and "
+                "rings, the incident beam, the scattering vectors <b>k</b>, and the scattered beams to "
+                "each detector group.<br><br>"
+                "Turning things off is how you make a busy scene readable — with six goniometer axes "
+                "and twenty detector groups the lab view gets crowded."
+            ),
+            target=lambda s: _settings_group(s.settings_view.show_goniometers),
+        ),
+        TutorialStep(
+            title="STL loading",
+            text=(
+                "STL files carry no units and no agreed orientation. <b>Scale</b> says what the numbers "
+                "in the file mean, and the three <b>degrees</b> fields plus the <b>translation "
+                "vector</b> correct a mesh that was exported in the wrong frame.<br><br>"
+                "These apply as the file is loaded, so they are separate from the initial orientation "
+                "in the main window — that describes how a correct sample sits in the beam, these fix "
+                "a file that was wrong to begin with."
+            ),
+            target=lambda s: _settings_group(s.settings_view.stl_scale_combo),
+        ),
+        TutorialStep(
+            title="Orientation files",
+            text=(
+                "When you load a list of orientations from a file, or export Euler angles, these say "
+                "which <b>axes</b> the angles are about and which <b>sense</b> each one turns in — the "
+                "convention your goniometer control software uses.<br><br>"
+                "Get these wrong and every angle is read or written in the wrong convention, which is "
+                "the sort of mistake that only shows up on the beamline."
+            ),
+            target=lambda s: _settings_group(s.settings_view.orient_axes),
+        ),
+        TutorialStep(
+            title="Monte Carlo absorption",
+            text=(
+                "The statistics behind the transmission estimate. <b>Events per point</b> trades "
+                "accuracy for time — raise it for a final answer, lower it while you are still "
+                "planning. <b>Max scatter point attempts</b> guards against a gauge volume that barely "
+                "intersects the sample.<br><br>"
+                "The tutorial has turned the events right down so its own calculation finishes quickly."
+            ),
+            target=lambda s: _settings_group(s.settings_view.mc_events),
+        ),
+        TutorialStep(
+            title="Attenuation",
+            text=(
+                "How the transmission result is reported. <b>Point</b> and <b>unit</b> pick the "
+                "wavelength or d-spacing the factors are quoted at. <b>Use data range scale</b> "
+                "stretches the colour map over the values actually present rather than fixing it to "
+                "0–1, which brings out small differences.<br><br>"
+                "<b>Highlight current orientation</b> is the grey ring around the current orientation "
+                "you saw on the transmission plot."
+            ),
+            target=lambda s: _settings_group(s.settings_view.att_point),
+        ),
+        TutorialStep(
+            title="Applying them",
+            text=(
+                "<b>Ok</b> and <b>Apply</b> save these and redraw; <b>Cancel</b> discards them. The "
+                "tutorial is cancelling — it has been running on a throwaway copy of the interface all "
+                "along, but the settings themselves are shared with your real session, so it will not "
+                "change them on your behalf."
+            ),
+            target=lambda s: s.settings_view.button_box,
+            action=_close_settings,
+            settle_ms=600,
+        ),
+        TutorialStep(
+            title="That is everything",
+            text=(
+                "Describe the sample, describe the instrument and how you will move it, read the pole "
+                "figure, export the plan — and tune the settings to your instrument.<br><br>"
+                "The full documentation is under <b>Help → Mantid Help</b>. Close this window whenever "
+                "you like; nothing here has touched your own session."
+            ),
+        ),
+    ],
+)
+
+
+CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP, RESULTS, EXPORT, SETTINGS)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -93,8 +93,12 @@ def _permute_directions(sandbox):
 
 
 def _show_pinned_directions(sandbox):
-    """
-    Update the sample shape and direction to be askew in the lab-frame
+    """Tilt the sample and pin the texture directions to it.
+
+    Both, together, because the check box on its own has nothing to show: it applies the initial
+    orientation to the sample directions as well as to the shape, so with the sample square to the
+    lab frame the pinned and unpinned directions are identical. Tilting it first is what makes the
+    difference visible on the pole figure.
     """
     set_spin_box(sandbox.view.spnInitX, 30.0)
     set_check_state(sandbox.view.chkTransformDirs, True)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -133,7 +133,7 @@ SAMPLE_SETUP = TutorialChapter(
                 "The setup controls are split into two halves. <b>Sample Setup</b> describes what you are "
                 "measuring; <b>Experimental Setup</b> describes the instrument and how you will move "
                 "the sample. We start with the sample. <br><br>"
-                "(<b>Show me</b> will simply select the <b>Sample Setup</b> tab incase you have changed to "
+                "(<b>Show me</b> will simply select the <b>Sample Setup</b> tab in case you have changed to "
                 "<b>Experimental Setup</b>)"
             ),
             target=lambda s: s.view.tabSetup,
@@ -188,7 +188,7 @@ SAMPLE_SETUP = TutorialChapter(
             title="How the sample sits in its own frame",
             text=(
                 "A shape file is not necessarily defined in the same orientation that it is mounted in the beam. "
-                "These angles rotate the sample once, before any goniometer motion,"
+                "These angles rotate the sample once, before any goniometer motion; "
                 "they describe how the sample sits in the beam before positioning."
             ),
             target=lambda s: s.view.initOrientation,
@@ -201,7 +201,7 @@ SAMPLE_SETUP = TutorialChapter(
                 "The position offsets move the sample relative to the instrument's origin. Together "
                 "with the gauge volume set up in the next chapter, this is what decides which part of "
                 "the sample is actually being measured.<br><br>"
-                "Note that without a gauge volume the <i>whole</i> sample is still assumed to be illuminated"
+                "Note that without a gauge volume the <i>whole</i> sample is still assumed to be illuminated "
                 "by the beam, hence the location of the scattering vector and sample directions remaining at "
                 "the sample centre."
             ),
@@ -243,7 +243,7 @@ SAMPLE_SETUP = TutorialChapter(
         TutorialStep(
             title="One rotation aligns both",
             text=(
-                "Tick it and a <b>initial orientation</b> (now set to 30 degrees) is applied to the sample "
+                "Tick it and an <b>initial orientation</b> (now set to 30 degrees) is applied to the sample "
                 "directions as well as to the shape. <br><br>"
                 "Try toggling the box yourself to see the lab-frame vs sample-frame definition.<br><br>"
                 "Watch the pole figure: the measurements have not changed, but the frame they are "

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -82,8 +82,9 @@ SAMPLE_SETUP = TutorialChapter(
             text=(
                 "This is a working copy of the interface, loaded with a demo sample. Everything the "
                 "tutorial does happens here — your own session is untouched.<br><br>"
-                "Press <b>Next</b> below when you have finished reading each step; nothing moves on "
-                "its own. <b>Back</b> re-reads a step, and the tabs above jump to a chapter."
+                "Each step explains a control first. Press <b>Show me</b> to watch the tutorial use "
+                "it, then <b>Next</b> to move on — nothing happens on its own. <b>Back</b> re-reads a "
+                "step, and the tabs above jump to a chapter."
             ),
         ),
         TutorialStep(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -1,0 +1,199 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""What the Texture Planner tutorial shows, in the order it shows it.
+
+Each step is written against the sandbox (see ``sandbox.py``), which is why the actions may reach
+for the presenter and the model as well as the widgets: the tour is demonstrating a workflow, and
+some of that workflow is what the interface does in response, not only what the user clicks.
+
+Two conventions worth knowing before adding a step:
+
+* **Targets are looked up, not held.** ``lambda sandbox: sandbox.view.btnXML`` rather than a
+  captured widget, because chapters are replayed against a freshly built interface whenever the
+  user jumps to one.
+* **Actions drive the interface, they do not fake it.** Where a step can go through the widget it
+  is pointing at, it does - so what the user watches is the interface really working. The
+  exceptions are called out where they occur, and each is a modal dialog that would otherwise stop
+  the tour dead.
+"""
+
+from mantid.simpleapi import SetSampleMaterial
+
+from mantidqt.widgets.tutorial.interaction import click, select_tab, set_check_state, set_spin_box, set_text
+from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
+
+# the tour's sample material: deliberately not the interface's default, so the "Current material"
+# label visibly changes when the step runs
+DEMO_MATERIAL = "Cu"
+
+# how long a file finder is given to finish its background search before the tour gives up on it.
+# Generous on purpose - the finder walks every configured data search directory, which on a real
+# instrument mount is a network round trip per candidate.
+FINDER_TIMEOUT_S = 60.0
+
+
+# ------------------------------------------------------------------------------------------------
+# helpers used by the steps
+# ------------------------------------------------------------------------------------------------
+
+
+def _set_finder(finder, path):
+    """Put a path into a Mantid file finder the way typing into it does.
+
+    ``setFileTextWithSearch`` starts a search on a background thread, so the file is not available
+    on the next line - the step that follows waits for ``_finder_ready``.
+    """
+    finder.setFileTextWithSearch(path)
+
+
+def _finder_ready(finder):
+    return not finder.isSearching()
+
+
+def _apply_material(sandbox):
+    """Set the sample material without the modal dialog the button opens.
+
+    ``btnSetMaterial`` opens the standard ``SetSampleMaterial`` algorithm dialog, which is modal:
+    it would block the tour's timers and the tutorial would stop at that step until the user dealt
+    with a dialog they had not asked for. So the step points at the button and explains it, and the
+    material is applied along the same path the dialog uses - the algorithm against the raw mesh
+    workspace, then ``on_material_set`` to share it with the rest - so the result the user sees is
+    exactly what clicking through the dialog would have produced.
+    """
+    SetSampleMaterial(InputWorkspace=sandbox.model.workspaces.WS_MESH_RAW, ChemicalFormula=DEMO_MATERIAL)
+    sandbox.presenter.on_material_set()
+
+
+# ------------------------------------------------------------------------------------------------
+# chapter 1 - sample setup
+# ------------------------------------------------------------------------------------------------
+
+
+SAMPLE_SETUP = TutorialChapter(
+    name="Sample setup",
+    description="Load a sample shape, give it a material, and place it in the beam.",
+    steps=[
+        TutorialStep(
+            title="Welcome to the Texture Planner",
+            text=(
+                "This is a working copy of the interface, loaded with a demo sample. Everything the "
+                "tutorial does happens here — your own session is untouched.<br><br>"
+                "Use <b>Pause</b> to stop and look around, <b>Back</b> to re-read a step, or "
+                "<b>Chapters…</b> to skip to a part you care about."
+            ),
+            dwell_ms=6000,
+        ),
+        TutorialStep(
+            title="Two setup tabs",
+            text=(
+                "Planning an experiment has two halves. <b>Sample Setup</b> describes what you are "
+                "measuring; <b>Experimental Setup</b> describes the instrument and how you will move "
+                "the sample. We start with the sample."
+            ),
+            target=lambda s: s.view.tabSetup,
+            action=lambda s: select_tab(s.view.tabSetup, "Sample Setup"),
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Load a sample shape",
+            text=(
+                "The sample's shape comes from a file: an <b>STL mesh</b> exported from CAD, or a "
+                "<b>CSG description</b> in Mantid's XML shape format. The tutorial is loading a 2 cm "
+                "cube defined in XML."
+            ),
+            target=lambda s: s.view.finder_xml,
+            action=lambda s: _set_finder(s.view.finder_xml, s.data.cube_xml_path),
+            await_=lambda s: _finder_ready(s.view.finder_xml),
+            await_timeout_s=FINDER_TIMEOUT_S,
+            await_text="Looking for the sample file…",
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Load it",
+            text=(
+                "<b>Load CSG</b> stays disabled until the file finder has found a valid file — the same "
+                "is true of the STL button above. Watch the <b>Lab View</b> on the right when it is "
+                "pressed."
+            ),
+            target=lambda s: s.view.btnXML,
+            action=lambda s: click(s.view.btnXML),
+            settle_ms=600,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Give the sample a material",
+            text=(
+                "Absorption depends on what the sample is made of. <b>Set Material</b> opens Mantid's "
+                "standard <i>SetSampleMaterial</i> dialog, where you give a chemical formula and a "
+                "density. The tutorial is setting copper for you rather than opening the dialog."
+            ),
+            target=lambda s: s.view.btnSetMaterial,
+            action=_apply_material,
+            settle_ms=400,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="The material is shown here",
+            text=(
+                "Whatever is currently set on the sample is displayed beside the button, so you can "
+                "tell at a glance whether the transmission estimates later on mean anything."
+            ),
+            target=lambda s: s.view.lblCurrentMaterialValue,
+            dwell_ms=4000,
+        ),
+        TutorialStep(
+            title="How the sample sits in its own frame",
+            text=(
+                "A shape file rarely arrives in the orientation you mounted it in. These angles rotate "
+                "the sample once, before any goniometer motion — they describe how the sample sits in "
+                "its holder."
+            ),
+            target=lambda s: s.view.initOrientation,
+            action=lambda s: set_spin_box(s.view.spnInitX, 30.0),
+            settle_ms=500,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="And where it sits in the beam",
+            text=(
+                "The position offsets move the sample relative to the instrument's origin. Together "
+                "with the gauge volume set up in the next chapter, this is what decides which part of "
+                "the sample is actually being measured."
+            ),
+            target=lambda s: s.view.initPosition,
+            action=lambda s: set_spin_box(s.view.spnInitPZ, 0.005),
+            settle_ms=500,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="Name your sample directions",
+            text=(
+                "Texture results are quoted in the sample's own frame — rolling, normal and transverse "
+                "for a rolled plate, for instance. Naming those directions here means the pole figure "
+                "is labelled in terms you recognise rather than in instrument coordinates."
+            ),
+            target=lambda s: s.view.grpDirectionWidgets,
+            action=lambda s: set_check_state(s.view.grpDirectionWidgets, True),
+            settle_ms=400,
+            dwell_ms=5500,
+        ),
+        TutorialStep(
+            title="Apply the directions",
+            text=(
+                "Edit the vectors and press <b>Update Directions</b> to re-project everything into the "
+                "new frame. The tutorial has renamed the first direction to show where it appears."
+            ),
+            target=lambda s: s.view.updateDirs,
+            action=lambda s: (set_text(s.view.lineedit_RD, "Rolling"), click(s.view.updateDirs)),
+            settle_ms=600,
+            dwell_ms=5000,
+        ),
+    ],
+)
+
+
+CHAPTERS = (SAMPLE_SETUP,)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -364,4 +364,159 @@ EXPERIMENTAL_SETUP = TutorialChapter(
 )
 
 
-CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP)
+# ------------------------------------------------------------------------------------------------
+# chapter 3 - reading the results
+# ------------------------------------------------------------------------------------------------
+
+
+RESULTS = TutorialChapter(
+    name="Reading the results",
+    description="The lab view, the pole figure, transmission, and the orientation table.",
+    steps=[
+        TutorialStep(
+            title="The lab view",
+            text=(
+                "The sample as the instrument sees it, in the currently selected orientation, together "
+                "with the beam and the detector directions. This is the sanity check that your sample "
+                "really is where you think it is."
+            ),
+            target=lambda s: s.view.grpSampleFigure,
+            dwell_ms=5500,
+        ),
+        TutorialStep(
+            title="The pole figure",
+            text=(
+                "Every detector group, for every orientation you added, projected into the sample's own "
+                "frame. Gaps here are directions your planned measurement never samples — which is the "
+                "whole reason for planning before beam time."
+            ),
+            target=lambda s: s.view.grpPoleFigure,
+            dwell_ms=6000,
+        ),
+        TutorialStep(
+            title="Transmission",
+            text=(
+                "Ticking this estimates how much of the beam survives the path through the sample for "
+                "each point, by Monte Carlo simulation, and colours the pole figure by it. It is the "
+                "slowest thing the interface does — the tutorial has turned the statistics right down."
+            ),
+            target=lambda s: s.view.chkTransmission,
+            dwell_ms=6000,
+        ),
+        TutorialStep(
+            title="Now with absorption",
+            text=(
+                "Dark points are directions where the beam has a long path through the sample, so they "
+                "will need longer counting times — or a different sample orientation."
+            ),
+            target=lambda s: s.view.grpPoleFigure,
+            action=lambda s: set_check_state(s.view.chkTransmission, True),
+            settle_ms=1200,
+            dwell_ms=6000,
+        ),
+        TutorialStep(
+            title="The orientation table",
+            text=(
+                "One row per orientation, with the goniometer angles that produce it. <b>Include</b> "
+                "controls whether an orientation is exported; <b>Select</b> is for the buttons below."
+            ),
+            target=lambda s: s.view.grpDynamicTable,
+            dwell_ms=5500,
+        ),
+        TutorialStep(
+            title="Selecting rows",
+            text=(
+                "<b>Select All</b> and <b>Deselect All</b> work on the selection column, and "
+                "<b>Delete Selected</b> removes those rows from the plan — useful once the pole figure "
+                "shows an orientation is not earning its beam time."
+            ),
+            target=lambda s: s.view.selectAll,
+            action=lambda s: (click(s.view.selectAll), click(s.view.deselectAll)),
+            settle_ms=700,
+            dwell_ms=5500,
+        ),
+    ],
+)
+
+
+# ------------------------------------------------------------------------------------------------
+# chapter 4 - exporting, and where the rest lives
+# ------------------------------------------------------------------------------------------------
+
+
+DEMO_EXPORT_FORMAT = "Sscanss2 Angles"
+
+
+EXPORT = TutorialChapter(
+    name="Exporting",
+    description="Write the plan out, and where the remaining options live.",
+    steps=[
+        TutorialStep(
+            title="Where to write it",
+            text=(
+                "The output section takes a directory and a file name. The tutorial is pointing it at a "
+                "temporary folder, so the file it writes in a moment is a real export that disappears "
+                "with this window."
+            ),
+            target=lambda s: s.view.finder_save_dir,
+            action=lambda s: _set_finder(s.view.finder_save_dir, s.data.save_directory),
+            await_=lambda s: _finder_ready(s.view.finder_save_dir),
+            await_timeout_s=FINDER_TIMEOUT_S,
+            await_text="Checking the output directory…",
+            settle_ms=400,
+            dwell_ms=5000,
+        ),
+        TutorialStep(
+            title="And what to call it",
+            text="Export stays disabled until both a directory and a file name are given.",
+            target=lambda s: s.view.saveFileLine,
+            action=lambda s: set_text(s.view.saveFileLine, s.data.save_filename),
+            settle_ms=400,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Pick a format",
+            text=(
+                "<b>Sscanss2 Angles</b> feeds the plan straight into SScanSS-2. There are also Euler and "
+                "matrix orientation files, a <b>Reference Workspace</b> that the Engineering Diffraction "
+                "interface can load, and — once transmission has been estimated — a set of counting-time "
+                "weightings."
+            ),
+            target=lambda s: s.view.cmbExportFormat,
+            action=lambda s: select_combo(s.view.cmbExportFormat, DEMO_EXPORT_FORMAT),
+            settle_ms=400,
+            dwell_ms=6000,
+        ),
+        TutorialStep(
+            title="Write it out",
+            text="Only the orientations ticked as <b>Include</b> in the table are written.",
+            target=lambda s: s.view.btnExport,
+            action=lambda s: click(s.view.btnExport),
+            settle_ms=800,
+            dwell_ms=4500,
+        ),
+        TutorialStep(
+            title="Everything else is in Settings",
+            text=(
+                "The cog holds the options the tour has skipped: how STL files are scaled and rotated on "
+                "load, which axes Euler angles are written about, the Monte Carlo statistics, and the "
+                "wavelength the attenuation is quoted at. They are remembered between sessions."
+            ),
+            target=lambda s: s.view.btn_settings,
+            dwell_ms=6500,
+        ),
+        TutorialStep(
+            title="That is the whole workflow",
+            text=(
+                "Describe the sample, describe the instrument and how you will move it, read the pole "
+                "figure, export the plan.<br><br>"
+                "The full documentation is under <b>Help → Mantid Help</b>. Close this window whenever "
+                "you like — nothing here has touched your own session."
+            ),
+            dwell_ms=8000,
+        ),
+    ],
+)
+
+
+CHAPTERS = (SAMPLE_SETUP, EXPERIMENTAL_SETUP, RESULTS, EXPORT)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -92,6 +92,14 @@ def _permute_directions(sandbox):
     click(view.updateDirs)
 
 
+def _show_pinned_directions(sandbox):
+    """
+    Update the sample shape and direction to be askew in the lab-frame
+    """
+    set_spin_box(sandbox.view.spnInitX, 30.0)
+    set_check_state(sandbox.view.chkTransformDirs, True)
+
+
 # ------------------------------------------------------------------------------------------------
 # chapter 1 - sample setup
 # ------------------------------------------------------------------------------------------------
@@ -104,19 +112,25 @@ SAMPLE_SETUP = TutorialChapter(
         TutorialStep(
             title="Welcome to the Texture Planner",
             text=(
-                "This is a working copy of the interface, loaded with a demo sample. Everything the "
-                "tutorial does happens here — your own session is untouched.<br><br>"
+                "This is a working copy of the interface, which we will step through as a demo. "
+                "Everything the tutorial does happens in this self-contained window, "
+                "the session which opened this tutorial is untouched.<br><br>"
                 "Each step explains a control first. Press <b>Show me</b> to watch the tutorial use "
-                "it, then <b>Next</b> to move on — nothing happens on its own. <b>Back</b> re-reads a "
-                "step, and the tabs above jump to a chapter."
+                "it, then <b>Next</b> to move on. <b>Back</b> re-reads a "
+                "step, and the tabs at the top of the window allow you to jump to a chapter.<br><br>"
+                "As the whole window is live, you can interact with the widgets being shown "
+                "(and are encouraged to do so) or indeed you can interact with any "
+                "of the interface just note that the more you change the less clear the rest of the tutorial may be!"
             ),
         ),
         TutorialStep(
             title="Two setup tabs",
             text=(
-                "Planning an experiment has two halves. <b>Sample Setup</b> describes what you are "
+                "The setup controls are split into two halves. <b>Sample Setup</b> describes what you are "
                 "measuring; <b>Experimental Setup</b> describes the instrument and how you will move "
-                "the sample. We start with the sample."
+                "the sample. We start with the sample. <br><br>"
+                "(<b>Show me</b> will simply select the <b>Sample Setup</b> tab incase you have changed to "
+                "<b>Experimental Setup</b>)"
             ),
             target=lambda s: s.view.tabSetup,
             action=lambda s: select_tab(s.view.tabSetup, "Sample Setup"),
@@ -124,8 +138,8 @@ SAMPLE_SETUP = TutorialChapter(
         TutorialStep(
             title="Load a sample shape",
             text=(
-                "The sample's shape comes from a file: an <b>STL mesh</b> exported from CAD, or a "
-                "<b>CSG description</b> in Mantid's XML shape format. The tutorial is loading a "
+                "The sample's shape comes from a file: an <b>STL mesh</b> exported from CAD/photo-scanning"
+                ", or a <b>CSG description</b> in Mantid's XML shape format. The tutorial is loading a "
                 "30 × 10 × 20 mm cuboid defined in XML — a deliberately lopsided block, so every "
                 "rotation of it looks different in the lab view."
             ),
@@ -151,7 +165,8 @@ SAMPLE_SETUP = TutorialChapter(
             text=(
                 "Absorption depends on what the sample is made of. <b>Set Material</b> opens Mantid's "
                 "standard <i>SetSampleMaterial</i> dialog, where you give a chemical formula and a "
-                "density. The tutorial is setting copper for you rather than opening the dialog."
+                "density. The tutorial is setting an example copper material for you rather than "
+                "interacting with the dialog."
             ),
             target=lambda s: s.view.btnSetMaterial,
             action=_apply_material,
@@ -168,20 +183,23 @@ SAMPLE_SETUP = TutorialChapter(
         TutorialStep(
             title="How the sample sits in its own frame",
             text=(
-                "A shape file rarely arrives in the orientation you mounted it in. These angles rotate "
-                "the sample once, before any goniometer motion — they describe how the sample sits in "
-                "its holder."
+                "A shape file is not necessarily defined in the same orientation that it is mounted in the beam. "
+                "These angles rotate the sample once, before any goniometer motion,"
+                "they describe how the sample sits in the beam before positioning."
             ),
             target=lambda s: s.view.initOrientation,
-            action=lambda s: set_spin_box(s.view.spnInitX, 30.0),
+            action=lambda s: set_spin_box(s.view.spnInitX, 90.0),
             settle_ms=500,
         ),
         TutorialStep(
-            title="And where it sits in the beam",
+            title="Where the sample sits in the beam",
             text=(
                 "The position offsets move the sample relative to the instrument's origin. Together "
                 "with the gauge volume set up in the next chapter, this is what decides which part of "
-                "the sample is actually being measured."
+                "the sample is actually being measured.<br><br>"
+                "Note that without a gauge volume the <i>whole</i> sample is still assumed to be illuminated"
+                "by the beam, hence the location of the scattering vector and sample directions remaining at "
+                "the sample centre."
             ),
             target=lambda s: s.view.initPosition,
             action=lambda s: set_spin_box(s.view.spnInitPZ, 0.005),
@@ -221,16 +239,15 @@ SAMPLE_SETUP = TutorialChapter(
         TutorialStep(
             title="One rotation aligns both",
             text=(
-                "Tick it and the <b>initial orientation</b> from earlier is applied to the sample "
-                "directions as well as to the shape. So you describe both in the frame they are easy "
-                "to describe in, and the single rotation that puts the shape in the beam carries the "
-                "directions with it.<br><br>"
+                "Tick it and a <b>initial orientation</b> (now set to 30 degrees) is applied to the sample "
+                "directions as well as to the shape. <br><br>"
+                "Try toggling the box yourself to see the lab-frame vs sample-frame definition.<br><br>"
                 "Watch the pole figure: the measurements have not changed, but the frame they are "
-                "quoted in has rotated with the sample."
+                "quoted in rotates with the sample."
             ),
             target=lambda s: s.view.chkTransformDirs,
             avoid=lambda s: (s.view.groupBox_textureVectors, s.view.grpPoleFigure),
-            action=lambda s: set_check_state(s.view.chkTransformDirs, True),
+            action=_show_pinned_directions,
             settle_ms=800,
         ),
         TutorialStep(
@@ -238,7 +255,8 @@ SAMPLE_SETUP = TutorialChapter(
             text=(
                 "<b>View in Lab Frame</b> shows what those directions have become in instrument "
                 "coordinates. The fields go read-only, because these values are derived — the sample "
-                "frame is still where you edit them."
+                "frame is still where you edit them.<br><br>"
+                "Again, try toggling this yourself"
             ),
             target=lambda s: s.view.chkLabDirs,
             # the change this makes shows up in the vector fields, not at the check box
@@ -277,7 +295,7 @@ SAMPLE_SETUP = TutorialChapter(
 # The planner opens on ENGINX, so the tour moves to another instrument: watching the detector
 # geometry and the pole figure change is what shows the control doing something.
 DEMO_INSTRUMENT = "IMAT"
-DEMO_GROUP = "Module1"
+DEMO_GROUP = "Module4"
 DEMO_GAUGE_VOLUME = "4mmCube"
 
 # The angle each added orientation is recorded at. Every one is different, so stepping through the
@@ -343,7 +361,7 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             settle_ms=400,
         ),
         TutorialStep(
-            title="…and a detector grouping",
+            title="Pick a detector grouping",
             text=(
                 "Texture measurements group detectors into banks that each look at the sample from a "
                 "different direction — every group becomes one point per orientation on the pole figure. "
@@ -451,7 +469,7 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             ),
             target=lambda s: s.view.spnIndex,
             action=_step_through_orientations,
-            settle_ms=700,
+            settle_ms=1000,
         ),
     ],
 )
@@ -491,8 +509,10 @@ RESULTS = TutorialChapter(
             title="The pole figure",
             text=(
                 "Every detector group, for every orientation you added, projected into the sample's own "
-                "frame. Gaps here are directions your planned measurement never samples — which is the "
-                "whole reason for planning before beam time."
+                "frame. The gaps here show you directions around your sample the proposed measurement "
+                "don't cover (remembering that the individual points just represent the average position of "
+                "all the detectors in the group and the actual depends on the entire group rather than "
+                "just this centre)"
             ),
             target=lambda s: s.view.grpPoleFigure,
         ),
@@ -515,7 +535,7 @@ RESULTS = TutorialChapter(
                 "• <b>Hollow</b> points — every other included orientation.<br>"
                 "• <b>Faint grey</b> points — the current orientation when it is <i>not</i> included.<br>"
                 "• Orientations that are neither current nor included are not drawn at all.<br><br>"
-                "So stepping the index selector walks the filled points around the figure."
+                "So stepping the index selector walks the filled points around the figure - try doing this now!"
             ),
             target=lambda s: s.view.grpPoleFigure,
         ),

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/chapters.py
@@ -23,7 +23,15 @@ Two conventions worth knowing before adding a step:
 
 from mantid.simpleapi import SetSampleMaterial
 
-from mantidqt.widgets.tutorial.interaction import click, select_combo, select_tab, set_check_state, set_spin_box, set_text
+from mantidqt.widgets.tutorial.interaction import (
+    click,
+    process_events,
+    select_combo,
+    select_tab,
+    set_check_state,
+    set_spin_box,
+    set_text,
+)
 from mantidqt.widgets.tutorial.step import TutorialChapter, TutorialStep
 
 # the tour's sample material: deliberately not the interface's default, so the "Current material"
@@ -68,6 +76,22 @@ def _apply_material(sandbox):
     sandbox.presenter.on_material_set()
 
 
+def _permute_directions(sandbox):
+    """Cycle the three texture directions, so a different one lands in the middle row.
+
+    The pole figure is projected about the second direction (see ``get_alpha_beta_from_cart``,
+    whose polar angle is measured from +y, and the second column of the model's ``ax_transform``
+    is what ends up there). Cycling is the clearest demonstration of that: nothing about the
+    measurement changes, only which axis it is viewed down.
+    """
+    view = sandbox.view
+    rd, nd, td = view.get_rd_dir(), view.get_nd_dir(), view.get_td_dir()
+    view.set_rd_dir(tuple(nd.split(",")))
+    view.set_nd_dir(tuple(td.split(",")))
+    view.set_td_dir(tuple(rd.split(",")))
+    click(view.updateDirs)
+
+
 # ------------------------------------------------------------------------------------------------
 # chapter 1 - sample setup
 # ------------------------------------------------------------------------------------------------
@@ -101,11 +125,12 @@ SAMPLE_SETUP = TutorialChapter(
             title="Load a sample shape",
             text=(
                 "The sample's shape comes from a file: an <b>STL mesh</b> exported from CAD, or a "
-                "<b>CSG description</b> in Mantid's XML shape format. The tutorial is loading a 2 cm "
-                "cube defined in XML."
+                "<b>CSG description</b> in Mantid's XML shape format. The tutorial is loading a "
+                "30 × 10 × 20 mm cuboid defined in XML — a deliberately lopsided block, so every "
+                "rotation of it looks different in the lab view."
             ),
             target=lambda s: s.view.finder_xml,
-            action=lambda s: _set_finder(s.view.finder_xml, s.data.cube_xml_path),
+            action=lambda s: _set_finder(s.view.finder_xml, s.data.cuboid_xml_path),
             await_=lambda s: _finder_ready(s.view.finder_xml),
             await_timeout_s=FINDER_TIMEOUT_S,
             await_text="Looking for the sample file…",
@@ -170,18 +195,27 @@ SAMPLE_SETUP = TutorialChapter(
                 "is labelled in terms you recognise rather than in instrument coordinates."
             ),
             target=lambda s: s.view.grpDirectionWidgets,
-            action=lambda s: set_check_state(s.view.grpDirectionWidgets, True),
-            settle_ms=400,
         ),
         TutorialStep(
-            title="Apply the directions",
+            title="The middle row is the pole figure axis",
             text=(
-                "Edit the vectors and press <b>Update Directions</b> to re-project everything into the "
-                "new frame. The tutorial has renamed the first direction to show where it appears."
+                "The order matters. The pole figure is always projected about the <b>second</b> of the "
+                "three directions — <b>ND</b> here — with the first and third becoming the horizontal "
+                "and vertical of the plot.<br><br>"
+                "So which direction you put in the middle row decides which pole you are looking down."
+            ),
+            target=lambda s: s.view.groupBox_textureVectors,
+        ),
+        TutorialStep(
+            title="Permute them and the projection changes",
+            text=(
+                "The tutorial is cycling the three vectors — the direction that was RD moves into the "
+                "middle row, so it becomes the pole. Press <b>Show me</b> and watch the pole figure "
+                "re-project: the same measurements, viewed down a different axis."
             ),
             target=lambda s: s.view.updateDirs,
-            action=lambda s: (set_text(s.view.lineedit_RD, "Rolling"), click(s.view.updateDirs)),
-            settle_ms=600,
+            action=_permute_directions,
+            settle_ms=800,
         ),
     ],
 )
@@ -192,17 +226,44 @@ SAMPLE_SETUP = TutorialChapter(
 # ------------------------------------------------------------------------------------------------
 
 
-# how many orientations the tour builds. Enough to make a pole figure and a table worth looking at,
-# few enough that the per-orientation absorption calculation in the next chapter stays quick.
-DEMO_ORIENTATION_COUNT = 3
-
-DEMO_GROUP = "Texture20"
+# The planner opens on ENGINX, so the tour moves to another instrument: watching the detector
+# geometry and the pole figure change is what shows the control doing something.
+DEMO_INSTRUMENT = "IMAT"
+DEMO_GROUP = "Module1"
 DEMO_GAUGE_VOLUME = "4mmCube"
+
+# The angle each added orientation is recorded at. Every one is different, so stepping through the
+# index selector afterwards visibly rotates the sample and moves its points on the pole figure -
+# with identical orientations there would be nothing to see. Kept short because the absorption
+# calculation in the next chapter runs once per orientation.
+# The first matches the angle the "dial in an orientation" step sets, so the orientation the user
+# just watched being dialled is the one that gets recorded rather than being silently reset.
+DEMO_ANGLES = (30.0, 60.0, 90.0)
 
 
 def _add_orientations(sandbox):
-    for _ in range(DEMO_ORIENTATION_COUNT):
-        click(sandbox.view.addOrientation)
+    """Record one orientation per angle in ``DEMO_ANGLES``.
+
+    Adding an orientation selects the new one and stores whatever the angle fields currently hold,
+    so the angle is set *before* each add. The first angle applies to the orientation the planner
+    already starts with, which is why there is one fewer add than there are angles.
+    """
+    view = sandbox.view
+    for index, angle in enumerate(DEMO_ANGLES):
+        if index > 0:
+            click(view.addOrientation)
+        set_spin_box(view.spnAngle0, angle)
+
+
+def _step_through_orientations(sandbox):
+    """Walk the index selector back through every orientation, ending on the first.
+
+    Ends on the first rather than the last so the lab view is left showing an orientation the user
+    has just watched it move to, rather than the one it was already displaying.
+    """
+    for index in reversed(range(len(DEMO_ANGLES))):
+        set_spin_box(sandbox.view.spnIndex, index + 1)
+        process_events(3)
 
 
 EXPERIMENTAL_SETUP = TutorialChapter(
@@ -223,17 +284,22 @@ EXPERIMENTAL_SETUP = TutorialChapter(
         TutorialStep(
             title="Pick an instrument",
             text=(
-                "Choosing an instrument loads its detector geometry. Picking <b>Custom</b> instead lets "
-                "you name any instrument definition Mantid can find, and supply your own grouping file."
+                "Choosing an instrument loads its detector geometry. The planner opens on ENGINX; the "
+                f"tutorial is switching to <b>{DEMO_INSTRUMENT}</b>, which has a different detector "
+                "layout.<br><br>"
+                "Picking <b>Custom</b> instead lets you name any instrument definition Mantid can find, "
+                "and supply your own grouping file."
             ),
             target=lambda s: s.view.cmbInstr,
+            action=lambda s: select_combo(s.view.cmbInstr, DEMO_INSTRUMENT),
+            settle_ms=400,
         ),
         TutorialStep(
             title="…and a detector grouping",
             text=(
                 "Texture measurements group detectors into banks that each look at the sample from a "
                 "different direction — every group becomes one point per orientation on the pole figure. "
-                f"The tutorial is selecting <b>{DEMO_GROUP}</b>."
+                f"The groups on offer follow the instrument; the tutorial is selecting <b>{DEMO_GROUP}</b>."
             ),
             target=lambda s: s.view.cmbGroup,
             action=lambda s: select_combo(s.view.cmbGroup, DEMO_GROUP),
@@ -258,8 +324,6 @@ EXPERIMENTAL_SETUP = TutorialChapter(
                 "with it the path lengths through the sample."
             ),
             target=lambda s: s.view.grpGaugeVol,
-            action=lambda s: set_check_state(s.view.grpGaugeVol, True),
-            settle_ms=400,
         ),
         TutorialStep(
             title="Choose a preset or your own shape",
@@ -322,7 +386,9 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             title="Add it to the list",
             text=(
                 "<b>Add Orientation</b> records the current angles as one measurement position. The "
-                f"tutorial is adding {DEMO_ORIENTATION_COUNT} of them so there is something to look at."
+                f"tutorial is adding {len(DEMO_ANGLES)}, each at a different angle — "
+                f"{', '.join(f'{angle:g}°' for angle in DEMO_ANGLES)} — so the plan covers more of the "
+                "pole figure."
             ),
             target=lambda s: s.view.addOrientation,
             action=_add_orientations,
@@ -332,10 +398,11 @@ EXPERIMENTAL_SETUP = TutorialChapter(
             title="Move between them",
             text=(
                 "The index selector steps through the orientations you have added. Whichever one is "
-                "selected is the one drawn in the lab view and highlighted on the pole figure."
+                "selected is the one drawn in the lab view and highlighted on the pole figure — watch "
+                "the sample turn as the tutorial steps back through them."
             ),
             target=lambda s: s.view.spnIndex,
-            action=lambda s: set_spin_box(s.view.spnIndex, 1),
+            action=_step_through_orientations,
             settle_ms=700,
         ),
     ],
@@ -398,13 +465,20 @@ RESULTS = TutorialChapter(
         ),
         TutorialStep(
             title="Selecting rows",
-            text=(
-                "<b>Select All</b> and <b>Deselect All</b> work on the selection column, and "
-                "<b>Delete Selected</b> removes those rows from the plan — useful once the pole figure "
-                "shows an orientation is not earning its beam time."
-            ),
+            text=("<b>Select All</b> ticks every row's selection box. Watch the <b>Select</b> column on the right of the table."),
             target=lambda s: s.view.selectAll,
-            action=lambda s: (click(s.view.selectAll), click(s.view.deselectAll)),
+            action=lambda s: click(s.view.selectAll),
+            settle_ms=700,
+        ),
+        TutorialStep(
+            title="…and clearing them",
+            text=(
+                "<b>Deselect All</b> clears the column again. <b>Delete Selected</b> removes the ticked "
+                "rows from the plan altogether — useful once the pole figure shows an orientation is "
+                "not earning its beam time."
+            ),
+            target=lambda s: s.view.deselectAll,
+            action=lambda s: click(s.view.deselectAll),
             settle_ms=700,
         ),
     ],

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/demo_data.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/demo_data.py
@@ -18,13 +18,34 @@ somewhere disposable.
 import os
 import tempfile
 
-from Engineering.common.xml_shapes import get_cube_xml
+# A cuboid rather than a cube, and deliberately not close to one: a cube looks identical from every
+# face, so rotating it in the lab view shows the user almost nothing. With three different edge
+# lengths every orientation looks distinct, which is the whole point of watching it turn.
+#
+# Comfortably larger than the 4 mm gauge volume preset the tour selects, so the gauge volume reads
+# as a small region inside the sample rather than swallowing it.
+CUBOID_WIDTH_M = 0.030  # x
+CUBOID_HEIGHT_M = 0.010  # y
+CUBOID_DEPTH_M = 0.020  # z
 
-# 2 cm on a side: comfortably larger than the 4 mm gauge volume preset the tour selects, so the
-# gauge volume is visibly a small region inside the sample rather than swallowing it
-CUBE_SIDE_M = 0.02
+SAMPLE_NAME = "tutorial_sample"
 
-CUBE_NAME = "tutorial_sample"
+
+def get_cuboid_xml(name, width, height, depth, centre=(0.0, 0.0, 0.0)):
+    """A CSG cuboid in Mantid's sample-shape XML.
+
+    ``Engineering.common.xml_shapes`` only offers a cube; this is the same shape with the three
+    edges given independently.
+    """
+    return (
+        f"<cuboid id='{name}'> "
+        f"<height val='{height}' /> "
+        f"<width val='{width}' /> "
+        f"<depth val='{depth}' /> "
+        f"<centre x='{centre[0]}' y='{centre[1]}' z='{centre[2]}' /> "
+        f"</cuboid> "
+        f"<algebra val='{name}' />"
+    )
 
 
 class DemoData:
@@ -37,7 +58,10 @@ class DemoData:
         self._tmpdir = tempfile.TemporaryDirectory(prefix="texture_planner_tutorial_", ignore_cleanup_errors=True)
         self.directory = self._tmpdir.name
 
-        self.cube_xml_path = self._write("tutorial_sample.xml", get_cube_xml(CUBE_NAME, CUBE_SIDE_M))
+        self.cuboid_xml_path = self._write(
+            "tutorial_sample.xml",
+            get_cuboid_xml(SAMPLE_NAME, CUBOID_WIDTH_M, CUBOID_HEIGHT_M, CUBOID_DEPTH_M),
+        )
 
         self.save_directory = os.path.join(self.directory, "output")
         os.makedirs(self.save_directory, exist_ok=True)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/demo_data.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/demo_data.py
@@ -1,0 +1,53 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""The sample the tutorial loads, and somewhere to export it to.
+
+Generated rather than shipped. A tutorial that needed a file from the external data store would
+skip itself for anyone who had not built that target - which is very nearly everyone the tutorial
+is for. A cuboid is also the clearest thing to watch rotate in the lab view.
+
+Everything lives in a temporary directory that goes when the tour does, which is what makes the
+export step safe to actually perform: the tour writes a real file, using the real export path, to
+somewhere disposable.
+"""
+
+import os
+import tempfile
+
+from Engineering.common.xml_shapes import get_cube_xml
+
+# 2 cm on a side: comfortably larger than the 4 mm gauge volume preset the tour selects, so the
+# gauge volume is visibly a small region inside the sample rather than swallowing it
+CUBE_SIDE_M = 0.02
+
+CUBE_NAME = "tutorial_sample"
+
+
+class DemoData:
+    """Files for the tour to load, in a directory that cleans itself up."""
+
+    def __init__(self):
+        # ignore_cleanup_errors because a file finder or a loader can still hold a handle open on
+        # Windows when the tour ends, and failing to remove a temporary directory is not something
+        # to interrupt the user about
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="texture_planner_tutorial_", ignore_cleanup_errors=True)
+        self.directory = self._tmpdir.name
+
+        self.cube_xml_path = self._write("tutorial_sample.xml", get_cube_xml(CUBE_NAME, CUBE_SIDE_M))
+
+        self.save_directory = os.path.join(self.directory, "output")
+        os.makedirs(self.save_directory, exist_ok=True)
+        self.save_filename = "tutorial_orientations"
+
+    def _write(self, name, contents):
+        path = os.path.join(self.directory, name)
+        with open(path, "w") as handle:
+            handle.write(contents)
+        return path
+
+    def cleanup(self):
+        self._tmpdir.cleanup()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
@@ -21,14 +21,10 @@ This object is also the context every tutorial step receives, which is why it ex
 the presenter and the model rather than only the window.
 """
 
-from qtpy.QtCore import Qt
-
 from mantidqtinterfaces.TexturePlanner.model import TexturePlannerModel
 from mantidqtinterfaces.TexturePlanner.presenter import TexturePlannerPresenter
 from mantidqtinterfaces.TexturePlanner.tutorial.demo_data import DemoData
 from mantidqtinterfaces.TexturePlanner.view import TexturePlannerView
-
-WINDOW_TITLE = "Texture Planner — Tutorial"
 
 # The tour ticks "show transmission", which runs MonteCarloAbsorption for every orientation
 # *synchronously*, on the GUI thread. At the interface's default 50 events per point that is long
@@ -52,11 +48,8 @@ class TutorialSandbox:
         # from inside one, and on a first-ever open would launch a second tour recursively
         self.presenter = TexturePlannerPresenter(self.model, self.view, offer_tutorial=False)
 
-        # a window in its own right rather than a panel inside the user's planner, but still owned
-        # by it so it stays in front and goes away with it
-        self.view.setWindowFlags(Qt.Window)
-        self.view.setWindowTitle(WINDOW_TITLE)
-
+        # deliberately not given window flags or a title: the tutorial shell takes this view as a
+        # child and is itself the window, so anything set here would never be seen
         self.model.absorption.mc_kwargs["EventsPerPoint"] = DEMO_MC_EVENTS_PER_POINT
 
         self._torn_down = False

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
@@ -52,11 +52,25 @@ class TutorialSandbox:
         # child and is itself the window, so anything set here would never be seen
         self.model.absorption.mc_kwargs["EventsPerPoint"] = DEMO_MC_EVENTS_PER_POINT
 
+        # The settings chapter opens this dialog and points into it. Left modal it would block the
+        # tutorial's own controls - Next included - until the user closed a dialog the tour had
+        # opened for them. Only ever on the sandbox's copy.
+        self.settings_view.setModal(False)
+
         self._torn_down = False
 
     @property
     def window(self):
         return self.view
+
+    @property
+    def settings_view(self):
+        """The settings dialog, which the settings chapter opens and annotates.
+
+        Note it writes to the *shared* QSettings when applied, so the tour must never press Ok or
+        Apply on it - see the settings chapter.
+        """
+        return self.presenter.settings_presenter.view
 
     def teardown(self):
         """Close the sandbox planner and remove its files. Safe to call more than once.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
@@ -1,0 +1,88 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""The throwaway Texture Planner the tutorial drives.
+
+A complete second instance - its own model, view and presenter - so the tour can load a sample,
+set a material, add orientations and export a file without any of it reaching the planner the user
+has open. Two things already in the interface make that safe rather than merely hopeful:
+
+* ``WorkspaceManager`` gives every instance's workspaces a name ending in a unique token, so two
+  planners never collide in the ADS, and
+* closing the window runs ``TexturePlannerPresenter.on_close``, which removes all of them.
+
+So the sandbox needs no special isolation of its own - it needs to be *closed*, which is what
+``teardown`` does.
+
+This object is also the context every tutorial step receives, which is why it exposes the view,
+the presenter and the model rather than only the window.
+"""
+
+from qtpy.QtCore import Qt
+
+from mantidqtinterfaces.TexturePlanner.model import TexturePlannerModel
+from mantidqtinterfaces.TexturePlanner.presenter import TexturePlannerPresenter
+from mantidqtinterfaces.TexturePlanner.tutorial.demo_data import DemoData
+from mantidqtinterfaces.TexturePlanner.view import TexturePlannerView
+
+WINDOW_TITLE = "Texture Planner — Tutorial"
+
+# The tour ticks "show transmission", which runs MonteCarloAbsorption for every orientation
+# *synchronously*, on the GUI thread. At the interface's default 50 events per point that is long
+# enough to look like the tutorial has hung. The tour is demonstrating where the control is and
+# what it produces, not the accuracy of the simulation, so the sandbox turns the statistics right
+# down - and only ever on its own model.
+DEMO_MC_EVENTS_PER_POINT = 3
+
+
+class TutorialSandbox:
+    """A Texture Planner built for the tutorial to drive, and the demo files it uses."""
+
+    def __init__(self, parent=None):
+        self.data = DemoData()
+
+        self.model = TexturePlannerModel()
+        # register_usage=False: this window is Mantid opening the interface to demonstrate it, not
+        # the user opening it to work, and counting it would inflate every real launch
+        self.view = TexturePlannerView(parent=parent, register_usage=False)
+        self.presenter = TexturePlannerPresenter(self.model, self.view)
+
+        # a window in its own right rather than a panel inside the user's planner, but still owned
+        # by it so it stays in front and goes away with it
+        self.view.setWindowFlags(Qt.Window)
+        self.view.setWindowTitle(WINDOW_TITLE)
+
+        self.model.absorption.mc_kwargs["EventsPerPoint"] = DEMO_MC_EVENTS_PER_POINT
+
+        self._torn_down = False
+
+    @property
+    def window(self):
+        return self.view
+
+    def teardown(self):
+        """Close the sandbox planner and remove its files. Safe to call more than once.
+
+        Closing is what removes the workspaces: ``closeEvent`` calls the presenter's ``on_close``,
+        which calls ``WorkspaceManager.cleanup``. Doing it by hand here as well would be a second
+        place to keep in step with what a planner owns.
+        """
+        if self._torn_down:
+            return
+        self._torn_down = True
+        self.view.close()
+        self.view.deleteLater()
+        self.data.cleanup()
+
+
+def make_sandbox_factory(parent=None):
+    """A no-argument factory for ``run_tutorial``, which rebuilds the sandbox whenever the user
+    jumps to a chapter."""
+
+    def build():
+        return TutorialSandbox(parent=parent)
+
+    return build

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
@@ -48,7 +48,9 @@ class TutorialSandbox:
         # register_usage=False: this window is Mantid opening the interface to demonstrate it, not
         # the user opening it to work, and counting it would inflate every real launch
         self.view = TexturePlannerView(parent=parent, register_usage=False)
-        self.presenter = TexturePlannerPresenter(self.model, self.view)
+        # offer_tutorial=False: this planner is the tutorial. Left True it would offer a tutorial
+        # from inside one, and on a first-ever open would launch a second tour recursively
+        self.presenter = TexturePlannerPresenter(self.model, self.view, offer_tutorial=False)
 
         # a window in its own right rather than a panel inside the user's planner, but still owned
         # by it so it stays in front and goes away with it

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/sandbox.py
@@ -52,25 +52,11 @@ class TutorialSandbox:
         # child and is itself the window, so anything set here would never be seen
         self.model.absorption.mc_kwargs["EventsPerPoint"] = DEMO_MC_EVENTS_PER_POINT
 
-        # The settings chapter opens this dialog and points into it. Left modal it would block the
-        # tutorial's own controls - Next included - until the user closed a dialog the tour had
-        # opened for them. Only ever on the sandbox's copy.
-        self.settings_view.setModal(False)
-
         self._torn_down = False
 
     @property
     def window(self):
         return self.view
-
-    @property
-    def settings_view(self):
-        """The settings dialog, which the settings chapter opens and annotates.
-
-        Note it writes to the *shared* QSettings when applied, so the tour must never press Ok or
-        Apply on it - see the settings chapter.
-        """
-        return self.presenter.settings_presenter.view
 
     def teardown(self):
         """Close the sandbox planner and remove its files. Safe to call more than once.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -40,11 +40,12 @@ FAST = {"settle_ms": 1}
 PLAY_TIMEOUT_MS = 300000
 
 
-class RecordingOverlay:
-    """Collects what the tour pointed at, instead of painting it."""
+class RecordingAnnotator:
+    """Collects what the tour pointed at and said, instead of painting any of it."""
 
     def __init__(self):
         self.targets = []
+        self.shown = []
 
     def set_target(self, widget):
         self.targets.append(widget)
@@ -52,19 +53,8 @@ class RecordingOverlay:
     def target_rect(self):
         return None
 
-    def show(self):
-        pass
-
-    def hide(self):
-        pass
-
-    def detach(self):
-        pass
-
-
-class RecordingBubble:
-    def __init__(self):
-        self.shown = []
+    def rect_of(self, _widget):
+        return None
 
     def show_step(self, text, title=""):
         self.shown.append((title, text))
@@ -73,6 +63,15 @@ class RecordingBubble:
         pass
 
     def place_beside(self, _spotlight, keep_clear=()):
+        pass
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def detach(self):
         pass
 
 
@@ -112,8 +111,8 @@ class TutorialChaptersTest(unittest.TestCase):
         process_events(3)
         self.addCleanup(self._teardown)
 
-        self.overlay = RecordingOverlay()
-        self.bubble = RecordingBubble()
+        self.annotator = RecordingAnnotator()
+
         self.failures = []
         self.finished = []
         self.spotlit = {}
@@ -134,7 +133,7 @@ class TutorialChaptersTest(unittest.TestCase):
         player ignores navigation while a step is settling or working, so clicking early would
         simply spin.
         """
-        player = TutorialPlayer(chapters, self.sandbox, self.overlay, self.bubble, parent=self.sandbox.window)
+        player = TutorialPlayer(chapters, self.sandbox, self.annotator, parent=self.sandbox.window)
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
         player.finished.connect(lambda: self.finished.append(True))
 
@@ -142,7 +141,7 @@ class TutorialChaptersTest(unittest.TestCase):
         # overlay because a step is presented twice - once explained, once refreshed after it has
         # been performed - and both times set a target.
         def remember(*_args):
-            self.spotlit[player.position] = self.overlay.targets[-1] if self.overlay.targets else None
+            self.spotlit[player.position] = self.annotator.targets[-1] if self.annotator.targets else None
             self.narrated.append(player.position)
 
         player.step_changed.connect(remember)
@@ -181,8 +180,8 @@ class TutorialChaptersTest(unittest.TestCase):
         self.sandbox = TutorialSandbox()
         self.sandbox.window.show()
         process_events(3)
-        self.overlay = RecordingOverlay()
-        self.bubble = RecordingBubble()
+        self.annotator = RecordingAnnotator()
+
         self.spotlit = {}
         self.narrated = []
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -1,0 +1,201 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Plays the whole tutorial against a real Texture Planner.
+
+The tour is written against widget names and presenter methods, so it drifts the moment either is
+renamed - and it drifts silently, because nothing else imports it. This is what makes that loud:
+every chapter is played end to end, and every step has to perform and to find what it points at.
+
+The observations are in ``subTest`` blocks so one broken step reports itself without hiding the
+rest. Building the sandbox is not - a failure there makes every following observation meaningless.
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from mantid.api import AnalysisDataService as ADS, FrameworkManager
+from qtpy.QtTest import QTest
+from qtpy.QtWidgets import QWidget
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.tutorial.interaction import process_events
+from mantidqt.widgets.tutorial.player import TutorialPlayer
+from mantidqt.widgets.tutorial.step import walk
+
+from mantidqtinterfaces.TexturePlanner.tutorial.chapters import CHAPTERS
+from mantidqtinterfaces.TexturePlanner.tutorial.sandbox import TutorialSandbox
+
+# the tour dwells for seconds at a time so it can be read; played at that speed the test would take
+# minutes. Every delay is overridden to the minimum, which exercises the same steps in the same
+# order without the reading time.
+FAST = {"dwell_ms": 1, "settle_ms": 1}
+
+PLAY_TIMEOUT_MS = 300000
+
+
+class RecordingOverlay:
+    """Collects what the tour pointed at, instead of painting it."""
+
+    def __init__(self):
+        self.targets = []
+
+    def set_target(self, widget):
+        self.targets.append(widget)
+
+    def target_rect(self):
+        return None
+
+    def show(self):
+        pass
+
+    def hide(self):
+        pass
+
+    def detach(self):
+        pass
+
+
+class RecordingBubble:
+    def __init__(self):
+        self.shown = []
+
+    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
+        self.shown.append((chapter_name, title, text))
+
+    def show_waiting(self, message):
+        pass
+
+    def place_beside(self, _spotlight):
+        pass
+
+    def set_navigation_enabled(self, back=True, next_=True):
+        pass
+
+    def set_paused(self, paused):
+        pass
+
+
+def _hurry(step):
+    return type(step)(
+        text=step.text,
+        target=step.target,
+        action=step.action,
+        title=step.title,
+        await_=step.await_,
+        await_timeout_s=step.await_timeout_s,
+        await_text=step.await_text,
+        **FAST,
+    )
+
+
+def _hurried_chapters():
+    return tuple(
+        type(chapter)(name=chapter.name, description=chapter.description, steps=[_hurry(s) for s in chapter.steps]) for chapter in CHAPTERS
+    )
+
+
+@start_qapplication
+class TutorialChaptersTest(unittest.TestCase):
+    """One test per chapter, plus the whole tour, because a chapter is what the user can jump to
+    and so is what has to work on its own."""
+
+    @classmethod
+    def setUpClass(cls):
+        # a view holding a FileFinderWidget fails inside setupUi with a message-less RuntimeError
+        # unless the framework is already up
+        FrameworkManager.Instance()
+
+    def setUp(self):
+        self.sandbox = TutorialSandbox()
+        self.sandbox.window.show()
+        process_events(3)
+        self.addCleanup(self._teardown)
+
+        self.overlay = RecordingOverlay()
+        self.bubble = RecordingBubble()
+        self.failures = []
+        self.finished = []
+
+    def _teardown(self):
+        owned = self.sandbox.model.workspaces._owned_ws_names
+        self.sandbox.teardown()
+        process_events(3)
+        leaked = [name for name in owned if ADS.doesExist(name)]
+        self.assertEqual(leaked, [], "the tutorial's workspaces must not outlive its window")
+
+    def _play(self, chapters, chapter_index=0, fast_forward=False):
+        player = TutorialPlayer(chapters, self.sandbox, self.overlay, self.bubble, parent=self.sandbox.window)
+        player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
+        player.finished.connect(lambda: self.finished.append(True))
+        player.start(chapter_index, fast_forward=fast_forward)
+
+        waited = 0
+        while not self.finished and waited < PLAY_TIMEOUT_MS:
+            QTest.qWait(10)
+            waited += 10
+        self.assertTrue(self.finished, f"the tour did not finish within {PLAY_TIMEOUT_MS / 1000}s")
+        return player
+
+    # ------------------------------------------------------------------ per chapter
+
+    def test_each_chapter_plays_on_its_own(self):
+        chapters = _hurried_chapters()
+        for index, chapter in enumerate(chapters):
+            with self.subTest(chapter=chapter.name):
+                self.failures = []
+                self.finished = []
+                # rebuilt for each chapter, exactly as the chapter picker does it
+                self._teardown_and_rebuild()
+                self._play(chapters, chapter_index=index, fast_forward=index > 0)
+                self.assertEqual(self.failures, [], f"steps failed in '{chapter.name}'")
+
+    def _teardown_and_rebuild(self):
+        self.sandbox.teardown()
+        process_events(3)
+        self.sandbox = TutorialSandbox()
+        self.sandbox.window.show()
+        process_events(3)
+        self.overlay = RecordingOverlay()
+        self.bubble = RecordingBubble()
+
+    # ------------------------------------------------------------------ the whole tour
+
+    def test_the_whole_tour_plays_without_a_step_failing(self):
+        self._play(_hurried_chapters())
+        for label, reason in self.failures:
+            with self.subTest(step=label):
+                self.fail(reason)
+        self.assertEqual(self.failures, [])
+
+    def test_every_step_that_points_at_something_found_a_live_widget(self):
+        chapters = _hurried_chapters()
+        self._play(chapters)
+
+        pointing = [step for _c, _s, _chapter, step in walk(chapters) if step.target is not None]
+        spotlit = [target for target in self.overlay.targets if target is not None]
+        self.assertEqual(
+            len(spotlit),
+            len(pointing),
+            "a step that names a target but highlighted nothing means the interface moved under the tour",
+        )
+        for target in spotlit:
+            with self.subTest(target=target.objectName() or type(target).__name__):
+                self.assertIsInstance(target, QWidget)
+
+    def test_every_step_was_narrated_in_order(self):
+        chapters = _hurried_chapters()
+        self._play(chapters)
+
+        expected = [(chapter.name, step.title, step.text) for _c, _s, chapter, step in walk(chapters)]
+        self.assertEqual(self.bubble.shown, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -189,6 +189,14 @@ class TutorialChaptersTest(unittest.TestCase):
             with self.subTest(target=target.objectName() or type(target).__name__):
                 self.assertIsInstance(target, QWidget)
 
+    def test_the_tour_really_exports_a_file(self):
+        # the export step goes through the interface's own export path, so a tour that stopped
+        # actually producing anything would otherwise still look like it was working
+        self._play(_hurried_chapters())
+
+        written = os.listdir(self.sandbox.data.save_directory)
+        self.assertTrue(written, "the export chapter should have written a real file to the demo directory")
+
     def test_every_step_was_narrated_in_order(self):
         chapters = _hurried_chapters()
         self._play(chapters)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -8,7 +8,7 @@
 
 The tour is written against widget names and presenter methods, so it drifts the moment either is
 renamed - and it drifts silently, because nothing else imports it. This is what makes that loud:
-every chapter is played end to end, and every step has to perform and to find what it points at.
+the tour is played end to end, and every step has to perform and to find what it points at.
 
 The observations are in ``subTest`` blocks so one broken step reports itself without hiding the
 rest. Building the sandbox is not - a failure there makes every following observation meaningless.
@@ -16,6 +16,7 @@ rest. Building the sandbox is not - a failure there makes every following observ
 
 import os
 import unittest
+from dataclasses import replace
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 os.environ.setdefault("MPLBACKEND", "Agg")
@@ -75,29 +76,24 @@ class RecordingAnnotator:
         pass
 
 
-def _hurry(step):
-    return type(step)(
-        text=step.text,
-        target=step.target,
-        action=step.action,
-        title=step.title,
-        await_=step.await_,
-        await_timeout_s=step.await_timeout_s,
-        await_text=step.await_text,
-        **FAST,
-    )
-
-
 def _hurried_chapters():
-    return tuple(
-        type(chapter)(name=chapter.name, description=chapter.description, steps=[_hurry(s) for s in chapter.steps]) for chapter in CHAPTERS
-    )
+    """The real tour, with only the pauses taken out.
+
+    ``replace`` rather than rebuilding each step field by field: a step written by hand here would
+    quietly stop matching the real one the moment ``TutorialStep`` gained a field, and the test
+    would be playing something subtly different from what ships.
+    """
+    return tuple(replace(chapter, steps=[replace(step, **FAST) for step in chapter.steps]) for chapter in CHAPTERS)
 
 
 @start_qapplication
 class TutorialChaptersTest(unittest.TestCase):
-    """One test per chapter, plus the whole tour, because a chapter is what the user can jump to
-    and so is what has to work on its own."""
+    """The whole tour played once, and then each chapter entered on its own - because a chapter is
+    what the user can jump to, and gets there by a different route (the interface is rebuilt and
+    fast-forwarded rather than walked through).
+
+    Playing the tour runs the interface for real, absorption calculation and all, so it is done as
+    few times as the two paths allow and everything else is asserted against what that recorded."""
 
     @classmethod
     def setUpClass(cls):
@@ -110,9 +106,10 @@ class TutorialChaptersTest(unittest.TestCase):
         self.sandbox.window.show()
         process_events(3)
         self.addCleanup(self._teardown)
+        self._reset_recording()
 
+    def _reset_recording(self):
         self.annotator = RecordingAnnotator()
-
         self.failures = []
         self.finished = []
         self.spotlit = {}
@@ -137,9 +134,9 @@ class TutorialChaptersTest(unittest.TestCase):
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
         player.finished.connect(lambda: self.finished.append(True))
 
-        # what the tour pointed at, per step. Recorded from the player rather than counted off the
-        # overlay because a step is presented twice - once explained, once refreshed after it has
-        # been performed - and both times set a target.
+        # what the tour pointed at, per step. Keyed off the player's position rather than counted
+        # off the annotator because a step is presented twice - once explained, once refreshed
+        # after it has been performed - and both times set a target.
         def remember(*_args):
             self.spotlit[player.position] = self.annotator.targets[-1] if self.annotator.targets else None
             self.narrated.append(player.position)
@@ -161,74 +158,70 @@ class TutorialChaptersTest(unittest.TestCase):
         self.assertTrue(self.finished, f"the tour did not finish within {PLAY_TIMEOUT_MS / 1000}s")
         return player
 
-    # ------------------------------------------------------------------ per chapter
-
-    def test_each_chapter_plays_on_its_own(self):
-        chapters = _hurried_chapters()
-        for index, chapter in enumerate(chapters):
-            with self.subTest(chapter=chapter.name):
-                self.failures = []
-                self.finished = []
-                # rebuilt for each chapter, exactly as choosing its tab does it
-                self._teardown_and_rebuild()
-                self._play(chapters, chapter_index=index, fast_forward=index > 0)
-                self.assertEqual(self.failures, [], f"steps failed in '{chapter.name}'")
-
-    def _teardown_and_rebuild(self):
-        self.sandbox.teardown()
-        process_events(3)
-        self.sandbox = TutorialSandbox()
-        self.sandbox.window.show()
-        process_events(3)
-        self.annotator = RecordingAnnotator()
-
-        self.spotlit = {}
-        self.narrated = []
-
     # ------------------------------------------------------------------ the whole tour
 
-    def test_the_whole_tour_plays_without_a_step_failing(self):
-        self._play(_hurried_chapters())
+    def test_the_whole_tour_plays_against_a_real_planner(self):
+        """One play, every observation it supports.
+
+        Each observation is its own ``subTest`` so a single broken step reports itself instead of
+        hiding the ones after it - which is the whole point of a test that exists to catch the tour
+        drifting away from a renamed widget.
+        """
+        chapters = _hurried_chapters()
+        self._play(chapters)
+
         for label, reason in self.failures:
             with self.subTest(step=label):
                 self.fail(reason)
-        self.assertEqual(self.failures, [])
-
-    def test_every_step_that_points_at_something_found_a_live_widget(self):
-        chapters = _hurried_chapters()
-        self._play(chapters)
 
         for chapter_index, step_index, chapter, step in walk(chapters):
             if step.target is None:
                 continue
             with self.subTest(chapter=chapter.name, step=step.label):
-                target = self.spotlit.get((chapter_index, step_index))
                 self.assertIsInstance(
-                    target,
+                    self.spotlit.get((chapter_index, step_index)),
                     QWidget,
                     "a step that names a target but highlighted nothing means the interface moved under the tour",
                 )
 
-    def test_the_tour_really_exports_a_file(self):
-        # the export step goes through the interface's own export path, so a tour that stopped
-        # actually producing anything would otherwise still look like it was working
-        self._play(_hurried_chapters())
+        with self.subTest("every step was shown, in order"):
+            # first appearance of each step: a step is presented twice, once explained and once
+            # refreshed after it has been performed
+            first_seen = []
+            for position in self.narrated:
+                if position not in first_seen:
+                    first_seen.append(position)
+            expected = [(chapter_index, step_index) for chapter_index, step_index, _chapter, _step in walk(chapters)]
+            self.assertEqual(first_seen, expected)
 
-        written = os.listdir(self.sandbox.data.save_directory)
-        self.assertTrue(written, "the export chapter should have written a real file to the demo directory")
+        with self.subTest("the export step wrote a real file"):
+            # it goes through the interface's own export path, so a tour that stopped producing
+            # anything would otherwise still look like it was working
+            self.assertTrue(
+                os.listdir(self.sandbox.data.save_directory),
+                "the export chapter should have written a real file to the demo directory",
+            )
 
-    def test_every_step_was_shown_in_order(self):
+    # ------------------------------------------------------------------ entering a chapter
+
+    def test_each_chapter_can_be_entered_on_its_own(self):
+        # what the chapter tabs do: the interface is rebuilt and the earlier chapters' actions
+        # replayed silently, rather than the tour being walked through to get there
         chapters = _hurried_chapters()
-        self._play(chapters)
+        for index, chapter in enumerate(chapters[1:], start=1):
+            with self.subTest(chapter=chapter.name):
+                self._rebuild_sandbox()
+                self._play(chapters, chapter_index=index, fast_forward=True)
+                self.assertEqual(self.failures, [], f"steps failed entering '{chapter.name}'")
 
-        # first appearance of each step, in the order the tour reached them
-        first_seen = []
-        for position in self.narrated:
-            if position not in first_seen:
-                first_seen.append(position)
-
-        expected = [(chapter_index, step_index) for chapter_index, step_index, _chapter, _step in walk(chapters)]
-        self.assertEqual(first_seen, expected)
+    def _rebuild_sandbox(self):
+        """Start over with a fresh interface, exactly as choosing a chapter tab does."""
+        self.sandbox.teardown()
+        process_events(3)
+        self.sandbox = TutorialSandbox()
+        self.sandbox.window.show()
+        process_events(3)
+        self._reset_recording()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -116,6 +116,8 @@ class TutorialChaptersTest(unittest.TestCase):
         self.bubble = RecordingBubble()
         self.failures = []
         self.finished = []
+        self.spotlit = {}
+        self.narrated = []
 
     def _teardown(self):
         owned = self.sandbox.model.workspaces._owned_ws_names
@@ -125,15 +127,26 @@ class TutorialChaptersTest(unittest.TestCase):
         self.assertEqual(leaked, [], "the tutorial's workspaces must not outlive its window")
 
     def _play(self, chapters, chapter_index=0, fast_forward=False):
-        """Play from ``chapter_index`` to the end, pressing Next the way a user would.
+        """Play from ``chapter_index`` to the end, driving it the way a user would.
 
-        Nothing advances on its own, so the test has to walk the tour. Each Next waits for the step
-        to be on screen first: the player ignores navigation while a step is still settling or
-        waiting on the interface, so clicking early would simply spin.
+        Each step is shown first, then performed with *Show me*, then left with *Next* - which is
+        the path a user actually takes, and the one that exercises both. The waits matter: the
+        player ignores navigation while a step is settling or working, so clicking early would
+        simply spin.
         """
         player = TutorialPlayer(chapters, self.sandbox, self.overlay, self.bubble, parent=self.sandbox.window)
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
         player.finished.connect(lambda: self.finished.append(True))
+
+        # what the tour pointed at, per step. Recorded from the player rather than counted off the
+        # overlay because a step is presented twice - once explained, once refreshed after it has
+        # been performed - and both times set a target.
+        def remember(*_args):
+            self.spotlit[player.position] = self.overlay.targets[-1] if self.overlay.targets else None
+            self.narrated.append(player.position)
+
+        player.step_changed.connect(remember)
+        player.step_applied.connect(remember)
         player.start(chapter_index, fast_forward=fast_forward)
 
         waited = 0
@@ -141,6 +154,9 @@ class TutorialChaptersTest(unittest.TestCase):
             if player.is_busy:
                 QTest.qWait(10)
                 waited += 10
+                continue
+            if not player.is_applied():
+                player.apply_step()
                 continue
             player.next_step()
         self.assertTrue(self.finished, f"the tour did not finish within {PLAY_TIMEOUT_MS / 1000}s")
@@ -167,6 +183,8 @@ class TutorialChaptersTest(unittest.TestCase):
         process_events(3)
         self.overlay = RecordingOverlay()
         self.bubble = RecordingBubble()
+        self.spotlit = {}
+        self.narrated = []
 
     # ------------------------------------------------------------------ the whole tour
 
@@ -181,16 +199,16 @@ class TutorialChaptersTest(unittest.TestCase):
         chapters = _hurried_chapters()
         self._play(chapters)
 
-        pointing = [step for _c, _s, _chapter, step in walk(chapters) if step.target is not None]
-        spotlit = [target for target in self.overlay.targets if target is not None]
-        self.assertEqual(
-            len(spotlit),
-            len(pointing),
-            "a step that names a target but highlighted nothing means the interface moved under the tour",
-        )
-        for target in spotlit:
-            with self.subTest(target=target.objectName() or type(target).__name__):
-                self.assertIsInstance(target, QWidget)
+        for chapter_index, step_index, chapter, step in walk(chapters):
+            if step.target is None:
+                continue
+            with self.subTest(chapter=chapter.name, step=step.label):
+                target = self.spotlit.get((chapter_index, step_index))
+                self.assertIsInstance(
+                    target,
+                    QWidget,
+                    "a step that names a target but highlighted nothing means the interface moved under the tour",
+                )
 
     def test_the_tour_really_exports_a_file(self):
         # the export step goes through the interface's own export path, so a tour that stopped
@@ -200,12 +218,18 @@ class TutorialChaptersTest(unittest.TestCase):
         written = os.listdir(self.sandbox.data.save_directory)
         self.assertTrue(written, "the export chapter should have written a real file to the demo directory")
 
-    def test_every_step_was_narrated_in_order(self):
+    def test_every_step_was_shown_in_order(self):
         chapters = _hurried_chapters()
         self._play(chapters)
 
-        expected = [(step.title, step.text) for _c, _s, _chapter, step in walk(chapters)]
-        self.assertEqual(self.bubble.shown, expected)
+        # first appearance of each step, in the order the tour reached them
+        first_seen = []
+        for position in self.narrated:
+            if position not in first_seen:
+                first_seen.append(position)
+
+        expected = [(chapter_index, step_index) for chapter_index, step_index, _chapter, _step in walk(chapters)]
+        self.assertEqual(first_seen, expected)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -72,7 +72,7 @@ class RecordingBubble:
     def show_waiting(self, message):
         pass
 
-    def place_beside(self, _spotlight):
+    def place_beside(self, _spotlight, keep_clear=()):
         pass
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/tutorial/test/test_chapters.py
@@ -32,10 +32,10 @@ from mantidqt.widgets.tutorial.step import walk
 from mantidqtinterfaces.TexturePlanner.tutorial.chapters import CHAPTERS
 from mantidqtinterfaces.TexturePlanner.tutorial.sandbox import TutorialSandbox
 
-# the tour dwells for seconds at a time so it can be read; played at that speed the test would take
-# minutes. Every delay is overridden to the minimum, which exercises the same steps in the same
-# order without the reading time.
-FAST = {"dwell_ms": 1, "settle_ms": 1}
+# the tour waits for the user at every step; a test drives it by pressing Next as fast as each
+# step becomes ready. The settle is cut to the minimum, which exercises the same steps in the same
+# order without the pauses that only exist to let a layout catch up on screen.
+FAST = {"settle_ms": 1}
 
 PLAY_TIMEOUT_MS = 300000
 
@@ -66,19 +66,13 @@ class RecordingBubble:
     def __init__(self):
         self.shown = []
 
-    def show_step(self, text, title="", chapter_name="", step_number=0, step_count=0):
-        self.shown.append((chapter_name, title, text))
+    def show_step(self, text, title=""):
+        self.shown.append((title, text))
 
     def show_waiting(self, message):
         pass
 
     def place_beside(self, _spotlight):
-        pass
-
-    def set_navigation_enabled(self, back=True, next_=True):
-        pass
-
-    def set_paused(self, paused):
         pass
 
 
@@ -131,6 +125,12 @@ class TutorialChaptersTest(unittest.TestCase):
         self.assertEqual(leaked, [], "the tutorial's workspaces must not outlive its window")
 
     def _play(self, chapters, chapter_index=0, fast_forward=False):
+        """Play from ``chapter_index`` to the end, pressing Next the way a user would.
+
+        Nothing advances on its own, so the test has to walk the tour. Each Next waits for the step
+        to be on screen first: the player ignores navigation while a step is still settling or
+        waiting on the interface, so clicking early would simply spin.
+        """
         player = TutorialPlayer(chapters, self.sandbox, self.overlay, self.bubble, parent=self.sandbox.window)
         player.step_failed.connect(lambda label, reason: self.failures.append((label, reason)))
         player.finished.connect(lambda: self.finished.append(True))
@@ -138,8 +138,11 @@ class TutorialChaptersTest(unittest.TestCase):
 
         waited = 0
         while not self.finished and waited < PLAY_TIMEOUT_MS:
-            QTest.qWait(10)
-            waited += 10
+            if player.is_busy:
+                QTest.qWait(10)
+                waited += 10
+                continue
+            player.next_step()
         self.assertTrue(self.finished, f"the tour did not finish within {PLAY_TIMEOUT_MS / 1000}s")
         return player
 
@@ -151,7 +154,7 @@ class TutorialChaptersTest(unittest.TestCase):
             with self.subTest(chapter=chapter.name):
                 self.failures = []
                 self.finished = []
-                # rebuilt for each chapter, exactly as the chapter picker does it
+                # rebuilt for each chapter, exactly as choosing its tab does it
                 self._teardown_and_rebuild()
                 self._play(chapters, chapter_index=index, fast_forward=index > 0)
                 self.assertEqual(self.failures, [], f"steps failed in '{chapter.name}'")
@@ -201,7 +204,7 @@ class TutorialChaptersTest(unittest.TestCase):
         chapters = _hurried_chapters()
         self._play(chapters)
 
-        expected = [(chapter.name, step.title, step.text) for _c, _s, chapter, step in walk(chapters)]
+        expected = [(step.title, step.text) for _c, _s, _chapter, step in walk(chapters)]
         self.assertEqual(self.bubble.shown, expected)
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (
     QToolBar,
     QGroupBox,
     QLineEdit,
+    QSizePolicy,
 )
 from qtpy import QtCore
 from qtpy.QtGui import QCloseEvent
@@ -169,16 +170,23 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
     def _setup_bottom_toolbar(self) -> None:
         # kept as an attribute rather than a local so the tutorial can point at the toolbar itself
         self.toolbar = QToolBar("Main Toolbar", self)
+        self.btn_settings = QPushButton()
+        self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
+        self.btn_settings.setToolTip("Settings")
+        self.toolbar.addWidget(self.btn_settings)
+
+        # an expanding blank widget is how a QToolBar is split into a left and a right group; it
+        # has no actions of its own for aligning what comes after it
+        spacer = QWidget()
+        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self.toolbar.addWidget(spacer)
+
         self.btn_tutorial = QPushButton()
         self.btn_tutorial.setIcon(get_icon("mdi.school", "black", 1.2))
         self.btn_tutorial.setToolTip("Guided tutorial")
         # the action, not the button, is what controls visibility here: a toolbar re-shows the
         # widget of any visible action, so hiding the button alone does not stick
         self._tutorial_action = self.toolbar.addWidget(self.btn_tutorial)
-        self.btn_settings = QPushButton()
-        self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
-        self.btn_settings.setToolTip("Settings")
-        self.toolbar.addWidget(self.btn_settings)
         self.addToolBar(QtCore.Qt.BottomToolBarArea, self.toolbar)
 
     def set_on_settings_clicked(self, slot: Callable) -> None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -172,7 +172,9 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self.btn_tutorial = QPushButton()
         self.btn_tutorial.setIcon(get_icon("mdi.school", "black", 1.2))
         self.btn_tutorial.setToolTip("Guided tutorial")
-        self.toolbar.addWidget(self.btn_tutorial)
+        # the action, not the button, is what controls visibility here: a toolbar re-shows the
+        # widget of any visible action, so hiding the button alone does not stick
+        self._tutorial_action = self.toolbar.addWidget(self.btn_tutorial)
         self.btn_settings = QPushButton()
         self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
         self.btn_settings.setToolTip("Settings")
@@ -186,7 +188,7 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self.btn_tutorial.clicked.connect(slot)
 
     def set_tutorial_button_visible(self, visible: bool) -> None:
-        self.btn_tutorial.setVisible(visible)
+        self._tutorial_action.setVisible(visible)
 
     def set_on_close(self, slot: Callable) -> None:
         self._on_close = slot

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -70,7 +70,10 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
     # algorithm worker thread) to hop back onto the GUI thread before touching workspaces/plots
     sig_material_set = QtCore.Signal()
 
-    def __init__(self, parent=None, presenter=None):
+    def __init__(self, parent=None, presenter=None, register_usage: bool = True):
+        """:param register_usage: whether to count this window as a use of the interface. False for
+        the throwaway copy the tutorial drives, which is Mantid opening the interface rather than
+        the user, and would otherwise double every real launch in the usage figures."""
         super().__init__(parent)
         self.setupUi(self)
         self.presenter = presenter
@@ -160,7 +163,8 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self._setup_settings_toolbar()
 
         # register startup
-        UsageService.registerFeatureUsage(FeatureType.Interface, "TexturePlanner", False)
+        if register_usage:
+            UsageService.registerFeatureUsage(FeatureType.Interface, "TexturePlanner", False)
 
     def _setup_settings_toolbar(self) -> None:
         toolbar = QToolBar("Main Toolbar", self)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TexturePlanner/view.py
@@ -160,22 +160,33 @@ class TexturePlannerView(QMainWindow, Ui_texplan):
         self.make_box_toggleable(self.grpOrientationFile)  # finder widget has some hidden features that toggling messes with
         self.make_box_toggleable(self.grpGaugeVol, self.set_gauge_vol_visible)
 
-        self._setup_settings_toolbar()
+        self._setup_bottom_toolbar()
 
         # register startup
         if register_usage:
             UsageService.registerFeatureUsage(FeatureType.Interface, "TexturePlanner", False)
 
-    def _setup_settings_toolbar(self) -> None:
-        toolbar = QToolBar("Main Toolbar", self)
+    def _setup_bottom_toolbar(self) -> None:
+        # kept as an attribute rather than a local so the tutorial can point at the toolbar itself
+        self.toolbar = QToolBar("Main Toolbar", self)
+        self.btn_tutorial = QPushButton()
+        self.btn_tutorial.setIcon(get_icon("mdi.school", "black", 1.2))
+        self.btn_tutorial.setToolTip("Guided tutorial")
+        self.toolbar.addWidget(self.btn_tutorial)
         self.btn_settings = QPushButton()
         self.btn_settings.setIcon(get_icon("mdi.settings", "black", 1.2))
         self.btn_settings.setToolTip("Settings")
-        toolbar.addWidget(self.btn_settings)
-        self.addToolBar(QtCore.Qt.BottomToolBarArea, toolbar)
+        self.toolbar.addWidget(self.btn_settings)
+        self.addToolBar(QtCore.Qt.BottomToolBarArea, self.toolbar)
 
     def set_on_settings_clicked(self, slot: Callable) -> None:
         self.btn_settings.clicked.connect(slot)
+
+    def set_on_tutorial_clicked(self, slot: Callable) -> None:
+        self.btn_tutorial.clicked.connect(slot)
+
+    def set_tutorial_button_visible(self, visible: bool) -> None:
+        self.btn_tutorial.setVisible(visible)
 
     def set_on_close(self, slot: Callable) -> None:
         self._on_close = slot


### PR DESCRIPTION
### Description of work

Adds a reusable framework for creating step by step tutorials that wrap around and interact with a live instance of an interface. Implements this for the Texture Planning UI

<img width="1556" height="1030" alt="image" src="https://github.com/user-attachments/assets/e3a55a11-8654-4722-8740-74d80359c4c8" />

<img width="1555" height="1032" alt="image" src="https://github.com/user-attachments/assets/14250e53-cc6a-4595-9e8b-b052f4f96a99" />

Features and implementation are documented in the new `dev-docs/source/GuiTutorialFramework.rst`

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Open the Texture Planner interface, the tutorial should pop up immediately. Go through it and see if you can follow everything and you like how it looks.

Close the tutorial and the interface.

Reopen the interface and check the tutorial isn't auto-launched.

Relaunch tutorial using button in bottom right

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
