### PR TITLE
Post Automated UI test results to Slack 

### DIFF
--- a/.github/scripts/ui_test_slack_summary.py
+++ b/.github/scripts/ui_test_slack_summary.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+"""Summarise the weekly automated UI test results as a Slack message.
+
+The results are the per-platform JUnit files that .github/workflows/weekly_ui_tests.yml
+uploads as artifacts. This reads them and writes a Slack Block Kit payload to a file; it
+does not post it. The workflow does that with curl, which keeps the webhook URL out of this
+script's environment entirely.
+
+The message is failure-list-first: every failing test is named, and no failure message or
+traceback is included. It exists to answer "what broke, and is it the same thing as last
+week" at a glance - the detail is one click away in the check runs and the test log
+artifacts, and reproducing a failure needs the test name rather than its output. A test is
+named by its JUnit `name` attribute alone, which for the ctest --output-junit file this
+reads is the ctest test name, i.e. what `ctest -R <name>` takes.
+
+A platform whose file is missing is reported rather than skipped. That is the case where
+the build itself failed, which is both the most important thing to say and the easiest to
+lose silently.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from xml.etree import ElementTree
+
+# The matrix.os values of weekly_ui_tests.yml, which name its artifacts
+PLATFORMS = ("Linux", "Windows")
+
+# Where the workflow's download-artifact step puts them
+ARTIFACT_DIR = pathlib.Path("artifacts")
+ARTIFACT_NAME = "junit-automated-ui-{platform}"
+JUNIT_FILENAME = "junit-uitest.xml"
+
+# A section block's text field caps at 3000 characters, so a platform's failing tests are
+# split over as many blocks as they need rather than being truncated. Kept below the limit
+# so that adding the heading line to a chunk cannot push it over.
+SECTION_TEXT_LIMIT = 2800
+
+# A message caps at 50 blocks. Past this many the list is cut short with a count of the
+# rest, so that a pathological run degrades instead of being rejected by the API.
+MAX_BLOCKS = 40
+
+
+def _summarise(junit_path: pathlib.Path) -> tuple[int, int, list]:
+    """Return (total, skipped, failing test names) for one JUnit file.
+
+    ctest --output-junit writes a single root <testsuite>; a <testsuites> wrapper is also
+    accepted so that a file from any other producer reads the same way.
+    """
+    root = ElementTree.parse(junit_path).getroot()
+    suites = [root] if root.tag == "testsuite" else root.iter("testsuite")
+
+    total = skipped = 0
+    failing = []
+    for suite in suites:
+        for case in suite.iter("testcase"):
+            total += 1
+            # ctest marks a test it did not run with status="notrun" as well as <skipped/>
+            if case.find("skipped") is not None or case.get("status") == "notrun":
+                skipped += 1
+            elif case.find("failure") is not None or case.find("error") is not None:
+                failing.append(case.get("name", "<unnamed test>"))
+
+    return total, skipped, failing
+
+
+def _failure_lines(names: list) -> list:
+    """Return the bulleted failing test names, cut short if there are absurdly many."""
+    listed = names[: MAX_BLOCKS * 10]
+    lines = [f"    • `{name}`" for name in listed]
+    if len(names) > len(listed):
+        lines.append(f"    • …and {len(names) - len(listed)} more, see the run")
+
+    return lines
+
+
+def _chunk(heading: str, lines: list) -> list:
+    """Return the section block texts for a heading and its lines, none over the size cap."""
+    texts = []
+    current = heading
+    for line in lines:
+        if len(current) + len(line) + 1 > SECTION_TEXT_LIMIT:
+            texts.append(current)
+            current = line
+        else:
+            current = f"{current}\n{line}"
+    texts.append(current)
+
+    return texts
+
+
+def _platform_sections(platform: str) -> tuple[list, bool]:
+    """Return the section block texts for one platform, and whether it needs attention."""
+    junit_path = ARTIFACT_DIR / ARTIFACT_NAME.format(platform=platform) / JUNIT_FILENAME
+    if not junit_path.exists():
+        return [f":question: *{platform}* — no results (build or upload failed)"], True
+
+    total, skipped, failing = _summarise(junit_path)
+    if not failing:
+        return [f":large_green_circle: *{platform}* — {total} passed, {skipped} skipped"], False
+
+    heading = f":red_circle: *{platform}* — {len(failing)} of {total} failed, {skipped} skipped"
+
+    return _chunk(heading, _failure_lines(failing)), True
+
+
+def _run_url() -> str:
+    return "{}/{}/actions/runs/{}".format(
+        os.environ.get("GITHUB_SERVER_URL", "https://github.com"),
+        os.environ.get("GITHUB_REPOSITORY", "mantidproject/mantid"),
+        os.environ.get("GITHUB_RUN_ID", "0"),
+    )
+
+
+def _payload() -> dict:
+    texts = []
+    needs_attention = False
+    for platform in PLATFORMS:
+        platform_texts, platform_needs_attention = _platform_sections(platform)
+        texts.extend(platform_texts)
+        needs_attention = needs_attention or platform_needs_attention
+
+    header = ":warning: Weekly UI tests: failures" if needs_attention else ":white_check_mark: Weekly UI tests: all green"
+
+    # Two of the block budget are spent on the header and the context blocks
+    sections = [{"type": "section", "text": {"type": "mrkdwn", "text": text}} for text in texts[: MAX_BLOCKS - 2]]
+
+    return {
+        # The notification preview and screen reader fallback: a Block Kit message without
+        # it arrives looking empty
+        "text": header,
+        "blocks": [
+            {"type": "header", "text": {"type": "plain_text", "text": header, "emoji": True}},
+            *sections,
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": f"<{_run_url()}|Full run and artifacts>"}]},
+        ],
+    }
+
+
+def _parse_args(argv: list) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarise the weekly automated UI test results as a Slack message.")
+    parser.add_argument("output_file", type=pathlib.Path, help="File to write the Slack Block Kit payload to")
+
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args(sys.argv[1:])
+    payload = _payload()
+    args.output_file.write_text(json.dumps(payload), encoding="utf-8")
+    print(f"Wrote Slack payload to {args.output_file}:")
+    print(json.dumps(payload, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ui_test_slack_summary.py
+++ b/.github/scripts/ui_test_slack_summary.py
@@ -115,6 +115,20 @@ def _run_url() -> str:
     )
 
 
+def _escape(text: str) -> str:
+    """Escape the three characters Slack treats as markup in message text."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _branch() -> str:
+    """The branch the run used: the default branch on a schedule, the chosen one on a dispatch.
+
+    Worth stating, because a dispatched run from a feature branch is otherwise
+    indistinguishable from the Sunday run of main.
+    """
+    return _escape(os.environ.get("GITHUB_REF_NAME", "unknown"))
+
+
 def _payload() -> dict:
     texts = []
     needs_attention = False
