### PR TITLE
Error on msvc compiler warnings

### DIFF
--- a/.github/actions/check-build-warnings/action.yml
+++ b/.github/actions/check-build-warnings/action.yml
@@ -4,6 +4,11 @@ inputs:
   log-file:
     description: 'Path to the captured build log, relative to the workspace'
     required: true
+  os:
+    description: |
+      Operating system the build ran on, i.e. the workflow's matrix.os value. It selects which
+      compiler's diagnostics are looked for, so that the other compiler's format cannot false match.
+    required: true
   allowed-warnings-count:
     description: |
       If warnings slip through to main this can be used to set a non-zero allowed count while those
@@ -19,7 +24,8 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         BUILD_LOG: ${{ inputs.log-file }}
+        BUILD_OS: ${{ inputs.os }}
         ALLOWED_WARNINGS_COUNT: ${{ inputs.allowed-warnings-count }}
       run: |
         pixi run --frozen python ${GITHUB_WORKSPACE}/.github/actions/check-build-warnings/count_warnings.py \
-          "${GITHUB_WORKSPACE}/${BUILD_LOG}" --allowed-warnings "${ALLOWED_WARNINGS_COUNT}"
+          "${GITHUB_WORKSPACE}/${BUILD_LOG}" --os "${BUILD_OS}" --allowed-warnings "${ALLOWED_WARNINGS_COUNT}"

--- a/.github/actions/check-build-warnings/count_warnings.py
+++ b/.github/actions/check-build-warnings/count_warnings.py
@@ -7,6 +7,14 @@ captured to a log file which this script scans afterwards. Only warnings that a
 developer can act on are counted, i.e. those attributed to a source file that is
 tracked in the repository. Warnings from third-party or generated code, and
 warnings without a source location, are reported but do not fail the job.
+
+Both the gcc/clang and the MSVC diagnostic formats are recognised, so the same
+script serves the Linux and Windows builds. Only one of them is looked for in any
+given log, chosen by --os, so that a line in the shape of the other compiler's
+diagnostics cannot be mistaken for a warning. Paths are resolved with the path
+flavour of the machine running the script, which in CI is the machine that ran
+the build; a Windows log scanned on Linux will report its absolute paths as
+uncounted rather than counting them.
 """
 
 import argparse
@@ -26,8 +34,35 @@ LOCATED_WARNING_RE = re.compile(r"^(?P<file>.+?):(?P<line>\d+):(?:(?P<column>\d+
 # Warnings carrying no source location, e.g. "cc1plus: warning: ..." or "ld: warning: ..."
 UNLOCATED_WARNING_RE = re.compile(r"^(?P<tool>[^\s:]+):\s+warning:\s+(?P<message>.*)$")
 
+# MSVC diagnostics of the form "path(line[,column]): warning C4101: message", where the
+# location may instead be the span "(line,column,end line,end column)". A parallel MSBuild
+# prefixes each line with the id of the node that emitted it, e.g. "  7>", and the same
+# warning is repeated, indented, in the summary it prints at the end of the build.
+# The location and node prefix are as matched by .github/matchers/msvc.json, which
+# annotates these same diagnostics as the build runs.
+MSVC_WARNING_RE = re.compile(
+    r"^(?:\s*\d+>)?\s*(?P<file>.+?)\((?P<line>\d+)(?:,(?P<column>\d+))?(?:,\d+,\d+)?\)\s*:\s*"
+    r"warning\s+(?P<code>[A-Za-z]+\d+)\s*:\s*(?P<message>.*)$"
+)
+
+# MSVC diagnostics carrying no source location, e.g. "LINK : warning LNK4098: ..." or
+# "cl : command line warning D9002 : ..."
+MSVC_UNLOCATED_WARNING_RE = re.compile(
+    r"^(?:\s*\d+>)?\s*(?P<tool>[^\s:]+)\s*:\s*(?:command line\s+)?warning\s+(?P<code>[A-Za-z]+\d+)\s*:\s*(?P<message>.*)$"
+)
+
+# The project MSBuild appends to every diagnostic, e.g. "... [C:\build\Kernel.vcxproj]"
+MSBUILD_PROJECT_SUFFIX_RE = re.compile(r"\s*\[[^\]]*\.[a-z]*proj\]\s*$")
+
 # Trailing warning flag, e.g. the "-Wconversion" in "... [-Wconversion]"
 WARNING_FLAG_RE = re.compile(r"\[(-W[^\]]+)\]\s*$")
+
+# Leading MSVC warning code, e.g. the "C4101" in "C4101: unreferenced local variable"
+WARNING_CODE_RE = re.compile(r"^([A-Za-z]+\d+):")
+
+# The diagnostic format the compiler emits on each of the runner operating systems, keyed
+# by the lower-cased matrix.os value the workflow passes to --os
+DIAGNOSTIC_FORMATS = {"linux": "gcc", "macos": "gcc", "windows": "msvc"}
 
 # The C/C++ extensions listed in .github/filters.yaml, plus those the build can emit
 SOURCE_SUFFIXES = frozenset((".c", ".cc", ".cpp", ".cu", ".cxx", ".h", ".hpp", ".hxx", ".tcc"))
@@ -42,7 +77,8 @@ def _source_path(raw_path: str, build_dir: pathlib.Path, workspace: pathlib.Path
     Relative paths are resolved against the build directory as that is the working
     directory of the build tool that emitted them.
     """
