### PR TITLE
Fix release notes when using online docs in a nightly install

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -145,7 +145,7 @@ std::string MantidVersion::versionForReleaseNotes(const VersionInfo &version) {
 
   const unsigned long minorVersion = std::stoul(version.minor);
   std::stringstream nextMinorVersionLabel;
-  nextMinorVersionLabel << version.major << "." << minorVersion + 1 << "." << "0";
+  nextMinorVersionLabel << version.major << "." << minorVersion + 1 << ".0";
 
   return nextMinorVersionLabel.str();
 }

--- a/Framework/Kernel/test/MantidVersionTest.h.in
+++ b/Framework/Kernel/test/MantidVersionTest.h.in
@@ -46,6 +46,10 @@ public:
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "3", ""}), "1.2.3");
   }
 
+  void testReleaseNotesWithMoreThanTwoPatchVersionNumbers() {
+      TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "3.4.5.6", ""}), "1.2.3");
+  }
+
   void testReleaseNotesRC() {
     TS_ASSERT_EQUALS(MantidVersion::versionForReleaseNotes({"1", "2", "3", "rc1"}), "1.2.3");
   }

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -8,13 +8,13 @@ from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 _presenter = None
 
 
-def show_help_page(relativeUrl, onlineBaseUrl="https://docs.mantidproject.org/"):
+def show_help_page(relativeUrl):
     """
     Show the help window at the given relative URL path.
-    Local docs path is now determined internally via ConfigService.
+    Local docs path is determined internally via ConfigService.
     """
     global _presenter
     if _presenter is None:
-        _presenter = HelpWindowPresenter(onlineBaseUrl=onlineBaseUrl)
+        _presenter = HelpWindowPresenter()
 
     _presenter.show_help_page(relativeUrl)

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -2,9 +2,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
 
-from qtpy.QtWidgets import QApplication
 from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 
 _presenter = None
@@ -20,46 +18,3 @@ def show_help_page(relativeUrl, onlineBaseUrl="https://docs.mantidproject.org/")
         _presenter = HelpWindowPresenter(onlineBaseUrl=onlineBaseUrl)
 
     _presenter.show_help_page(relativeUrl)
