### PR TITLE
Improve skipping package deletion for PRs from forks

### DIFF
--- a/.github/workflows/delete-old-nightlies.yml
+++ b/.github/workflows/delete-old-nightlies.yml
@@ -27,8 +27,9 @@ on:
 env:
   # the secrets are only available on branches in the main repository
   RELEASES_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN || 'unset_token' }}
-  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN || 'unset_token' }}
-  ANACONDA_TOKEN_MANTIDORNL: ${{ secrets.ANACONDA_TOKEN_MANTIDORNL || 'unset_token' }}
+  # pkg-remove does not use the token during pull request dry runs
+  ANACONDA_TOKEN: ${{ github.event_name == 'pull_request' && 'dry-run-no-token-required' || secrets.ANACONDA_TOKEN }}
+  ANACONDA_TOKEN_MANTIDORNL: ${{ github.event_name == 'pull_request' && 'dry-run-no-token-required' || secrets.ANACONDA_TOKEN_MANTIDORNL }}
 
 jobs:
   github-releases:
@@ -64,11 +65,6 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
-      - name: fail if ANACONDA_TOKEN is unavailable
-        if: ${{ env.ANACONDA_TOKEN == 'unset_token' }}
-        run: |
-          echo "ANACONDA_TOKEN is unset_token. The ANACONDA_TOKEN secret is not available in this workflow context."
-          exit 1
       - name: check out setup-pixi action
         uses: actions/checkout@v7
         with:
@@ -102,11 +98,6 @@ jobs:
           - mantidworkbench
           - mantiddocs
     steps:
-      - name: fail if ANACONDA_TOKEN_MANTIDORNL is unavailable
-        if: ${{ env.ANACONDA_TOKEN_MANTIDORNL == 'unset_token' }}
-        run: |
-          echo "ANACONDA_TOKEN_MANTIDORNL is unset_token. The ANACONDA_TOKEN_MANTIDORNL secret is not available in this workflow context."
-          exit 1
       - name: check out setup-pixi action
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
For PRs from forks that modify one of the files listed in the filter, this would fail because the secret for anaconda was missing. This doesn't matter in PRs where dryrun=true. 

There is no associated issue.

Assisted-by: GPT-5.4 GitHub Copilot <copilot@github.com>

### To test:

Look at the jobs for deleting old nighly packages from anaconda. They will all pass on this PR from a fork.

*This does not require release notes* because it is a change to CI for cleaning up old packages.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
