### PR TITLE
Split conda packages into separate steps

### DIFF
--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -74,11 +74,30 @@ jobs:
       - uses: ./.github/actions/setup-pixi
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
 
-      - name: Build conda packages
+      - name: Clean conda package output directory
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
         run: |
           rm -rf ${GITHUB_WORKSPACE}/conda-bld
-          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid --build-qt --build-docs --build-workbench
+
+      - name: Build mantid and mantidmpi conda packages
+        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-mantid
+
+      - name: Build mantidqt conda package
+        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-qt
+
+      - name: Build mantiddocs conda package
+        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-docs
+
+      - name: Build mantidworkbench conda package
+        if: ${{ needs.check-filters.outputs.code_changes == 'true' }}
+        run: |
+          bash -ex ${GITHUB_WORKSPACE}/source/buildconfig/Jenkins/Conda/package-conda ${GITHUB_WORKSPACE} --build-workbench
 
       - name: Upload conda packages
         if: ${{ needs.check-filters.outputs.code_changes == 'true' }}


### PR DESCRIPTION
This makes reading the logs easier because you don't have to scroll to the particular package that is being made. It will also give times for the individual packages being built and which pass/fail.

There is no associated issue

### To test:

Look at the [linux package build](https://github.com/mantidproject/mantid/actions/runs/34390409463/job/102598229673?pr=42194) and see that each package is a separate step and you can even see timings.

*This does not require release notes* because it is a minor change to CI.

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