-    candidate = pathlib.Path(raw_path)
+    # MSVC reports Windows separators, which pathlib only understands on Windows
+    candidate = pathlib.Path(raw_path.replace("\\", "/"))
     if candidate.suffix.lower() not in SOURCE_SUFFIXES:
         return None
 
@@ -60,8 +96,43 @@ def _source_path(raw_path: str, build_dir: pathlib.Path, workspace: pathlib.Path
     return relative
 
 
-def _scan(log_path: pathlib.Path, build_dir: pathlib.Path, workspace: pathlib.Path) -> tuple[list, list, int]:
-    """Return the deduplicated counted warnings, the uncounted warning lines and the number of lines read."""
+def _parse_gcc_warning(line: str) -> tuple | None:
+    """Return (path, line, column, message) for a located gcc/clang warning, else None."""
+    match = LOCATED_WARNING_RE.match(line)
+    if not match:
+        return None
+
+    return match["file"], int(match["line"]), int(match["column"] or 0), match["message"]
+
+
+def _parse_msvc_warning(line: str) -> tuple | None:
+    """Return (path, line, column, message) for a located MSVC warning, else None."""
+    match = MSVC_WARNING_RE.match(line)
+    if not match:
+        return None
+
+    # MSVC identifies a warning by its code rather than a flag, so keep the code in the
+    # message where it is both reported and available to group on. The project MSBuild
+    # appends is dropped as it adds nothing beyond the source location.
+    message = f"{match['code']}: {MSBUILD_PROJECT_SUFFIX_RE.sub('', match['message'])}"
+
+    return match["file"], int(match["line"]), int(match["column"] or 0), message
+
+
+# The parser and the unlocated-warning pattern belonging to each diagnostic format. A log
+# only ever holds one of them, so the other is not tried at all and cannot false match.
+WARNING_PARSERS = {
+    "gcc": (_parse_gcc_warning, UNLOCATED_WARNING_RE),
+    "msvc": (_parse_msvc_warning, MSVC_UNLOCATED_WARNING_RE),
+}
+
+
+def _scan(log_path: pathlib.Path, build_dir: pathlib.Path, workspace: pathlib.Path, diagnostics: str) -> tuple[list, list, int]:
+    """Return the deduplicated counted warnings, the uncounted warning lines and the number of lines read.
+
+    Only the diagnostics of the named format, 'gcc' or 'msvc', are looked for.
+    """
+    parse_warning, unlocated_warning_re = WARNING_PARSERS[diagnostics]
     counted = {}
     uncounted = []
     lines_read = 0
@@ -70,17 +141,18 @@ def _scan(log_path: pathlib.Path, build_dir: pathlib.Path, workspace: pathlib.Pa
         for raw_line in handle:
             lines_read += 1
             line = ANSI_RE.sub("", raw_line.rstrip("\r\n"))
-            match = LOCATED_WARNING_RE.match(line)
-            if match:
-                relative = _source_path(match["file"], build_dir, workspace)
+            warning = parse_warning(line)
+            if warning:
+                raw_path, line_number, column, message = warning
+                relative = _source_path(raw_path, build_dir, workspace)
                 if relative is None:
                     uncounted.append(line)
                 else:
                     # A warning in a header is re-emitted once per translation unit
                     # that includes it, so key on the location and message.
-                    key = (relative.as_posix(), int(match["line"]), int(match["column"] or 0), match["message"])
+                    key = (relative.as_posix(), line_number, column, message)
                     counted.setdefault(key, None)
-            elif UNLOCATED_WARNING_RE.match(line):
+            elif unlocated_warning_re.match(line):
                 uncounted.append(line)
 
     return sorted(counted), uncounted, lines_read
@@ -95,6 +167,10 @@ def _format(warning: tuple) -> str:
 
 def _warning_flag(message: str) -> str:
     match = WARNING_FLAG_RE.search(message)
+    if match:
+        return match.group(1)
+
+    match = WARNING_CODE_RE.match(message)
 
     return match.group(1) if match else "unflagged"
 
@@ -111,9 +187,23 @@ def _write_step_summary(warnings: list) -> None:
         handle.write("\n".join(lines))
 
 
+def _host_os() -> str:
+    """The --os default, so that a developer scanning a local build log needs no flag."""
+    return {"win32": "windows", "cygwin": "windows", "darwin": "macos"}.get(sys.platform, "linux")
+
+
 def _parse_args(argv: list) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Fail a CI job when the C++ compiler emitted warnings.")
     parser.add_argument("log_file", type=pathlib.Path, help="Build log to scan")
+    parser.add_argument(
+        "--os",
+        type=str.lower,
+        choices=sorted(DIAGNOSTIC_FORMATS),
+        default=_host_os(),
+        help="Operating system the build ran on, given as the workflow's matrix.os value and matched without regard "
+        "to case. It selects which compiler's diagnostics are looked for, so that the other compiler's format "
+        "cannot false match (default: the platform this runs on)",
+    )
     parser.add_argument(
         "--build-dir",
         type=pathlib.Path,
@@ -145,7 +235,9 @@ def main() -> int:
         print(f"::error::Build log {log_path} does not exist, cannot check for compiler warnings")
         return 1
 
-    counted, uncounted, lines_read = _scan(log_path, build_dir, workspace)
+    diagnostics = DIAGNOSTIC_FORMATS[args.os]
+    print(f"Checking {log_path} for {diagnostics} compiler warnings")
+    counted, uncounted, lines_read = _scan(log_path, build_dir, workspace, diagnostics)
 
     # An empty log means the build output was not captured, which must not pass silently
     if lines_read == 0:

--- a/.github/actions/check-build-warnings/test_count_warnings.py
+++ b/.github/actions/check-build-warnings/test_count_warnings.py
@@ -25,8 +25,17 @@ import count_warnings
 
 WARNING = "conversion from 'int' to 'char' may change value [-Wconversion]"
 
+# MSVC names the warning by a code rather than a flag, and MSBuild appends the project
+MSVC_WARNING = "'demonstration': unreferenced local variable"
+MSVC_PROJECT = "Kernel.vcxproj"
+
 
 class CountWarningsTestCase(unittest.TestCase):
+    # The diagnostic format the log under test is written in, and the matrix.os value that
+    # selects it. The MSVC cases override both.
+    diagnostics = "gcc"
+    os_name = "Linux"
+
     def setUp(self):
         self._workspace_dir = tempfile.TemporaryDirectory()
         # Resolve so comparisons match count_warnings, which resolves both sides
@@ -43,7 +52,7 @@ class CountWarningsTestCase(unittest.TestCase):
 
     def _scan(self, log_path: pathlib.Path):
         """Scan a build log, returning (counted, uncounted, lines read)."""
-        return count_warnings._scan(log_path, self.build_dir, self.workspace)
+        return count_warnings._scan(log_path, self.build_dir, self.workspace, self.diagnostics)
 
     def _run_main(self, argv, env=None):
         """Return (exit code, stdout) for a main() call, keeping the test output clean."""
@@ -58,8 +67,8 @@ class CountWarningsTestCase(unittest.TestCase):
         return exit_code, stdout.getvalue()
 
     def _build_dir_args(self) -> list:
-        """The flags every main() call needs so relative log paths resolve like they do in CI."""
-        return ["--build-dir", str(self.build_dir)]
+        """The flags every main() call needs to read the log the way CI does."""
+        return ["--build-dir", str(self.build_dir), "--os", self.os_name]
 
 
 class TestScan(CountWarningsTestCase):
@@ -179,6 +188,175 @@ class TestScan(CountWarningsTestCase):
         self.assertEqual(lines_read, 3)
 
 
+class TestScanMSVC(CountWarningsTestCase):
+    """The Windows build compiles with MSVC, whose diagnostics look nothing like gcc's."""
+
+    diagnostics = "msvc"
+    os_name = "Windows"
+
+    def _msvc_line(self, path, location="90,7", warning=MSVC_WARNING, node="", project=MSVC_PROJECT) -> str:
+        suffix = f" [{self.build_dir}/Framework/Kernel/{project}]" if project else ""
+
+        return f"{node}{path}({location}): warning C4101: {warning}{suffix}"
+
+    def test_counts_warning_for_workspace_source_file(self):
+        log_path = self._write_log(self._msvc_line(f"{self.workspace}/Framework/Kernel/src/Foo.cpp"))
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 90, 7, f"C4101: {MSVC_WARNING}")])
+        self.assertEqual(uncounted, [])
+
+    def test_counts_warning_that_has_no_column(self):
+        # cl only reports a column under /diagnostics:column, the default since VS2019
+        log_path = self._write_log(self._msvc_line(f"{self.workspace}/Framework/Kernel/src/Foo.cpp", location="90"))
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 90, 0, f"C4101: {MSVC_WARNING}")])
+
+    def test_counts_warning_reported_as_a_span(self):
+        # MSBuild can report the end of the offending expression as well as its start
+        log_path = self._write_log(self._msvc_line(f"{self.workspace}/Framework/Kernel/src/Foo.cpp", location="90,7,90,28"))
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [("Framework/Kernel/src/Foo.cpp", 90, 7, f"C4101: {MSVC_WARNING}")])
+
+    def test_normalises_windows_path_separators(self):
+        log_path = self._write_log(self._msvc_line(r"..\Framework\Kernel\src\Foo.cpp"))
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual([warning[0] for warning in counted], ["Framework/Kernel/src/Foo.cpp"])
+
+    def test_deduplicates_a_warning_repeated_by_the_msbuild_node_prefix_and_summary(self):
+        source = f"{self.workspace}/Framework/Kernel/src/Foo.cpp"
+        log_path = self._write_log(
+            self._msvc_line(source, node="  7>"),
+            "  7>Foo.cpp",
+            # MSBuild reprints every warning, indented, in its end of build summary
+            "    " + self._msvc_line(source),
+        )
+
+        counted, _, _ = self._scan(log_path)
+
+        self.assertEqual(len(counted), 1)
+
+    def test_excludes_paths_outside_the_workspace(self):
+        log_path = self._write_log(self._msvc_line("/opt/conda/envs/mantid/include/boost/thing.hpp"))
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 1)
+
+    def test_records_warnings_without_a_source_location_as_uncounted(self):
+        log_path = self._write_log(
+            "LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs",
+            "cl : command line warning D9002 : ignoring unknown option '-Wfoo'",
+        )
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 2)
+
+    def test_ignores_lines_that_are_not_warnings(self):
+        source = f"{self.workspace}/Framework/Kernel/src/Foo.cpp"
+        log_path = self._write_log(
+            "  7>Foo.cpp",
+            f"{source}(90,7): note: see reference to function template instantiation 'void bar(void)'",
+            f"{source}(90,7): error C2065: 'demonstration': undeclared identifier [{self.build_dir}/Kernel.vcxproj]",
+            "    0 Warning(s)",
+        )
+
+        counted, uncounted, lines_read = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(uncounted, [])
+        self.assertEqual(lines_read, 4)
+
+    def test_does_not_mistake_a_directory_containing_brackets_for_a_location(self):
+        source = r"C:\Program Files (x86)\Windows Kits\10\include\winbase.h"
+        log_path = self._write_log(self._msvc_line(source, project=""))
+
+        counted, uncounted, _ = self._scan(log_path)
+
+        self.assertEqual(counted, [])
+        self.assertEqual(len(uncounted), 1)
+
+    def test_fails_the_job_on_an_msvc_warning(self):
+        log_path = self._write_log(self._msvc_line(r"..\Framework\Kernel\src\Foo.cpp"))
+
+        exit_code, output = self._run_main([str(log_path), *self._build_dir_args()])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("::error::Build produced 1 compiler warning(s)", output)
+        self.assertIn("Framework/Kernel/src/Foo.cpp:90:7", output)
+        self.assertIn("C4101", output)
+        self.assertNotIn(MSVC_PROJECT, output)
+
+
+class TestOsSelectsTheDiagnosticFormat(CountWarningsTestCase):
+    """--os narrows the scan to the compiler that actually produced the log."""
+
+    def _gcc_line(self) -> str:
+        return f"{self.workspace}/Framework/Kernel/src/Foo.cpp:12:5: warning: {WARNING}"
+
+    def _msvc_line(self) -> str:
+        return f"{self.workspace}/Framework/Kernel/src/Foo.cpp(12,5): warning C4101: {MSVC_WARNING}"
+
+    def test_a_linux_log_is_not_searched_for_msvc_diagnostics(self):
+        log_path = self._write_log(self._msvc_line())
+
+        counted, uncounted, _ = count_warnings._scan(log_path, self.build_dir, self.workspace, "gcc")
+
+        self.assertEqual(counted, [])
+        self.assertEqual(uncounted, [])
+
+    def test_a_windows_log_is_not_searched_for_gcc_diagnostics(self):
+        log_path = self._write_log(self._gcc_line())
+
+        counted, uncounted, _ = count_warnings._scan(log_path, self.build_dir, self.workspace, "msvc")
+
+        self.assertEqual(counted, [])
+        self.assertEqual(uncounted, [])
+
+    def test_passes_a_windows_log_holding_only_gcc_shaped_lines(self):
+        log_path = self._write_log(self._gcc_line())
+
+        exit_code, output = self._run_main([str(log_path), "--build-dir", str(self.build_dir), "--os", "Windows"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("No compiler warnings found", output)
+
+    def test_matches_the_matrix_os_value_without_regard_to_case(self):
+        log_path = self._write_log(self._msvc_line())
+
+        for os_name in ("Windows", "windows", "WINDOWS"):
+            with self.subTest(os=os_name):
+                exit_code, _ = self._run_main([str(log_path), "--build-dir", str(self.build_dir), "--os", os_name])
+
+                self.assertEqual(exit_code, 1)
+
+    def test_rejects_an_unknown_os(self):
+        with contextlib.redirect_stderr(io.StringIO()) as stderr:
+            with self.assertRaises(SystemExit) as raised:
+                count_warnings._parse_args(["build.log", "--os", "Solaris"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("invalid choice", stderr.getvalue())
+
+    def test_defaults_to_the_platform_it_runs_on(self):
+        for platform, expected in (("linux", "linux"), ("darwin", "macos"), ("win32", "windows")):
+            with self.subTest(platform=platform):
+                with mock.patch.object(count_warnings.sys, "platform", platform):
+                    args = count_warnings._parse_args(["build.log"])
+
+                self.assertEqual(args.os, expected)
+
+
 class TestWarningFlag(unittest.TestCase):
     def test_extracts_the_trailing_warning_flag(self):
         message = WARNING
@@ -186,6 +364,13 @@ class TestWarningFlag(unittest.TestCase):
         flag = count_warnings._warning_flag(message)
 
         self.assertEqual(flag, "-Wconversion")
+
+    def test_extracts_the_leading_msvc_warning_code(self):
+        message = f"C4101: {MSVC_WARNING}"
+
+        flag = count_warnings._warning_flag(message)
+
+        self.assertEqual(flag, "C4101")
 
     def test_reports_a_warning_with_no_flag_as_unflagged(self):
         message = "something happened"

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -240,11 +240,15 @@ jobs:
 
       # Runs after the whole build has completed so that every warning is reported at once,
       # and before the tests so that a warning stops the job from proceeding any further.
+      # The parser understands both the gcc and the MSVC diagnostic formats, so the same
+      # check covers the Linux and the Windows build.
+      # TODO: Needs to be expanded for clang on osx.
       - uses: ./.github/actions/check-build-warnings
         name: Check for compiler warnings
-        if: ${{ matrix.os == 'Linux' && needs.check-filters.outputs.code_changes == 'true' }}
+        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
         with:
           log-file: build/test_logs/build_${{ matrix.os }}.log
+          os: ${{ matrix.os }}
 
       - name: Run unit tests
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -83,6 +83,14 @@ void ConvertUnits::init() {
  * distance
  */
 void ConvertUnits::exec() {
+#ifdef _WIN32
+  // Deliberate, Windows-only warning demonstrating that the CI compiler warning check
+  // understands MSVC diagnostics: cl reports C4101 'unreferenced local variable'. Remove
+  // this block once the check has been seen to fail the Windows build.
+  // cppcheck-suppress unusedVariable
+  int demonstrationOfMSVCWarningCheck;
+#endif
+
   // Get the workspaces
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   const bool acceptPointData = getProperty("ConvertFromPointData");

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -83,14 +83,6 @@ void ConvertUnits::init() {
  * distance
  */
 void ConvertUnits::exec() {
-#ifdef _WIN32
-  // Deliberate, Windows-only warning demonstrating that the CI compiler warning check
-  // understands MSVC diagnostics: cl reports C4101 'unreferenced local variable'. Remove
-  // this block once the check has been seen to fail the Windows build.
-  // cppcheck-suppress unusedVariable
-  int demonstrationOfMSVCWarningCheck;
-#endif
-
   // Get the workspaces
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   const bool acceptPointData = getProperty("ConvertFromPointData");


### PR DESCRIPTION
To bring msvc in line with linux, expand the tooling to fail the build when there are windows compiler warnings.

Refs #39497

Assisted-by: Opus 4.8 <noreply@anthropic.com>

### To test:

Look at the [first build](https://github.com/mantidproject/mantid/actions/runs/33674637914/job/100680131392?pr=42151) which intentionally introduced a windows-only compiler warning to see that the compiler warning fails the build.

*This does not require release notes* because it is a change to CI.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
