### PR TITLE
Restore unit labels on Instrument View line plot

### DIFF
--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -254,7 +254,7 @@ class FullInstrumentViewView(QWidget):
 
         self._detector_spectrum_fig = Figure()
         self._detector_spectrum_axes = self._detector_spectrum_fig.add_subplot(111, projection="mantid")
-        self._detector_spectrum_fig.set_layout_engine(layout="tight")
+        self._detector_spectrum_fig.set_layout_engine(layout="constrained")
         self._detector_figure_canvas = FigureCanvas(self._detector_spectrum_fig)
         self._detector_figure_canvas.setMinimumSize(QSize(0, 0))
         self._plot_toolbar = MantidNavigationToolbar(self._detector_figure_canvas, None)

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -254,7 +254,7 @@ class FullInstrumentViewView(QWidget):
 
         self._detector_spectrum_fig = Figure()
         self._detector_spectrum_axes = self._detector_spectrum_fig.add_subplot(111, projection="mantid")
-        self._detector_spectrum_fig.subplots_adjust(left=0.05, right=0.98, bottom=0.1, top=0.95)
+        self._detector_spectrum_fig.set_layout_engine(layout="tight")
         self._detector_figure_canvas = FigureCanvas(self._detector_spectrum_fig)
         self._detector_figure_canvas.setMinimumSize(QSize(0, 0))
         self._plot_toolbar = MantidNavigationToolbar(self._detector_figure_canvas, None)
@@ -1239,7 +1239,7 @@ class FullInstrumentViewView(QWidget):
 
             for x, label in zip(x_values, labels):
                 self._lineplot_overlays.append(self._detector_spectrum_axes.axvline(x, color=item_color, linestyle="--"))
-                self._detector_spectrum_axes.text(
+                peak_label = self._detector_spectrum_axes.text(
                     x,
                     0.99,
                     label,
@@ -1250,6 +1250,7 @@ class FullInstrumentViewView(QWidget):
                     fontsize=8,
                     rotation=90,
                 )
+                peak_label.set_in_layout(False)
             self.redraw_lineplot()
 
     @_skip_if_closing

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.layout_engine import TightLayoutEngine
+from matplotlib.layout_engine import ConstrainedLayoutEngine
 from qtpy.QtCore import Qt
 from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import CreateSampleWorkspace
@@ -174,9 +174,9 @@ class TestFullInstrumentViewView(unittest.TestCase):
         self._view.redraw_lineplot()
         self._view._detector_figure_canvas.draw.assert_called_once()
 
-    def test_lineplot_figure_uses_tight_layout(self):
+    def test_lineplot_figure_uses_constrained_layout(self):
         # Keeps the axis labels, which carry the units, inside the canvas as the pane is resized
-        self.assertIsInstance(self._view._detector_spectrum_fig.get_layout_engine(), TightLayoutEngine)
+        self.assertIsInstance(self._view._detector_spectrum_fig.get_layout_engine(), ConstrainedLayoutEngine)
 
     def test_axis_labels_visible_when_peak_labels_outside_plot_range(self):
         # A peak label outside the x range used to defeat the tight layout, which then warned and gave
@@ -197,7 +197,7 @@ class TestFullInstrumentViewView(unittest.TestCase):
             warnings.simplefilter("always")
             figure.canvas.draw()
 
-        self.assertEqual([], [str(w.message) for w in caught if "Tight layout" in str(w.message)])
+        self.assertEqual([], [str(w.message) for w in caught if "Constrained layout" in str(w.message)])
         renderer = figure.canvas.get_renderer()
         self.assertGreater(axes.xaxis.label.get_window_extent(renderer).y0, 0)
         self.assertGreater(axes.yaxis.label.get_window_extent(renderer).x0, 0)

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -5,10 +5,13 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL-3.0+
 import unittest
+import warnings
 from unittest import mock
 from unittest.mock import MagicMock
 
 import numpy as np
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.layout_engine import TightLayoutEngine
 from qtpy.QtCore import Qt
 from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import CreateSampleWorkspace
@@ -170,6 +173,34 @@ class TestFullInstrumentViewView(unittest.TestCase):
     def test_redraw_lineplot(self):
         self._view.redraw_lineplot()
         self._view._detector_figure_canvas.draw.assert_called_once()
+
+    def test_lineplot_figure_uses_tight_layout(self):
+        # Keeps the axis labels, which carry the units, inside the canvas as the pane is resized
+        self.assertIsInstance(self._view._detector_spectrum_fig.get_layout_engine(), TightLayoutEngine)
+
+    def test_axis_labels_visible_when_peak_labels_outside_plot_range(self):
+        # A peak label outside the x range used to defeat the tight layout, which then warned and gave
+        # up, leaving the axis labels, and so the units, off the canvas
+        figure = self._view._detector_spectrum_fig
+        FigureCanvasAgg(figure)
+        axes = self._view._detector_spectrum_axes
+        axes.set_xlabel("Time-of-flight")
+        axes.set_ylabel("Counts")
+        axes.set_xlim(0, 1)
+        mock_item = MagicMock()
+        mock_item.foreground().color().name.return_value = "#ff7f0e"
+        self._view._peak_ws_list = MagicMock()
+        self._view._peak_ws_list.findItems.return_value = [mock_item]
+
+        self._view.plot_lineplot_peak_overlays([[85.0]], [["(1,1,1)"]], ["ws1"])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            figure.canvas.draw()
+
+        self.assertEqual([], [str(w.message) for w in caught if "Tight layout" in str(w.message)])
+        renderer = figure.canvas.get_renderer()
+        self.assertGreater(axes.xaxis.label.get_window_extent(renderer).y0, 0)
+        self.assertGreater(axes.yaxis.label.get_window_extent(renderer).x0, 0)
 
     def test_add_rectangular_widget(self) -> None:
         self._view.add_rectangular_widget()


### PR DESCRIPTION
Currently the lineplot in the new IV does not show the axes labels properly when detectors are selected, this fixes that.

PR #41981 (https://github.com/mantidproject/mantid/pull/41981/commits/f5aa290708e430aa7af30a0c2b4b02892cff6ff0) removed calls to `tight_layout` to fix a bug when peak labels were drawn beyond the edge of the axes. But this meant that the axes unit labels were no longer visible. This puts the tight layout back in, but excludes the labels.

### To test:

Check peak overlays and zooming on the line plot so that a labelled peak is beyond the edge of the x axis.

*This does not require release notes* because it's a fix for an unreleased change.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
