### PR TITLE
Handle negative Uiso values in LoadCIF

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -6,11 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=no-init,too-few-public-methods
 from mantid.api import AlgorithmFactory, FileAction, FileProperty, PythonAlgorithm, WorkspaceProperty
-from mantid.kernel import Direction
+from mantid.kernel import Direction, Logger
 from mantid.geometry import SpaceGroupFactory, CrystalStructure, UnitCell
 
 import re
 import numpy as np
+
+logger = Logger("LoadCIF")
 
 
 # pylint: disable=invalid-name
@@ -262,6 +264,11 @@ class AtomListBuilder(object):
             isotropicUs += [convertBtoU(getFloatOrNone(b)) for b in isotropicBsNoErrors]
         else:
             isotropicUs += [None] * len(labels)
+
+        for i, u in enumerate(isotropicUs):
+            if u is not None and u < 0:
+                isotropicUs[i] = 0
+                logger.warning("Negative isotropic U-value encountered for label {0}, setting to 0.".format(labels[i]))
 
         isotropicUMap = dict(list(zip(labels, isotropicUs)))
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -262,6 +262,61 @@ class AtomListBuilderTest(unittest.TestCase):
 
         self.assertEqual(self.builder._getAtoms(data), "Si 1/8 1/8 1/8 1.0 0.012665147955292222;Al 0.34 0.56 0.23 1.0")
 
+    def test_getAtoms_negative_u(self):
+        data = self._getData(
+            dict(
+                [
+                    ("_atom_site_label", ["Si", "Al"]),
+                    ("_atom_site_occupancy", ["1.0", "1.0(0)"]),
+                    ("_atom_site_u_iso_or_equiv", ["0.01", "-0.02"]),
+                ]
+            )
+        )
+
+        # A negative U_iso is unphysical, it is clamped to 0.
+        self.assertEqual(self.builder._getAtoms(data), "Si 1/8 1/8 1/8 1.0 0.01;Al 0.34 0.56 0.23 1.0 0")
+
+    def test_getAtoms_negative_b(self):
+        data = self._getData(
+            dict(
+                [
+                    ("_atom_site_label", ["Si", "Al"]),
+                    ("_atom_site_occupancy", ["1.0", "1.0(0)"]),
+                    ("_atom_site_b_iso_or_equiv", ["1.0", "-2.0"]),
+                ]
+            )
+        )
+
+        # A negative B_iso converts to a negative U_iso, which is clamped to 0.
+        self.assertEqual(self.builder._getAtoms(data), "Si 1/8 1/8 1/8 1.0 0.012665147955292222;Al 0.34 0.56 0.23 1.0 0")
+
+    def test_getAtoms_negative_u_with_error_estimate(self):
+        data = self._getData(
+            dict(
+                [
+                    ("_atom_site_label", ["Si", "Al"]),
+                    ("_atom_site_occupancy", ["1.0", "1.0(0)"]),
+                    ("_atom_site_u_iso_or_equiv", ["-0.01(2)", "0.02"]),
+                ]
+            )
+        )
+
+        self.assertEqual(self.builder._getAtoms(data), "Si 1/8 1/8 1/8 1.0 0;Al 0.34 0.56 0.23 1.0 0.02")
+
+    def test_getAtoms_negative_and_invalid_u(self):
+        data = self._getData(
+            dict(
+                [
+                    ("_atom_site_label", ["Si", "Al"]),
+                    ("_atom_site_occupancy", ["1.0", "1.0(0)"]),
+                    ("_atom_site_u_iso_or_equiv", ["-0.01", "sdfsdfs"]),
+                ]
+            )
+        )
+
+        # The unparsable value stays None (and is dropped), the negative one is clamped to 0.
+        self.assertEqual(self.builder._getAtoms(data), "Si 1/8 1/8 1/8 1.0 0;Al 0.34 0.56 0.23 1.0")
+
     def test_getAtoms_aniso_u_orthogonal(self):
         uElements = {
             "11": ["0.01", "0.02"],


### PR DESCRIPTION
### Description of work

Added check in LoadCIF so that negative Uiso values get set to zero instead, and a warning is logged. That way LoadCIF can still function without failing on negative Uiso values.


Assisted-by: Opus 5 noreply@anthropic.com

Closes EWM item [16607](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16607)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Make sure the tests pass or try to load a CIF that has negative Uiso values and see that a warning gets logged.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
