### PR TITLE
Fix OpenGL incompatibility legacy vs new Instrument View

### DIFF
--- a/docs/source/release/v7.0.0/Workbench/InstrumentViewer/Bugfixes/42178.rst
+++ b/docs/source/release/v7.0.0/Workbench/InstrumentViewer/Bugfixes/42178.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where opening the new Instrument View stopped the original Instrument View from drawing for the rest of the session, reporting OpenGL errors instead. Both can now be opened in any order.

--- a/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
+++ b/qt/python/instrumentview/instrumentview/FullInstrumentViewWindow.py
@@ -57,6 +57,7 @@ from instrumentview.ShapeWidgets import (
     EllipseSelectionShape,
 )
 from instrumentview.ShapeOverlayManager import ShapeOverlayManager
+from instrumentview.SurfaceFormat import preserve_default_surface_format
 
 from contextlib import suppress
 from typing import Callable
@@ -250,7 +251,8 @@ class FullInstrumentViewView(QWidget):
         self._right_column_graphics = QWidget()
         self._parent_hsplitter = QSplitter(Qt.Horizontal)
         # TODO: get connections out of setup
-        self.main_plotter = BackgroundPlotter(show=False, menu_bar=False, toolbar=False, off_screen=self._off_screen)
+        with preserve_default_surface_format():
+            self.main_plotter = BackgroundPlotter(show=False, menu_bar=False, toolbar=False, off_screen=self._off_screen)
 
         self._detector_spectrum_fig = Figure()
         self._detector_spectrum_axes = self._detector_spectrum_fig.add_subplot(111, projection="mantid")

--- a/qt/python/instrumentview/instrumentview/SurfaceFormat.py
+++ b/qt/python/instrumentview/instrumentview/SurfaceFormat.py
@@ -1,0 +1,27 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from contextlib import contextmanager
+
+from qtpy.QtGui import QSurfaceFormat
+
+
+@contextmanager
+def preserve_default_surface_format():
+    """Undo pyvistaqt's overwrite of the process-wide default QSurfaceFormat.
+
+    ``QVTKRenderWindowInteractor.__init__`` (pyvistaqt >= 0.13) calls
+    ``QSurfaceFormat.setDefaultFormat`` with an OpenGL 3.2 core profile. Workbench sets a
+    compatibility profile at startup because the legacy Instrument View uses fixed-function
+    OpenGL, so leaving the core profile in place makes every QOpenGLWidget created afterwards
+    fail to render. A QOpenGLWidget captures the default format when it is constructed, so
+    restoring it here leaves the plotter's own widget untouched.
+    """
+    saved = QSurfaceFormat.defaultFormat()
+    try:
+        yield
+    finally:
+        QSurfaceFormat.setDefaultFormat(saved)

--- a/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_view.py
+++ b/qt/python/instrumentview/instrumentview/alfview/test/test_alf_instrument_view_view.py
@@ -8,6 +8,8 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
+from qtpy.QtGui import QSurfaceFormat
+
 from mantidqt.utils.qt.testing import start_qapplication
 from instrumentview.alfview.ALFInstrumentViewView import ALFInstrumentViewView
 from instrumentview.ShapeWidgets import RectangleSelectionShape
