### PR TITLE
Instrument metadata for Instrument 2.0

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -32,6 +32,7 @@ namespace Geometry {
 class ComponentInfo;
 class DetectorInfo;
 class IDetector;
+class InstrumentMetadata;
 class ParameterMap;
 class XMLInstrumentParameter;
 } // namespace Geometry
@@ -158,6 +159,8 @@ public:
 
   const Geometry::ComponentInfo &componentInfo() const;
   Geometry::ComponentInfo &mutableComponentInfo();
+
+  Geometry::InstrumentMetadata const &instrumentMetadata() const;
 
   std::string getInstrumentName() const;
 

--- a/Framework/API/inc/MantidAPI/PanelsSurfaceCalculator.h
+++ b/Framework/API/inc/MantidAPI/PanelsSurfaceCalculator.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "MantidAPI/DllConfig.h"
-#include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Quat.h"
@@ -19,8 +18,6 @@
 #include <vector>
 
 using Mantid::Geometry::ComponentInfo;
-using Mantid::Geometry::Instrument;
-using Mantid::Geometry::Instrument_const_sptr;
 using Mantid::Kernel::V3D;
 
 namespace Mantid {
@@ -47,7 +44,6 @@ public:
       const ComponentInfo &componentInfo,
       std::function<std::vector<size_t>(const ComponentInfo &, size_t, std::vector<bool> &)> operation);
   std::optional<Kernel::V2D> getSideBySideViewPos(const ComponentInfo &componentInfo,
-                                                  const Instrument_const_sptr &instrument,
                                                   const size_t componentIndex) const;
 
 private:

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -20,6 +20,7 @@
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/ParameterFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
@@ -843,6 +844,10 @@ SpectrumInfo &ExperimentInfo::mutableSpectrumInfo() {
 const Geometry::ComponentInfo &ExperimentInfo::componentInfo() const { return m_parmap->componentInfo(); }
 
 ComponentInfo &ExperimentInfo::mutableComponentInfo() { return m_parmap->mutableComponentInfo(); }
+
+Geometry::InstrumentMetadata const &ExperimentInfo::instrumentMetadata() const {
+  return m_parmap->instrumentMetadata();
+}
 
 /// Sets the SpectrumDefinition for all spectra.
 void ExperimentInfo::setSpectrumDefinitions(Kernel::cow_ptr<std::vector<SpectrumDefinition>> spectrumDefinitions) {

--- a/Framework/API/src/PanelsSurfaceCalculator.cpp
+++ b/Framework/API/src/PanelsSurfaceCalculator.cpp
@@ -387,12 +387,10 @@ std::vector<size_t> PanelsSurfaceCalculator::tubeDetectorParentIDs(const Compone
  * Gives the specified side-by-side view position from the IDF
  *
  * @param componentInfo :: ComponentInfo object from the workspace
- * @param instrument :: Instrument object from the workspace
  * @param componentIndex :: Component index to check
  * @returns :: Side-by-side position from the IDF
  */
 std::optional<Kernel::V2D> PanelsSurfaceCalculator::getSideBySideViewPos(const ComponentInfo &componentInfo,
-                                                                         const Instrument_const_sptr &,
                                                                          const size_t componentIndex) const {
   const auto pos = componentInfo.sideBySideViewPosition(componentIndex);
   if (pos.X() == EMPTY_DBL())

--- a/Framework/API/src/PanelsSurfaceCalculator.cpp
+++ b/Framework/API/src/PanelsSurfaceCalculator.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
+#include "MantidKernel/EmptyValues.h"
 
 #include <cmath>
 #include <numeric>
@@ -391,15 +392,12 @@ std::vector<size_t> PanelsSurfaceCalculator::tubeDetectorParentIDs(const Compone
  * @returns :: Side-by-side position from the IDF
  */
 std::optional<Kernel::V2D> PanelsSurfaceCalculator::getSideBySideViewPos(const ComponentInfo &componentInfo,
-                                                                         const Instrument_const_sptr &instrument,
+                                                                         const Instrument_const_sptr &,
                                                                          const size_t componentIndex) const {
-  const auto *componentID = componentInfo.componentID(componentIndex);
-  const auto component = instrument->getComponentByID(componentID);
-  if (!component) {
-    return std::optional<Kernel::V2D>();
-  }
-
-  return component->getSideBySideViewPos();
+  const auto pos = componentInfo.sideBySideViewPosition(componentIndex);
+  if (pos.X() == EMPTY_DBL())
+    return std::nullopt;
+  return pos;
 }
 
 } // namespace Mantid::API

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -15,6 +15,7 @@
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/FitParameter.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/XMLInstrumentParameter.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DateAndTime.h"
@@ -80,6 +81,42 @@ public:
     std::shared_ptr<const Instrument> inst3 = inst2->baseInstrument();
     TS_ASSERT_EQUALS(inst3.get(), inst1.get());
     TS_ASSERT_EQUALS(inst3->getName(), "MyTestInst");
+  }
+
+  void test_GetInstrumentMetadata() {
+    ExperimentInfo ws;
+    auto inst1 = std::make_shared<Instrument>();
+    inst1->setName("MyTestInst");
+    inst1->setFilename("/some/path/MyTestInst_Definition.xml");
+    inst1->setXmlText("<instrument/>");
+    const DateAndTime validFrom("2020-01-01T00:00:00");
+    inst1->setValidFromDate(validFrom);
+    inst1->setDefaultView("3D");
+    inst1->setDefaultViewAxis("Z-");
+    ws.setInstrument(inst1);
+
+    const auto &metadata = ws.instrumentMetadata();
+    TS_ASSERT_EQUALS(metadata.filename(), "/some/path/MyTestInst_Definition.xml");
+    TS_ASSERT_EQUALS(metadata.xmlText(), "<instrument/>");
+    TS_ASSERT_EQUALS(metadata.validFromDate(), validFrom);
+    TS_ASSERT_EQUALS(metadata.defaultView(), "3D");
+    TS_ASSERT_EQUALS(metadata.defaultAxis(), "Z-");
+    TSM_ASSERT("No physical instrument was set", !metadata.physicalInstrument());
+  }
+
+  void test_GetInstrumentMetadata_physicalInstrument() {
+    ExperimentInfo ws;
+    auto inst1 = std::make_shared<Instrument>();
+    inst1->setName("MyTestInst");
+    auto physInst = std::make_unique<Instrument>();
+    physInst->setName("MyPhysicalInst");
+    inst1->setPhysicalInstrument(std::move(physInst));
+    ws.setInstrument(inst1);
+
+    const auto physical = ws.instrumentMetadata().physicalInstrument();
+    TSM_ASSERT("Physical instrument should be present", physical);
+    TS_ASSERT_EQUALS(physical->getName(), "MyPhysicalInst");
+    TSM_ASSERT("Physical instrument should share the owning instrument's ParameterMap", physical->isParametrized());
   }
 
   void test_GetSetSample() {

--- a/Framework/API/test/PanelsSurfaceCalculatorTest.h
+++ b/Framework/API/test/PanelsSurfaceCalculatorTest.h
@@ -107,6 +107,14 @@ public:
     TS_ASSERT_DELTA(0, rotation.imagK(), tol);
   }
 
+  void testGetSideBySideViewPos() {
+    const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
+    const size_t tubeIndex = 4;
+    const auto p = PanelsSurfaceCalculator();
+    const auto pos = p.getSideBySideViewPos(ws->componentInfo(), ws->getInstrument(), tubeIndex);
+    TSM_ASSERT("No side-by-side view position declared in this test instrument", !pos.has_value());
+  }
+
   void testTransformedBoundingBoxPoints() {
     const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(1, 5, 10);
     const auto p = PanelsSurfaceCalculator();

--- a/Framework/API/test/PanelsSurfaceCalculatorTest.h
+++ b/Framework/API/test/PanelsSurfaceCalculatorTest.h
@@ -111,7 +111,7 @@ public:
     const auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
     const size_t tubeIndex = 4;
     const auto p = PanelsSurfaceCalculator();
-    const auto pos = p.getSideBySideViewPos(ws->componentInfo(), ws->getInstrument(), tubeIndex);
+    const auto pos = p.getSideBySideViewPos(ws->componentInfo(), tubeIndex);
     TSM_ASSERT("No side-by-side view position declared in this test instrument", !pos.has_value());
   }
 

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -39,6 +39,9 @@ private:
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_scaleFactors;
   Mantid::Kernel::cow_ptr<std::vector<ComponentType>> m_componentType;
   std::shared_ptr<const std::vector<std::string>> m_names;
+  /// Side-by-side (unwrapped) instrument-view position, set from the IDF and never
+  /// modified afterwards; EMBTY_DBL for components with no declared position
+  std::shared_ptr<const std::vector<Eigen::Vector2d>> m_sideBySideViewPositions;
 
   const size_t m_size;
   const int64_t m_sourceIndex;
@@ -77,7 +80,8 @@ public:
       std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
       std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
       std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-      int64_t sourceIndex, int64_t sampleIndex);
+      std::shared_ptr<const std::vector<Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+      int64_t sampleIndex);
   /// Copy assignment not permitted because of the way DetectorInfo stored
   ComponentInfo &operator=(const ComponentInfo &other) = delete;
   /// Clone method
@@ -144,6 +148,7 @@ public:
   Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Eigen::Vector3d &scaleFactor);
   ComponentType componentType(const size_t componentIndex) const;