@@ -135,7 +149,10 @@ def _payload() -> dict:
         "blocks": [
             {"type": "header", "text": {"type": "plain_text", "text": header, "emoji": True}},
             *sections,
-            {"type": "context", "elements": [{"type": "mrkdwn", "text": f"<{_run_url()}|Full run and artifacts>"}]},
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"Branch `{_branch()}` · <{_run_url()}|Full run and artifacts>"}],
+            },
         ],
     }
 

--- a/.github/scripts/ui_test_slack_summary.py
+++ b/.github/scripts/ui_test_slack_summary.py
@@ -2,21 +2,14 @@
 
 """Summarise the weekly automated UI test results as a Slack message.
 
-The results are the per-platform JUnit files that .github/workflows/weekly_ui_tests.yml
-uploads as artifacts. This reads them and writes a Slack Block Kit payload to a file; it
-does not post it. The workflow does that with curl, which keeps the webhook URL out of this
-script's environment entirely.
+Reads the per-platform JUnit files that .github/workflows/weekly_ui_tests.yml uploads as
+artifacts and writes a Slack Block Kit payload. The workflow posts it with curl, so the
+webhook URL never enters this script's environment.
 
-The message is failure-list-first: every failing test is named, and no failure message or
-traceback is included. It exists to answer "what broke, and is it the same thing as last
-week" at a glance - the detail is one click away in the check runs and the test log
-artifacts, and reproducing a failure needs the test name rather than its output. A test is
-named by its JUnit `name` attribute alone, which for the ctest --output-junit file this
-reads is the ctest test name, i.e. what `ctest -R <name>` takes.
-
-A platform whose file is missing is reported rather than skipped. That is the case where
-the build itself failed, which is both the most important thing to say and the easiest to
-lose silently.
+Every failing test is named and no failure output is included: the JUnit name is the ctest
+test name, i.e. what `ctest -R` takes to reproduce one, and the output is a click away in
+the check runs and the test log artifacts. A platform whose file is missing is reported
+rather than skipped - that is the run where the build itself died.
 """
 
 import argparse
