### PR TITLE
fixed QWindowsWindow::setGeometry errors by rearranging layout with resizes

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -459,10 +459,10 @@ class MainWindow(QMainWindow):
 
     def prep_window_for_reset(self):
         """Function to reset all dock widgets to a state where they can be
-        ordered by setup_default_layout"""
+        ordered by setup_default_layout.
+        """
         for widget in self.widgets:
             widget.dockwidget.setFloating(False)  # Bring back any floating windows
-            self.addDockWidget(Qt.LeftDockWidgetArea, widget.dockwidget)  # Un-tabify all widgets
             widget.toggle_view(False)
 
     def setup_default_layouts(self):
@@ -489,42 +489,69 @@ class MainWindow(QMainWindow):
                 # column 2
                 [[memorywidget], [logmessages]],
             ],
+            # Relative width of each column, in the same order as "widgets" above.
+            # Only the ratio between entries matters.
+            "column_width_ratios": [1, 3, 1],
         }
 
         size = self.size()  # Preserve size on reset
         self.arrange_layout(default_layout)
+
+        # Don't restore a size larger than the current screen's
+        # available area (mirrors the same clamp already applied in restoreSettings()).
+        available = self.screen().availableGeometry()
+        size = QSize(min(size.width(), available.width()), min(size.height(), available.height()))
         self.resize(size)
 
     def arrange_layout(self, layout):
         """Arrange the layout of the child widgets according to the supplied layout"""
+        # Widgets are now introduced one at a time below,
+        # each immediately split into its own slot, eliminating
+        # the QWindowsWindow::setGeometry warnings
         self.prep_window_for_reset()
         widgets_layout = layout["widgets"]
         with widget_updates_disabled(self):
-            # flatten list
-            widgets = [item for column in widgets_layout for row in column for item in row]
-            # show everything
-            for w in widgets:
-                w.toggle_view(True)
-            # split everything on the horizontal
-            for i in range(len(widgets) - 1):
-                first, second = widgets[i], widgets[i + 1]
-                self.splitDockWidget(first.dockwidget, second.dockwidget, Qt.Horizontal)
-            # now arrange the rows
+            # Fix the column skeleton FIRST, using only each column's
+            # anchor widget (its first row's first widget), before any column
+            # is subdivided internally. Once a column has been split
+            # vertically, its top-row widget only occupies the top slice.
+            column_anchors = [column[0][0] for column in widgets_layout]
+            for anchor in column_anchors:
+                anchor.toggle_view(True)
+            self.addDockWidget(Qt.LeftDockWidgetArea, column_anchors[0].dockwidget)
+            for i in range(len(column_anchors) - 1):
+                self.splitDockWidget(column_anchors[i].dockwidget, column_anchors[i + 1].dockwidget, Qt.Horizontal)
+
+            # subdivide column's full-height
             for column in widgets_layout:
+                # Stack this column's rows vertically, below its own anchor --
+                # never touches any other column's widgets.
                 for i in range(len(column) - 1):
                     first_row, second_row = column[i], column[i + 1]
+                    second_row[0].toggle_view(True)
                     self.splitDockWidget(first_row[0].dockwidget, second_row[0].dockwidget, Qt.Vertical)
 
-            # and finally tabify those in the same position
-            for column in widgets_layout:
+                # Tabify widgets sharing the same row within this column.
                 for row in column:
                     for i in range(len(row) - 1):
                         first, second = row[i], row[i + 1]
+                        second.toggle_view(True)
                         self.tabifyDockWidget(first.dockwidget, second.dockwidget)
 
                     # Raise front widget per row
                     row[0].dockwidget.show()
                     row[0].dockwidget.raise_()
+
+            screen = self.screen() or QApplication.primaryScreen()
+            total_width = screen.availableGeometry().width()
+            ratios = layout.get("column_width_ratios") or [1] * len(column_anchors)
+            ratio_sum = sum(ratios)
+            target_widths = [max(total_width * r // ratio_sum, 1) for r in ratios]
+            self.resizeDocks(
+                [anchor.dockwidget for anchor in column_anchors],
+                target_widths,
+                Qt.Horizontal,
+            )
 
     # ----------------------- Events ---------------------------------
     def closeEvent(self, event):


### PR DESCRIPTION
### Description of work
This PR fixes `QWindowsWindow::setGeometry` errors from mantid workbench when restoring the default layout and docking and redocking widgets. The errors were due to the addition of widget sizes exceeding the available window's dimensions and were resolved by rearranging the column skeleton of the widgets with proper sizes. 

<!-- Please provide an outline and reasoning for the work.
If there is no linked issue provide context.
-->

Closes #42088. <!-- One line per closed issue. -->

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1. laucnh mantid workbench
2. try view->restore default layout
3. the default view should be restored
4. there should not be any `QWindowsWindow::setGeometry` error in the launch console.
5. repeat the same with different displays ex: additional monitors
6. repeat the same when mantid workbench is maximized or not maximized
7. repeat the test after undocking widgets and changing the default view in mantid workbench

**Note** : there is a separate issue giving the below warning at startup and was **not** fixed in this PR
`QFont::setPointSize: Point size <= 0 (-1), must be greater than 0`

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