+  const Eigen::Vector2d &sideBySideViewPosition(const size_t componentIndex) const;
 
   size_t scanCount() const;
   size_t scanSize() const;

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -12,6 +12,7 @@
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -39,9 +40,8 @@ private:
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_scaleFactors;
   Mantid::Kernel::cow_ptr<std::vector<ComponentType>> m_componentType;
   std::shared_ptr<const std::vector<std::string>> m_names;
-  /// Side-by-side (unwrapped) instrument-view position, set from the IDF and never
-  /// modified afterwards; EMBTY_DBL for components with no declared position
-  std::shared_ptr<const std::vector<Eigen::Vector2d>> m_sideBySideViewPositions;
+  /// Side-by-side (unwrapped) instrument-view position, set from the IDF
+  std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> m_sideBySideViewPositions;
 
   const size_t m_size;
   const int64_t m_sourceIndex;
@@ -80,7 +80,7 @@ public:
       std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
       std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
       std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-      std::shared_ptr<const std::vector<Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+      std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
       int64_t sampleIndex);
   /// Copy assignment not permitted because of the way DetectorInfo stored
   ComponentInfo &operator=(const ComponentInfo &other) = delete;
@@ -148,7 +148,7 @@ public:
   Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Eigen::Vector3d &scaleFactor);
   ComponentType componentType(const size_t componentIndex) const;
-  const Eigen::Vector2d &sideBySideViewPosition(const size_t componentIndex) const;
+  Eigen::Vector2d const &sideBySideViewPosition(const size_t componentIndex) const;
 
   size_t scanCount() const;
   size_t scanSize() const;

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/make_cow.h"
 #include <algorithm>
 #include <iterator>