@@ -26,31 +19,23 @@ import pathlib
 import sys
 from xml.etree import ElementTree
 
-# The matrix.os values of weekly_ui_tests.yml, which name its artifacts
 PLATFORMS = ("Linux", "Windows")
 
-# Where the workflow's download-artifact step puts them
-ARTIFACT_DIR = pathlib.Path("artifacts")
-ARTIFACT_NAME = "junit-automated-ui-{platform}"
-JUNIT_FILENAME = "junit-uitest.xml"
+# Where weekly_ui_tests.yml's download-artifact step puts each platform's results
+JUNIT_PATH = "artifacts/junit-automated-ui-{platform}/junit-uitest.xml"
 
-# A section block's text field caps at 3000 characters, so a platform's failing tests are
-# split over as many blocks as they need rather than being truncated. Kept below the limit
-# so that adding the heading line to a chunk cannot push it over.
+# A section block's text caps at 3000 characters, so a long list is split over several
 SECTION_TEXT_LIMIT = 2800
 
-# A message caps at 50 blocks. Past this many the list is cut short with a count of the
-# rest, so that a pathological run degrades instead of being rejected by the API.
-MAX_BLOCKS = 40
+# The suite is ~25 tests, so this never truncates in practice. It is here to bound the
+# block count, as a message caps at 50 blocks.
+MAX_LISTED_FAILURES = 100
 
 
 def _summarise(junit_path: pathlib.Path) -> tuple[int, int, list]:
-    """Return (total, skipped, failing test names) for one JUnit file.
-
-    ctest --output-junit writes a single root <testsuite>; a <testsuites> wrapper is also
-    accepted so that a file from any other producer reads the same way.
-    """
+    """Return (total, skipped, failing test names) for one JUnit file."""
     root = ElementTree.parse(junit_path).getroot()
+    # ctest --output-junit writes a single root <testsuite>; a <testsuites> wrapper is accepted too
     suites = [root] if root.tag == "testsuite" else root.iter("testsuite")
 
     total = skipped = 0
@@ -67,34 +52,25 @@ def _summarise(junit_path: pathlib.Path) -> tuple[int, int, list]:
     return total, skipped, failing
 
 
-def _failure_lines(names: list) -> list:
-    """Return the bulleted failing test names, cut short if there are absurdly many."""
-    listed = names[: MAX_BLOCKS * 10]
-    lines = [f"    • `{name}`" for name in listed]
-    if len(names) > len(listed):
-        lines.append(f"    • …and {len(names) - len(listed)} more, see the run")
+def _failure_sections(heading: str, names: list) -> list:
+    """Return the section texts listing the failing tests, none of them over the size cap."""
+    lines = [f"    • `{name}`" for name in names[:MAX_LISTED_FAILURES]]
+    if len(names) > MAX_LISTED_FAILURES:
+        lines.append(f"    • …and {len(names) - MAX_LISTED_FAILURES} more, see the run")
 
-    return lines
-
-
-def _chunk(heading: str, lines: list) -> list:
-    """Return the section block texts for a heading and its lines, none over the size cap."""
-    texts = []
-    current = heading
+    texts = [heading]
     for line in lines:
-        if len(current) + len(line) + 1 > SECTION_TEXT_LIMIT:
-            texts.append(current)
-            current = line
+        if len(texts[-1]) + len(line) + 1 > SECTION_TEXT_LIMIT:
+            texts.append(line)
         else:
-            current = f"{current}\n{line}"
-    texts.append(current)
+            texts[-1] = f"{texts[-1]}\n{line}"
 
     return texts
 
 
 def _platform_sections(platform: str) -> tuple[list, bool]:
-    """Return the section block texts for one platform, and whether it needs attention."""
-    junit_path = ARTIFACT_DIR / ARTIFACT_NAME.format(platform=platform) / JUNIT_FILENAME
+    """Return the section texts for one platform, and whether it needs attention."""
+    junit_path = pathlib.Path(JUNIT_PATH.format(platform=platform))
     if not junit_path.exists():
         return [f":question: *{platform}* — no results (build or upload failed)"], True
 
@@ -102,73 +78,46 @@ def _platform_sections(platform: str) -> tuple[list, bool]:
     if not failing:
         return [f":large_green_circle: *{platform}* — {total} passed, {skipped} skipped"], False
 
-    heading = f":red_circle: *{platform}* — {len(failing)} of {total} failed, {skipped} skipped"
-
-    return _chunk(heading, _failure_lines(failing)), True
+    return _failure_sections(f":red_circle: *{platform}* — {len(failing)} of {total} failed, {skipped} skipped", failing), True
 
 
-def _run_url() -> str:
-    return "{}/{}/actions/runs/{}".format(
-        os.environ.get("GITHUB_SERVER_URL", "https://github.com"),
-        os.environ.get("GITHUB_REPOSITORY", "mantidproject/mantid"),
-        os.environ.get("GITHUB_RUN_ID", "0"),
-    )
+def _context() -> str:
+    """The branch and run link. The branch is named because a dispatch otherwise looks like the Sunday run."""
+    env = os.environ.get
+    branch = env("GITHUB_REF_NAME", "unknown").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    repository = f"{env('GITHUB_SERVER_URL', 'https://github.com')}/{env('GITHUB_REPOSITORY', 'mantidproject/mantid')}"
 
-
-def _escape(text: str) -> str:
-    """Escape the three characters Slack treats as markup in message text."""
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-
-
-def _branch() -> str:
-    """The branch the run used: the default branch on a schedule, the chosen one on a dispatch.
-
-    Worth stating, because a dispatched run from a feature branch is otherwise
-    indistinguishable from the Sunday run of main.
-    """
-    return _escape(os.environ.get("GITHUB_REF_NAME", "unknown"))
+    return f"Branch `{branch}` · <{repository}/actions/runs/{env('GITHUB_RUN_ID', '0')}|Full run and artifacts>"
 
 
 def _payload() -> dict:
     texts = []
     needs_attention = False
     for platform in PLATFORMS:
-        platform_texts, platform_needs_attention = _platform_sections(platform)
+        platform_texts, platform_failed = _platform_sections(platform)
         texts.extend(platform_texts)
-        needs_attention = needs_attention or platform_needs_attention
+        needs_attention |= platform_failed
 
     header = ":warning: Weekly UI tests: failures" if needs_attention else ":white_check_mark: Weekly UI tests: all green"
 
-    # Two of the block budget are spent on the header and the context blocks
-    sections = [{"type": "section", "text": {"type": "mrkdwn", "text": text}} for text in texts[: MAX_BLOCKS - 2]]
-
     return {
-        # The notification preview and screen reader fallback: a Block Kit message without
-        # it arrives looking empty
+        # The notification preview and screen reader fallback; without it the message arrives looking empty
         "text": header,
         "blocks": [
             {"type": "header", "text": {"type": "plain_text", "text": header, "emoji": True}},
-            *sections,
-            {
-                "type": "context",
-                "elements": [{"type": "mrkdwn", "text": f"Branch `{_branch()}` · <{_run_url()}|Full run and artifacts>"}],
-            },
+            *({"type": "section", "text": {"type": "mrkdwn", "text": text}} for text in texts),
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": _context()}]},
         ],
     }
 
 
