### PR TITLE
Instrument 2.0 methods for grid and rectangular detectors

### DIFF
--- a/Framework/Algorithms/src/CalculateEfficiency.cpp
+++ b/Framework/Algorithms/src/CalculateEfficiency.cpp
@@ -13,8 +13,8 @@
 #include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/Detector.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include <vector>
@@ -308,49 +308,49 @@ void CalculateEfficiency::maskComponent(MatrixWorkspace &ws, const std::string &
 void CalculateEfficiency::maskEdges(const MatrixWorkspace_sptr &ws, int left, int right, int high, int low,
                                     const std::string &componentName) {
 
-  auto instrument = ws->getInstrument();
+  const auto &componentInfo = ws->componentInfo();
 
-  std::shared_ptr<Mantid::Geometry::RectangularDetector> component;
+  size_t componentIndex;
   try {
-    component = std::const_pointer_cast<Mantid::Geometry::RectangularDetector>(
-        std::dynamic_pointer_cast<const Mantid::Geometry::RectangularDetector>(
-            instrument->getComponentByName(componentName)));
+    componentIndex = componentInfo.indexOfAny(componentName);
   } catch (std::exception &) {
     g_log.warning("Expecting the component " + componentName + " to be a RectangularDetector. maskEdges not executed.");
     return;
   }
-  if (!component) {
+  if (!componentInfo.isGridDetector(componentIndex)) {
     g_log.warning("Component " + componentName + " is not a RectangularDetector. MaskEdges not executed.");
     return;
   }
 
+  const auto grid = componentInfo.pixelGridComponent(componentIndex);
+
   std::vector<int> IDs;
   int i = 0;
 
-  while (i < left * component->idstep()) {
-    IDs.emplace_back(component->idstart() + i);
+  while (i < left * grid.idStep) {
+    IDs.emplace_back(grid.idStart + i);
     i += 1;
   }
   // right
-  i = component->maxDetectorID() - right * component->idstep();
-  while (i < component->maxDetectorID()) {
+  i = grid.maxDetectorID - right * grid.idStep;
+  while (i < grid.maxDetectorID) {
     IDs.emplace_back(i);
     i += 1;
   }
   // low: 0,256,512,768,..,1,257,513
   for (int row = 0; row < low; row++) {
-    i = row + component->idstart();
-    while (i < component->nelements() * component->idstep() - component->idstep() + low + component->idstart()) {
+    i = row + grid.idStart;
+    while (i < grid.nX * grid.idStep - grid.idStep + low + grid.idStart) {
       IDs.emplace_back(i);
-      i += component->idstep();
+      i += grid.idStep;
     }
   }
   // high # 255, 511, 767..
   for (int row = 0; row < high; row++) {
-    i = component->idstep() + component->idstart() - row - 1;
-    while (i < component->nelements() * component->idstep() + component->idstart()) {
+    i = grid.idStep + grid.idStart - row - 1;
+    while (i < grid.nX * grid.idStep + grid.idStart) {
       IDs.emplace_back(i);
-      i += component->idstep();
+      i += grid.idStep;
     }
   }
 

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -18,7 +18,7 @@
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CPUTimer.h"
@@ -284,57 +284,16 @@ void DiffractionEventCalibrateDetectors::exec() {
   // `inputW` but want to access original positions (etc.) via `detList` below.
   const auto &dummyW = create<EventWorkspace>(*inputW, 1, inputW->binEdges(0));
   Instrument_const_sptr inst = dummyW->getInstrument();
+  const auto &componentInfo = dummyW->componentInfo();
 
-  // Build a list of Rectangular Detectors
-  std::vector<std::shared_ptr<RectangularDetector>> detList;
+  // Build a list of Rectangular/Grid Detectors (as component indices)
+  std::vector<size_t> detList;
   // --------- Loading only one bank ----------------------------------
   std::string onebank = getProperty("BankName");
   bool doOneBank = (!onebank.empty());
-  for (int i = 0; i < inst->nelements(); i++) {
-    std::shared_ptr<RectangularDetector> det;
-    std::shared_ptr<ICompAssembly> assem;
-    std::shared_ptr<ICompAssembly> assem2;
-
-    det = std::dynamic_pointer_cast<RectangularDetector>((*inst)[i]);
-    if (det) {
-      if (det->getName() == onebank)
-        detList.emplace_back(det);
-      if (!doOneBank)
-        detList.emplace_back(det);
-    } else {
-      // Also, look in the first sub-level for RectangularDetectors (e.g. PG3).
-      // We are not doing a full recursive search since that will be very long
-      // for lots of pixels.
-      assem = std::dynamic_pointer_cast<ICompAssembly>((*inst)[i]);
-      if (assem) {
-        for (int j = 0; j < assem->nelements(); j++) {
-          det = std::dynamic_pointer_cast<RectangularDetector>((*assem)[j]);
-          if (det) {
-            if (det->getName() == onebank)
-              detList.emplace_back(det);
-            if (!doOneBank)
-              detList.emplace_back(det);
-
-          } else {
-            // Also, look in the second sub-level for RectangularDetectors (e.g.
-            // PG3).
-            // We are not doing a full recursive search since that will be very
-            // long for lots of pixels.
-            assem2 = std::dynamic_pointer_cast<ICompAssembly>((*assem)[j]);
-            if (assem2) {
-              for (int k = 0; k < assem2->nelements(); k++) {
-                det = std::dynamic_pointer_cast<RectangularDetector>((*assem2)[k]);
-                if (det) {
-                  if (det->getName() == onebank)
-                    detList.emplace_back(det);
-                  if (!doOneBank)
-                    detList.emplace_back(det);
-                }
-              }
-            }
-          }
-        }
-      }
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    if (componentInfo.isGridDetector(i) && (!doOneBank || componentInfo.name(i) == onebank)) {
+      detList.emplace_back(i);
     }
   }
 
@@ -377,8 +336,10 @@ void DiffractionEventCalibrateDetectors::exec() {
 
   Progress prog(this, 0.0, 1.0, detList.size());
   for (int det = 0; det < static_cast<int>(detList.size()); det++) {
+    const size_t bankIndex = detList[det];
+    const std::string bankName = componentInfo.name(bankIndex);
     std::string par[6];
-    par[0] = detList[det]->getName();
+    par[0] = bankName;
     par[1] = inname;
     par[2] = outname;
     std::ostringstream strpeakOpt;
@@ -391,8 +352,8 @@ void DiffractionEventCalibrateDetectors::exec() {
     auto alg2 = AlgorithmFactory::Instance().create("CreateGroupingWorkspace", 1);
     alg2->initialize();
     alg2->setProperty("InputWorkspace", inputW);
-    alg2->setPropertyValue("GroupNames", detList[det]->getName());
-    std::string groupWSName = "group_" + detList[det]->getName();
+    alg2->setPropertyValue("GroupNames", bankName);
+    std::string groupWSName = "group_" + bankName;
     alg2->setPropertyValue("OutputWorkspace", groupWSName);
     alg2->executeAsChildAlg();
     par[5] = groupWSName;
@@ -475,18 +436,18 @@ void DiffractionEventCalibrateDetectors::exec() {
 
     Kernel::V3D CalCenter =
         V3D(gsl_vector_get(s->x, 0) * 0.01, gsl_vector_get(s->x, 1) * 0.01, gsl_vector_get(s->x, 2) * 0.01);
-    Kernel::V3D Center = detList[det]->getPos() + CalCenter;
-    int pixmax = detList[det]->xpixels() - 1;
-    int pixmid = (detList[det]->ypixels() - 1) / 2;
-    BoundingBox box;
-    detList[det]->getBoundingBoxAtXY(pixmax, pixmid, box);
+    const auto grid = componentInfo.pixelGridComponent(bankIndex);
+    Kernel::V3D Center = componentInfo.position(bankIndex) + CalCenter;
+    int pixmax = grid.nX - 1;
+    int pixmid = (grid.nY - 1) / 2;
+    BoundingBox box = componentInfo.boundingBox(componentInfo.detectorIndexAtXYZ(bankIndex, pixmax, pixmid, 0));
     double baseX = box.xMax();
     double baseY = box.yMax();
     double baseZ = box.zMax();
     Kernel::V3D Base = V3D(baseX, baseY, baseZ) + CalCenter;
-    pixmid = (detList[det]->xpixels() - 1) / 2;
-    pixmax = detList[det]->ypixels() - 1;
-    detList[det]->getBoundingBoxAtXY(pixmid, pixmax, box);
+    pixmid = (grid.nX - 1) / 2;
+    pixmax = grid.nY - 1;
+    box = componentInfo.boundingBox(componentInfo.detectorIndexAtXYZ(bankIndex, pixmid, pixmax, 0));
     double upX = box.xMax();
     double upY = box.yMax();
     double upZ = box.zMax();
@@ -528,9 +489,8 @@ void DiffractionEventCalibrateDetectors::exec() {
     Up.normalize();
     Center *= 100.0;
     // << det+1  << "  "
-    outfile << "5  " << detList[det]->getName().substr(4) << "  " << detList[det]->xpixels() << "  "
-            << detList[det]->ypixels() << "  " << 100.0 * detList[det]->xsize() << "  " << 100.0 * detList[det]->ysize()
-            << "  "
+    outfile << "5  " << bankName.substr(4) << "  " << grid.nX << "  " << grid.nY << "  "
+            << 100.0 * (grid.nX * grid.xStep) << "  " << 100.0 * (grid.nY * grid.yStep) << "  "
             << "0.2000"
             << "  " << Center.norm() << "  ";
     Center.write(outfile);
@@ -547,7 +507,7 @@ void DiffractionEventCalibrateDetectors::exec() {
 
     // Remove the now-unneeded grouping workspace
     AnalysisDataService::Instance().remove(groupWSName);
-    prog.report(detList[det]->getName());
+    prog.report(bankName);
   }
 
   // Closing

--- a/Framework/Algorithms/src/ResizeRectangularDetector.cpp
+++ b/Framework/Algorithms/src/ResizeRectangularDetector.cpp
@@ -12,7 +12,6 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -83,23 +82,26 @@ void ResizeRectangularDetector::exec() {
   if (ComponentName.empty())
     throw std::runtime_error("You must specify a ComponentName.");
 
-  IComponent_const_sptr comp;
-
-  comp = inst->getComponentByName(ComponentName);
-  if (!comp)
-    throw std::runtime_error("Component with name " + ComponentName + " was not found.");
-
-  RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp);
-  if (!det)
-    throw std::runtime_error("Component with name " + ComponentName + " is not a RectangularDetector.");
-
   auto input = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+  auto &componentInfo = input->mutableComponentInfo();
+
+  size_t componentIndex;
+  try {
+    componentIndex = componentInfo.indexOfAny(ComponentName);
+  } catch (std::invalid_argument &) {
+    throw std::runtime_error("Component with name " + ComponentName + " was not found.");
+  }
+  if (!componentInfo.isGridDetector(componentIndex)) {
+    throw std::runtime_error("Component with name " + ComponentName + " is not a RectangularDetector.");
+  }
   Geometry::ParameterMap &pmap = input->instrumentParameters();
-  auto oldscalex = pmap.getDouble(det->getName(), std::string("scalex"));
-  auto oldscaley = pmap.getDouble(det->getName(), std::string("scaley"));
+  const std::string &resolvedName = componentInfo.name(componentIndex);
+  auto oldscalex = pmap.getDouble(resolvedName, std::string("scalex"));
+  auto oldscaley = pmap.getDouble(resolvedName, std::string("scaley"));
   // Add a parameter for the new scale factors
-  pmap.addDouble(det->getComponentID(), "scalex", ScaleX);
-  pmap.addDouble(det->getComponentID(), "scaley", ScaleY);
+  auto *componentID = const_cast<IComponent *>(componentInfo.componentID(componentIndex));
+  pmap.addDouble(componentID, "scalex", ScaleX);
+  pmap.addDouble(componentID, "scaley", ScaleY);
   pmap.clearPositionSensitiveCaches();
 
   // Positions of detectors are now stored in DetectorInfo, so we must update
@@ -112,8 +114,7 @@ void ResizeRectangularDetector::exec() {
     relscalex /= oldscalex[0];
   if (!oldscaley.empty())
     relscaley /= oldscaley[0];
-  applyRectangularDetectorScaleToComponentInfo(input->mutableComponentInfo(), comp->getComponentID(), relscalex,
-                                               relscaley);
+  applyRectangularDetectorScaleToComponentInfo(componentInfo, componentID, relscalex, relscaley);
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -13,10 +13,9 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidGeometry/ICompAssembly.h"
 #include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -172,51 +171,17 @@ void SmoothNeighbours::findNeighboursRectangular() {
 
   m_progress->resetNumSteps(m_inWS->getNumberHistograms(), 0.2, 0.5);
 
-  Instrument_const_sptr inst = m_inWS->getInstrument();
+  const auto &componentInfo = m_inWS->componentInfo();
+  const auto &detectorInfo = m_inWS->detectorInfo();
 
   // To get the workspace index from the detector ID
   const detid2index_map pixel_to_wi = m_inWS->getDetectorIDToWorkspaceIndexMap(true, true);
 
-  Progress prog(this, 0.0, 1.0, inst->nelements());
-
-  // Build a list of Rectangular Detectors
-  std::vector<std::shared_ptr<RectangularDetector>> detList;
-  for (int i = 0; i < inst->nelements(); i++) {
-    std::shared_ptr<RectangularDetector> det;
-    std::shared_ptr<ICompAssembly> assem;
-    std::shared_ptr<ICompAssembly> assem2;
-
-    det = std::dynamic_pointer_cast<RectangularDetector>((*inst)[i]);
-    if (det) {
-      detList.emplace_back(det);
-    } else {
-      // Also, look in the first sub-level for RectangularDetectors (e.g. PG3).
-      // We are not doing a full recursive search since that will be very long
-      // for lots of pixels.
-      assem = std::dynamic_pointer_cast<ICompAssembly>((*inst)[i]);
-      if (assem) {
-        for (int j = 0; j < assem->nelements(); j++) {
-          det = std::dynamic_pointer_cast<RectangularDetector>((*assem)[j]);
-          if (det) {
-            detList.emplace_back(det);
-
-          } else {
-            // Also, look in the second sub-level for RectangularDetectors (e.g.
-            // PG3).
-            // We are not doing a full recursive search since that will be very
-            // long for lots of pixels.
-            assem2 = std::dynamic_pointer_cast<ICompAssembly>((*assem)[j]);
-            if (assem2) {
-              for (int k = 0; k < assem2->nelements(); k++) {
-                det = std::dynamic_pointer_cast<RectangularDetector>((*assem2)[k]);
-                if (det) {
-                  detList.emplace_back(det);
-                }
-              }
-            }
-          }
-        }
-      }
+  // Build a list of Rectangular/Grid Detectors (as component indices)
+  std::vector<size_t> detList;
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    if (componentInfo.isGridDetector(i)) {
+      detList.emplace_back(i);
     }
   }
 
@@ -228,6 +193,8 @@ void SmoothNeighbours::findNeighboursRectangular() {
     findNeighboursUbiquitous();
     return;
   }
+
+  Progress prog(this, 0.0, 1.0, detList.size());
 
   // Resize the vector we are setting
   m_neighbours.resize(m_inWS->getNumberHistograms());
@@ -250,7 +217,7 @@ void SmoothNeighbours::findNeighboursRectangular() {
   std::vector<std::pair<int, int>> idToIndexMap;
   idToIndexMap.reserve(detList.size());
   for (int i = 0; i < static_cast<int>(detList.size()); i++)
-    idToIndexMap.emplace_back(detList[i]->getDetectorIDAtXY(0, 0), i);
+    idToIndexMap.emplace_back(detectorInfo.detid(componentInfo.detectorIndexAtXYZ(detList[i], 0, 0, 0)), i);
 
   // To sort in descending order
   if (sum)
@@ -258,10 +225,11 @@ void SmoothNeighbours::findNeighboursRectangular() {
 
   // Loop through the RectangularDetector's we listed before.
   for (const auto &idIndex : idToIndexMap) {
-    std::shared_ptr<RectangularDetector> det = detList[idIndex.second];
-    const std::string det_name = det->getName();
-    for (int j = 0; j < det->xpixels(); j += sumX) {
-      for (int k = 0; k < det->ypixels(); k += sumY) {
+    const size_t bankIndex = detList[idIndex.second];
+    const auto grid = componentInfo.pixelGridComponent(bankIndex);
+    const std::string det_name = componentInfo.name(bankIndex);
+    for (int j = 0; j < grid.nX; j += sumX) {
+      for (int k = 0; k < grid.nY; k += sumY) {
         double totalWeight = 0;
         // Neighbours and weights
         std::vector<weightedNeighbour> neighbours;
@@ -273,11 +241,11 @@ void SmoothNeighbours::findNeighboursRectangular() {
 
             // Find the pixel ID at that XY position on the rectangular
             // detector
-            if (j + ix >= det->xpixels() - m_edge || j + ix < m_edge)
+            if (j + ix >= grid.nX - m_edge || j + ix < m_edge)
               continue;
-            if (k + iy >= det->ypixels() - m_edge || k + iy < m_edge)
+            if (k + iy >= grid.nY - m_edge || k + iy < m_edge)
               continue;
-            int pixelID = det->getDetectorIDAtXY(j + ix, k + iy);
+            int pixelID = detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, j + ix, k + iy, 0));
 
             // Find the corresponding workspace index, if any
             auto mapEntry = pixel_to_wi.find(pixelID);

--- a/Framework/Algorithms/src/SumNeighbours.cpp
+++ b/Framework/Algorithms/src/SumNeighbours.cpp
@@ -12,9 +12,8 @@
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
-#include "MantidGeometry/ICompAssembly.h"
-#include "MantidGeometry/IComponent.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 
 #include <boost/algorithm/string.hpp>
@@ -66,15 +65,14 @@ void SumNeighbours::exec() {
 
   // Get the input workspace
   Mantid::API::MatrixWorkspace_sptr inWS = getProperty("InputWorkspace");
+  const auto &componentInfo = inWS->componentInfo();
   const auto &spectrumInfo = inWS->spectrumInfo();
   const auto &det = spectrumInfo.detector(0);
-  // Check if grandparent is rectangular detector
-  std::shared_ptr<const Geometry::IComponent> parent = det.getParent();
-  std::shared_ptr<const RectangularDetector> rect;
-
-  if (parent) {
-    rect = std::dynamic_pointer_cast<const RectangularDetector>(parent->getParent());
-  }
+  // Check if grandparent is a Rectangular/Grid detector
+  const size_t detIndex = componentInfo.indexOf(det.getComponentID());
+  const size_t parentIndex = componentInfo.parent(detIndex);
+  const size_t grandparentIndex = componentInfo.parent(parentIndex);
+  const bool rect = componentInfo.isGridDetector(grandparentIndex);
 
   Mantid::API::MatrixWorkspace_sptr outWS;
 

--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SRC_FILES src/ComponentInfo.cpp src/DetectorInfo.cpp src/SpectrumInfo.cpp)
 
 set(INC_FILES inc/MantidBeamline/ComponentInfo.h inc/MantidBeamline/ComponentType.h inc/MantidBeamline/DetectorInfo.h
-              inc/MantidBeamline/SpectrumInfo.h
+              inc/MantidBeamline/PixelGridComponent.h inc/MantidBeamline/SpectrumInfo.h
 )
 
 set(TEST_FILES ComponentInfoTest.h DetectorInfoTest.h SpectrumInfoTest.h)

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -8,6 +8,7 @@
 
 #include "MantidBeamline/ComponentType.h"
 #include "MantidBeamline/DllConfig.h"
+#include "MantidBeamline/PixelGridComponent.h"
 #include "MantidKernel/cow_ptr.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -42,6 +43,8 @@ private:
   std::shared_ptr<const std::vector<std::string>> m_names;
   /// Side-by-side (unwrapped) instrument-view position, set from the IDF
   std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> m_sideBySideViewPositions;
+  /// Rectangular/Grid bank pixel-grid metadata (indices/IDs) for Rectangular/Grid components
+  std::shared_ptr<const std::map<size_t, PixelGridComponent>> m_pixelGridComponents;
 
   const size_t m_size;
   const int64_t m_sourceIndex;
@@ -80,7 +83,8 @@ public:
       std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
       std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
       std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-      std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+      std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions,
+      std::shared_ptr<const std::map<size_t, PixelGridComponent>> pixelGridComponents, int64_t sourceIndex,
       int64_t sampleIndex);
   /// Copy assignment not permitted because of the way DetectorInfo stored
   ComponentInfo &operator=(const ComponentInfo &other) = delete;
@@ -148,7 +152,10 @@ public:
   Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Eigen::Vector3d &scaleFactor);
   ComponentType componentType(const size_t componentIndex) const;
-  Eigen::Vector2d const &sideBySideViewPosition(const size_t componentIndex) const;
+  Eigen::Vector2d const &sideBySideViewPosition(size_t const componentIndex) const;
+  PixelGridComponent const &pixelGridComponent(size_t const componentIndex) const;
+  bool isGridDetector(size_t const componentIndex) const;
+  size_t detectorIndexAtXYZ(size_t const componentIndex, int const x, int const y, int const z) const;
 
   size_t scanCount() const;
   size_t scanSize() const;

--- a/Framework/Beamline/inc/MantidBeamline/PixelGridComponent.h
+++ b/Framework/Beamline/inc/MantidBeamline/PixelGridComponent.h
@@ -11,11 +11,7 @@
 namespace Mantid {
 namespace Beamline {
 
-/** PixelGridComponent : structural metadata for a Rectangular/Grid detector
- * bank, i.e. the legacy Geometry::RectangularDetector/GridDetector fields
- * that have no other home on ComponentInfo. Pixel counts and detector-ID
- * numbering are never parametrized (unlike position/rotation/scale), so this
- * is captured once, at instrument-build time, and never changes afterwards.
+/** PixelGridComponent : structural metadata for a Rectangular/Grid banks
  */
 struct PixelGridComponent {
   /// Number of pixels in the X (horizontal) direction
@@ -28,8 +24,7 @@ struct PixelGridComponent {
   double xStart = 0;
   double yStart = 0;
   double zStart = 0;
-  /// Step size between neighbouring pixels; captured once at instrument-build
-  /// time so any parametrized scaling (e.g. "scalex") already baked in.
+  /// Step size between neighbouring pixels
   double xStep = 0;
   double yStep = 0;
   double zStep = 0;

--- a/Framework/Beamline/inc/MantidBeamline/PixelGridComponent.h
+++ b/Framework/Beamline/inc/MantidBeamline/PixelGridComponent.h
@@ -1,0 +1,51 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <array>
+
+namespace Mantid {
+namespace Beamline {
+
+/** PixelGridComponent : structural metadata for a Rectangular/Grid detector
+ * bank, i.e. the legacy Geometry::RectangularDetector/GridDetector fields
+ * that have no other home on ComponentInfo. Pixel counts and detector-ID
+ * numbering are never parametrized (unlike position/rotation/scale), so this
+ * is captured once, at instrument-build time, and never changes afterwards.
+ */
+struct PixelGridComponent {
+  /// Number of pixels in the X (horizontal) direction
+  int nX = 0;
+  /// Number of pixels in the Y (vertical) direction
+  int nY = 0;
+  /// Number of pixels in the Z (usually beam) direction; 0 for a 2D (rectangular) bank
+  int nZ = 0;
+  /// Position (in the bank's own local, unrotated, unscaled frame) of pixel (0, 0, 0)
+  double xStart = 0;
+  double yStart = 0;
+  double zStart = 0;
+  /// Step size between neighbouring pixels; captured once at instrument-build
+  /// time so any parametrized scaling (e.g. "scalex") already baked in.
+  double xStep = 0;
+  double yStep = 0;
+  double zStep = 0;
+  /// Detector ID of the first pixel
+  int idStart = 0;
+  /// Step size in ID for each pixel along the first-filled axis
+  int idStep = 0;
+  /// Step size in ID for each row along the second-filled axis
+  int idStepByRow = 0;
+  /// Axis order (each of 'x', 'y', 'z') in which detector IDs are filled
+  std::array<char, 3> idFillOrder{{'x', 'y', 'z'}};
+  /// Minimum detector ID in the bank
+  int minDetectorID = 0;
+  /// Maximum detector ID in the bank
+  int maxDetectorID = 0;
+};
+
+} // namespace Beamline
+} // namespace Mantid

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -20,6 +20,7 @@ namespace Mantid::Beamline {
 namespace {
 
 Eigen::Vector2d const EMPTY_VEC2D(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL());
+PixelGridComponent const EMPTY_PIXEL_GRID{};
 
 void failMerge(const std::string &what) {
   throw std::runtime_error(std::string("Cannot merge ComponentInfo: ") + what);
@@ -56,7 +57,8 @@ ComponentInfo::ComponentInfo(
     std::shared_ptr<std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>> rotations,
     std::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
     std::shared_ptr<std::vector<ComponentType>> componentType, std::shared_ptr<const std::vector<std::string>> names,
-    std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions, int64_t sourceIndex,
+    std::shared_ptr<const std::map<size_t, Eigen::Vector2d>> sideBySideViewPositions,
+    std::shared_ptr<const std::map<size_t, PixelGridComponent>> pixelGridComponents, int64_t sourceIndex,
     int64_t sampleIndex)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(std::move(assemblySortedComponentIndices)),
@@ -65,6 +67,7 @@ ComponentInfo::ComponentInfo(
       m_rotations(std::move(rotations)), m_scaleFactors(std::move(scaleFactors)),
       m_componentType(std::move(componentType)), m_names(std::move(names)),
       m_sideBySideViewPositions(std::move(sideBySideViewPositions)),
+      m_pixelGridComponents(std::move(pixelGridComponents)),
       m_size(ComponentInfo::computeTotalSize(*m_assemblySortedDetectorIndices, *m_detectorRanges)),
       m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex), m_detectorInfo(nullptr) {
   if (m_rotations->size() != m_positions->size()) {
@@ -613,6 +616,46 @@ Eigen::Vector2d const &ComponentInfo::sideBySideViewPosition(const size_t compon
   return EMPTY_VEC2D;
 }
 
+const PixelGridComponent &ComponentInfo::pixelGridComponent(const size_t componentIndex) const {
+  if (m_pixelGridComponents) {
+    const auto it = m_pixelGridComponents->find(componentIndex);
+    if (it != m_pixelGridComponents->end()) {
+      return it->second;
+    }
+  }
+  return EMPTY_PIXEL_GRID;
+}
+
+bool ComponentInfo::isGridDetector(const size_t componentIndex) const {
+  return m_pixelGridComponents && m_pixelGridComponents->contains(componentIndex);
+}
+
+/**
+ * Given the component index of a Rectangular/Grid bank, and pixel indices
+ * (x, y[, z]) into it, return the detector index of that pixel.
+ *
+ * The instrument tree for such a bank always nests x-columns then y-pixels
+ * (and, if 3D, an outer layer of z-layers) regardless of the bank's detector-ID
+ * numbering scheme, so this is a pure tree walk and does not depend on
+ * idStart/idStep/idStepByRow/idFillOrder at all.
+ */
+size_t ComponentInfo::detectorIndexAtXYZ(const size_t componentIndex, const int x, const int y, const int z) const {
+  const auto &grid = pixelGridComponent(componentIndex);
+  if (x < 0 || x >= grid.nX)
+    throw std::out_of_range("ComponentInfo::detectorIndexAtXYZ: x is out of range.");
+  if (y < 0 || y >= grid.nY)
+    throw std::out_of_range("ComponentInfo::detectorIndexAtXYZ: y is out of range.");
+  if (grid.nZ > 0 && (z < 0 || z >= grid.nZ))
+    throw std::out_of_range("ComponentInfo::detectorIndexAtXYZ: z is out of range.");
+
+  size_t index = componentIndex;
+  if (grid.nZ > 0)
+    index = children(index).at(z);
+  index = children(index).at(x);
+  index = children(index).at(y);
+  return index;
+}
+
 bool ComponentInfo::uniqueName(const std::string &name) const { return unique_if_exists((*m_names), name); }
 
 size_t ComponentInfo::indexOfAny(const std::string &name) const {
@@ -802,6 +845,11 @@ size_t ComponentInfo::getMemorySize() const {
   if (m_sideBySideViewPositions) {
     mem += sizeof(*m_sideBySideViewPositions) +
            m_sideBySideViewPositions->size() * sizeof(std::pair<const size_t, Eigen::Vector2d>);
+  }
+  // m_pixelGridComponents: map object + heap buffer for the map's key-value pairs
+  if (m_pixelGridComponents) {
+    mem += sizeof(*m_pixelGridComponents) +
+           m_pixelGridComponents->size() * sizeof(std::pair<const size_t, PixelGridComponent>);
   }
 
   // m_scanIntervals: inline vector's heap buffer

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -10,6 +10,7 @@
 
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidBeamline/PixelGridComponent.h"
 #include "MantidKernel/EmptyValues.h"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -27,6 +28,7 @@ using PosVec = std::vector<Eigen::Vector3d>;
 using RotVec = std::vector<Eigen::Quaterniond, Eigen::aligned_allocator<Eigen::Quaterniond>>;
 using StrVec = std::vector<std::string>;
 using SideBySideMap = std::map<size_t, Eigen::Vector2d>;
+using PixelGridMap = std::map<size_t, PixelGridComponent>;
 
 /// Sentinel returned by ComponentInfo::sideBySideViewPosition() to mean "not set"
 Eigen::Vector2d unsetSideBySideViewPos() { return Eigen::Vector2d(Mantid::EMPTY_DBL(), Mantid::EMPTY_DBL()); }
@@ -66,6 +68,7 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeFl
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
+  auto pixelGridComponents = std::make_shared<const PixelGridMap>();
 
   std::vector<size_t> branch(detPositions.size());
   std::iota(branch.begin(), branch.end(), 0);
@@ -75,7 +78,7 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeFl
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
       parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, sideBySideViewPositions,
-      -1, -1);
+      pixelGridComponents, -1, -1);
 
   componentInfo->setDetectorInfo(detectorInfo.get());
 
@@ -140,13 +143,14 @@ makeTreeExampleAndReturnGeometricArguments() {
   auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
+  auto pixelGridComponents = std::make_shared<const PixelGridMap>();
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(2, std::vector<size_t>(2));
 
   auto compInfo = std::make_shared<ComponentInfo>(
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
       parentIndices, children, compPositions, compRotations, scaleFactors, isRectangularBank, names,
-      sideBySideViewPositions, -1, -1);
+      sideBySideViewPositions, pixelGridComponents, -1, -1);
 
   compInfo->setDetectorInfo(detectorInfo.get());
 
@@ -192,6 +196,7 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeTr
   auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
   // Rectangular bank flag
   auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
+  auto pixelGridComponents = std::make_shared<const PixelGridMap>();
 
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(2, std::vector<size_t>(2));
 
@@ -199,11 +204,71 @@ std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>> makeTr
       bankSortedDetectorIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(detectorRanges),
       bankSortedComponentIndices, std::make_shared<const std::vector<std::pair<size_t, size_t>>>(componentRanges),
       parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names, sideBySideViewPositions,
-      -1, -1);
+      pixelGridComponents, -1, -1);
 
   componentInfo->setDetectorInfo(detectorInfo.get());
 
   return std::make_tuple(componentInfo, detectorInfo);
+}
+
+/*
+ * Builds a minimal 2 (x) by 3 (y) Rectangular-bank-shaped tree:
+ *
+ *          bank (index 8, Rectangular)
+ *         /    \
+ *    xCol0(6)  xCol1(7)
+ *    /  |  \    /  |  \
+ *   0   1   2  3   4   5    <- detector indices
+ *
+ * matching the real tree layout GridDetector::createLayer produces (x-columns
+ * nested outside y-pixels, independent of idFillOrder). Returns the
+ * ComponentInfo/DetectorInfo pair plus the bank's own component index.
+ */
+std::tuple<std::shared_ptr<ComponentInfo>, std::shared_ptr<DetectorInfo>, size_t> makeRectangularBankTree() {
+  const size_t bankIndex = 8;
+  auto bankSortedDetectorIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{0, 1, 2, 3, 4, 5});
+  auto bankSortedComponentIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{6, 7, 8});
+  auto parentIndices = std::make_shared<const std::vector<size_t>>(std::vector<size_t>{6, 6, 6, 7, 7, 7, 8, 8, 8});
+  auto detectorRanges = std::make_shared<const std::vector<std::pair<size_t, size_t>>>(
+      std::vector<std::pair<size_t, size_t>>{{0, 3}, {3, 6}, {0, 6}});
+  auto componentRanges = std::make_shared<const std::vector<std::pair<size_t, size_t>>>(
+      std::vector<std::pair<size_t, size_t>>{{0, 0}, {0, 0}, {0, 2}});
+  auto positions = std::make_shared<PosVec>(3, Eigen::Vector3d{0, 0, 0});
+  auto rotations = std::make_shared<RotVec>(3, Eigen::Quaterniond::Identity());
+  auto scaleFactors = std::make_shared<PosVec>(9, Eigen::Vector3d{1, 1, 1});
+  auto names =
+      std::make_shared<StrVec>(StrVec{"det0", "det1", "det2", "det3", "det4", "det5", "xCol0", "xCol1", "bank"});
+  auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
+  auto componentType = std::make_shared<std::vector<ComponentType>>(
+      std::vector<ComponentType>{ComponentType::Unstructured, ComponentType::Unstructured, ComponentType::Rectangular});
+
+  PixelGridComponent bankGrid;
+  bankGrid.nX = 2;
+  bankGrid.nY = 3;
+  bankGrid.nZ = 0;
+  bankGrid.idStart = 100;
+  bankGrid.idStep = 1;
+  bankGrid.idStepByRow = 10;
+  bankGrid.idFillOrder = {{'x', 'y', 'z'}};
+  bankGrid.minDetectorID = 100;
+  bankGrid.maxDetectorID = 121;
+  // Only the bank itself (absolute index 8) is Rectangular/Grid; xCol0 (6) and
+  // xCol1 (7) have no entry at all in the (sparse) map.
+  auto pixelGridComponents = std::make_shared<const PixelGridMap>(PixelGridMap{{bankIndex, bankGrid}});
+
+  auto children = std::make_shared<std::vector<std::vector<size_t>>>(
+      std::vector<std::vector<size_t>>{{0, 1, 2}, {3, 4, 5}, {6, 7}});
+
+  auto componentInfo = std::make_shared<ComponentInfo>(
+      bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges, parentIndices, children,
+      positions, rotations, scaleFactors, componentType, names, sideBySideViewPositions, pixelGridComponents, -1, -1);
+
+  PosVec detPositions(6);
+  RotVec detRotations(6);
+  auto detectorInfo = std::make_shared<DetectorInfo>(detPositions, detRotations);
+  componentInfo->setDetectorInfo(detectorInfo.get());
+
+  return std::make_tuple(componentInfo, detectorInfo, bankIndex);
 }
 
 // Helper to clone and resync both Info objects
@@ -263,11 +328,12 @@ public:
     auto names = std::make_shared<StrVec>(4);
     auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1);
+    auto pixelGridComponents = std::make_shared<const PixelGridMap>();
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(3));
 
     ComponentInfo componentInfo(bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges,
                                 parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names,
-                                sideBySideViewPositions, -1, -1);
+                                sideBySideViewPositions, pixelGridComponents, -1, -1);
 
     DetectorInfo detectorInfo; // Detector info size 0
     TS_ASSERT_THROWS(componentInfo.setDetectorInfo(&detectorInfo), std::invalid_argument &);
@@ -295,12 +361,13 @@ public:
     auto names = std::make_shared<StrVec>();
     auto sideBySideViewPositions = std::make_shared<const SideBySideMap>();
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
+    auto pixelGridComponents = std::make_shared<const PixelGridMap>();
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(); // invalid but not
                                                                           // being tested
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, bankSortedComponentIndices, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, isRectangularBank,
-                                   names, sideBySideViewPositions, -1, -1),
+                                   names, sideBySideViewPositions, pixelGridComponents, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -332,12 +399,13 @@ public:
     auto componentRanges =
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
+    auto pixelGridComponents = std::make_shared<const PixelGridMap>();
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(); // invalid but not
                                                                           // being tested
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, componentsInSubtree, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, isRectangularBank,
-                                   names, sideBySideViewPositions, -1, -1),
+                                   names, sideBySideViewPositions, pixelGridComponents, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -371,11 +439,12 @@ public:
         std::make_shared<const std::vector<std::pair<size_t, size_t>>>(std::vector<std::pair<size_t, size_t>>{{0, 0}});
     auto componentTypes =
         std::make_shared<std::vector<Mantid::Beamline::ComponentType>>(1, Mantid::Beamline::ComponentType::Generic);
+    auto pixelGridComponents = std::make_shared<const PixelGridMap>();
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>{1, 2}); // invalid
 
     TS_ASSERT_THROWS(ComponentInfo(detectorsInSubtree, detectorRanges, componentsInSubtree, componentRanges,
                                    parentIndices, children, positions, rotations, scaleFactors, componentTypes, names,
-                                   sideBySideViewPositions, -1, -1),
+                                   sideBySideViewPositions, pixelGridComponents, -1, -1),
                      std::invalid_argument &);
   }
 
@@ -761,6 +830,7 @@ public:
     auto scaleFactors = std::make_shared<PosVec>(4, Eigen::Vector3d{1, 1, 1});
     auto names = std::make_shared<StrVec>(4);
     auto isRectangularBank = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
+    auto pixelGridComponents = std::make_shared<const PixelGridMap>();
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>{0, 1, 2});
 
     const Eigen::Vector2d detector1Pos{1.5, -2.5};
@@ -770,7 +840,7 @@ public:
 
     ComponentInfo componentInfo(bankSortedDetectorIndices, detectorRanges, bankSortedComponentIndices, componentRanges,
                                 parentIndices, children, positions, rotations, scaleFactors, isRectangularBank, names,
-                                sideBySideViewPositions, -1, -1);
+                                sideBySideViewPositions, pixelGridComponents, -1, -1);
 
     TSM_ASSERT_EQUALS("Not set for detector 0", componentInfo.sideBySideViewPosition(0), unsetSideBySideViewPos());
     TS_ASSERT_EQUALS(componentInfo.sideBySideViewPosition(1), detector1Pos);
@@ -1302,5 +1372,51 @@ public:
     auto size3 = comp3->getMemorySize(); // 30
     // 20 - 10 == 30 - 20
     TS_ASSERT_EQUALS(size2 - size1, size3 - size2);
+  }
+
+  void test_pixel_grid_component_default_for_non_bank() {
+    auto [compInfo, detInfo, bankIndex] = makeRectangularBankTree();
+    // xCol0 (index 6) is a plain Unstructured assembly, not a Rectangular/Grid bank.
+    const auto &grid = compInfo->pixelGridComponent(6);
+    TS_ASSERT_EQUALS(grid.nX, 0);
+    TS_ASSERT_EQUALS(grid.nY, 0);
+  }
+
+  void test_pixel_grid_component_reads_constructed_value() {
+    auto [compInfo, detInfo, bankIndex] = makeRectangularBankTree();
+    const auto &grid = compInfo->pixelGridComponent(bankIndex);
+    TS_ASSERT_EQUALS(grid.nX, 2);
+    TS_ASSERT_EQUALS(grid.nY, 3);
+    TS_ASSERT_EQUALS(grid.nZ, 0);
+    TS_ASSERT_EQUALS(grid.idStart, 100);
+    TS_ASSERT_EQUALS(grid.idStep, 1);
+    TS_ASSERT_EQUALS(grid.idStepByRow, 10);
+    TS_ASSERT_EQUALS(grid.idFillOrder[0], 'x');
+    TS_ASSERT_EQUALS(grid.minDetectorID, 100);
+    TS_ASSERT_EQUALS(grid.maxDetectorID, 121);
+  }
+
+  void test_is_grid_detector() {
+    auto [compInfo, detInfo, bankIndex] = makeRectangularBankTree();
+    TSM_ASSERT("Bank is Rectangular/Grid", compInfo->isGridDetector(bankIndex));
+    TSM_ASSERT("xCol0 is a plain Unstructured assembly", !compInfo->isGridDetector(6));
+    TSM_ASSERT("xCol1 is a plain Unstructured assembly", !compInfo->isGridDetector(7));
+  }
+
+  void test_detector_index_at_xyz() {
+    auto [compInfo, detInfo, bankIndex] = makeRectangularBankTree();
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 0, 0, 0), 0);
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 0, 1, 0), 1);
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 0, 2, 0), 2);
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 1, 0, 0), 3);
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 1, 1, 0), 4);
+    TS_ASSERT_EQUALS(compInfo->detectorIndexAtXYZ(bankIndex, 1, 2, 0), 5);
+  }
+
+  void test_detector_index_at_xyz_throws_out_of_range() {
+    auto [compInfo, detInfo, bankIndex] = makeRectangularBankTree();
+    TS_ASSERT_THROWS(compInfo->detectorIndexAtXYZ(bankIndex, 2, 0, 0), const std::out_of_range &);
+    TS_ASSERT_THROWS(compInfo->detectorIndexAtXYZ(bankIndex, 0, 3, 0), const std::out_of_range &);
+    TS_ASSERT_THROWS(compInfo->detectorIndexAtXYZ(bankIndex, -1, 0, 0), const std::out_of_range &);
   }
 };

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -46,7 +46,6 @@ private:
   int findPixelID(const std::string &bankName, int col, int row);
   void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace &peakWS);
   void sizeBanks(const std::string &bankName, int &nCols, int &nRows);
-  Geometry::Instrument_const_sptr m_inst;
 
   /// Input 2D Workspace
   API::MatrixWorkspace_sptr m_inWS;

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidCrystal/DllConfig.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/FileDescriptor.h"
 
@@ -73,12 +74,12 @@ private:
   /// Throws std::length_error on mismatch
   void checkNumberPeaks(const Mantid::DataObjects::PeaksWorkspace_sptr &outWS, const std::string &filename);
 
-  /// Local cache of bank IComponents used in file
-  std::map<std::string, std::shared_ptr<const Geometry::IComponent>> m_banks;
+  /// Local cache of bank component indices used in file
+  std::map<std::string, size_t> m_bankIndices;
 
-  /// Retrieve cached bank (or load and cache for next time)
-  std::shared_ptr<const Geometry::IComponent>
-  getCachedBankByName(const std::string &bankname, const std::shared_ptr<const Geometry::Instrument> &inst);
+  /// Retrieve cached bank component index (or look up and cache for next time).
+  /// Throws std::invalid_argument (via ComponentInfo::indexOfAny) if bankname does not exist.
+  size_t getCachedBankIndex(std::string const &bankname, Geometry::ComponentInfo const &componentInfo);
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/MaskPeaksWorkspace.h
+++ b/Framework/Crystal/inc/MantidCrystal/MaskPeaksWorkspace.h
@@ -43,8 +43,7 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
-  std::size_t getWkspIndex(const detid2index_map &pixel_to_wi, const Geometry::IComponent_const_sptr &comp, const int x,
-                           const int y);
+  std::size_t getWkspIndex(const detid2index_map &pixel_to_wi, const size_t bankIndex, const int x, const int y);
   void getTofRange(double &tofMin, double &tofMax, const double tofPeak, const HistogramData::HistogramX &tof);
   int findPixelID(const std::string &bankName, int col, int row);
 

--- a/Framework/Crystal/src/CalibrationHelpers.cpp
+++ b/Framework/Crystal/src/CalibrationHelpers.cpp
@@ -66,24 +66,23 @@ void adjustBankPositionsAndSizes(const std::vector<std::string> &bankNames, cons
   std::shared_ptr<ParameterMap> pmap = newInstrument.getParameterMap();
 
   for (const auto &bankName : bankNames) {
-    std::shared_ptr<const IComponent> bank1 = newInstrument.getComponentByName(bankName);
-    std::shared_ptr<const Geometry::RectangularDetector> bank =
-        std::dynamic_pointer_cast<const RectangularDetector>(bank1);
+    const size_t bankComponentIndex = componentInfo.indexOfAny(bankName);
+    const size_t parentIndex = componentInfo.parent(bankComponentIndex);
 
-    Quat relRot = bank->getRelativeRot();
-    Quat parentRot = bank->getParent()->getRotation();
+    Quat relRot = componentInfo.relativeRotation(bankComponentIndex);
+    Quat parentRot = componentInfo.rotation(parentIndex);
     Quat newRot = parentRot * rot * relRot;
 
-    const auto bankComponentIndex = componentInfo.indexOf(bank->getComponentID());
     componentInfo.setRotation(bankComponentIndex, newRot);
 
     V3D rotatedPos = V3D(pos);
-    bank->getParent()->getRotation().rotate(rotatedPos);
+    parentRot.rotate(rotatedPos);
 
-    componentInfo.setPosition(bankComponentIndex, rotatedPos + bank->getPos());
+    componentInfo.setPosition(bankComponentIndex, rotatedPos + componentInfo.position(bankComponentIndex));
 
-    std::vector<double> oldScalex = pmap->getDouble(bank->getName(), std::string("scalex"));
-    std::vector<double> oldScaley = pmap->getDouble(bank->getName(), std::string("scaley"));
+    const std::string &resolvedBankName = componentInfo.name(bankComponentIndex);
+    std::vector<double> oldScalex = pmap->getDouble(resolvedBankName, std::string("scalex"));
+    std::vector<double> oldScaley = pmap->getDouble(resolvedBankName, std::string("scaley"));
 
     double scalex, scaley;
     if (!oldScalex.empty())
@@ -96,11 +95,12 @@ void adjustBankPositionsAndSizes(const std::vector<std::string> &bankNames, cons
     else
       scaley = detHtScale;
 
-    pmap->addDouble(bank.get(), std::string("scalex"), scalex);
-    pmap->addDouble(bank.get(), std::string("scaley"), scaley);
+    auto *bankComponentID = const_cast<IComponent *>(componentInfo.componentID(bankComponentIndex));
+    pmap->addDouble(bankComponentID, std::string("scalex"), scalex);
+    pmap->addDouble(bankComponentID, std::string("scaley"), scaley);
 
     if (detWScale != 1.0 || detHtScale != 1.0)
-      applyRectangularDetectorScaleToComponentInfo(componentInfo, bank->getComponentID(), detWScale, detHtScale);
+      applyRectangularDetectorScaleToComponentInfo(componentInfo, bankComponentID, detWScale, detHtScale);
   }
 }
 

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -9,7 +9,7 @@
 #include "MantidGeometry/Crystal/EdgePixel.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/VectorHelper.h"
 #include <boost/algorithm/clamp.hpp>
@@ -302,7 +302,6 @@ void CentroidPeaks::integrateEvent() {
  */
 void CentroidPeaks::exec() {
   m_inWS = getProperty("InputWorkspace");
-  m_inst = m_inWS->getInstrument();
   // For quickly looking up workspace index from det id
   m_wi_to_detid_map = m_inWS->getDetectorIDToWorkspaceIndexMap();
 
@@ -316,20 +315,16 @@ void CentroidPeaks::exec() {
 }
 
 int CentroidPeaks::findPixelID(const std::string &bankName, int col, int row) {
-  std::shared_ptr<const IComponent> parent = m_inst->getComponentByName(bankName);
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    return RDet->getDetectorIDAtXY(col, row);
+  const auto &componentInfo = m_inWS->componentInfo();
+  const size_t bankIndex = componentInfo.indexOfAny(bankName);
+  if (componentInfo.isGridDetector(bankIndex)) {
+    const auto &detectorInfo = m_inWS->detectorInfo();
+    return detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, col, row, 0));
   } else {
-    std::string bankName0 = bankName;
-    // Only works for WISH
-    bankName0.erase(0, 4);
-    std::ostringstream pixelString;
-    pixelString << m_inst->getName() << "/" << bankName0 << "/" << bankName << "/tube" << std::setw(3)
-                << std::setfill('0') << col << "/pixel" << std::setw(4) << std::setfill('0') << row;
-    std::shared_ptr<const Geometry::IComponent> component = m_inst->getComponentByName(pixelString.str());
-    std::shared_ptr<const Detector> pixel = std::dynamic_pointer_cast<const Detector>(component);
-    return pixel->getID();
+    auto children = componentInfo.children(bankIndex);
+    auto grandChildren = componentInfo.children(children[col - 1]);
+    auto const &detectorInfo = m_inWS->detectorInfo();
+    return detectorInfo.detid(grandChildren[row - 1]);
   }
 }
 
@@ -355,23 +350,18 @@ void CentroidPeaks::removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace &peakWS)
 void CentroidPeaks::sizeBanks(const std::string &bankName, int &nCols, int &nRows) {
   if (bankName == "None")
     return;
-  ExperimentInfo expInfo;
-  expInfo.setInstrument(m_inst);
-  const auto &compInfo = expInfo.componentInfo();
+  const auto &compInfo = m_inWS->componentInfo();
 
   // Get a single bank
-  auto bank = m_inst->getComponentByName(bankName);
-  auto bankID = bank->getComponentID();
-  auto allBankDetectorIndexes = compInfo.detectorsInSubtree(compInfo.indexOf(bankID));
+  const size_t bankIndex = compInfo.indexOfAny(bankName);
+  auto allBankDetectorIndexes = compInfo.detectorsInSubtree(bankIndex);
 
-  nRows = static_cast<int>(compInfo.componentsInSubtree(compInfo.indexOf(bankID)).size() -
-                           allBankDetectorIndexes.size() - 1);
+  nRows = static_cast<int>(compInfo.componentsInSubtree(bankIndex).size() - allBankDetectorIndexes.size() - 1);
   nCols = static_cast<int>(allBankDetectorIndexes.size()) / nRows;
 
   if (nCols * nRows != static_cast<int>(allBankDetectorIndexes.size())) {
     // Need grandchild instead of child
-    nRows = static_cast<int>(compInfo.componentsInSubtree(compInfo.indexOf(bankID)).size() -
-                             allBankDetectorIndexes.size() - 2);
+    nRows = static_cast<int>(compInfo.componentsInSubtree(bankIndex).size() - allBankDetectorIndexes.size() - 2);
     nCols = static_cast<int>(allBankDetectorIndexes.size()) / nRows;
   }
 }

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -823,6 +823,9 @@ void IntegratePeakTimeSlices::FindPlane(V3D &center, V3D &xvec, V3D &yvec, doubl
 
   std::shared_ptr<const RectangularDetector> ddet = std::dynamic_pointer_cast<const RectangularDetector>(panel);
 
+  // NOTE: uses legacy accessors rather than ComponentInfo because peak.getInstrument()
+  // is not guaranteed to be parametrized (no ParameterMap available in that case), which
+  // GridDetector/RectangularDetector's own accessors handle natively but ComponentInfo cannot.
   if (ddet) {
     std::pair<int, int> CR = ddet->getXYForDetectorID(det->getID());
     ROW = CR.second;

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -346,35 +346,35 @@ DataObjects::Peak LoadIsawPeaks::readPeak(const PeaksWorkspace_sptr &outWS, std:
 
 //----------------------------------------------------------------------------------------------
 int LoadIsawPeaks::findPixelID(const PeaksWorkspace_sptr &ws, const std::string &bankName, int col, int row) {
-  const auto inst = ws->getInstrument();
-  std::shared_ptr<const IComponent> parent = getCachedBankByName(bankName, inst);
+  const auto &componentInfo = ws->componentInfo();
 
-  if (!parent)
+  size_t bankIndex;
+  try {
+    bankIndex = getCachedBankIndex(bankName, componentInfo);
+  } catch (std::invalid_argument &) {
     return -1; // peak not in any detector.
+  }
 
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    return RDet->getDetectorIDAtXY(col, row);
+  const auto &detectorInfo = ws->detectorInfo();
+  if (componentInfo.isGridDetector(bankIndex)) {
+    return detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, col, row, 0));
   } else {
-    const auto &componentInfo = ws->componentInfo();
-    const size_t parentIndex = componentInfo.indexOfAny(bankName);
-    auto children = componentInfo.children(parentIndex);
+    auto children = componentInfo.children(bankIndex);
 
     if (!children.empty() && componentInfo.name(children[0]) == "sixteenpack") {
       children = componentInfo.children(children[0]);
     }
     int col0 = col - 1;
     // WISH detectors are in bank in this order in instrument
-    if (inst->getName() == "WISH")
+    if (ws->getInstrumentName() == "WISH")
       col0 = (col % 2 == 0 ? col / 2 + 75 : (col - 1) / 2);
 
     auto grandchildren = componentInfo.children(children[col0]);
-    const auto *first = componentInfo.componentID(grandchildren[row - 1]);
-    const auto *det = dynamic_cast<const Geometry::IDetector *>(first);
-    if (!det) {
+    const size_t detIndex = grandchildren[row - 1];
+    if (!componentInfo.isDetector(detIndex)) {
       return -1; // peak not in any detector.
     }
-    return det->getID();
+    return detectorInfo.detid(detIndex);
   }
 }
 
@@ -563,9 +563,9 @@ void LoadIsawPeaks::checkNumberPeaks(const PeaksWorkspace_sptr &outWS, const std
 }
 
 //----------------------------------------------------------------------------------------------
-/** Retrieves pointer to given bank from local cache.
+/** Retrieves component index of given bank from local cache.
  *
- * When the bank isn't in the local cache, it is loaded and
+ * When the bank isn't in the local cache, it is looked up and
  * added to the cache for later use. Lifetime of the cache
  * is bound to the lifetime of this instance of the algorithm
  * (typically, the instance should be destroyed once exec()
@@ -575,16 +575,17 @@ void LoadIsawPeaks::checkNumberPeaks(const PeaksWorkspace_sptr &outWS, const std
  * work for caching any component without modification.
  *
  * @param bankname :: the name of the requested bank
- * @param inst :: the instrument from which to load the bank if it is not yet
- *cached
- * @return A shared pointer to the request bank (empty shared pointer if not
- *found)
+ * @param componentInfo :: the ComponentInfo to look the bank up in if it is
+ *not yet cached
+ * @return The component index of the requested bank
+ * @throws std::invalid_argument if bankname does not exist
  */
-std::shared_ptr<const IComponent>
-LoadIsawPeaks::getCachedBankByName(const std::string &bankname,
-                                   const std::shared_ptr<const Geometry::Instrument> &inst) {
-  m_banks.try_emplace(bankname, inst->getComponentByName(bankname));
-  return m_banks[bankname];
+size_t LoadIsawPeaks::getCachedBankIndex(const std::string &bankname, const Geometry::ComponentInfo &componentInfo) {
+  auto it = m_bankIndices.find(bankname);
+  if (it == m_bankIndices.end()) {
+    it = m_bankIndices.try_emplace(bankname, componentInfo.indexOfAny(bankname)).first;
+  }
+  return it->second;
 }
 
 } // namespace Mantid::Crystal

--- a/Framework/Crystal/src/LoadIsawSpectrum.cpp
+++ b/Framework/Crystal/src/LoadIsawSpectrum.cpp
@@ -9,7 +9,8 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/OptionalBool.h"
@@ -82,45 +83,6 @@ void LoadIsawSpectrum::exec() {
     }
   }
   infile.close();
-  // Build a list of Rectangular Detectors
-  std::vector<std::shared_ptr<RectangularDetector>> detList;
-  for (int i = 0; i < inst->nelements(); i++) {
-    std::shared_ptr<RectangularDetector> det;
-    std::shared_ptr<ICompAssembly> assem;
-    std::shared_ptr<ICompAssembly> assem2;
-
-    det = std::dynamic_pointer_cast<RectangularDetector>((*inst)[i]);
-    if (det) {
-      detList.emplace_back(det);
-    } else {
-      // Also, look in the first sub-level for RectangularDetectors (e.g. PG3).
-      // We are not doing a full recursive search since that will be very long
-      // for lots of pixels.
-      assem = std::dynamic_pointer_cast<ICompAssembly>((*inst)[i]);
-      if (assem) {
-        for (int j = 0; j < assem->nelements(); j++) {
-          det = std::dynamic_pointer_cast<RectangularDetector>((*assem)[j]);
-          if (det) {
-            detList.emplace_back(det);
-          } else {
-            // Also, look in the second sub-level for RectangularDetectors (e.g.
-            // PG3).
-            // We are not doing a full recursive search since that will be very
-            // long for lots of pixels.
-            assem2 = std::dynamic_pointer_cast<ICompAssembly>((*assem)[j]);
-            if (assem2) {
-              for (int k = 0; k < assem2->nelements(); k++) {
-                det = std::dynamic_pointer_cast<RectangularDetector>((*assem2)[k]);
-                if (det) {
-                  detList.emplace_back(det);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
 
   if (spectra.size() < 1)
     throw std::runtime_error("The number of spectra in the loaded file is zero.");
@@ -133,18 +95,53 @@ void LoadIsawSpectrum::exec() {
   outWS->setDistribution(true);
   outWS->rebuildSpectraMapping(false);
 
+  const auto &componentInfo = outWS->componentInfo();
+  const auto &detectorInfo = outWS->detectorInfo();
+
+  // Build a list of Rectangular/Grid Detectors (as component indices)
+  // Do this after creating the workspace, to avoid double-walking the instrument tree
+  std::vector<size_t> detList;
+  for (const size_t i : componentInfo.children(componentInfo.root())) {
+    if (componentInfo.isGridDetector(i)) {
+      detList.emplace_back(i);
+    } else {
+      // Also, look in the first sub-level for RectangularDetectors (e.g. PG3).
+      // We are not doing a full recursive search since that will be very long
+      // for lots of pixels.
+      for (const size_t j : componentInfo.children(i)) {
+        if (componentInfo.isGridDetector(j)) {
+          detList.emplace_back(j);
+        } else {
+          // Also, look in the second sub-level for RectangularDetectors (e.g.
+          // PG3).
+          // We are not doing a full recursive search since that will be very
+          // long for lots of pixels.
+          for (const size_t k : componentInfo.children(j)) {
+            if (componentInfo.isGridDetector(k)) {
+              detList.emplace_back(k);
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Go through each point at this run / bank
   for (size_t i = 0; i < spectra.size(); i++) {
     auto &outSpec = outWS->getSpectrum(i);
     outSpec.clearDetectorIDs();
-    for (int j = 0; j < detList[i]->xpixels(); j++)
-      for (int k = 0; k < detList[i]->ypixels(); k++)
-        outSpec.addDetectorID(static_cast<detid_t>(detList[i]->getDetectorIDAtXY(j, k)));
+    const size_t bankIndex = detList[i];
+    const auto grid = componentInfo.pixelGridComponent(bankIndex);
+    for (int j = 0; j < grid.nX; j++) {
+      for (int k = 0; k < grid.nY; k++) {
+        outSpec.addDetectorID(detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, j, k, 0)));
+      }
+    }
     auto &outX = outSpec.mutableX();
     auto &outY = outSpec.mutableY();
     auto &outE = outSpec.mutableE();
     // This is the scattered beam direction
-    V3D dir = detList[i]->getPos() - samplePos;
+    V3D dir = componentInfo.position(bankIndex) - samplePos;
 
     // Find spectra at wavelength of 1 for normalization
     std::vector<double> xdata(1, 1.0); // wl = 1

--- a/Framework/Crystal/src/LoadIsawSpectrum.cpp
+++ b/Framework/Crystal/src/LoadIsawSpectrum.cpp
@@ -116,11 +116,9 @@ void LoadIsawSpectrum::exec() {
           // PG3).
           // We are not doing a full recursive search since that will be very
           // long for lots of pixels.
-          for (const size_t k : componentInfo.children(j)) {
-            if (componentInfo.isGridDetector(k)) {
-              detList.emplace_back(k);
-            }
-          }
+          const auto &grandchildren = componentInfo.children(j);
+          std::copy_if(grandchildren.begin(), grandchildren.end(), std::back_inserter(detList),
+                       [&componentInfo](size_t k) { return componentInfo.isGridDetector(k); });
         }
       }
     }

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -13,6 +13,7 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/VectorHelper.h"
@@ -73,8 +74,7 @@ void MaskPeaksWorkspace::exec() {
 
   // To get the workspace index from the detector ID
   const detid2index_map pixel_to_wi = m_inputW->getDetectorIDToWorkspaceIndexMap();
-  // Get some stuff from the input workspace
-  Geometry::Instrument_const_sptr inst = m_inputW->getInstrument();
+  const auto &componentInfo = m_inputW->componentInfo();
 
   // Init a table workspace
   DataObjects::TableWorkspace_sptr tablews = std::make_shared<DataObjects::TableWorkspace>();
@@ -99,8 +99,10 @@ void MaskPeaksWorkspace::exec() {
     const string &bankName = peak.getBankName();
     if (bankName == "None")
       continue;
-    Geometry::IComponent_const_sptr comp = inst->getComponentByName(bankName);
-    if (!comp) {
+    size_t bankIndex;
+    try {
+      bankIndex = componentInfo.indexOfAny(bankName);
+    } catch (std::invalid_argument &) {
       g_log.debug() << "Component " + bankName + " does not exist in instrument\n";
       continue;
     }
@@ -109,7 +111,7 @@ void MaskPeaksWorkspace::exec() {
     double x0;
     double xf;
     bool tofRangeSet(false);
-    size_t wi = this->getWkspIndex(pixel_to_wi, comp, xPeak, yPeak);
+    size_t wi = this->getWkspIndex(pixel_to_wi, bankIndex, xPeak, yPeak);
     if (wi != static_cast<size_t>(EMPTY_INT())) { // scope limit the workspace index
       this->getTofRange(x0, xf, peak.getTOF(), m_inputW->x(wi));
       tofRangeSet = true;
@@ -120,7 +122,7 @@ void MaskPeaksWorkspace::exec() {
     for (int ix = m_xMin; ix <= m_xMax; ix++) {
       for (int iy = m_yMin; iy <= m_yMax; iy++) {
         // Find the pixel ID at that XY position on the rectangular detector
-        size_t wj = this->getWkspIndex(pixel_to_wi, comp, xPeak + ix, yPeak + iy);
+        size_t wj = this->getWkspIndex(pixel_to_wi, bankIndex, xPeak + ix, yPeak + iy);
         if (wj == static_cast<size_t>(EMPTY_INT()))
           continue;
         spectra.insert(wj);
@@ -182,20 +184,21 @@ void MaskPeaksWorkspace::retrieveProperties() {
   }
 }
 
-size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, const Geometry::IComponent_const_sptr &comp,
-                                        const int x, const int y) {
-  Geometry::RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const Geometry::RectangularDetector>(comp);
-  Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
+size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, const size_t bankIndex, const int x,
+                                        const int y) {
+  const auto &componentInfo = m_inputW->componentInfo();
 
-  if (det) {
-    if (x >= det->xpixels() || x < 0 || y >= det->ypixels() || y < 0) {
+  if (componentInfo.isGridDetector(bankIndex)) {
+    const auto &detectorInfo = m_inputW->detectorInfo();
+    const auto grid = componentInfo.pixelGridComponent(bankIndex);
+    if (x >= grid.nX || x < 0 || y >= grid.nY || y < 0) {
       // throw std::runtime_error("Failed to find workspace index for x=" + std::to_string(x) + " y=" +
-      // std::to_string(y) + "(max x=" + std::to_string(det->xpixels()) +
-      // ", max y=" + std::to_string(det->ypixels()) + ")"); // Useful for debugging
+      // std::to_string(y) + "(max x=" + std::to_string(grid.nX) +
+      // ", max y=" + std::to_string(grid.nY) + ")"); // Useful for debugging
       return EMPTY_INT();
     }
 
-    int pixelID = det->getDetectorIDAtXY(x, y);
+    int pixelID = detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, x, y, 0));
 
     // Find the corresponding workspace index, if any
     auto wiEntry = pixel_to_wi.find(pixelID);
@@ -206,9 +209,7 @@ size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, cons
     }
     return wiEntry->second;
   } else {
-    const auto &componentInfo = m_inputW->componentInfo();
-    const size_t compIndex = componentInfo.indexOfAny(comp->getName());
-    auto children = componentInfo.children(compIndex);
+    auto children = componentInfo.children(bankIndex);
 
     auto grandchildren = componentInfo.children(children[0]);
 
@@ -216,7 +217,7 @@ size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, cons
     auto NCOLS = static_cast<int>(children.size());
 
     std::ostringstream msg;
-    if (Iptr->getName().compare("CORELLI") == 0) {
+    if (m_inputW->getInstrumentName() == "CORELLI") {
       msg << "Instrument is CORELLI\n";
       // CORELLI has one extra layer than WISH
       auto greatgrandchildren = componentInfo.children(grandchildren[0]);
@@ -237,7 +238,7 @@ size_t MaskPeaksWorkspace::getWkspIndex(const detid2index_map &pixel_to_wi, cons
       return EMPTY_INT();
     }
 
-    std::string bankName = comp->getName();
+    std::string bankName = componentInfo.name(bankIndex);
     auto it = pixel_to_wi.find(findPixelID(bankName, x, y));
     if (it == pixel_to_wi.end())
       return EMPTY_INT();
@@ -273,22 +274,22 @@ void MaskPeaksWorkspace::getTofRange(double &tofMin, double &tofMax, const doubl
  * @return int
  */
 int MaskPeaksWorkspace::findPixelID(const std::string &bankName, int col, int row) {
-  Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
-  std::shared_ptr<const IComponent> parent = Iptr->getComponentByName(bankName);
-
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    return RDet->getDetectorIDAtXY(col, row);
-  } else if (Iptr->getName().compare("CORELLI") == 0) {
+  auto const &componentInfo = m_inputW->componentInfo();
+  size_t const parentIndex = componentInfo.indexOfAny(bankName);
+  if (componentInfo.isGridDetector(parentIndex)) {
+    auto const &detectorInfo = m_inputW->detectorInfo();
+    return detectorInfo.detid(componentInfo.detectorIndexAtXYZ(parentIndex, col, row, 0));
+  } else if (m_inputW->getInstrumentName() == "CORELLI") {
     // Checking for CORELLI
     // pixel full name example
     //      /CORELLI/A row/bank10/sixteenpack/tube10/pixel23
     //                                ^ the extra layer that makes CORELLI different from WISH
     std::ostringstream pixelString;
-    pixelString << parent->getFullName() // /CORELLI/A row/bank10
-                << "/sixteenpack"        // /sixteenpack
-                << "/tube" << col        // /tube10
-                << "/pixel" << row;      // /pixel23
+    pixelString << componentInfo.name(parentIndex) // /CORELLI/A row/bank10
+                << "/sixteenpack"                  // /sixteenpack
+                << "/tube" << col                  // /tube10
+                << "/pixel" << row;                // /pixel23
+    Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
     std::shared_ptr<const Geometry::IComponent> component = Iptr->getComponentByName(pixelString.str());
     std::shared_ptr<const Detector> pixel = std::dynamic_pointer_cast<const Detector>(component);
     //
@@ -298,8 +299,9 @@ int MaskPeaksWorkspace::findPixelID(const std::string &bankName, int col, int ro
     // Only works for WISH
     bankName0.erase(0, 4);
     std::ostringstream pixelString;
-    pixelString << Iptr->getName() << "/" << bankName0 << "/" << bankName << "/tube" << std::setw(3)
+    pixelString << m_inputW->getInstrumentName() << "/" << bankName0 << "/" << bankName << "/tube" << std::setw(3)
                 << std::setfill('0') << col << "/pixel" << std::setw(4) << std::setfill('0') << row;
+    Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
     std::shared_ptr<const Geometry::IComponent> component = Iptr->getComponentByName(pixelString.str());
     std::shared_ptr<const Detector> pixel = std::dynamic_pointer_cast<const Detector>(component);
     return pixel->getID();

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -638,19 +638,20 @@ double SaveHKL::spectrumCalc(double TOF, int iSpec, const std::vector<std::vecto
 void SaveHKL::sizeBanks(const std::string &bankName, int &nCols, int &nRows) {
   if (bankName == "None")
     return;
-  std::shared_ptr<const IComponent> parent = m_ws->getInstrument()->getComponentByName(bankName);
-  if (!parent)
+  const auto &componentInfo = m_ws->componentInfo();
+  size_t parentIndex;
+  try {
+    parentIndex = componentInfo.indexOfAny(bankName);
+  } catch (std::invalid_argument &) {
     return;
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
+  }
+  if (componentInfo.isGridDetector(parentIndex)) {
+    const auto grid = componentInfo.pixelGridComponent(parentIndex);
 
-    nCols = RDet->xpixels();
-    nRows = RDet->ypixels();
+    nCols = grid.nX;
+    nRows = grid.nY;
   } else {
-    const auto &componentInfo = m_ws->componentInfo();
-    size_t parentIndex = componentInfo.indexOfAny(bankName);
-
-    if (m_ws->getInstrument()->getName() == "CORELLI") // for Corelli with sixteenpack under bank
+    if (m_ws->getInstrumentName() == "CORELLI") // for Corelli with sixteenpack under bank
     {
       auto children = componentInfo.children(parentIndex);
       if (!children.empty()) {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -454,8 +454,9 @@ bool SaveIsawPeaks::bankMasked(size_t componentIndex, const Geometry::DetectorIn
 V3D SaveIsawPeaks::findPixelPos(const std::string &bankName, int col, int row) {
   auto parent = inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
-    const auto RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    return RDet->getPosAtXY(col, row);
+    const auto &componentInfo = this->m_ws->componentInfo();
+    const size_t bankIndex = componentInfo.indexOf(parent->getComponentID());
+    return componentInfo.position(componentInfo.detectorIndexAtXYZ(bankIndex, col, row, 0));
   } else {
     const auto &componentInfo = this->m_ws->componentInfo();
     const size_t parentIndex = componentInfo.indexOfAny(bankName);
@@ -478,17 +479,21 @@ V3D SaveIsawPeaks::findPixelPos(const std::string &bankName, int col, int row) {
 void SaveIsawPeaks::sizeBanks(const std::string &bankName, int &NCOLS, int &NROWS, double &xsize, double &ysize) {
   if (bankName == "None")
     return;
-  const auto parent = inst->getComponentByName(bankName);
-  if (parent->type() == "RectangularDetector") {
-    const auto RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
+  const auto &componentInfo = this->m_ws->componentInfo();
+  size_t parentIndex;
+  try {
+    parentIndex = componentInfo.indexOfAny(bankName);
+  } catch (std::invalid_argument &) {
+    return;
+  }
+  if (componentInfo.isGridDetector(parentIndex)) {
+    const auto grid = componentInfo.pixelGridComponent(parentIndex);
 
-    NCOLS = RDet->xpixels();
-    NROWS = RDet->ypixels();
-    xsize = RDet->xsize();
-    ysize = RDet->ysize();
+    NCOLS = grid.nX;
+    NROWS = grid.nY;
+    xsize = grid.nX * grid.xStep;
+    ysize = grid.nY * grid.yStep;
   } else {
-    const auto &componentInfo = this->m_ws->componentInfo();
-    const size_t parentIndex = componentInfo.indexOfAny(bankName);
     auto children = componentInfo.children(parentIndex);
 
     if (!children.empty() && componentInfo.name(children[0]) == "sixteenpack") {

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -10,7 +10,6 @@
 #include "MantidCrystal/AnvredCorrection.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
@@ -459,17 +458,18 @@ void SaveLauenorm::exec() {
 void SaveLauenorm::sizeBanks(const std::string &bankName, int &nCols, int &nRows) {
   if (bankName == "None")
     return;
-  std::shared_ptr<const IComponent> parent = ws->getInstrument()->getComponentByName(bankName);
-  if (!parent)
+  const auto &componentInfo = ws->componentInfo();
+  size_t parentIndex;
+  try {
+    parentIndex = componentInfo.indexOfAny(bankName);
+  } catch (std::invalid_argument &) {
     return;
-  if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-
-    nCols = RDet->xpixels();
-    nRows = RDet->ypixels();
+  }
+  if (componentInfo.isGridDetector(parentIndex)) {
+    const auto grid = componentInfo.pixelGridComponent(parentIndex);
+    nCols = grid.nX;
+    nRows = grid.nY;
   } else {
-    const auto &componentInfo = ws->componentInfo();
-    const size_t parentIndex = componentInfo.indexOfAny(bankName);
     auto children = componentInfo.children(parentIndex);
     auto grandchildren = componentInfo.children(children[0]);
     nRows = static_cast<int>(grandchildren.size());

--- a/Framework/Crystal/test/CentroidPeaksTest.h
+++ b/Framework/Crystal/test/CentroidPeaksTest.h
@@ -16,11 +16,15 @@
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/FacilityHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/CompAssembly.h"
+#include "MantidGeometry/Instrument/Detector.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>
 #include <cxxtest/TestSuite.h>
+#include <iomanip>
 #include <random>
 
 using namespace Mantid;
@@ -91,6 +95,110 @@ public:
     TS_ASSERT_EQUALS(dets.size(), 100 * 100 + 2);
 
     return retVal;
+  }
+
+  /** Build a small tube instrument:
+   * - one bank ("bank1")
+   * - containing nTubes tubes ("tubeNNN")
+   * - of nPixelsPerTube pixels ("pixelNNNN") each.
+   * This follows WISH's nesting convention
+   */
+  Instrument_sptr createTestInstrumentTubes(int nTubes, int nPixelsPerTube) {
+    auto testInst = std::make_shared<Instrument>("TestTubes");
+
+    auto pixelShape = ComponentCreationHelper::createCappedCylinder(0.01, 0.03, V3D(0.0, -0.015, 0.0),
+                                                                    V3D(0.0, 1.0, 0.0), "pixel-shape");
+
+    auto *bankGroup = new CompAssembly("1");
+    auto *bank = new CompAssembly("bank1");
+    int detID = 1;
+    for (int col = 1; col <= nTubes; ++col) {
+      std::ostringstream tubeName;
+      tubeName << "tube" << std::setw(3) << std::setfill('0') << col;
+      auto *tube = new CompAssembly(tubeName.str());
+      for (int row = 1; row <= nPixelsPerTube; ++row) {
+        std::ostringstream pixelName;
+        pixelName << "pixel" << std::setw(4) << std::setfill('0') << row;
+        auto *pixel = new Detector(pixelName.str(), detID, pixelShape, tube);
+        pixel->setPos(0.0, (row - 1) * 0.03, 0.0);
+        tube->add(pixel);
+        testInst->markAsDetector(pixel);
+        ++detID;
+      }
+      tube->setPos((col - 1) * 0.02, 0.0, 0.0);
+      bank->add(tube);
+    }
+    bank->setPos(0.0, 0.0, 1.0);
+    bankGroup->add(bank);
+    testInst->add(bankGroup);
+
+    ComponentCreationHelper::addSourceToInstrument(testInst, V3D(0.0, 0.0, -10.0));
+    ComponentCreationHelper::addSampleToInstrument(testInst, V3D(0.0, 0.0, 0.0));
+
+    return testInst;
+  }
+
+  void test_non_rectangular_detector() {
+    const int nTubes = 2;
+    const int nPixelsPerTube = 3;
+    auto instrument = createTestInstrumentTubes(nTubes, nPixelsPerTube);
+
+    const int numPixels = nTubes * nPixelsPerTube;
+    const int numBins = 10;
+    const double binDelta = 10.0;
+    EventWorkspace_sptr ws = create<EventWorkspace>(numPixels, BinEdges(numBins, LinearGenerator(0.0, binDelta)));
+    ws->setInstrument(instrument);
+    ws->rebuildSpectraMapping();
+    ws->getAxis(0)->setUnit("TOF");
+
+    // The "true" peak is at tube 2 (col=2), pixel 2 (row=2), i.e. detector ID 5.
+    const detid_t targetID = 5;
+    const int targetBin = numBins / 2;
+    for (int pix = 0; pix < numPixels; ++pix) {
+      auto &el = ws->getSpectrum(pix);
+      // Background in every bin, every pixel, so intensity is never zero.
+      for (int i = 0; i < numBins; ++i) {
+        el += TofEvent((i + 0.5) * binDelta, 0);
+      }
+      if (pix == targetID - 1) {
+        // A strong excess at the target pixel's bin, so the centroid pulls in.
+        for (int i = 0; i < 100; ++i) {
+          el += TofEvent((targetBin + 0.5) * binDelta, 0);
+        }
+      }
+    }
+
+    MatrixWorkspace_sptr inputW = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
+
+    PeaksWorkspace_sptr peaksWS(new PeaksWorkspace());
+    Peak peakObj(instrument, targetID, 2.0);
+    peakObj.setRunNumber(1);
+    peaksWS->addPeak(peakObj);
+    AnalysisDataService::Instance().addOrReplace("GenericTubes", peaksWS);
+    inputW->mutableRun().addProperty("run_number", 1);
+
+    CentroidPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    alg.setProperty("InputWorkspace", inputW);
+    alg.setProperty("InPeaksWorkspace", "GenericTubes");
+    alg.setProperty("OutPeaksWorkspace", "GenericTubes");
+    alg.setProperty("PeakRadius", 5);
+    alg.setProperty("EdgePixels", 0);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    PeaksWorkspace_sptr result;
+    TS_ASSERT_THROWS_NOTHING(result = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("GenericTubes"));
+    TS_ASSERT(result);
+    if (!result)
+      return;
+    Peak &resultPeak = result->getPeak(0);
+    TS_ASSERT_EQUALS(resultPeak.getBankName(), "bank1");
+    TS_ASSERT_EQUALS(resultPeak.getCol(), 2);
+    TS_ASSERT_EQUALS(resultPeak.getRow(), 2);
+    TS_ASSERT_EQUALS(resultPeak.getDetectorID(), targetID);
+
+    AnalysisDataService::Instance().remove("GenericTubes");
   }
 
   void test_Init() {

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -19,7 +19,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/DeltaEMode.h"
 #include "MantidKernel/DynamicPointerCastHelper.h"
@@ -673,16 +673,16 @@ void LoadILLReflectometry::sampleAngle(const Nexus::NXEntry &entry) {
 
 /// Initialize m_pixelWidth from the IDF as the step of rectangular detector
 void LoadILLReflectometry::initPixelWidth() {
-  const auto &instrument = m_localWorkspace->getInstrument();
-  const auto &detectorPanels = instrument->getAllComponentsWithName("detector");
-  if (detectorPanels.size() != 1) {
+  const auto &componentInfo = m_localWorkspace->componentInfo();
+  if (!componentInfo.uniqueName("detector")) {
     throw std::runtime_error("IDF should have a single 'detector' component.");
   }
-  const auto &detector = std::dynamic_pointer_cast<const Geometry::RectangularDetector>(detectorPanels.front());
+  const size_t detectorIndex = componentInfo.indexOfAny("detector");
+  const auto grid = componentInfo.pixelGridComponent(detectorIndex);
   if (m_instrument == Supported::D17) {
-    m_pixelWidth = std::abs(detector->xstep());
+    m_pixelWidth = std::abs(grid.xStep);
   } else {
-    m_pixelWidth = std::abs(detector->ystep());
+    m_pixelWidth = std::abs(grid.yStep);
   }
 }
 

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -19,7 +19,6 @@
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/V3D.h"
@@ -121,6 +120,9 @@ void LoadIsawDetCal::exec() {
 
   std::string instname = inst->getName();
 
+  auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+  auto &componentInfo = expInfoWS->mutableComponentInfo();
+
   const auto filenames = getFilenames();
 
   // Output summary to log file
@@ -129,44 +131,11 @@ void LoadIsawDetCal::exec() {
   std::ifstream input(filenames[0].c_str(), std::ios_base::in);
   std::string line;
   std::string detname;
-  // Build a list of Rectangular Detectors
-  std::vector<std::shared_ptr<RectangularDetector>> detList;
-  for (int i = 0; i < inst->nelements(); i++) {
-    std::shared_ptr<RectangularDetector> det;
-    std::shared_ptr<ICompAssembly> assem;
-    std::shared_ptr<ICompAssembly> assem2;
-
-    det = std::dynamic_pointer_cast<RectangularDetector>((*inst)[i]);
-    if (det) {
-      detList.emplace_back(det);
-    } else {
-      // Also, look in the first sub-level for RectangularDetectors (e.g. PG3).
-      // We are not doing a full recursive search since that will be very long
-      // for lots of pixels.
-      assem = std::dynamic_pointer_cast<ICompAssembly>((*inst)[i]);
-      if (assem) {
-        for (int j = 0; j < assem->nelements(); j++) {
-          det = std::dynamic_pointer_cast<RectangularDetector>((*assem)[j]);
-          if (det) {
-            detList.emplace_back(det);
-
-          } else {
-            // Also, look in the second sub-level for RectangularDetectors (e.g.
-            // PG3).
-            // We are not doing a full recursive search since that will be very
-            // long for lots of pixels.
-            assem2 = std::dynamic_pointer_cast<ICompAssembly>((*assem)[j]);
-            if (assem2) {
-              for (int k = 0; k < assem2->nelements(); k++) {
-                det = std::dynamic_pointer_cast<RectangularDetector>((*assem2)[k]);
-                if (det) {
-                  detList.emplace_back(det);
-                }
-              }
-            }
-          }
-        }
-      }
+  // Build a list of Rectangular/Grid Detectors (as component indices)
+  std::vector<size_t> detList;
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    if (componentInfo.isGridDetector(i)) {
+      detList.emplace_back(i);
     }
   }
   std::unordered_set<int> uniqueBanks; // for CORELLI and WISH
@@ -174,10 +143,6 @@ void LoadIsawDetCal::exec() {
   if (instname == "WISH")
     bankPart = "WISHpanel";
   if (detList.empty()) {
-    // Get all components using ComponentInfo
-    auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
-    const auto &componentInfo = expInfoWS->componentInfo();
-
     // iterate over the top level components, which contain the banks
     size_t const rootIndex = componentInfo.root();
     auto const topChildren = componentInfo.children(rootIndex);
@@ -197,8 +162,6 @@ void LoadIsawDetCal::exec() {
     }
   }
 
-  auto expInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(ws);
-  auto &componentInfo = expInfoWS->mutableComponentInfo();
   std::vector<ComponentScaling> rectangularDetectorScalings;
 
   while (std::getline(input, line)) {
@@ -255,26 +218,23 @@ void LoadIsawDetCal::exec() {
           break;
       }
     }
-    std::shared_ptr<RectangularDetector> det;
     std::string bankName = getBankName(bankPart, id);
-    auto matchingDetector =
-        std::find_if(detList.begin(), detList.end(), [&bankName](const std::shared_ptr<RectangularDetector> &detector) {
-          return detector->getName() == bankName;
-        });
-    if (matchingDetector != detList.end()) {
-      det = *matchingDetector;
-    }
+    auto matchingDetector = std::find_if(detList.begin(), detList.end(), [&bankName, &componentInfo](size_t index) {
+      return componentInfo.name(index) == bankName;
+    });
 
     V3D rX(base_x, base_y, base_z);
     V3D rY(up_x, up_y, up_z);
 
-    if (det) {
-      detname = det->getName();
+    if (matchingDetector != detList.end()) {
+      const size_t bankIndex = *matchingDetector;
+      detname = componentInfo.name(bankIndex);
       center(x, y, z, detname, ws, componentInfo);
 
       ComponentScaling detScaling;
-      detScaling.scaleX = CM_TO_M * width / det->xsize();
-      detScaling.scaleY = CM_TO_M * height / det->ysize();
+      const auto grid = componentInfo.pixelGridComponent(bankIndex);
+      detScaling.scaleX = CM_TO_M * width / (grid.nX * grid.xStep);
+      detScaling.scaleY = CM_TO_M * height / (grid.nY * grid.yStep);
       detScaling.componentName = detname;
       // Scaling will need both scale factors if LoadIsawPeaks or LoadIsawDetCal
       // has already
@@ -300,7 +260,8 @@ void LoadIsawDetCal::exec() {
 
       rectangularDetectorScalings.emplace_back(detScaling);
 
-      doRotation(rX, rY, componentInfo, det);
+      IComponent_const_sptr bankComponent(componentInfo.componentID(bankIndex), NoDeleting());
+      doRotation(rX, rY, componentInfo, bankComponent);
     }
     auto bank = uniqueBanks.find(id);
     if (bank == uniqueBanks.end())

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -213,8 +213,8 @@ void SaveIsawDetCal::exec() {
 V3D SaveIsawDetCal::findPixelPos(const std::string &bankName, int col, int row, const ComponentInfo &componentInfo) {
   std::shared_ptr<const IComponent> parent = inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
-    return RDet->getPosAtXY(col, row);
+    const size_t bankIndex = componentInfo.indexOf(parent->getComponentID());
+    return componentInfo.position(componentInfo.detectorIndexAtXYZ(bankIndex, col, row, 0));
   } else {
     const size_t parentIndex = componentInfo.indexOfAny(bankName);
     auto children = componentInfo.children(parentIndex);
@@ -236,12 +236,12 @@ void SaveIsawDetCal::sizeBanks(const std::string &bankName, int &NCOLS, int &NRO
     return;
   std::shared_ptr<const IComponent> parent = inst->getComponentByName(bankName);
   if (parent->type() == "RectangularDetector") {
-    std::shared_ptr<const RectangularDetector> RDet = std::dynamic_pointer_cast<const RectangularDetector>(parent);
+    const auto grid = componentInfo.pixelGridComponent(componentInfo.indexOf(parent->getComponentID()));
 
-    NCOLS = RDet->xpixels();
-    NROWS = RDet->ypixels();
-    xsize = RDet->xsize();
-    ysize = RDet->ysize();
+    NCOLS = grid.nX;
+    NROWS = grid.nY;
+    xsize = grid.nX * grid.xStep;
+    ysize = grid.nY * grid.yStep;
   } else {
     const size_t parentIndex = componentInfo.indexOfAny(bankName);
     auto children = componentInfo.children(parentIndex);

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -33,6 +33,8 @@ namespace DataObjects {
  */
 class MANTID_DATAOBJECTS_DLL Peak : public BasePeak {
 public:
+  // NOTE: constructors currently require a legacy instrument pointer
+  // Future work for Instrument 2.0 most change this to work with ComponentInfo and DetectorInfo instead
   Peak();
   Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::V3D &QLabFrame,
        std::optional<double> detectorDistance = std::nullopt);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -7,12 +7,15 @@
 #pragma once
 
 #include "MantidBeamline/ComponentType.h"
+#include "MantidBeamline/PixelGridComponent.h"
 #include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument/ComponentInfoIterator.h"
 #include "MantidGeometry/Instrument/SolidAngleParams.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidTypes/Core/DateAndTime.h"
 #include <memory>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -118,6 +121,10 @@ public:
   const std::string &name(const size_t componentIndex) const;
   void setScaleFactor(const size_t componentIndex, const Kernel::V3D &scaleFactor);
   Kernel::V2D sideBySideViewPosition(const size_t componentIndex) const;
+  Beamline::PixelGridComponent pixelGridComponent(const size_t componentIndex) const;
+  size_t detectorIndexAtXYZ(const size_t componentIndex, const int x, const int y, const int z) const;
+  std::tuple<int, int, int> xyzForDetectorID(const size_t componentIndex, const detid_t detectorID) const;
+  bool isGridDetector(size_t const componentIndex) const;
   size_t root() const;
 
   const IComponent *componentID(const size_t componentIndex) const { return (*m_componentIds)[componentIndex]; }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidBeamline/ComponentType.h"
+#include "MantidBeamline/PixelGridComponent.h"
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
 #include <Eigen/Geometry>
@@ -127,6 +128,9 @@ private:
 
   /// Side-by-side (unwrapped) instrument-view positions when declared in the IDF.
   std::shared_ptr<std::map<size_t, Eigen::Vector2d>> m_sideBySideViewPositions;
+
+  /// Rectangular/Grid bank pixel-grid metadata
+  std::shared_ptr<std::map<size_t, Beamline::PixelGridComponent>> m_pixelGridComponents;
 
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId, const size_t componentIndex);
 

--- a/Framework/Geometry/src/Crystal/EdgePixel.cpp
+++ b/Framework/Geometry/src/Crystal/EdgePixel.cpp
@@ -9,7 +9,6 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
 
 namespace Mantid::Geometry {
 
@@ -26,10 +25,10 @@ bool edgePixel(ComponentInfo const &compInfo, const std::string &bankName, int c
     return false;
   }
   size_t parentIndex = compInfo.indexOfAny(bankName);
-  if (compInfo.componentType(parentIndex) == Beamline::ComponentType::Rectangular) {
-    auto RDet = dynamic_cast<Geometry::RectangularDetector const *const>(compInfo.componentID(parentIndex));
+  if (compInfo.isGridDetector(parentIndex)) {
+    auto const grid = compInfo.pixelGridComponent(parentIndex);
 
-    return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge || row >= (RDet->ypixels() - Edge);
+    return col < Edge || col >= (grid.nX - Edge) || row < Edge || row >= (grid.nY - Edge);
   } else {
 
     // get the children and grandchildren from the component info

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -277,6 +277,79 @@ Kernel::V2D ComponentInfo::sideBySideViewPosition(const size_t componentIndex) c
   return Kernel::toV2D(m_componentInfo->sideBySideViewPosition(componentIndex));
 }
 
+bool ComponentInfo::isGridDetector(size_t const componentIndex) const {
+  return m_componentInfo->isGridDetector(componentIndex);
+}
+
+Beamline::PixelGridComponent ComponentInfo::pixelGridComponent(const size_t componentIndex) const {
+  if (!isGridDetector(componentIndex)) {
+    throw std::runtime_error("ComponentType is not Rectangular or Grid in ComponentInfo::pixelGridComponent.");
+  }
+  return m_componentInfo->pixelGridComponent(componentIndex);
+}
+
+size_t ComponentInfo::detectorIndexAtXYZ(const size_t componentIndex, const int x, const int y, const int z) const {
+  return m_componentInfo->detectorIndexAtXYZ(componentIndex, x, y, z);
+}
+
+namespace {
+std::tuple<int, int, int> xyzFillFirstZ(const Beamline::PixelGridComponent &grid, int col, int id) {
+  if (grid.idFillOrder[1] == 'y') {
+    int row = (id / grid.idStepByRow) % grid.nY;
+    int layer = (id / grid.idStepByRow) / grid.nY;
+    return {layer, row, col};
+  }
+  int row = (id / grid.idStepByRow) % grid.nX;
+  int layer = (id / grid.idStepByRow) / grid.nX;
+  return {row, layer, col};
+}
+
+std::tuple<int, int, int> xyzFillFirstY(const Beamline::PixelGridComponent &grid, int col, int id) {
+  if (grid.idFillOrder[1] == 'z') {
+    int row = (id / grid.idStepByRow) % grid.nZ;
+    int layer = (id / grid.idStepByRow) / grid.nZ;
+    return {layer, col, row};
+  }
+  int row = (id / grid.idStepByRow) % grid.nX;
+  int layer = (id / grid.idStepByRow) / grid.nX;
+  return {row, col, layer};
+}
+
+std::tuple<int, int, int> xyzFillFirstX(const Beamline::PixelGridComponent &grid, int col, int id) {
+  if (grid.idFillOrder[1] == 'y') {
+    int row = (id / grid.idStepByRow) % grid.nY;
+    int layer = (id / grid.idStepByRow) / grid.nY;
+    return {col, row, layer};
+  }
+  int row = (id / grid.idStepByRow) % grid.nZ;
+  int layer = (id / grid.idStepByRow) / grid.nZ;
+  return {col, layer, row};
+}
+} // namespace
+
+/**
+ * Given the component index of a Rectangular/Grid bank, and a detector ID
+ * within it, return the (x, y, z) pixel indices of that detector.
+ *
+ * Ports Geometry::GridDetector::getXYZForDetectorID's arithmetic exactly
+ * (detector-ID numbering is never parametrized, so this is safe to compute
+ * from the cached PixelGridComponent alone).
+ */
+std::tuple<int, int, int> ComponentInfo::xyzForDetectorID(const size_t componentIndex, const detid_t detectorID) const {
+  const auto grid = pixelGridComponent(componentIndex);
+
+  const int id = detectorID - grid.idStart;
+  if (grid.idStepByRow == 0 || grid.idStep == 0)
+    return {-1, -1, -1};
+  const int col = (id % grid.idStepByRow) / grid.idStep;
+
+  if (grid.idFillOrder[0] == 'z')
+    return xyzFillFirstZ(grid, col, id);
+  if (grid.idFillOrder[0] == 'y')
+    return xyzFillFirstY(grid, col, id);
+  return xyzFillFirstX(grid, col, id);
+}
+
 double ComponentInfo::solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams &params) const {
   if (!hasValidShape(componentIndex))
     throw Kernel::Exception::NullPointerException("ComponentInfo::solidAngle", "shape");

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -14,6 +14,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidGeometry/Instrument/GridDetector.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
@@ -57,6 +58,29 @@ bool hasValidShape(const ObjCompAssembly &obj) {
   return shape != nullptr && shape->hasValidShape();
 }
 
+/// Captures the pixel-grid metadata of a Rectangular/Grid bank once, at
+/// instrument-build time. None of these fields are ever parametrized (unlike
+/// position/rotation/scale), so this snapshot remains valid for the lifetime
+/// of the resulting Beamline::ComponentInfo.
+Beamline::PixelGridComponent makePixelGridComponent(const GridDetector &grid) {
+  Beamline::PixelGridComponent pixelGrid;
+  pixelGrid.nX = grid.xpixels();
+  pixelGrid.nY = grid.ypixels();
+  pixelGrid.nZ = grid.zpixels();
+  pixelGrid.xStart = grid.xstart();
+  pixelGrid.yStart = grid.ystart();
+  pixelGrid.zStart = grid.zstart();
+  pixelGrid.xStep = grid.xstep();
+  pixelGrid.yStep = grid.ystep();
+  pixelGrid.zStep = grid.zstep();
+  pixelGrid.idStart = grid.idstart();
+  pixelGrid.idStep = grid.idstep();
+  pixelGrid.idStepByRow = grid.idstepbyrow();
+  pixelGrid.idFillOrder = grid.idFillOrder();
+  pixelGrid.minDetectorID = grid.minDetectorID();
+  pixelGrid.maxDetectorID = grid.maxDetectorID();
+  return pixelGrid;
+}
 } // namespace
 
 /**
@@ -89,7 +113,8 @@ InstrumentVisitor::InstrumentVisitor(std::shared_ptr<const Instrument> instrumen
           std::make_shared<std::vector<Eigen::Vector3d>>(m_orderedDetectorIds->size(), Eigen::Vector3d{1, 1, 1})),
       m_componentType(std::make_shared<std::vector<Beamline::ComponentType>>()),
       m_names(std::make_shared<std::vector<std::string>>(m_orderedDetectorIds->size())),
-      m_sideBySideViewPositions(std::make_shared<std::map<size_t, Eigen::Vector2d>>()) {
+      m_sideBySideViewPositions(std::make_shared<std::map<size_t, Eigen::Vector2d>>()),
+      m_pixelGridComponents(std::make_shared<std::map<size_t, Beamline::PixelGridComponent>>()) {
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
   }
@@ -243,6 +268,7 @@ size_t InstrumentVisitor::registerRectangularBank(const ICompAssembly &bank) {
   auto index = registerComponentAssembly(bank);
   size_t rangesIndex = index - m_orderedDetectorIds->size();
   (*m_componentType)[rangesIndex] = Beamline::ComponentType::Rectangular;
+  (*m_pixelGridComponents)[index] = makePixelGridComponent(dynamic_cast<const GridDetector &>(bank));
   return index;
 }
 
@@ -255,6 +281,7 @@ size_t InstrumentVisitor::registerGridBank(const ICompAssembly &bank) {
   auto index = registerComponentAssembly(bank);
   size_t rangesIndex = index - m_orderedDetectorIds->size();
   (*m_componentType)[rangesIndex] = Beamline::ComponentType::Grid;
+  (*m_pixelGridComponents)[index] = makePixelGridComponent(dynamic_cast<const GridDetector &>(bank));
   return index;
 }
 
@@ -378,7 +405,7 @@ std::unique_ptr<Beamline::ComponentInfo> InstrumentVisitor::componentInfo() cons
   return std::make_unique<Mantid::Beamline::ComponentInfo>(
       m_assemblySortedDetectorIndices, m_detectorRanges, m_assemblySortedComponentIndices, m_componentRanges,
       m_parentComponentIndices, m_children, m_positions, m_rotations, m_scaleFactors, m_componentType, m_names,
-      m_sideBySideViewPositions, m_sourceIndex, m_sampleIndex);
+      m_sideBySideViewPositions, m_pixelGridComponents, m_sourceIndex, m_sampleIndex);
 }
 
 std::unique_ptr<Beamline::DetectorInfo> InstrumentVisitor::detectorInfo() const {

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -14,6 +14,7 @@
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/InstrumentVisitor.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
+#include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Surfaces/Cylinder.h"
 #include "MantidGeometry/Surfaces/Plane.h"
@@ -104,9 +105,10 @@ std::unique_ptr<Beamline::ComponentInfo> makeSingleBeamlineComponentInfo(
   auto componentType = std::make_shared<std::vector<ComponentType>>(1, ComponentType::Generic);
   auto children = std::make_shared<std::vector<std::vector<size_t>>>(1);
   auto sideBySideViewPositions = std::make_shared<std::map<size_t, Eigen::Vector2d>>();
-  return std::make_unique<Beamline::ComponentInfo>(detectorIndices, detectorRanges, componentIndices, componentRanges,
-                                                   parentIndices, children, positions, rotations, scaleFactors,
-                                                   componentType, names, sideBySideViewPositions, -1, -1);
+  auto pixelGridComponents = std::make_shared<std::map<size_t, Beamline::PixelGridComponent>>();
+  return std::make_unique<Beamline::ComponentInfo>(
+      detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions, rotations,
+      scaleFactors, componentType, names, sideBySideViewPositions, pixelGridComponents, -1, -1);
 }
 } // namespace
 
@@ -143,9 +145,10 @@ public:
     auto isRectBank = std::make_shared<std::vector<ComponentType>>(2, ComponentType::Generic);
     auto children = std::make_shared<std::vector<std::vector<size_t>>>(1, std::vector<size_t>(1));
     auto sideBySideViewPositions = std::make_shared<std::map<size_t, Eigen::Vector2d>>();
+    auto pixelGridComponents = std::make_shared<std::map<size_t, Beamline::PixelGridComponent>>();
     auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,
-        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, -1, -1);
+        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, pixelGridComponents, -1, -1);
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
 
@@ -188,9 +191,10 @@ public:
     auto sideBySideViewPositions =
         std::make_shared<std::map<size_t, Eigen::Vector2d>>(std::map<size_t, Eigen::Vector2d>{{0, panelPos}});
 
+    auto pixelGridComponents = std::make_shared<std::map<size_t, Beamline::PixelGridComponent>>();
     auto internalInfo = std::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges, parentIndices, children, positions,
-        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, -1, -1);
+        rotations, scaleFactors, isRectBank, names, sideBySideViewPositions, pixelGridComponents, -1, -1);
 
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
@@ -671,6 +675,103 @@ public:
     TS_ASSERT_EQUALS(panel.bottomRight, 12);
     TS_ASSERT_EQUALS(panel.topLeft, 3);
     TS_ASSERT_EQUALS(panel.topRight, 15);
+  }
+
+  void test_pixel_grid_component_for_rectangular_bank() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    size_t bankIndex = componentInfo->root() - 3;
+
+    auto bank = std::dynamic_pointer_cast<const RectangularDetector>(instrument->getComponentByName("bank1"));
+    TS_ASSERT(bank);
+
+    auto grid = componentInfo->pixelGridComponent(bankIndex);
+    TS_ASSERT_EQUALS(grid.nX, bank->xpixels());
+    TS_ASSERT_EQUALS(grid.nY, bank->ypixels());
+    TS_ASSERT_EQUALS(grid.nZ, bank->zpixels());
+    TS_ASSERT_DELTA(grid.xStart, bank->xstart(), 1e-12);
+    TS_ASSERT_DELTA(grid.yStart, bank->ystart(), 1e-12);
+    TS_ASSERT_DELTA(grid.zStart, bank->zstart(), 1e-12);
+    TS_ASSERT_DELTA(grid.xStep, bank->xstep(), 1e-12);
+    TS_ASSERT_DELTA(grid.yStep, bank->ystep(), 1e-12);
+    TS_ASSERT_DELTA(grid.zStep, bank->zstep(), 1e-12);
+    TS_ASSERT_EQUALS(grid.idStart, bank->idstart());
+    TS_ASSERT_EQUALS(grid.idStep, bank->idstep());
+    TS_ASSERT_EQUALS(grid.idStepByRow, bank->idstepbyrow());
+    const auto &expectedFillOrder = bank->idFillOrder();
+    TS_ASSERT_EQUALS(grid.idFillOrder[0], expectedFillOrder[0]);
+    TS_ASSERT_EQUALS(grid.idFillOrder[1], expectedFillOrder[1]);
+    TS_ASSERT_EQUALS(grid.idFillOrder[2], expectedFillOrder[2]);
+    TS_ASSERT_EQUALS(grid.minDetectorID, bank->minDetectorID());
+    TS_ASSERT_EQUALS(grid.maxDetectorID, bank->maxDetectorID());
+  }
+
+  void test_pixel_grid_component_throws_for_non_bank() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+
+    TS_ASSERT_THROWS(componentInfo->pixelGridComponent(componentInfo->root()), std::runtime_error &);
+    TS_ASSERT_THROWS(componentInfo->pixelGridComponent(0), std::runtime_error &);
+  }
+
+  void test_is_grid_detector() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    size_t bankIndex = componentInfo->root() - 3;
+
+    TSM_ASSERT("Bank is Rectangular", componentInfo->isGridDetector(bankIndex));
+    TSM_ASSERT("Root is not Rectangular/Grid", !componentInfo->isGridDetector(componentInfo->root()));
+    TSM_ASSERT("A detector is not Rectangular/Grid", !componentInfo->isGridDetector(0));
+  }
+
+  void test_detector_index_at_xyz_matches_legacy_getAtXY() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    const auto &detectorInfo = std::get<1>(wrappers);
+    size_t bankIndex = componentInfo->root() - 3;
+
+    auto bank = std::dynamic_pointer_cast<const RectangularDetector>(instrument->getComponentByName("bank1"));
+    TS_ASSERT(bank);
+
+    for (int x = 0; x < 4; ++x) {
+      for (int y = 0; y < 4; ++y) {
+        auto detIndex = componentInfo->detectorIndexAtXYZ(bankIndex, x, y, 0);
+        TS_ASSERT_EQUALS(detectorInfo->detid(detIndex), bank->getDetectorIDAtXY(x, y));
+      }
+    }
+  }
+
+  void test_detector_index_at_xyz_throws_out_of_range() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    size_t bankIndex = componentInfo->root() - 3;
+
+    TS_ASSERT_THROWS(componentInfo->detectorIndexAtXYZ(bankIndex, 4, 0, 0), const std::out_of_range &);
+    TS_ASSERT_THROWS(componentInfo->detectorIndexAtXYZ(bankIndex, 0, 4, 0), const std::out_of_range &);
+    TS_ASSERT_THROWS(componentInfo->detectorIndexAtXYZ(bankIndex, -1, 0, 0), const std::out_of_range &);
+  }
+
+  void test_xyz_for_detector_id_matches_legacy_getXYZForDetectorID() {
+    auto instrument = ComponentCreationHelper::createTestInstrumentRectangular2(1, 4);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instrument);
+    const auto &componentInfo = std::get<0>(wrappers);
+    size_t bankIndex = componentInfo->root() - 3;
+
+    auto bank = std::dynamic_pointer_cast<const RectangularDetector>(instrument->getComponentByName("bank1"));
+    TS_ASSERT(bank);
+
+    for (detid_t id = bank->minDetectorID(); id <= bank->maxDetectorID(); ++id) {
+      auto [expectedX, expectedY, expectedZ] = bank->getXYZForDetectorID(id);
+      auto [x, y, z] = componentInfo->xyzForDetectorID(bankIndex, id);
+      TS_ASSERT_EQUALS(x, expectedX);
+      TS_ASSERT_EQUALS(y, expectedY);
+      TS_ASSERT_EQUALS(z, expectedZ);
+    }
   }
 
   void test_has_detectors() {

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToDetectorFaceMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToDetectorFaceMD.h
@@ -39,7 +39,8 @@ private:
   void init() override;
   void exec() override;
 
-  std::map<int, Geometry::RectangularDetector_const_sptr> getBanks();
+  /// Component indices of the rectangular bank for each requested bank number
+  std::map<int, size_t> getBanks();
 
   template <class T, class MDE, size_t nd>
   void convertEventList(std::shared_ptr<Mantid::DataObjects::MDEventWorkspace<MDE, nd>> outWS, size_t workspaceIndex,

--- a/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDetectorFaceMD.cpp
@@ -10,7 +10,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/MDEventFactory.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -115,30 +115,28 @@ void ConvertToDetectorFaceMD::convertEventList(std::shared_ptr<Mantid::DataObjec
  * @return map with key = bank number; value = pointer to the rectangular
  *detector
  */
-std::map<int, RectangularDetector_const_sptr> ConvertToDetectorFaceMD::getBanks() {
-  Instrument_const_sptr inst = in_ws->getInstrument();
+std::map<int, size_t> ConvertToDetectorFaceMD::getBanks() {
+  auto const &componentInfo = in_ws->componentInfo();
 
   std::vector<int> bankNums = this->getProperty("BankNumbers");
   std::sort(bankNums.begin(), bankNums.end());
 
-  std::map<int, RectangularDetector_const_sptr> banks;
+  std::map<int, size_t> banks;
 
   if (bankNums.empty()) {
     // --- Find all rectangular detectors ----
-    auto const &componentInfo = in_ws->componentInfo();
     size_t const root = componentInfo.root();
     auto const topChildren = componentInfo.children(root);
     for (size_t const panel : topChildren) {
       size_t parentIndex = componentInfo.findBankParent(panel, "bank");
       auto const children = componentInfo.children(parentIndex);
       for (size_t const child : children) {
-        if (componentInfo.componentType(child) == Beamline::ComponentType::Rectangular) {
+        if (componentInfo.isGridDetector(child)) {
           std::string name = componentInfo.name(child);
           std::string bankNumStr = name.substr(4, name.size() - 4);
           int bankNum = -1;
           if (Mantid::Kernel::Strings::convert(bankNumStr, bankNum)) {
-            banks[bankNum] = RectangularDetector_const_sptr(
-                dynamic_cast<const RectangularDetector *>(componentInfo.componentID(child)), NoDeleting());
+            banks[bankNum] = child;
           }
         }
       }
@@ -147,20 +145,24 @@ std::map<int, RectangularDetector_const_sptr> ConvertToDetectorFaceMD::getBanks(
     // -- Find detectors using the numbers given ---
     for (auto &bankNum : bankNums) {
       std::string bankName = "bank" + Mantid::Kernel::Strings::toString(bankNum);
-      IComponent_const_sptr comp = inst->getComponentByName(bankName);
-      RectangularDetector_const_sptr det = std::dynamic_pointer_cast<const RectangularDetector>(comp);
-      if (det)
-        banks[bankNum] = det;
+      try {
+        const size_t bankIndex = componentInfo.indexOfAny(bankName);
+        if (componentInfo.isGridDetector(bankIndex)) {
+          banks[bankNum] = bankIndex;
+        }
+      } catch (std::invalid_argument &) {
+        // No such component; skip this bank number.
+      }
     }
   }
 
   for (auto &bank : banks) {
-    RectangularDetector_const_sptr det = bank.second;
+    const auto grid = componentInfo.pixelGridComponent(bank.second);
     // Track the largest detector
-    if (det->xpixels() > m_numXPixels)
-      m_numXPixels = det->xpixels();
-    if (det->ypixels() > m_numYPixels)
-      m_numYPixels = det->ypixels();
+    if (grid.nX > m_numXPixels)
+      m_numXPixels = grid.nX;
+    if (grid.nY > m_numYPixels)
+      m_numYPixels = grid.nY;
   }
 
   if (banks.empty())
@@ -185,7 +187,7 @@ void ConvertToDetectorFaceMD::exec() {
   m_detID_to_WI = in_ws->getDetectorIDToWorkspaceIndexVector(m_detID_to_WI_offset, true);
 
   // Get the map of the banks we'll display
-  std::map<int, RectangularDetector_const_sptr> banks = this->getBanks();
+  std::map<int, size_t> banks = this->getBanks();
 
   // Find the size in the TOF dimension
   double tof_min, tof_max;
@@ -238,17 +240,20 @@ void ConvertToDetectorFaceMD::exec() {
   ExperimentInfo_sptr ei(in_ws->cloneExperimentInfo());
   uint16_t expInfoIndex = outWS->addExperimentInfo(ei);
   uint16_t goniometerIndex(0);
+  const auto &componentInfo = in_ws->componentInfo();
+  const auto &detectorInfo = in_ws->detectorInfo();
   // ---------------- Convert each bank --------------------------------------
   for (auto &bank : banks) {
     int bankNum = bank.first;
-    RectangularDetector_const_sptr det = bank.second;
-    for (int x = 0; x < det->xpixels(); x++)
-      for (int y = 0; y < det->ypixels(); y++) {
+    const size_t bankIndex = bank.second;
+    const auto grid = componentInfo.pixelGridComponent(bankIndex);
+    for (int x = 0; x < grid.nX; x++)
+      for (int y = 0; y < grid.nY; y++) {
         // Find the workspace index for this pixel coordinate
-        detid_t detID = det->getDetectorIDAtXY(x, y);
+        detid_t detID = detectorInfo.detid(componentInfo.detectorIndexAtXYZ(bankIndex, x, y, 0));
         size_t wi = m_detID_to_WI[detID + m_detID_to_WI_offset];
         if (wi >= in_ws->getNumberHistograms())
-          throw std::runtime_error("Invalid workspace index found in bank " + det->getName() + "!");
+          throw std::runtime_error("Invalid workspace index found in bank " + componentInfo.name(bankIndex) + "!");
 
         auto xPos = static_cast<coord_t>(x);
         auto yPos = static_cast<coord_t>(y);

--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -10,7 +10,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/PropertyManagerDataService.h"
 #include "MantidWorkflowAlgorithms/EQSANSInstrument.h"
@@ -227,45 +227,43 @@ void SANSBeamFinder::maskEdges(const MatrixWorkspace_sptr &beamCenterWS, int hig
 
   auto instrument = beamCenterWS->getInstrument();
 
-  std::shared_ptr<Mantid::Geometry::RectangularDetector> component;
+  const auto &componentInfo = beamCenterWS->componentInfo();
+  size_t componentIndex;
   try {
-    component = std::const_pointer_cast<Mantid::Geometry::RectangularDetector>(
-        std::dynamic_pointer_cast<const Mantid::Geometry::RectangularDetector>(
-            instrument->getComponentByName(componentName)));
+    componentIndex = componentInfo.indexOfAny(componentName);
   } catch (std::exception &) {
     g_log.warning("Expecting the component " + componentName + " to be a RectangularDetector. maskEdges not executed.");
     return;
   }
 
-  if (!component) {
+  if (!componentInfo.isGridDetector(componentIndex)) {
     g_log.warning("Expecting the component " + componentName + " to be a RectangularDetector. maskEdges not executed.");
     return;
   }
 
   std::vector<int> IDs;
 
+  const auto grid = componentInfo.pixelGridComponent(componentIndex);
+
   // right
-  for (int i = 0; i < right * component->idstep(); i++) {
-    IDs.emplace_back(component->idstart() + i);
+  for (int i = 0; i < right * grid.idStep; i++) {
+    IDs.emplace_back(grid.idStart + i);
   }
   // left
-  for (int i = component->maxDetectorID(); i > (component->maxDetectorID() - left * component->idstep()); i--) {
+  for (int i = grid.maxDetectorID; i > (grid.maxDetectorID - left * grid.idStep); i--) {
     IDs.emplace_back(i);
   }
   // low
   // 0,256,512,768,..,1,257,513
   for (int row = 0; row < low; row++) { // 0,1
-    for (int i = row + component->idstart();
-         i < component->nelements() * component->idstep() - component->idstep() + low + component->idstart();
-         i += component->idstep()) {
+    for (int i = row + grid.idStart; i < grid.nX * grid.idStep - grid.idStep + low + grid.idStart; i += grid.idStep) {
       IDs.emplace_back(i);
     }
   }
   // high
   // 255, 511, 767..
   for (int row = 0; row < high; row++) {
-    for (int i = component->idstep() + component->idstart() - row - 1;
-         i < component->nelements() * component->idstep() + component->idstart(); i += component->idstep()) {
+    for (int i = grid.idStep + grid.idStart - row - 1; i < grid.nX * grid.idStep + grid.idStart; i += grid.idStep) {
       IDs.emplace_back(i);
     }
   }


### PR DESCRIPTION
### Description of work

Many instruments make use of `GridDetector` and `RectangularDetector`, which store individual detectors in regular arrays.  The locations of detectors can, therefore, be described in terms of regular coordinates and steps.  Many algorithms check if the instrument uses a `RectangularDetector`, and if so makes use of properties such as detector step, number of rows, number of columns, etc.

To make this accessible through Instrument 2.0, it is necessary to *store* that information somewhere.  This requires `ComponentInfo` to have a new container to hold this.

A unordered map was chosen, as only a small number of components (compared to total number of detectors) actually need this object.   The map is keyed by the detector index, so that the grid info can be looked up in the same way other things are.  This has the bonus that now we can check if a component is a `RectangularDetector` or `GridDetector` (which is fairly common) by checking for its key in the map.

This adds the new method, and cleans up many algorithms that were relying on old grid methods.

[EWM 16947](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16947)

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:

Code review.  Ensure existing tests run.

*This does not require release notes* because it is an internal refactor.


<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