@@ -75,6 +77,35 @@ class TestALFInstrumentViewView(unittest.TestCase):
         self._view.set_overlaid_shape_controls_checked(False)
         self.assertFalse(self._view._add_selection.isChecked())
         self.assertIsNone(self._view._shape_overlay_manager)
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.Figure")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.FigureCanvas")
+    @mock.patch("qtpy.QtWidgets.QHBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QVBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
+    def test_default_surface_format_restored_after_creating_plotter(
+        self, mock_plotter, mock_splitter, mock_v_layout, mock_h_layout, mock_canvas, mock_figure
+    ):
+        """pyvistaqt resets the process-wide default QSurfaceFormat to an OpenGL core profile when it
+        builds the plotter widget. Left in place it could break an QOpenGLWidget created afterwards"""
+        self.addCleanup(QSurfaceFormat.setDefaultFormat, QSurfaceFormat.defaultFormat())
+        compatibility_format = QSurfaceFormat()
+        compatibility_format.setProfile(QSurfaceFormat.CompatibilityProfile)
+        QSurfaceFormat.setDefaultFormat(compatibility_format)
+
+        def clobber_default_format(*_args, **_kwargs):
+            core_format = QSurfaceFormat()
+            core_format.setProfile(QSurfaceFormat.CoreProfile)
+            core_format.setVersion(3, 2)
+            QSurfaceFormat.setDefaultFormat(core_format)
+            return MagicMock()
+
+        mock_plotter.side_effect = clobber_default_format
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            ALFInstrumentViewView()
+
+        self.assertEqual(QSurfaceFormat.defaultFormat().profile(), QSurfaceFormat.CompatibilityProfile)
 
 
 if __name__ == "__main__":

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewView.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/ReflectometryInstrumentViewView.py
@@ -14,6 +14,7 @@ from qtpy.QtCore import QTimer
 from mantidqt.utils.qt.qappthreadcall import run_on_qapp_thread
 from instrumentview.ShapeOverlayManager import ShapeOverlayManager
 from instrumentview.ShapeWidgets import RectangleSelectionShape
+from instrumentview.SurfaceFormat import preserve_default_surface_format
 
 
 @run_on_qapp_thread()
@@ -55,7 +56,8 @@ class ReflectometryInstrumentViewView(QWidget):
             return
         self._initialised = True
 
-        self.main_plotter = BackgroundPlotter(show=False, menu_bar=False, toolbar=False, off_screen=False)
+        with preserve_default_surface_format():
+            self.main_plotter = BackgroundPlotter(show=False, menu_bar=False, toolbar=False, off_screen=False)
         self.layout().addWidget(self.main_plotter.app_window)
 
     def set_on_resize_callback(self, callback) -> None:

--- a/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_view.py
+++ b/qt/python/instrumentview/instrumentview/isisreflectometry/test/test_reflectometry_instrument_view_view.py
@@ -9,6 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from qtpy.QtCore import QSize
+from qtpy.QtGui import QSurfaceFormat
 
 from mantidqt.utils.qt.testing import start_qapplication
 from instrumentview.isisreflectometry.ReflectometryInstrumentViewView import ReflectometryInstrumentViewView
@@ -58,6 +59,27 @@ class TestReflectometryInstrumentViewView(unittest.TestCase):
     def test_initialise_sets_initialised_flag(self, mock_bg_plotter_cls):
         self._view.initialise()
         self.assertTrue(self._view._initialised)
+
+    @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
+    def test_initialise_restores_default_surface_format(self, mock_bg_plotter_cls):
+        """pyvistaqt resets the process-wide default QSurfaceFormat to an OpenGL core profile when it
+        builds the plotter widget. Left in place it could break an QOpenGLWidget created afterwards"""
+        self.addCleanup(QSurfaceFormat.setDefaultFormat, QSurfaceFormat.defaultFormat())
+        compatibility_format = QSurfaceFormat()
+        compatibility_format.setProfile(QSurfaceFormat.CompatibilityProfile)
+        QSurfaceFormat.setDefaultFormat(compatibility_format)
+
+        def clobber_default_format(*_args, **_kwargs):
+            core_format = QSurfaceFormat()
+            core_format.setProfile(QSurfaceFormat.CoreProfile)
+            core_format.setVersion(3, 2)
+            QSurfaceFormat.setDefaultFormat(core_format)
+            return MagicMock()
+
+        mock_bg_plotter_cls.side_effect = clobber_default_format
+        self._view.initialise()
+
+        self.assertEqual(QSurfaceFormat.defaultFormat().profile(), QSurfaceFormat.CompatibilityProfile)
 
     @mock.patch("instrumentview.isisreflectometry.ReflectometryInstrumentViewView.BackgroundPlotter")
     def test_initialise_is_idempotent(self, mock_bg_plotter_cls):

--- a/qt/python/instrumentview/instrumentview/test/test_view.py
+++ b/qt/python/instrumentview/instrumentview/test/test_view.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QSurfaceFormat
 from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import CreateSampleWorkspace
 from instrumentview.FullInstrumentViewWindow import FullInstrumentViewView, _LIGHT_GREY
@@ -462,6 +463,34 @@ class TestFullInstrumentViewView(unittest.TestCase):
         with mock.patch.object(self._view._show_sample_position_check_box, "set_colour") as mock_set_colour:
             self._view._on_show_sample_position_toggled(False)
         mock_set_colour.assert_called_once_with(_LIGHT_GREY)
+
+    @mock.patch("instrumentview.FullInstrumentViewWindow.FigureCanvas")
+    @mock.patch("qtpy.QtWidgets.QHBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QVBoxLayout.addWidget")
+    @mock.patch("qtpy.QtWidgets.QSplitter.addWidget")
+    @mock.patch("instrumentview.FullInstrumentViewWindow.BackgroundPlotter")
+    def test_default_surface_format_restored_after_creating_plotter(
+        self, mock_plotter, mock_splitter, mock_v_layout, mock_h_layout, mock_canvas
+    ):
+        """pyvistaqt resets the process-wide default QSurfaceFormat to an OpenGL core profile when it
+        builds the plotter widget. Left in place it could break an QOpenGLWidget created afterwards"""
+        self.addCleanup(QSurfaceFormat.setDefaultFormat, QSurfaceFormat.defaultFormat())
+        compatibility_format = QSurfaceFormat()
+        compatibility_format.setProfile(QSurfaceFormat.CompatibilityProfile)
+        QSurfaceFormat.setDefaultFormat(compatibility_format)
+
+        def clobber_default_format(*_args, **_kwargs):
+            core_format = QSurfaceFormat()
+            core_format.setProfile(QSurfaceFormat.CoreProfile)
+            core_format.setVersion(3, 2)
+            QSurfaceFormat.setDefaultFormat(core_format)
+            return MagicMock()
+
+        mock_plotter.side_effect = clobber_default_format
+        with mock.patch("mantidqt.utils.qt.qappthreadcall.force_method_calls_to_qapp_thread"):
+            FullInstrumentViewView()
+
+        self.assertEqual(QSurfaceFormat.defaultFormat().profile(), QSurfaceFormat.CompatibilityProfile)
 
 
 if __name__ == "__main__":

--- a/qt/widgets/instrumentview/src/GLDisplay.cpp
+++ b/qt/widgets/instrumentview/src/GLDisplay.cpp
@@ -16,6 +16,7 @@
 
 #include <QApplication>
 #include <QSpinBox>
+#include <QSurfaceFormat>
 #include <QTime>
 #include <QtOpenGL>
 
@@ -30,6 +31,14 @@ namespace MantidQt::MantidWidgets {
 constexpr Qt::CursorShape GLCursor = Qt::ArrowCursor;
 
 GLDisplay::GLDisplay(QWidget *parent) : IGLDisplay(parent), m_isKeyPressed(false) {
+  // We use deprecated OpenGL calls so anything with a profile version >= 3 causes failures to render.
+  // Third-party Qt/OpenGL libraries can reset QSurfaceFormat::defaultFormat() to a core profile,
+  // which makes every widget created afterwards fail to render.
+  QSurfaceFormat format;
+  format.setProfile(QSurfaceFormat::CompatibilityProfile);
+  format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+  setFormat(format);
+
   setFocusPolicy(Qt::StrongFocus);
   setAutoFillBackground(false);
   // Enable right-click in pick mode


### PR DESCRIPTION
Following the update of `pyvistaqt` to 0.13, `pyvistaqt` sets the OpenGL `SurfaceFormat` to something incompatible with the legacy Instrument View. In https://github.com/mantidproject/mantid/blob/dac6b8b276142d43012854388083550d98c8c4d2/qt/applications/workbench/workbench/app/workbench_process.py#L179 Workbench sets a `SurfaceFormat` compatible with deprecated OpenGL calls, but only once on starting Workbench. Hence, once one opened the new Instrument View, the old one would display a bunch of OpenGL errors instead of rendering.

This PR fixes the problem in two places:
- Set the correct `SurfaceFormat` when creating a `GLDisplay`, not just when starting Workbench. (Might even be able to delete the one in `workbench_process.py.`)
- When closing a `pyvistaqt` widget, revert the `SurfaceFormat` back to what is was before opening

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

To see the problem: open the nightly, open and close the new Instrument View, open the old Instrument View.

Open the old and new Instrument View, in any order (restart Workbench each time to check both ways), should draw with no problems. Also check that ALFView and the ISISReflectometry (Preview tab) interfaces work fine with both instrument views (option in the Workbench settings to switch between them)

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