@@ -17,6 +18,9 @@
 namespace Mantid::Beamline {
 
 namespace {
+
+Eigen::Vector2d const EMPTY_VEC2D(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL());
+
 void failMerge(const std::string &what) {
   throw std::runtime_error(std::string("Cannot merge ComponentInfo: ") + what);
 }
@@ -52,7 +56,7 @@ ComponentInfo::ComponentInfo(
     std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
     std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
     std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-    std::shared_ptr<const std::vector<Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+    std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
     int64_t sampleIndex)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(std::move(assemblySortedComponentIndices)),
@@ -92,10 +96,6 @@ ComponentInfo::ComponentInfo(
   if (m_names->size() != m_size) {
     throw std::invalid_argument("ComponentInfo should be provided same number "
                                 "of names as number of components");
-  }
-  if (m_sideBySideViewPositions->size() != m_size) {
-    throw std::invalid_argument("ComponentInfo should be provided same number "
-                                "of side-by-side view positions as number of components");
   }
 
   // Calculate total size of all assemblies
@@ -603,8 +603,14 @@ Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
 
 const std::string &ComponentInfo::name(const size_t componentIndex) const { return (*m_names)[componentIndex]; }
 
-const Eigen::Vector2d &ComponentInfo::sideBySideViewPosition(const size_t componentIndex) const {
-  return (*m_sideBySideViewPositions)[componentIndex];
+Eigen::Vector2d const &ComponentInfo::sideBySideViewPosition(const size_t componentIndex) const {
+  if (m_sideBySideViewPositions) {
+    const auto it = m_sideBySideViewPositions->find(componentIndex);
+    if (it != m_sideBySideViewPositions->end()) {
+      return it->second;
+    }
+  }
+  return EMPTY_VEC2D;
 }
 
 bool ComponentInfo::uniqueName(const std::string &name) const { return unique_if_exists((*m_names), name); }
@@ -792,8 +798,11 @@ size_t ComponentInfo::getMemorySize() const {
     mem += std::accumulate(m_names->cbegin(), m_names->cend(), size_t{0},
                            [](size_t acc, const auto &str) { return acc + str.capacity(); });
   }
-  if (m_sideBySideViewPositions)
-    mem += sizeof(*m_sideBySideViewPositions) + m_sideBySideViewPositions->size() * sizeof(Eigen::Vector2d);
+  // m_sideBySideViewPositions: map object + heap buffer for the map's key-value pairs
+  if (m_sideBySideViewPositions) {
+    mem += sizeof(*m_sideBySideViewPositions) +
+           m_sideBySideViewPositions->size() * sizeof(std::pair<const size_t, Eigen::Vector2d>);
+  }
 
   // m_scanIntervals: inline vector's heap buffer
   mem += m_scanIntervals.capacity() * sizeof(std::pair<int64_t, int64_t>);

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -52,13 +52,15 @@ ComponentInfo::ComponentInfo(
     std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
     std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
     std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-    int64_t sourceIndex, int64_t sampleIndex)
+    std::shared_ptr<const std::vector<Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+    int64_t sampleIndex)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(std::move(assemblySortedComponentIndices)),
       m_detectorRanges(std::move(detectorRanges)), m_componentRanges(std::move(componentRanges)),
       m_parentIndices(std::move(parentIndices)), m_children(std::move(children)), m_positions(std::move(positions)),
       m_rotations(std::move(rotations)), m_scaleFactors(std::move(scaleFactors)),
       m_componentType(std::move(componentType)), m_names(std::move(names)),
+      m_sideBySideViewPositions(std::move(sideBySideViewPositions)),
       m_size(ComponentInfo::computeTotalSize(*m_assemblySortedDetectorIndices, *m_detectorRanges)),
       m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex), m_detectorInfo(nullptr) {
   if (m_rotations->size() != m_positions->size()) {
@@ -90,6 +92,10 @@ ComponentInfo::ComponentInfo(
   if (m_names->size() != m_size) {
     throw std::invalid_argument("ComponentInfo should be provided same number "
                                 "of names as number of components");
+  }
+  if (m_sideBySideViewPositions->size() != m_size) {
+    throw std::invalid_argument("ComponentInfo should be provided same number "
+                                "of side-by-side view positions as number of components");
   }
 
   // Calculate total size of all assemblies
@@ -597,6 +603,10 @@ Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
 
 const std::string &ComponentInfo::name(const size_t componentIndex) const { return (*m_names)[componentIndex]; }
 
+const Eigen::Vector2d &ComponentInfo::sideBySideViewPosition(const size_t componentIndex) const {
+  return (*m_sideBySideViewPositions)[componentIndex];
+}
+
 bool ComponentInfo::uniqueName(const std::string &name) const { return unique_if_exists((*m_names), name); }
 
 size_t ComponentInfo::indexOfAny(const std::string &name) const {
@@ -782,6 +792,8 @@ size_t ComponentInfo::getMemorySize() const {
     mem += std::accumulate(m_names->cbegin(), m_names->cend(), size_t{0},
                            [](size_t acc, const auto &str) { return acc + str.capacity(); });
   }
+  if (m_sideBySideViewPositions)
+    mem += sizeof(*m_sideBySideViewPositions) + m_sideBySideViewPositions->size() * sizeof(Eigen::Vector2d);
 
   // m_scanIntervals: inline vector's heap buffer
   mem += m_scanIntervals.capacity() * sizeof(std::pair<int64_t, int64_t>);

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -10,6 +10,7 @@
 
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidKernel/EmptyValues.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
 #include <memory>
@@ -24,6 +25,10 @@ namespace {
 using PosVec = std::vector<Eigen::Vector3d>;
 using RotVec = std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>;
 using StrVec = std::vector<std::string>;
+using SideBySideVec = std::vector<Eigen::Vector2d>;
+
+/// Sentinel used by ComponentInfo::sideBySideViewPosition() to mean "not set"
+Eigen::Vector2d unsetSideBySideViewPos() { return Eigen::Vector2d(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL()); }
 
 /*
  * Makes a tree which in which all detectors are arranged in a single flat
@@ -55,6 +60,9 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeFl
     names->emplace_back("det" + std::to_string(detIndex));
   }
   names->emplace_back("root");
+  // Side-by-side view positions (unset for all components in this fixture)
+  auto sideBySideViewPositions =
+      std::make_shared<const SideBySideVec>(detPositions.size() + 1, unsetSideBySideViewPos());
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
@@ -66,7 +74,8 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeFl
   auto componentInfo = std::make_shared<ComponentInfo>(
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
-      parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, -1, -1);
+      parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, sideBySideViewPositions,
+      -1, -1);
 
   componentInfo->setDetectorInfo(detectorInfo.get());
 
@@ -127,6 +136,8 @@ makeTreeExampleAndReturnGeometricArguments() {
   auto scaleFactors = std::make_shared<PosVec>(PosVec(5, Eigen::Vector3d{1, 1, 1}));
   // Component names
   auto names = std::make_shared<StrVec>(5);
+  // Side-by-side view positions (unset for all components in this fixture)
+  auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(5, unsetSideBySideViewPos());
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(2, std::vector<size_t>(2));
@@ -134,7 +145,8 @@ makeTreeExampleAndReturnGeometricArguments() {
   auto compInfo = std::make_shared<ComponentInfo>(
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
-      parentIndices, children, compPositions, compRotations, scaleFactors, isRectangularBank, names, -1, -1);
+      parentIndices, children, compPositions, compRotations, scaleFactors, isRectangularBank, names,
+      sideBySideViewPositions, -1, -1);
 
   compInfo->setDetectorInfo(detectorInfo.get());
 
@@ -175,6 +187,8 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeTr
   auto scaleFactors = std::make_shared<PosVec>(PosVec(5, Eigen::Vector3d{1, 1, 1}));
   // Component names
   auto names = std::make_shared<StrVec>(5);
+  // Side-by-side view positions (unset for all components in this fixture)
+  auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(5, unsetSideBySideViewPos());
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
@@ -184,7 +198,8 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeTr
   auto componentInfo = std::make_shared<ComponentInfo>(
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
-      parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, -1, -1);
+      parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, sideBySideViewPositions,
+      -1, -1);
 
   componentInfo->setDetectorInfo(detectorInfo.get());
 
@@ -246,12 +261,13 @@ public:
     auto rotations = std::make_shared<RotVec>(1);
     auto scaleFactors = std::make_shared<PosVec>(4);
     auto names = std::make_shared<StrVec>(4);
+    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(4, unsetSideBySideViewPos());
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(3));
 
     ComponentInfo componentInfo(bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges,
                                 parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names,
-                                -1, -1);
+                                sideBySideViewPositions, -1, -1);
 
     DetectorInfo detectorInfo; // Detector info size 0
     TS_ASSERT_THROWS(componentInfo.setDetectorInfo(&detectorInfo), std::invalid_argument &);
@@ -277,13 +293,14 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>();
     auto names = std::make_shared<StrVec>();
+    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>();
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(); // invalid but not
                                                                           // being tested
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, bankSortedComponentIndices, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, isRectangularBank,
-                                   names, -1, -1),
+                                   names, sideBySideViewPositions, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -310,6 +327,7 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>();
     auto names = std::make_shared<StrVec>();
+    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>();
     // Only one component. So single empty component range.
     auto componentRanges =
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
@@ -319,7 +337,7 @@ public:
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, componentsInSubtree, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, isRectangularBank,
-                                   names, -1, -1),
+                                   names, sideBySideViewPositions, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -347,6 +365,7 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>(1);
     auto names = std::make_shared<StrVec>(1);
+    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(1, unsetSideBySideViewPos());
     // Only one component. So single empty component range.
     auto componentRanges =
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
@@ -356,7 +375,7 @@ public:
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, componentsInSubtree, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, componentTypes, names,
-                                   -1, -1),
+                                   sideBySideViewPositions, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -716,6 +735,46 @@ public:
     ComponentInfo &compInfo = *std::get<0>(infos);
     TS_ASSERT_EQUALS(compInfo.name(compInfo.root()), "root");
     TS_ASSERT_EQUALS(compInfo.name(0), "det0");
+  }
+
+  void test_side_by_side_view_position_default_unset() {
+    auto infos = makeTreeExample();
+    auto &compInfo = *std::get<0>(infos);
+
+    for (size_t i = 0; i < compInfo.size(); ++i) {
+      TSM_ASSERT_EQUALS("No side-by-side view position unless explicitly provided", compInfo.sideBySideViewPosition(i),
+                        unsetSideBySideViewPos());
+    }
+  }
+
+  void test_side_by_side_view_position_reads_constructed_value() {
+    // Imitate an instrument with 3 detectors and nothing more.
+    auto bankSortedDetectorIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{0, 1, 2});
+    auto bankSortedComponentIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>(1));
+    auto parentIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{3, 3, 3, 3});
+    auto detectorRanges =
+        std::make_shared<const std::vector<std::pair<size_t, size_t>>>(1, std::pair<size_t, size_t>{0, 3});
+    auto componentRanges =
+        std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 1}});
+    auto positions = std::make_shared<PosVec>(1);
+    auto rotations = std::make_shared<RotVec>(1);
+    auto scaleFactors = std::make_shared<PosVec>(4, Eigen::Vector3d{1, 1, 1});
+    auto names = std::make_shared<StrVec>(4);
+    auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
+    auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>{0, 1, 2});
+
+    const Eigen::Vector2d detector1Pos{1.5, -2.5};
+    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(
+        SideBySideVec{unsetSideBySideViewPos(), detector1Pos, unsetSideBySideViewPos(), unsetSideBySideViewPos()});
+
+    ComponentInfo componentInfo(bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges,
+                                parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names,
+                                sideBySideViewPositions, -1, -1);
+
+    TSM_ASSERT_EQUALS("Not set for detector 0", componentInfo.sideBySideViewPosition(0), unsetSideBySideViewPos());
+    TS_ASSERT_EQUALS(componentInfo.sideBySideViewPosition(1), detector1Pos);
+    TSM_ASSERT_EQUALS("Not set for detector 2", componentInfo.sideBySideViewPosition(2), unsetSideBySideViewPos());
+    TSM_ASSERT_EQUALS("Not set for root", componentInfo.sideBySideViewPosition(3), unsetSideBySideViewPos());
   }
 
   void test_indexOfAny_name_throws_when_name_invalid() {

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/EmptyValues.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <string>
@@ -25,9 +26,9 @@ namespace {
 using PosVec = std::vector<Eigen::Vector3d>;
 using RotVec = std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>;
 using StrVec = std::vector<std::string>;
-using SideBySideVec = std::vector<Eigen::Vector2d>;
+using SideBySideMap = std::map<size_t, Eigen::Vector2d>;
 
-/// Sentinel used by ComponentInfo::sideBySideViewPosition() to mean "not set"
+/// Sentinel returned by ComponentInfo::sideBySideViewPosition() to mean "not set"
 Eigen::Vector2d unsetSideBySideViewPos() { return Eigen::Vector2d(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL()); }
 
 /*
@@ -61,8 +62,7 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeFl
   }
   names->emplace_back("root");
   // Side-by-side view positions (unset for all components in this fixture)
-  auto sideBySideViewPositions =
-      std::make_shared<const SideBySideVec>(detPositions.size() + 1, unsetSideBySideViewPos());
+  auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
@@ -137,7 +137,7 @@ makeTreeExampleAndReturnGeometricArguments() {
   // Component names
   auto names = std::make_shared<StrVec>(5);
   // Side-by-side view positions (unset for all components in this fixture)
-  auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(5, unsetSideBySideViewPos());
+  auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(2, std::vector<size_t>(2));
@@ -188,7 +188,7 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeTr
   // Component names
   auto names = std::make_shared<StrVec>(5);
   // Side-by-side view positions (unset for all components in this fixture)
-  auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(5, unsetSideBySideViewPos());
+  auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
@@ -261,7 +261,7 @@ public:
     auto rotations = std::make_shared<RotVec>(1);
     auto scaleFactors = std::make_shared<PosVec>(4);
     auto names = std::make_shared<StrVec>(4);
-    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(4, unsetSideBySideViewPos());
+    auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(3));
 
@@ -293,7 +293,7 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>();
     auto names = std::make_shared<StrVec>();
-    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>();
+    auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(); // invalid but not
                                                                           // being tested
@@ -327,7 +327,7 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>();
     auto names = std::make_shared<StrVec>();
-    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>();
+    auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     // Only one component. So single empty component range.
     auto componentRanges =
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
@@ -365,7 +365,7 @@ public:
 
     auto scaleFactors = std::make_shared<PosVec>(1);
     auto names = std::make_shared<StrVec>(1);
-    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(1, unsetSideBySideViewPos());
+    auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     // Only one component. So single empty component range.
     auto componentRanges =
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
@@ -764,8 +764,9 @@ public:
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>{0, 1, 2});
 
     const Eigen::Vector2d detector1Pos{1.5, -2.5};
-    auto sideBySideViewPositions = std::make_shared<const SideBySideVec>(
-        SideBySideVec{unsetSideBySideViewPos(), detector1Pos, unsetSideBySideViewPos(), unsetSideBySideViewPos()});
+    // Only detector 1 has a declared side-by-side view position; detectors 0/2 and the
+    // root (3) have no entry at all in the (sparse) map.
+    auto sideBySideViewPositions = std::make_shared<const SideBySideMap>(SideBySideMap{{1, detector1Pos}});
 
     ComponentInfo componentInfo(bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges,
                                 parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names,

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -24,6 +24,7 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ReducedCell.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -521,9 +522,9 @@ void SCDCalibratePanels::saveXmlFile(const string &FileName, const boost::contai
   // create the file and add the header
   ofstream oss3(FileName.c_str());
   oss3 << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
-  oss3 << " <parameter-file instrument=\"" << instrument.getName() << "\" valid-from=\""
-       << instrument.getValidFromDate().toISO8601String() << "\">\n";
   ParameterMap_sptr pmap = instrument.getParameterMap();
+  oss3 << " <parameter-file instrument=\"" << instrument.getName() << "\" valid-from=\""
+       << pmap->instrumentMetadata().validFromDate().toISO8601String() << "\">\n";
 
   // write out the detector banks
   for (auto bankName : AllBankNames) {

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -20,6 +20,7 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
@@ -1216,7 +1217,7 @@ void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
 
   // configure root node
   parafile.put("<xmlattr>.instrument", instrument->getName());
-  parafile.put("<xmlattr>.valid-from", instrument->getValidFromDate().toISO8601String());
+  parafile.put("<xmlattr>.valid-from", pmap.instrumentMetadata().validFromDate().toISO8601String());
 
   // get L1 info for source
   ptree src;

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -16,6 +16,7 @@
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidKernel/EnumeratedString.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/OptionalBool.h"
@@ -179,7 +180,7 @@ void LoadDiffCal::getInstrument(H5File &file) {
       m_instrument = tempWS->getInstrument();
 
       g_log.information() << "Loaded instrument \"" << m_instrument->getName() << "\" from \""
-                          << m_instrument->getFilename() << "\"\n";
+                          << tempWS->instrumentMetadata().filename() << "\"\n";
     } else {
       g_log.debug("LoadInstrument child algorithm did not execute successfully. No instrument will be associated with "
                   "the output workspaces.");

--- a/Framework/DataHandling/src/SaveDetectorsGrouping.cpp
+++ b/Framework/DataHandling/src/SaveDetectorsGrouping.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/Run.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 
 #include <Poco/DOM/AutoPtr.h>
 #include <Poco/DOM/DOMWriter.h>
@@ -153,7 +154,7 @@ void SaveDetectorsGrouping::printToXML(const std::map<int, std::vector<detid_t>>
   AutoPtr<Element> pRoot = pDoc->createElement("detector-grouping");
   pDoc->appendChild(pRoot);
   pRoot->setAttribute("instrument", instrumentName);
-  pRoot->setAttribute("idf-date", instrument->getValidFromDate().toISO8601String());
+  pRoot->setAttribute("idf-date", mGroupWS->instrumentMetadata().validFromDate().toISO8601String());
 
   // Set description if was specified by user
   if (mGroupWS->run().hasProperty("Description")) {

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
@@ -315,14 +316,14 @@ void SaveDiffCal::exec() {
   std::string instrumentSource;
   if (bool(groupingWS)) {
     instrumentName = groupingWS->getInstrument()->getName();
-    instrumentSource = groupingWS->getInstrument()->getFilename();
+    instrumentSource = groupingWS->instrumentMetadata().filename();
   }
   if (bool(maskWS)) {
     if (instrumentName.empty()) {
       instrumentName = maskWS->getInstrument()->getName();
     }
     if (instrumentSource.empty()) {
-      instrumentSource = maskWS->getInstrument()->getFilename();
+      instrumentSource = maskWS->instrumentMetadata().filename();
     }
   }
   if (!instrumentSource.empty()) {

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 
 #include <boost/lexical_cast.hpp>
@@ -137,7 +138,7 @@ void SaveParameterFile::exec() {
   std::ofstream file(filename.c_str(), std::ofstream::trunc);
   file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   file << "<parameter-file instrument=\"" << instrument->getName() << "\"";
-  file << " valid-from=\"" << instrument->getValidFromDate().toISO8601String() << "\">\n";
+  file << " valid-from=\"" << ws->instrumentMetadata().validFromDate().toISO8601String() << "\">\n";
 
   prog.resetNumSteps(static_cast<int64_t>(toSave.size()), 0.6, 1.0);
   // Iterate through all the parameters we want to save and build an XML

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SRC_FILES
     src/Instrument/GridDetectorPixel.cpp
     src/Instrument/IDFObject.cpp
     src/Instrument/InstrumentDefinitionParser.cpp
+    src/Instrument/InstrumentMetadata.cpp
     src/Instrument/InstrumentVisitor.cpp
     src/Instrument/ObjCompAssembly.cpp
     src/Instrument/ObjComponent.cpp
@@ -208,6 +209,7 @@ set(INC_FILES
     inc/MantidGeometry/Instrument/IDFObject.h
     inc/MantidGeometry/Instrument/InfoIteratorBase.h
     inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+    inc/MantidGeometry/Instrument/InstrumentMetadata.h
     inc/MantidGeometry/Instrument/InstrumentVisitor.h
     inc/MantidGeometry/Instrument/ObjCompAssembly.h
     inc/MantidGeometry/Instrument/ObjComponent.h

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -20,6 +20,7 @@ namespace Mantid {
 
 namespace Kernel {
 class Quat;
+class V2D;
 class V3D;
 } // namespace Kernel
 
@@ -116,6 +117,7 @@ public:
   Kernel::V3D scaleFactor(const size_t componentIndex) const;
   const std::string &name(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Kernel::V3D &scaleFactor);
+  Kernel::V2D sideBySideViewPosition(const size_t componentIndex) const;
   size_t root() const;
 
   const IComponent *componentID(const size_t componentIndex) const { return (*m_componentIds)[componentIndex]; }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentMetadata.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentMetadata.h
@@ -1,0 +1,53 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/Instrument_fwd.h"
+#include "MantidTypes/Core/DateAndTime.h"
+#include <string>
+
+namespace Mantid {
+namespace Geometry {
+
+/** InstrumentMetadata : metadata related to the entire instrument
+ * - valid-from/to dates
+ * - source IDF filename
+ * - raw IDF XML text
+ * - default instrument-view type/axis
+ * - physical/neutronic instrument split for indirect-geometry instruments
+ * Created at instrument load and read-only thereafter.
+ */
+class MANTID_GEOMETRY_DLL InstrumentMetadata {
+public:
+  InstrumentMetadata(const Types::Core::DateAndTime &validFromDate, const Types::Core::DateAndTime &validToDate,
+                     std::string filename, std::string xmlText, std::string defaultView, std::string defaultAxis,
+                     Instrument_const_sptr physicalInstrument);
+
+  const Types::Core::DateAndTime &validFromDate() const;
+  const Types::Core::DateAndTime &validToDate() const;
+  const std::string &filename() const;
+  const std::string &xmlText() const;
+  const std::string &defaultView() const;
+  const std::string &defaultAxis() const;
+  /// INDIRECT GEOMETRY INSTRUMENTS ONLY : the physical instrument, if one was specified.
+  /// This is a legacy Instrument 1.0 object. Replacing it needs its own nested ComponentInfo/DetectorInfo
+  /// design (tracked separately).
+  Instrument_const_sptr physicalInstrument() const;
+
+private:
+  Types::Core::DateAndTime m_validFromDate;
+  Types::Core::DateAndTime m_validToDate;
+  std::string m_filename;
+  std::string m_xmlText;
+  std::string m_defaultView;
+  std::string m_defaultAxis;
+  Instrument_const_sptr m_physicalInstrument;
+};
+
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -124,6 +124,9 @@ private:
   /// Component names
   std::shared_ptr<std::vector<std::string>> m_names;
 
+  /// Side-by-side (unwrapped) instrument-view positions; unset entries hold EMPTY_DBL
+  std::shared_ptr<std::vector<Eigen::Vector2d>> m_sideBySideViewPositions;
+
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId, const size_t componentIndex);
 
   std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>> makeWrappers() const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -12,6 +12,7 @@
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -124,8 +125,8 @@ private:
   /// Component names
   std::shared_ptr<std::vector<std::string>> m_names;
 
-  /// Side-by-side (unwrapped) instrument-view positions; unset entries hold EMPTY_DBL
-  std::shared_ptr<std::vector<Eigen::Vector2d>> m_sideBySideViewPositions;
+  /// Side-by-side (unwrapped) instrument-view positions when declared in the IDF.
+  std::shared_ptr<std::map<size_t, Eigen::Vector2d>> m_sideBySideViewPositions;
 
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId, const size_t componentIndex);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -26,6 +26,7 @@ namespace Geometry {
 class ComponentInfo;
 class DetectorInfo;
 class Instrument;
+class InstrumentMetadata;
 
 /** @class ParameterMap ParameterMap.h
 
@@ -302,6 +303,7 @@ public:
   Geometry::DetectorInfo &mutableDetectorInfo();
   const Geometry::ComponentInfo &componentInfo() const;
   Geometry::ComponentInfo &mutableComponentInfo();
+  Geometry::InstrumentMetadata const &instrumentMetadata() const;
   size_t detectorIndex(const detid_t detID) const;
   size_t componentIndex(const Geometry::ComponentID componentId) const;
   const std::vector<Geometry::ComponentID> &componentIds() const;
@@ -313,6 +315,8 @@ private:
 
   /// Assignment operator
   ParameterMap &operator=(ParameterMap *rhs);
+  /// Builds m_instrumentMetadata from m_instrument. Requires m_instrument to be set.
+  void buildInstrumentMetadata();
   /// internal function to get position of the parameter in the parameter map
   component_map_it positionOf(const IComponent *comp, const char *name, const char *type);
   /// const version of the internal function to get position of the parameter in
@@ -338,6 +342,10 @@ private:
   /// Pointer to the ComponentInfo wrapper. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
   std::unique_ptr<Geometry::ComponentInfo> m_componentInfo;
+
+  /// Whole-of-instrument metadata built alongside m_componentInfo/m_detectorInfo. NULL
+  /// unless the instrument is associated with an ExperimentInfo object.
+  std::unique_ptr<Geometry::InstrumentMetadata> m_instrumentMetadata;
 
   /// Pointer to the owning instrument for translating detector IDs into
   /// detector indices when accessing the DetectorInfo object. If the workspace

--- a/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
@@ -13,6 +13,7 @@
 #include <boost/unordered_map.hpp>
 #include <deque>
 #include <list>
+#include <memory>
 #include <mutex>
 
 namespace Mantid {
@@ -38,6 +39,7 @@ class MANTID_GEOMETRY_DLL InstrumentRayTracer {
 public:
   /// Constructor taking an instrument
   InstrumentRayTracer(Instrument_const_sptr instrument);
+  ~InstrumentRayTracer();
   /// Trace a given track from the instrument source in the given direction
   /// and compile a list of results that this track intersects.
   void trace(const Kernel::V3D &dir) const;
@@ -53,6 +55,11 @@ private:
   InstrumentRayTracer();
   /// Fire the given track at the instrument
   void fireRay(Track &testRay) const;
+  /// ComponentInfo/DetectorInfo for m_instrument, built and owned here only if
+  /// m_instrument is not parametrized (and so has none cached of its own to reuse).
+  void ensureOwnedInfoIsBuilt() const;
+  const ComponentInfo &componentInfo() const;
+  const DetectorInfo &detectorInfo() const;
 
   /// Pointer to the instrument
   Instrument_const_sptr m_instrument;
@@ -63,6 +70,8 @@ private:
   mutable boost::unordered_map<IComponent *, BoundingBox> m_boxCache;
   /// Mutex to lock box cache
   mutable std::mutex m_mutex;
+  mutable std::unique_ptr<ComponentInfo> m_ownedComponentInfo;
+  mutable std::unique_ptr<DetectorInfo> m_ownedDetectorInfo;
 };
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -273,6 +273,10 @@ void ComponentInfo::setScaleFactor(const size_t componentIndex, const Kernel::V3
   m_componentInfo->setScaleFactor(componentIndex, Kernel::toVector3d(scaleFactor));
 }
 
+Kernel::V2D ComponentInfo::sideBySideViewPosition(const size_t componentIndex) const {
+  return Kernel::toV2D(m_componentInfo->sideBySideViewPosition(componentIndex));
+}
+
 double ComponentInfo::solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams &params) const {
   if (!hasValidShape(componentIndex))
     throw Kernel::Exception::NullPointerException("ComponentInfo::solidAngle", "shape");

--- a/Framework/Geometry/src/Instrument/InstrumentMetadata.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentMetadata.cpp
@@ -1,0 +1,33 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
+
+namespace Mantid::Geometry {
+
+InstrumentMetadata::InstrumentMetadata(const Types::Core::DateAndTime &validFromDate,
+                                       const Types::Core::DateAndTime &validToDate, std::string filename,
+                                       std::string xmlText, std::string defaultView, std::string defaultAxis,
+                                       Instrument_const_sptr physicalInstrument)
+    : m_validFromDate(validFromDate), m_validToDate(validToDate), m_filename(std::move(filename)),
+      m_xmlText(std::move(xmlText)), m_defaultView(std::move(defaultView)), m_defaultAxis(std::move(defaultAxis)),
+      m_physicalInstrument(std::move(physicalInstrument)) {}
+
+const Types::Core::DateAndTime &InstrumentMetadata::validFromDate() const { return m_validFromDate; }
+
+const Types::Core::DateAndTime &InstrumentMetadata::validToDate() const { return m_validToDate; }
+
+const std::string &InstrumentMetadata::filename() const { return m_filename; }
+
+const std::string &InstrumentMetadata::xmlText() const { return m_xmlText; }
+
+const std::string &InstrumentMetadata::defaultView() const { return m_defaultView; }
+
+const std::string &InstrumentMetadata::defaultAxis() const { return m_defaultAxis; }
+
+Instrument_const_sptr InstrumentMetadata::physicalInstrument() const { return m_physicalInstrument; }
+
+} // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -19,6 +19,7 @@
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/EigenConversionHelpers.h"
+#include "MantidKernel/EmptyValues.h"
 
 #include <algorithm>
 #include <memory>
@@ -56,6 +57,14 @@ bool hasValidShape(const ObjCompAssembly &obj) {
   const auto *shape = obj.shape().get();
   return shape != nullptr && shape->hasValidShape();
 }
+
+/// Converts a legacy, possibly-unset side-by-side view position to the
+/// Eigen::Vector2d representation used by Beamline::ComponentInfo.
+Eigen::Vector2d toVector2dOrSentinel(const std::optional<Kernel::V2D> &pos) {
+  if (!pos)
+    return Eigen::Vector2d(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL());
+  return Kernel::toVector2d(*pos);
+}
 } // namespace
 
 /**
@@ -87,7 +96,8 @@ InstrumentVisitor::InstrumentVisitor(std::shared_ptr<const Instrument> instrumen
       m_scaleFactors(
           std::make_shared<std::vector<Eigen::Vector3d>>(m_orderedDetectorIds->size(), Eigen::Vector3d{1, 1, 1})),
       m_componentType(std::make_shared<std::vector<Beamline::ComponentType>>()),
-      m_names(std::make_shared<std::vector<std::string>>(m_orderedDetectorIds->size())) {
+      m_names(std::make_shared<std::vector<std::string>>(m_orderedDetectorIds->size())),
+      m_sideBySideViewPositions(std::make_shared<std::vector<Eigen::Vector2d>>(m_orderedDetectorIds->size())) {
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
   }
@@ -130,6 +140,7 @@ size_t InstrumentVisitor::commonRegistration(const IComponent &component) {
   m_shapes->emplace_back(m_nullShape);
   m_scaleFactors->emplace_back(Kernel::toVector3d(component.getScaleFactor()));
   m_names->emplace_back(component.getName());
+  m_sideBySideViewPositions->emplace_back(toVector2dOrSentinel(component.getSideBySideViewPos()));
   clearLegacyParameters(m_pmap, component);
   return componentIndex;
 }
@@ -322,6 +333,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
     m_monitorIndices->emplace_back(detectorIndex);
   }
   (*m_names)[detectorIndex] = detector.getName();
+  (*m_sideBySideViewPositions)[detectorIndex] = toVector2dOrSentinel(detector.getSideBySideViewPos());
   clearLegacyParameters(m_pmap, detector);
 
   /* Note that positions and rotations for detectors are currently
@@ -370,7 +382,7 @@ std::unique_ptr<Beamline::ComponentInfo> InstrumentVisitor::componentInfo() cons
   return std::make_unique<Mantid::Beamline::ComponentInfo>(
       m_assemblySortedDetectorIndices, m_detectorRanges, m_assemblySortedComponentIndices, m_componentRanges,
       m_parentComponentIndices, m_children, m_positions, m_rotations, m_scaleFactors, m_componentType, m_names,
-      m_sourceIndex, m_sampleIndex);
+      m_sideBySideViewPositions, m_sourceIndex, m_sampleIndex);
 }
 
 std::unique_ptr<Beamline::DetectorInfo> InstrumentVisitor::detectorInfo() const {

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -19,7 +19,6 @@
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/EigenConversionHelpers.h"
-#include "MantidKernel/EmptyValues.h"
 
 #include <algorithm>
 #include <memory>
@@ -58,13 +57,6 @@ bool hasValidShape(const ObjCompAssembly &obj) {
   return shape != nullptr && shape->hasValidShape();
 }
 
-/// Converts a legacy, possibly-unset side-by-side view position to the
-/// Eigen::Vector2d representation used by Beamline::ComponentInfo.
-Eigen::Vector2d toVector2dOrSentinel(const std::optional<Kernel::V2D> &pos) {
-  if (!pos)
-    return Eigen::Vector2d(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL());
-  return Kernel::toVector2d(*pos);
-}
 } // namespace
 
 /**
@@ -97,7 +89,7 @@ InstrumentVisitor::InstrumentVisitor(std::shared_ptr<const Instrument> instrumen
           std::make_shared<std::vector<Eigen::Vector3d>>(m_orderedDetectorIds->size(), Eigen::Vector3d{1, 1, 1})),
       m_componentType(std::make_shared<std::vector<Beamline::ComponentType>>()),
       m_names(std::make_shared<std::vector<std::string>>(m_orderedDetectorIds->size())),
-      m_sideBySideViewPositions(std::make_shared<std::vector<Eigen::Vector2d>>(m_orderedDetectorIds->size())) {
+      m_sideBySideViewPositions(std::make_shared<std::map<size_t, Eigen::Vector2d>>()) {
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
   }
@@ -140,7 +132,9 @@ size_t InstrumentVisitor::commonRegistration(const IComponent &component) {
   m_shapes->emplace_back(m_nullShape);
   m_scaleFactors->emplace_back(Kernel::toVector3d(component.getScaleFactor()));
   m_names->emplace_back(component.getName());
-  m_sideBySideViewPositions->emplace_back(toVector2dOrSentinel(component.getSideBySideViewPos()));
+  if (const auto &sideBySideViewPos = component.getSideBySideViewPos()) {
+    (*m_sideBySideViewPositions)[componentIndex] = Kernel::toVector2d(*sideBySideViewPos);
+  }
   clearLegacyParameters(m_pmap, component);
   return componentIndex;
 }
@@ -333,7 +327,9 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
     m_monitorIndices->emplace_back(detectorIndex);
   }
   (*m_names)[detectorIndex] = detector.getName();
-  (*m_sideBySideViewPositions)[detectorIndex] = toVector2dOrSentinel(detector.getSideBySideViewPos());
+  if (const auto &sideBySideViewPos = detector.getSideBySideViewPos()) {
+    (*m_sideBySideViewPositions)[detectorIndex] = Kernel::toVector2d(*sideBySideViewPos);
+  }
   clearLegacyParameters(m_pmap, detector);
 
   /* Note that positions and rotations for detectors are currently

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/FitParameter.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/ParameterFactory.h"
 #include "MantidKernel/Cache.h"
@@ -72,8 +73,10 @@ ParameterMap::ParameterMap(const ParameterMap &other)
       m_cacheLocMap(std::make_unique<Kernel::Cache<const ComponentID, Kernel::V3D>>(*other.m_cacheLocMap)),
       m_cacheRotMap(std::make_unique<Kernel::Cache<const ComponentID, Kernel::Quat>>(*other.m_cacheRotMap)),
       m_instrument(other.m_instrument) {
-  if (m_instrument)
+  if (m_instrument) {
     std::tie(m_componentInfo, m_detectorInfo) = m_instrument->makeBeamline(*this, &other);
+    buildInstrumentMetadata();
+  }
 }
 
 // Defined as default in source for forward declaration with std::unique_ptr.
@@ -1203,6 +1206,14 @@ Geometry::ComponentInfo &ParameterMap::mutableComponentInfo() {
   return *m_componentInfo;
 }
 
+/// Only for use by ExperimentInfo. Returns a reference to the InstrumentMetadata.
+const Geometry::InstrumentMetadata &ParameterMap::instrumentMetadata() const {
+  if (!m_instrumentMetadata) {
+    throw std::runtime_error("Cannot return reference to NULL InstrumentMetadata");
+  }
+  return *m_instrumentMetadata;
+}
+
 /// Only for use by Detector. Returns a detector index for a detector ID.
 size_t ParameterMap::detectorIndex(const detid_t detID) const { return m_instrument->detectorIndex(detID); }
 
@@ -1217,6 +1228,7 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
   if (!instrument) {
     m_componentInfo = nullptr;
     m_detectorInfo = nullptr;
+    m_instrumentMetadata = nullptr;
     return;
   }
   if (m_instrument)
@@ -1231,6 +1243,22 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
   } else {
     std::tie(m_componentInfo, m_detectorInfo) = m_instrument->makeBeamline(*this);
   }
+  buildInstrumentMetadata();
+}
+
+/// Builds m_instrumentMetadata from m_instrument. Requires m_instrument to be set.
+void ParameterMap::buildInstrumentMetadata() {
+  // Mirrors Instrument::getPhysicalInstrument()'s parametrized branch: a physical
+  // instrument must share the same ParameterMap as the owning (neutronic) instrument.
+  Instrument_const_sptr physicalInstrument;
+  if (const auto &basePhysicalInstrument = m_instrument->getPhysicalInstrument()) {
+    physicalInstrument =
+        std::make_shared<Instrument>(basePhysicalInstrument, std::shared_ptr<ParameterMap>(this, NoDeleting()));
+  }
+  m_instrumentMetadata = std::make_unique<InstrumentMetadata>(
+      m_instrument->getValidFromDate(), m_instrument->getValidToDate(), m_instrument->getFilename(),
+      m_instrument->getXmlText(), m_instrument->getDefaultView(), m_instrument->getDefaultAxis(),
+      std::move(physicalInstrument));
 }
 
 /** Return memory used by the parameter map, in bytes.

--- a/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
+++ b/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
@@ -9,6 +9,10 @@
 //-------------------------------------------------------------
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
 #include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/InstrumentVisitor.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Objects/Track.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/V3D.h"
@@ -45,6 +49,8 @@ InstrumentRayTracer::InstrumentRayTracer(Instrument_const_sptr instrument) : m_i
     throw std::invalid_argument(errorMsg);
   }
 }
+
+InstrumentRayTracer::~InstrumentRayTracer() = default;
 
 /**
  * Trace a given track from the instrument source in the given direction. For
@@ -95,16 +101,15 @@ Links InstrumentRayTracer::getResults() const {
  */
 IDetector_const_sptr InstrumentRayTracer::getDetectorResult() const {
   Links results = this->getResults();
+  const auto &compInfo = componentInfo();
+  const auto &detInfo = detectorInfo();
 
   // Go through all results
   Links::const_iterator resultItr = results.begin();
   for (; resultItr != results.end(); ++resultItr) {
-    IComponent_const_sptr component = m_instrument->getComponentByID(resultItr->componentID);
-    IDetector_const_sptr det = std::dynamic_pointer_cast<const IDetector>(component);
-    if (det) {
-      if (!m_instrument->isMonitor(det->getID())) {
-        return det;
-      }
+    const size_t index = compInfo.indexOf(resultItr->componentID);
+    if (compInfo.isDetector(index) && !detInfo.isMonitor(index)) {
+      return m_instrument->getDetector(detInfo.detid(index));
     } // (is a detector)
   } // each ray tracer result
   return IDetector_const_sptr();
@@ -113,6 +118,29 @@ IDetector_const_sptr InstrumentRayTracer::getDetectorResult() const {
 //-------------------------------------------------------------
 // Private member functions
 //-------------------------------------------------------------
+
+/// Builds m_ownedComponentInfo/m_ownedDetectorInfo if not already built. Only
+/// needed when m_instrument is not parametrized, in which case it has no
+/// ComponentInfo/DetectorInfo of its own to reuse.
+void InstrumentRayTracer::ensureOwnedInfoIsBuilt() const {
+  if (!m_ownedComponentInfo)
+    std::tie(m_ownedComponentInfo, m_ownedDetectorInfo) = InstrumentVisitor::makeWrappers(*m_instrument);
+}
+
+const ComponentInfo &InstrumentRayTracer::componentInfo() const {
+  if (m_instrument->isParametrized())
+    return m_instrument->getParameterMap()->componentInfo();
+  ensureOwnedInfoIsBuilt();
+  return *m_ownedComponentInfo;
+}
+
+const DetectorInfo &InstrumentRayTracer::detectorInfo() const {
+  if (m_instrument->isParametrized())
+    return m_instrument->getParameterMap()->detectorInfo();
+  ensureOwnedInfoIsBuilt();
+  return *m_ownedDetectorInfo;
+}
+
 /**
  * Fire the test ray at the instrument and perform a bread-first search of the
  * object tree to find the objects that were intersected.

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -25,6 +25,7 @@
 
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include <Eigen/Geometry>
+#include <map>
 #include <memory>
 
 using namespace Mantid;
@@ -102,8 +103,7 @@ std::unique_ptr<Beamline::ComponentInfo> makeSingleBeamlineComponentInfo(
   using Mantid::Beamline::ComponentType;
   auto componentType = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(1);
-  auto sideBySideViewPositions =
-      std::make_shared<std::vector<Eigen::Vector2d>>(1, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL()));
+  auto sideBySideViewPositions = std::make_shared<std::map<size_t, Eigen::Vector2d>>();
   return std::make_unique<Beamline::ComponentInfo>(detectorIndices, detectorRanges, componentIndices, componentRanges,
                                                    parentIndices, children, positions, rotations, scaleFactors,
                                                    componentType, names, sideBySideViewPositions, -1, -1);
@@ -142,8 +142,7 @@ public:
     using Mantid::Beamline::ComponentType;
     auto isRectBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(1));
-    auto sideBySideViewPositions =
-        std::make_shared<std::vector<Eigen::Vector2d>>(2, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL()));
+    auto sideBySideViewPositions = std::make_shared<std::map<size_t, Eigen::Vector2d>>();
     auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,
         rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, -1, -1);
@@ -184,8 +183,10 @@ public:
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(1));
 
     const Eigen::Vector2d panelPos{2.0, 3.5};
-    auto sideBySideViewPositions = std::make_shared<std::vector<Eigen::Vector2d>>(
-        std::vector<Eigen::Vector2d>{panelPos, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL())});
+    // Only component 0 has a declared side-by-side view position; component 1 has no
+    // entry at all in the (sparse) map.
+    auto sideBySideViewPositions =
+        std::make_shared<std::map<size_t, Eigen::Vector2d>>(std::map<size_t, Eigen::Vector2d>{{0, panelPos}});
 
     auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -20,6 +20,7 @@
 #include "MantidGeometry/Surfaces/Sphere.h"
 #include "MantidGeometry/Surfaces/Surface.h"
 #include "MantidKernel/EigenConversionHelpers.h"
+#include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Exception.h"
 
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
@@ -101,9 +102,11 @@ std::unique_ptr<Beamline::ComponentInfo> makeSingleBeamlineComponentInfo(
   using Mantid::Beamline::ComponentType;
   auto componentType = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(1);
+  auto sideBySideViewPositions =
+      std::make_shared<std::vector<Eigen::Vector2d>>(1, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL()));
   return std::make_unique<Beamline::ComponentInfo>(detectorIndices, detectorRanges, componentIndices, componentRanges,
                                                    parentIndices, children, positions, rotations, scaleFactors,
-                                                   componentType, names, -1, -1);
+                                                   componentType, names, sideBySideViewPositions, -1, -1);
 }
 } // namespace
 
@@ -139,9 +142,11 @@ public:
     using Mantid::Beamline::ComponentType;
     auto isRectBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(1));
-    auto internalInfo = std::make_unique<Beamline::ComponentInfo>(detectorIndices, detectorRanges, componentIndices,
-                                                                  componentRanges, parentIndices, children, positions,
-                                                                  rotations, scaleFactors, isRectBank, names, -1, -1);
+    auto sideBySideViewPositions =
+        std::make_shared<std::vector<Eigen::Vector2d>>(2, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL()));
+    auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
+        detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,
+        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, -1, -1);
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
 
@@ -155,6 +160,48 @@ public:
     ComponentInfo info(std::move(internalInfo), componentIds, makeComponentIDMap(componentIds), shapes);
     TS_ASSERT_EQUALS(info.indexOf(comp1.getComponentID()), 0);
     TS_ASSERT_EQUALS(info.indexOf(comp2.getComponentID()), 1);
+  }
+
+  void test_side_by_side_view_position() {
+    auto detectorIndices = std::make_shared<std::vector<size_t>>(); // No detectors in this example
+    auto detectorRanges = std::make_shared<std::vector<std::pair<size_t, size_t>>>();
+    detectorRanges->emplace_back(std::make_pair(0, 0));
+    detectorRanges->emplace_back(std::make_pair(0, 0));
+
+    auto componentIndices = std::make_shared<std::vector<size_t>>(std::vector<size_t>{0, 1});
+    auto componentRanges = std::make_shared<std::vector<std::pair<size_t, size_t>>>();
+    componentRanges->emplace_back(std::make_pair(0, 0));
+    componentRanges->emplace_back(std::make_pair(0, 0));
+
+    auto parentIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{1, 1});
+
+    auto positions = std::make_shared<std::vector<Eigen::Vector3d>>(2);
+    auto rotations = std::make_shared<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>>(2);
+    auto scaleFactors = std::make_shared<std::vector<Eigen::Vector3d>>(2);
+    auto names = std::make_shared<std::vector<std::string>>(2);
+    using Mantid::Beamline::ComponentType;
+    auto isRectBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
+    auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(1));
+
+    const Eigen::Vector2d panelPos{2.0, 3.5};
+    auto sideBySideViewPositions = std::make_shared<std::vector<Eigen::Vector2d>>(
+        std::vector<Eigen::Vector2d>{panelPos, Eigen::Vector2d(EMPTY_DBL(), EMPTY_DBL())});
+
+    auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
+        detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,
+        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, -1, -1);
+
+    Mantid::Geometry::ObjComponent comp1("component1");
+    Mantid::Geometry::ObjComponent comp2("component2");
+    auto componentIds = std::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+        std::vector<Mantid::Geometry::ComponentID>{&comp1, &comp2});
+    auto shapes = std::make_shared<std::vector<std::shared_ptr<const Geometry::IObject>>>();
+    shapes->emplace_back(std::make_shared<const Geometry::CSGObject>());
+    shapes->emplace_back(std::make_shared<const Geometry::CSGObject>());
+
+    ComponentInfo info(std::move(internalInfo), componentIds, makeComponentIDMap(componentIds), shapes);
+    TS_ASSERT_EQUALS(info.sideBySideViewPosition(0), Kernel::V2D(2.0, 3.5));
+    TSM_ASSERT_EQUALS("Not set for component 1", info.sideBySideViewPosition(1), Kernel::V2D(EMPTY_DBL(), EMPTY_DBL()));
   }
 
   void test_partial_copy() {

--- a/Framework/Kernel/inc/MantidKernel/EigenConversionHelpers.h
+++ b/Framework/Kernel/inc/MantidKernel/EigenConversionHelpers.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/Quat.h"
+#include "MantidKernel/V2D.h"
 #include "MantidKernel/V3D.h"
 
 #include <Eigen/Geometry>
@@ -25,6 +26,9 @@ namespace Kernel {
 /// Converts Eigen::Vector3d to Kernel::V3D
 inline Kernel::V3D toV3D(const Eigen::Vector3d &vec) { return Kernel::V3D(vec[0], vec[1], vec[2]); }
 
+/// Converts Eigen::Vector2d to Kernel::V2D
+inline Kernel::V2D toV2D(const Eigen::Vector2d &vec) { return Kernel::V2D(vec[0], vec[1]); }
+
 /// Converts Eigen::Quaterniond to Kernel::Quat
 inline Kernel::Quat toQuat(const Eigen::Quaterniond &quat) {
   return Kernel::Quat(quat.w(), quat.x(), quat.y(), quat.z());
@@ -32,6 +36,9 @@ inline Kernel::Quat toQuat(const Eigen::Quaterniond &quat) {
 
 /// Converts Kernel::V3D to Eigen::Vector3d
 inline Eigen::Vector3d toVector3d(const Kernel::V3D &vec) { return Eigen::Vector3d(vec[0], vec[1], vec[2]); }
+
+/// Converts Kernel::V2D to Eigen::Vector2d
+inline Eigen::Vector2d toVector2d(const Kernel::V2D &vec) { return Eigen::Vector2d(vec.X(), vec.Y()); }
 
 /// Converts Kernel::Quat to Eigen::Quaterniond
 inline Eigen::Quaterniond toQuaterniond(const Kernel::Quat &quat) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/PanelsSurfaceCalculator.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/PanelsSurfaceCalculator.cpp
@@ -163,11 +163,10 @@ list getAllTubeDetectorFlatGroupParents(PanelsSurfaceCalculator &self, const obj
   return pyAllTubeGroupParents;
 }
 
-tuple getSideBySideViewPos(const PanelsSurfaceCalculator &self, const object &componentInfo, const object &instrument,
+tuple getSideBySideViewPos(const PanelsSurfaceCalculator &self, const object &componentInfo,
                            const size_t componentIndex) {
   const std::shared_ptr<ComponentInfo> cInfoSharedPtr = extract<std::shared_ptr<ComponentInfo>>(componentInfo);
-  const std::shared_ptr<Instrument> instrumentSharedPtr = extract<std::shared_ptr<Instrument>>(instrument);
-  const auto sideBySidePos = self.getSideBySideViewPos(*(cInfoSharedPtr).get(), instrumentSharedPtr, componentIndex);
+  const auto sideBySidePos = self.getSideBySideViewPos(*(cInfoSharedPtr).get(), componentIndex);
   list position;
   list result;
   if (!sideBySidePos.has_value()) {
@@ -218,8 +217,7 @@ void export_PanelsSurfaceCalculator() {
       .def("getAllTubeDetectorFlatGroupParents", &getAllTubeDetectorFlatGroupParents,
            (arg("self"), arg("componentInfo")),
            "Returns the parent component indices of detectors of all groups of tubes arranged in flat banks")
-      .def("getSideBySideViewPos", &getSideBySideViewPos,
-           (arg("self"), arg("componentInfo"), arg("instrument"), arg("componentIndex")),
+      .def("getSideBySideViewPos", &getSideBySideViewPos, (arg("self"), arg("componentInfo"), arg("componentIndex")),
            "Returns a tuple indicating whether the bank side-by-side projection position has been specified in the "
            "IDF, and what it is.");
 }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2D.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2D.cpp
@@ -12,6 +12,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidIndexing/SpectrumNumber.h"
 #include "MantidKernel/Logger.h"
@@ -92,7 +93,7 @@ public:
     dict state;
     state["title"] = ws.getTitle();
     state["instrument_name"] = ws.getInstrument()->getName();
-    state["instrument_xml"] = ws.getInstrument()->getXmlText();
+    state["instrument_xml"] = ws.instrumentMetadata().xmlText();
     state["unit_x"] = ws.getAxis(0)->unit()->unitID();
     state["unit_y"] = ws.getAxis(1)->unit()->unitID();
     state["spectra"] = spectraList;

--- a/docs/source/release/v7.0.0/Framework/Python/Deprecated/42181.rst
+++ b/docs/source/release/v7.0.0/Framework/Python/Deprecated/42181.rst
@@ -1,0 +1,1 @@
+- `PanelSurfaceCalculator.getSideBySideViewPos()` will no longer take an instrument parameter.

--- a/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
+++ b/qt/python/instrumentview/instrumentview/Projections/SideBySide.py
@@ -149,7 +149,7 @@ class SideBySide(Projection, projection_types={ProjectionType.SIDE_BY_SIDE: {"ax
             flat_bank.steps = np.abs([bank.xstep(), bank.ystep(), bank.zstep()])
             flat_bank.pixels = [bank.xpixels(), bank.ypixels(), bank.zpixels()]
             parent_component_index = component_info.parent(int(self._detector_id_component_index_map[flat_bank.detector_ids[0]]))
-            override_pos = self._calculator.getSideBySideViewPos(component_info, instrument, parent_component_index)
+            override_pos = self._calculator.getSideBySideViewPos(component_info, parent_component_index)
             flat_bank.has_position_in_idf = override_pos[0]
             if flat_bank.has_position_in_idf:
                 flat_bank.reference_position = np.array(override_pos[1] + [0])
@@ -190,7 +190,7 @@ class SideBySide(Projection, projection_types={ProjectionType.SIDE_BY_SIDE: {"ax
             flat_bank.dimensions = np.max(flat_bank.relative_projected_positions, axis=0) - np.min(
                 flat_bank.relative_projected_positions, axis=0
             )
-            override_pos = self._calculator.getSideBySideViewPos(component_info, self._workspace.getInstrument(), group[0])
+            override_pos = self._calculator.getSideBySideViewPos(component_info, group[0])
             flat_bank.has_position_in_idf = override_pos[0]
             if flat_bank.has_position_in_idf:
                 flat_bank.reference_position = np.array(override_pos[1] + [0])

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -23,6 +23,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/InstrumentMetadata.h"
 #include "MantidGeometry/Instrument/InstrumentVisitor.h"
 
 #include "MantidKernel/ConfigService.h"
@@ -251,7 +252,7 @@ void InstrumentActor::setupPhysicalInstrumentIfExists() {
   auto sharedWorkspace = getWorkspace();
   Mantid::Kernel::ReadLock _lock(*sharedWorkspace);
 
-  auto instr = sharedWorkspace->getInstrument()->getPhysicalInstrument();
+  auto instr = sharedWorkspace->instrumentMetadata().physicalInstrument();
   if (instr) {
     auto infos = InstrumentVisitor::makeWrappers(*instr);
     m_physicalComponentInfo = std::move(infos.first);
@@ -401,7 +402,7 @@ Instrument_const_sptr InstrumentActor::getInstrument() const {
   if (isPhysicalView()) {
     // First see if there is a 'physical' instrument available. Use it if there
     // is.
-    auto instr = sharedWorkspace->getInstrument()->getPhysicalInstrument();
+    auto instr = sharedWorkspace->instrumentMetadata().physicalInstrument();
     if (instr)
       return instr;
   }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -215,7 +215,7 @@ void PanelsSurface::processStructured(size_t rootIndex) {
     }
   }
 
-  info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, m_instrActor->getInstrument(), rootIndex);
+  info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, rootIndex);
 }
 
 void PanelsSurface::processGrid(size_t rootIndex) {
@@ -336,7 +336,7 @@ std::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
 
   // read any bank centre override from the bank - note that due to the logic higher up that sets bankIndex, the
   // override will only be read from components one or two levels up from a tube
-  info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, m_instrActor->getInstrument(), bankIndex);
+  info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, bankIndex);
 
   return bankIndex;
 }
@@ -421,8 +421,7 @@ void PanelsSurface::processUnstructured(size_t rootIndex, std::vector<bool> &vis
       info->polygon << QPointF(udet.u, udet.v);
     }
 
-    info->bankCentreOverride =
-        m_calculator.getSideBySideViewPos(componentInfo, m_instrActor->getInstrument(), rootIndex);
+    info->bankCentreOverride = m_calculator.getSideBySideViewPos(componentInfo, rootIndex);
   }
 }
 


### PR DESCRIPTION
### Description of work

Implements two methods needed for Instrument 2.0 transition, that did not have implementations.

One is the specification needed for a side-by-side view.  This occurs in some instruments (SNAP is one example), which can be put into a flat 2D view where components are "unwrapped" and placed next to one another.  Since this specification is usually sparse (at the level of banks or panels), the specifications are stored in an ordered map to save space.

The other is a structure to hold metadata, such as the name of the IDF file or the validity dates of the instrument.  Some algorithms call for this info.  This data does not naturally fit in the Instrument 2.0 objects (`ComponentInfo`/`DetectorInfo`), so the new object, initialized on load, holds this info.

### To test:

Build workbench.  Run the following:
```python
snap = LoadEmptyInstrument(InstrumentName = "SNAP")

grouped = CreateGroupingWorkspace(snap, GroupDetectorsBy = "bank")
SaveDetectorsGrouping(InputWorkspace="grouped", OutputFile="/tmp/grouped.xml")
```

Look at the SNAP instrument and view it side-by-side.  Use the legacy view option; it should look like this:
<img width="1267" height="950" alt="image" src="https://github.com/user-attachments/assets/c1f8772b-430e-478a-9a49-41189571f3fd" />

Open the file `/tmp/grouped.xml` and inspect the `idf-date` field.  It should be `""2025-01-31 10:00:00""` (taken from the SNAP IDF).

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