-def _parse_args(argv: list) -> argparse.Namespace:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Summarise the weekly automated UI test results as a Slack message.")
     parser.add_argument("output_file", type=pathlib.Path, help="File to write the Slack Block Kit payload to")
+    args = parser.parse_args(sys.argv[1:])
 
-    return parser.parse_args(argv)
-
-
-def main() -> int:
-    args = _parse_args(sys.argv[1:])
     payload = _payload()
     args.output_file.write_text(json.dumps(payload), encoding="utf-8")
-    print(f"Wrote Slack payload to {args.output_file}:")
     print(json.dumps(payload, indent=2))
 
     return 0

--- a/.github/workflows/weekly_ui_tests.yml
+++ b/.github/workflows/weekly_ui_tests.yml
@@ -183,9 +183,8 @@ jobs:
           action_fail: false
           action_fail_on_inconclusive: false
 
-      # The check runs published above are only found by someone going looking for them, so
-      # the same results are pushed to Slack. Both steps run even when the test job failed,
-      # which is when the notification matters most.
+      # The check runs above are only seen by someone going looking for them. Both steps run
+      # even when the tests failed, which is when the notification matters most.
       - name: Build Slack summary
         if: always()
         run: python3 .github/scripts/ui_test_slack_summary.py slack-payload.json
@@ -195,14 +194,12 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.AUTOMATED_UI_SLACK_BOT }}
         run: |
-          # the secret is not available to a fork, and a report-only workflow must not go
-          # red over a notification it was never able to send
+          # the secret is unavailable to a fork, and a report-only workflow must not go red
+          # over a notification it was never able to send
           if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
             echo "AUTOMATED_UI_SLACK_BOT is not set - skipping the Slack notification"
             exit 0
           fi
-          # a rejected post is a bug in the payload above, so let it fail the job rather
-          # than leaving the notification quietly dead
           curl --silent --show-error --fail-with-body -X POST \
             -H 'Content-type: application/json' \
             --data @slack-payload.json "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/weekly_ui_tests.yml
+++ b/.github/workflows/weekly_ui_tests.yml
@@ -142,8 +142,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      contents: read
 
     steps:
+      - name: Checkout the Slack summary script
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Download JUnit results
         uses: actions/download-artifact@v8
         # nothing to publish is a normal outcome here, e.g. if every build failed
@@ -174,3 +182,27 @@ jobs:
           files: artifacts/junit-automated-ui-Windows/junit-uitest.xml
           action_fail: false
           action_fail_on_inconclusive: false
+
+      # The check runs published above are only found by someone going looking for them, so
+      # the same results are pushed to Slack. Both steps run even when the test job failed,
+      # which is when the notification matters most.
+      - name: Build Slack summary
+        if: always()
+        run: python3 .github/scripts/ui_test_slack_summary.py slack-payload.json
+
+      - name: Post to Slack
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.AUTOMATED_UI_SLACK_BOT }}
+        run: |
+          # the secret is not available to a fork, and a report-only workflow must not go
+          # red over a notification it was never able to send
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "AUTOMATED_UI_SLACK_BOT is not set - skipping the Slack notification"
+            exit 0
+          fi
+          # a rejected post is a bug in the payload above, so let it fail the job rather
+          # than leaving the notification quietly dead
+          curl --silent --show-error --fail-with-body -X POST \
+            -H 'Content-type: application/json' \
+            --data @slack-payload.json "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
### Description of work

Adds a snippet to the end of the automated test workflow that uses the new `ui_test_slack_summary.py` to format the results. The workflow then pushes the formatted results to the #automated-ui-tests slack channel

### To test:

I'll set off a workflow run on this branch (https://github.com/mantidproject/mantid/actions/runs/34205655076) - it should appear on the slack channel

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