-
-
-def main(cmdargs=sys.argv):
-    """
-    Run this script standalone to test the Python-based Help Window.
-    Local docs path is determined from Mantid's ConfigService.
-    """
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Standalone test of the Python-based Mantid Help Window.")
-    parser.add_argument(
-        "relativeUrl", nargs="?", default="", help="Relative doc path (e.g. 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
-    )
-
-    parser.add_argument(
-        "--online-base-url",
-        default="https://docs.mantidproject.org/",
-        help="Base URL for online docs if local docs path from config is invalid or not found.",
-    )
-    args = parser.parse_args(cmdargs or sys.argv[1:])
-
-    try:
-        import mantid.kernel
-
-        log = mantid.kernel.Logger("HelpWindowBridge")
-        log.information("Mantid kernel imported successfully.")
-    except ImportError as e:
-        print(f"ERROR: Failed to import Mantid Kernel: {e}", file=sys.stderr)
-        print(
-            "Ensure Mantid is built and PYTHONPATH is set correctly (e.g., export PYTHONPATH=/path/to/mantid/build/bin:$PYTHONPATH)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    app = QApplication(sys.argv)
-
-    show_help_page(relativeUrl=args.relativeUrl, onlineBaseUrl=args.online_base_url)
-
-    sys.exit(app.exec())
-
-
-if __name__ == "__main__":
-    main()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -7,37 +7,9 @@
 import os
 
 # --- Logger and ConfigService Setup ---
-try:
-    from mantid.kernel import Logger
-    from mantid.kernel import ConfigService
-except ImportError:
-    print("Warning: Mantid Kernel (Logger/ConfigService) not found, using basic print/dummy.")
-
-    class Logger:
-        def __init__(self, name):
-            self._name = name
-
-        def warning(self, msg):
-            print(f"WARNING [{self._name}]: {msg}")
-
-        def debug(self, msg):
-            print(f"DEBUG [{self._name}]: {msg}")
-
-        def information(self, msg):
-            print(f"INFO [{self._name}]: {msg}")
-
-        def error(self, msg):
-            print(f"ERROR [{self._name}]: {msg}")
-
-    class ConfigService:  # Dummy for environments without Mantid
-        @staticmethod
-        def Instance():
-            class DummyInstance:
-                def getString(self, key, pathAbsolute=True):
-                    return None
-
-            return DummyInstance()
-
+from mantid.kernel import Logger
+from mantid.kernel import ConfigService
+from mantid.kernel import version
 
 log = Logger("HelpWindowModel")
 # --------------------------------------
@@ -47,28 +19,20 @@ from qtpy.QtCore import QUrl  # noqa: E402
 
 
 def getMantidVersionString():
-    """Placeholder function to get Mantid version (e.g., 'v6.13.0')."""
-    try:
-        import mantid  # Keep import local as it might fail
+    # Assume it's a nightly build if patch > 100, (i.e. patch == YYYYMMDD.TIME)
+    if version.patch > 100:
+        return "nightly"
 
-        if hasattr(mantid, "__version__"):
-            versionParts = str(mantid.__version__).split(".")
-            if len(versionParts) >= 2:
-                return f"v{versionParts[0]}.{versionParts[1]}.0"
-    except ImportError:
-        pass  # Mantid might not be available
-    log.warning("Could not determine Mantid version for documentation URL.")
-    return None
+    return f"v{version.major}.{version.minor}.{version.patch}"
 
 
 class HelpWindowModel:
     MODE_OFFLINE = "Offline Docs"
     MODE_ONLINE = "Online Docs"
 
-    def __init__(self, online_base="https://docs.mantidproject.org/"):
-        # Store raw online base early, needed for fallback logic below
-        self._raw_online_base = online_base.rstrip("/")
+    ONLINE_BASE_URL = "https://docs.mantidproject.org"
 
+    def __init__(self):
         # --- Step 1: Attempt to get local path ---
         local_docs_path_from_config = self._get_doc_path()
 
@@ -153,8 +117,6 @@ class HelpWindowModel:
             abs_local_path = os.path.abspath(local_docs_path)  # Ensure absolute
             # Base URL for local files needs 'file:///' prefix and correct path format
             self._base_url = QUrl.fromLocalFile(abs_local_path).toString()
-            self._version_string = None  # Version string not applicable for local docs mode
-            log.debug(f"Final state: Mode='{self._mode_string}', Base URL='{self._base_url}'")
 
         else:
             # --- Configure for ONLINE Mode ---
@@ -167,25 +129,13 @@ class HelpWindowModel:
             self._is_local = False
             self._mode_string = self.MODE_ONLINE
 
-            # Attempt to get versioned URL for online mode
-            self._version_string = getMantidVersionString()  # Might return None
+            # Use version string to link to either versioned or nightly docs.
+            version_string = getMantidVersionString()
 
             # Set final base URL based on online path and version string
-            if self._version_string:
-                base_online = self._raw_online_base
-                base_online = base_online.removesuffix("/stable")
-                # Avoid double versioning if base_online already has it
-                if self._version_string not in base_online:
-                    self._base_url = f"{base_online.rstrip('/')}/{self._version_string}"
-                    log.debug(f"Using versioned online URL: {self._base_url}")
-                else:  # Use provided base as-is (likely includes 'stable' or version)
-                    self._base_url = self._raw_online_base
-                    log.debug(f"Using provided online base URL (version/stable implied): {self._base_url}")
-            else:  # No version string found, use raw online base
-                self._base_url = self._raw_online_base
-                log.debug(f"Using default online base URL (version unknown): {self._base_url}")
+            self._base_url = f"{self.ONLINE_BASE_URL}/{version_string}"
 
-            log.debug(f"Final state: Mode='{self._mode_string}', Base URL='{self._base_url}', Version='{self._version_string}'")
+        log.debug(f"Final state: Mode='{self._mode_string}', Base URL='{self._base_url}'")
 
     # --- Getter methods remain the same ---
     def is_local_docs_mode(self):

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -20,10 +20,10 @@ from qtpy.QtCore import QUrl  # noqa: E402
 
 def getMantidVersionString():
     # Assume it's a nightly build if patch > 100, (i.e. patch == YYYYMMDD.TIME)
-    if version.patch > 100:
+    if int(float(version().patch)) > 100:
         return "nightly"
 
-    return f"v{version.major}.{version.minor}.{version.patch}"
+    return f"v{version().major}.{version().minor}.{version().patch}"
 
 
 class HelpWindowModel:

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -19,11 +19,12 @@ from qtpy.QtCore import QUrl  # noqa: E402
 
 
 def getMantidVersionString():
+    first_patch_number = int(version().patch.split(".", 1)[0])
     # Assume it's a nightly build if patch > 100, (i.e. patch == YYYYMMDD.TIME)
-    if int(float(version().patch)) > 100:
+    if first_patch_number > 100:
         return "nightly"
 
-    return f"v{version().major}.{version().minor}.{version().patch}"
+    return f"v{version().major}.{version().minor}.{first_patch_number}"
 
 
 class HelpWindowModel:

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -38,10 +38,9 @@ class HelpWindowPresenter:
     Uses QDesktopServices to open both local and online documentation URLs.
     """
 
-    def __init__(self, parentApp=None, onlineBaseUrl="https://docs.mantidproject.org/"):
-        log.debug(f"Initializing with onlineBaseUrl='{onlineBaseUrl}'")
+    def __init__(self, parentApp=None):
         try:
-            self.model = HelpWindowModel(online_base=onlineBaseUrl)
+            self.model = HelpWindowModel()
         except Exception as e:
             log.error(f"Failed to initialize HelpWindowModel: {e}")
             self.model = None

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -64,7 +64,7 @@ class HelpWindowPresenter:
             log.error(f"Documentation file not found: {e}")
             # Fallback to online docs if local file not found
             try:
-                fallback_url = QUrl(f"{self.model._raw_online_base}/{relativeUrl}")
+                fallback_url = QUrl(f"{self.model.ONLINE_BASE_URL}/{relativeUrl}")
                 log.debug(f"Attempting fallback to online docs: {fallback_url.toString()}")
                 if not QDesktopServices.openUrl(fallback_url):
                     log.error(f"Failed to open fallback URL: {fallback_url.toString()}")

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -72,29 +72,3 @@ class HelpWindowPresenter:
                 log.error(f"Fallback to online docs failed: {fallback_error}")
         except Exception as e:
             log.error(f"Error opening help page '{relativeUrl}': {e}")
-
-    def show_home_page(self):
-        """
-        Opens the documentation home page in the system browser.
-        """
-        if not self.model:
-            log.error("Cannot show home page, model is not available.")
-            return
-
-        log.debug("Opening home page in system browser.")
-        try:
-            homeUrl = self.model.get_home_url()
-            if not QDesktopServices.openUrl(homeUrl):
-                log.error(f"Failed to open home URL in system browser: {homeUrl.toString()}")
-        except FileNotFoundError as e:
-            log.error(f"Home page file not found: {e}")
-            # Fallback to online docs
-            try:
-                fallback_url = QUrl(f"{self.model._raw_online_base}/index.html")
-                log.debug(f"Attempting fallback to online home page: {fallback_url.toString()}")
-                if not QDesktopServices.openUrl(fallback_url):
-                    log.error(f"Failed to open fallback home URL: {fallback_url.toString()}")
-            except Exception as fallback_error:
-                log.error(f"Fallback to online home page failed: {fallback_error}")
-        except Exception as e:
-            log.error(f"Error opening home page: {e}")

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -231,5 +231,35 @@ class TestHelpWindowModelDocPathDiscovery(unittest.TestCase):
         self.assertEqual(discovered_path, "", "Should return empty string when no docs found")
 
 
+class TestHelpWindowModelOnlineUrl(unittest.TestCase):
+    def test_nightly_url_with_nightly_version_number(self):
+        # Return empty string from _get_doc_path to force online mode.
+        with (
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.version") as mock_version,
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.HelpWindowModel._get_doc_path", return_value=""),
+        ):
+            # Set version number to a nightly version.
+            mock_version.return_value.major = "6"
+            mock_version.return_value.minor = "13"
+            mock_version.return_value.patch = "20260904.1412"
+            model = HelpWindowModel()
+            self.assertEqual(model.MODE_ONLINE, model.get_mode_string())
+            self.assertEqual(model.ONLINE_BASE_URL + "/nightly/", model.get_base_url())
+
+    def test_nightly_url_with_release_version_number(self):
+        # Return empty string from _get_doc_path to force online mode.
+        with (
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.version") as mock_version,
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.HelpWindowModel._get_doc_path", return_value=""),
+        ):
+            # Set version number to a release version.
+            mock_version.return_value.major = "6"
+            mock_version.return_value.minor = "13"
+            mock_version.return_value.patch = "1"
+            model = HelpWindowModel()
+            self.assertEqual(model.MODE_ONLINE, model.get_mode_string())
+            self.assertEqual(model.ONLINE_BASE_URL + "/v6.13.1/", model.get_base_url())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -14,7 +14,6 @@ from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel
 # --- Define Constants ---
 CONFIG_SERVICE_LOOKUP_PATH = "mantidqt.widgets.helpwindow.helpwindowmodel.ConfigService"
 VERSION_FUNC_LOOKUP_PATH = "mantidqt.widgets.helpwindow.helpwindowmodel.getMantidVersionString"
-ONLINE_BASE_EXAMPLE = "https://example.org"
 # ------------------------
 
 
@@ -40,7 +39,7 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
 
         mock_ConfigService.getPropertiesDir.return_value = self.props_dir
 
-        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
+        model = HelpWindowModel()
 
         self.assertTrue(model.is_local_docs_mode(), "Expected is_local_docs_mode() True")
         self.assertEqual(model.MODE_OFFLINE, model.get_mode_string(), "Expected mode string 'Offline Docs'")
@@ -87,18 +86,18 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
         """Test online mode when ConfigService returns emtpy path."""
         mock_ConfigService.getPropertiesDir.return_value = ""
 
-        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
+        model = HelpWindowModel()
 
         self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() False")
         self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string 'Online Docs'")
         test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
         self.assertFalse(test_url.isLocalFile(), "Expected a non-local (http/https) URL")
         self.assertEqual(test_url.scheme(), "https")
-        self.assertTrue(ONLINE_BASE_EXAMPLE in test_url.toString())
+        self.assertTrue(model.ONLINE_BASE_URL in test_url.toString())
         self.assertTrue("algorithms/MyAlgorithm-v1.html" in test_url.toString())
         home_url = model.get_home_url()
         self.assertFalse(home_url.isLocalFile(), "Expected an online docs home URL")
-        self.assertTrue(ONLINE_BASE_EXAMPLE in home_url.toString())
+        self.assertTrue(model.ONLINE_BASE_URL in home_url.toString())
 
         mock_ConfigService.getPropertiesDir.assert_called_once_with()
 
@@ -107,35 +106,12 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
         """Test fallback to online mode when ConfigService returns an invalid/non-existent directory path."""
         mock_ConfigService.getPropertiesDir.return_value = self.invalid_path
 
-        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
+        model = HelpWindowModel()
 
         self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() False")
         self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string 'Online Docs' on fallback")
 
         mock_ConfigService.getPropertiesDir.assert_called_once_with()
-
-    @patch(CONFIG_SERVICE_LOOKUP_PATH)
-    @patch(VERSION_FUNC_LOOKUP_PATH, return_value=None)
-    def test_online_url_construction_with_trailing_slashes(self, mock_version_func, mock_ConfigService):
-        """Test online base URL construction handles trailing slashes correctly (forced online)."""
-        mock_ConfigService.getPropertiesDir.return_value = ""
-
-        model1 = HelpWindowModel(online_base="https://example.org")
-        model2 = HelpWindowModel(online_base="https://example.org/")
-
-        self.assertFalse(model1.is_local_docs_mode(), "Model1 should be in online mode")
-        self.assertFalse(model2.is_local_docs_mode(), "Model2 should be in online mode")
-        self.assertTrue(model1.get_base_url().endswith("/"), "get_base_url() should add trailing slash")
-        self.assertTrue(model2.get_base_url().endswith("/"), "get_base_url() should keep trailing slash")
-        self.assertEqual(model1.get_base_url(), model2.get_base_url(), "Base URLs should be identical")
-
-        url1 = model1.build_help_url("test.html")
-        url2 = model2.build_help_url("test.html")
-
-        self.assertEqual(url1.toString(), url2.toString(), "Generated URLs should be identical")
-        self.assertEqual(url1.toString(), "https://example.org/test.html", "Generated URL should be correct (no version)")
-        self.assertTrue(mock_version_func.called)
-        mock_ConfigService.getPropertiesDir.assert_called()
 
 
 class TestHelpWindowModelDocPathDiscovery(unittest.TestCase):

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -260,6 +260,25 @@ class TestHelpWindowModelOnlineUrl(unittest.TestCase):
             self.assertEqual(model.MODE_ONLINE, model.get_mode_string())
             self.assertEqual(model.ONLINE_BASE_URL + "/v6.13.1/", model.get_base_url())
 
+    def test_nightly_url_with_release_version_number_uses_only_first_patch_number(self):
+        """
+        The version number supports multiple ".patch" numbers, but we generally only
+        upload versioned major.minor.patch, so we must ensure that we strip extra patch
+        numbers in the online help URL.
+        """
+        # Return empty string from _get_doc_path to force online mode.
+        with (
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.version") as mock_version,
+            patch("mantidqt.widgets.helpwindow.helpwindowmodel.HelpWindowModel._get_doc_path", return_value=""),
+        ):
+            # Set version number to a release version.
+            mock_version.return_value.major = "6"
+            mock_version.return_value.minor = "13"
+            mock_version.return_value.patch = "1.2"
+            model = HelpWindowModel()
+            self.assertEqual(model.MODE_ONLINE, model.get_mode_string())
+            self.assertEqual(model.ONLINE_BASE_URL + "/v6.13.1/", model.get_base_url())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -274,7 +274,7 @@ class TestHelpWindowModelOnlineUrl(unittest.TestCase):
             # Set version number to a release version.
             mock_version.return_value.major = "6"
             mock_version.return_value.minor = "13"
-            mock_version.return_value.patch = "1.2"
+            mock_version.return_value.patch = "1.1.3.4"
             model = HelpWindowModel()
             self.assertEqual(model.MODE_ONLINE, model.get_mode_string())
             self.assertEqual(model.ONLINE_BASE_URL + "/v6.13.1/", model.get_base_url())


### PR DESCRIPTION
### Description of work
Fixes the release notes link for nightly packages when docs are in online mode (when you don't have mantiddocs installed). Uses the version number to decide whether it's a nightly version, and if so, sets the base of the URL to the nightly docs site. Otherwise, points to the released version of the release notes.

Also removed some redundant code from when we shipped a Python help widget.

Closes #42149 

### To test:
**On Linux only**. A few things to check to give good coverage. In all cases, launch mantidworkbench and click the release notes button in the about widget:
1. Into a new conda environment: `mamba install -c mantid-test/label/nightly-docs-nightly mantidworkbench`. Should take you to v7.0 release notes using nightly link.
2. Into the same conda env as above: `mamba install -c mantid-test/label/nightly-docs-nightly mantiddocs`. Should take you to v7.0 release notes using local file system.
3. Into a new conda environment: `mamba install -c mantid-test/label/nightly-docs-release mantidworkbench`. Should take you to the v6.16.1 release notes using the v6.16.1 versioned docs online.
4. Into the same conda environment as above  `mamba install -c mantid-test/label/nightly-docs-release mantiddocs`. Should take you to the v6.16.1 release notes on local file system.

You can also try to open some other help windows without mantiddocs installed to see what happens.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
