### PR TITLE
Move IMAGINE MaskBTPTest to systemtest so we can set required memory

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -8,7 +8,7 @@ import unittest
 from unittest import mock
 from mantid.api import mtd, AnalysisDataService
 from mantid.kernel import config
-from mantid.simpleapi import ClearMaskFlag, DeleteWorkspace, LoadEmptyInstrument, MaskBTP
+from mantid.simpleapi import DeleteWorkspace, LoadEmptyInstrument, MaskBTP
 from testhelpers import WorkspaceCreationHelper
 from numpy import concatenate, arange, sort, array_equal, where
 
@@ -330,35 +330,6 @@ class MaskBTPTest(unittest.TestCase):
         masked_pixels = MaskBTP(Workspace=ws_name, Pixel="0-9")
         # 10 pixels * 512 tubes * 3 banks
         self.assertEqual(len(masked_pixels), 10 * 512 * 3)
-        self.checkConsistentMask(wksp, masked_pixels)
-
-        DeleteWorkspace(ws_name)
-
-    def testIMAGINEMaskBTP(self):
-        ws_name = mtd.unique_hidden_name()
-        LoadEmptyInstrument(InstrumentName="IMAGINE", OutputWorkspace=ws_name)
-        wksp = mtd[ws_name]
-
-        # Test masking individual bank 11 (512*512 pixels)
-        masked_bank11 = MaskBTP(Workspace=ws_name, Bank="11")
-        self.assertEqual(len(masked_bank11), 512 * 512)
-        self.checkConsistentMask(wksp, masked_bank11)
-
-        # Clear mask to start fresh
-        ClearMaskFlag(Workspace=ws_name)
-
-        # Test masking multiple banks (banks 11-18, first series)
-        masked_banks = MaskBTP(Workspace=ws_name, Bank="11-18")
-        self.assertEqual(len(masked_banks), 8 * 512 * 512)
-        self.checkConsistentMask(wksp, masked_banks)
-
-        # Clear mask to start fresh
-        ClearMaskFlag(Workspace=ws_name)
-
-        # Test masking specific pixels (first 10 pixels in all banks, 0-indexed)
-        masked_pixels = MaskBTP(Workspace=ws_name, Pixel="0-9")
-        # 10 pixels * 512 tubes * 80 banks
-        self.assertEqual(len(masked_pixels), 10 * 512 * 80)
         self.checkConsistentMask(wksp, masked_pixels)
 
         DeleteWorkspace(ws_name)

--- a/Testing/SystemTests/tests/framework/CMakeLists.txt
+++ b/Testing/SystemTests/tests/framework/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SYSTEST_NAMES
     # LRReductionWithReferenceTest  # Skipped due to missing import.
     LRScalingFactorsTest.py
     MagnetismReflectometryReductionTest.py
+    MaskBTPTest.py
     MaxEntTest.py
     MDNormBackgroundHYSPECTest.py
     MDNormCORELLITest.py

--- a/Testing/SystemTests/tests/framework/MaskBTPTest.py
+++ b/Testing/SystemTests/tests/framework/MaskBTPTest.py
@@ -1,0 +1,70 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import systemtesting
+from mantid.api import mtd
+from mantid.simpleapi import ClearMaskFlag, DeleteWorkspace, LoadEmptyInstrument, MaskBTP
+
+# tests run x10 slower with this on, but it may be useful to track down issues refactoring
+CHECK_CONSISTENCY = False
+
+
+class MaskBTPTest(systemtesting.MantidSystemTest):
+    """MaskBTP on IMAGINE, which has 80 banks of 512x512 pixels. This is a system test
+    rather than a unit test purely because of the memory needed to hold the instrument."""
+
+    def requiredMemoryMB(self):
+        """Requires 30Gb"""
+        return 30000
+
+    def checkConsistentMask(self, wksp, masked):
+        if not CHECK_CONSISTENCY:
+            return
+        compInfo = wksp.componentInfo()
+        detInfo = wksp.detectorInfo()
+        # detector ids are any number, detector index are 0->number of detectors
+        detIds = detInfo.detectorIDs()
+        for detIndex, detId in enumerate(detIds):
+            if not compInfo.isDetector(detIndex):
+                continue
+
+            if detInfo.isMonitor(detIndex):
+                self.assertFalse(detInfo.isMasked(detIndex), "DetID={} is a monitor and shouldn't be masked".format(detId))
+            else:
+                self.assertEqual(
+                    detInfo.isMasked(detIndex),
+                    detId in masked,
+                    'DetID={} is has incorrect mask bit. "{}" should be "{}"'.format(detId, detInfo.isMasked(int(detId)), detId in masked),
+                )
+
+    def runTest(self):
+        ws_name = mtd.unique_hidden_name()
+        LoadEmptyInstrument(InstrumentName="IMAGINE", OutputWorkspace=ws_name)
+        wksp = mtd[ws_name]
+
+        # Test masking individual bank 11 (512*512 pixels)
+        masked_bank11 = MaskBTP(Workspace=ws_name, Bank="11")
+        self.assertEqual(len(masked_bank11), 512 * 512)
+        self.checkConsistentMask(wksp, masked_bank11)
+
+        # Clear mask to start fresh
+        ClearMaskFlag(Workspace=ws_name)
+
+        # Test masking multiple banks (banks 11-18, first series)
+        masked_banks = MaskBTP(Workspace=ws_name, Bank="11-18")
+        self.assertEqual(len(masked_banks), 8 * 512 * 512)
+        self.checkConsistentMask(wksp, masked_banks)
+
+        # Clear mask to start fresh
+        ClearMaskFlag(Workspace=ws_name)
+
+        # Test masking specific pixels (first 10 pixels in all banks, 0-indexed)
+        masked_pixels = MaskBTP(Workspace=ws_name, Pixel="0-9")
+        # 10 pixels * 512 tubes * 80 banks
+        self.assertEqual(len(masked_pixels), 10 * 512 * 80)
+        self.checkConsistentMask(wksp, masked_pixels)
+
+        DeleteWorkspace(ws_name)


### PR DESCRIPTION
### Description of work

Loading the IMAGINE IDF requires lots of memory so moving the MaskBTPTest for IMAGINE to a systemtest so we can set required memory and unittests can be run on systems with less than 32Gb of RAM.

The IDF and test was originally added in #40824


### To test:

The system test for MaskBTP should now skip when you have insufficient memory,

```
Test module MaskBTPTest has 1 test:
    - MaskBTPTest.MaskBTPTest
Insufficient memory available to run test! 24333.2 MB available, need 30000 MB.
```

<!-- Include sufficient instructions for someone unfamiliar with the application to test.
Ok to refer back to instructions in the issue.
-->

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
