### PR TITLE
Fix ISIS Reflectometry plots for summed TOF workspaces

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Plotting/model/PlottingModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Plotting/model/PlottingModel.cpp
@@ -21,6 +21,7 @@
 #include <exception>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -204,14 +205,6 @@ Mantid::API::MatrixWorkspace_sptr createPeakCentreWorkspace(Mantid::API::MatrixW
   return peakCentreWorkspace;
 }
 
-Mantid::API::WorkspaceGroup_sptr workspaceGroupFromADS(std::string const &workspaceName) {
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
-  if (!ads.doesExist(workspaceName)) {
-    return nullptr;
-  }
-  return std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ads.retrieveWS<Mantid::API::Workspace>(workspaceName));
-}
-
 bool workspaceHasRunNumber(Mantid::API::MatrixWorkspace const &workspace, std::string const &runNumber) {
   auto const &run = workspace.run();
   return run.hasProperty("run_number") && run.getProperty("run_number")->value() == runNumber;
@@ -234,22 +227,44 @@ bool workspaceMatchesRunAndPeriod(Mantid::API::MatrixWorkspace const &workspace,
   return !plottingWorkspace.periodNumber || workspaceHasCurrentPeriod(workspace, *plottingWorkspace.periodNumber);
 }
 
+Mantid::API::MatrixWorkspace_sptr matchingTOFWorkspace(Mantid::API::Workspace_sptr const &workspace,
+                                                       PlottingWorkspace const &plottingWorkspace,
+                                                       std::string const &expectedRunNumber) {
+  if (auto matrixWorkspace = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(workspace)) {
+    return workspaceMatchesRunAndPeriod(*matrixWorkspace, plottingWorkspace, expectedRunNumber) ? matrixWorkspace
+                                                                                                : nullptr;
+  }
+  if (auto group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace)) {
+    for (size_t index = 0; index < group->size(); ++index) {
+      if (auto match = matchingTOFWorkspace(group->getItem(index), plottingWorkspace, expectedRunNumber)) {
+        return match;
+      }
+    }
+  }
+  return nullptr;
+}
+
 Mantid::API::MatrixWorkspace_sptr rawTOFWorkspaceFor(PlottingWorkspace const &plottingWorkspace) {
-  if (plottingWorkspace.runNumbers.size() != 1) {
+  if (plottingWorkspace.runNumbers.empty()) {
     return nullptr;
   }
 
-  auto const &expectedRunNumber = plottingWorkspace.runNumbers.front();
-  for (auto const &groupName : std::vector<std::string>{"TOF", "__TOF"}) {
-    auto const workspaceGroup = workspaceGroupFromADS(groupName);
-    if (!workspaceGroup) {
+  auto const expectedRunNumber =
+      std::accumulate(std::next(plottingWorkspace.runNumbers.begin()), plottingWorkspace.runNumbers.end(),
+                      plottingWorkspace.runNumbers.front(), [](std::string joined, std::string const &run) {
+                        joined += '+';
+                        joined += run;
+                        return joined;
+                      });
+  auto &ads = Mantid::API::AnalysisDataService::Instance();
+  // Summed inputs remain outside the TOF groups after reduction.
+  for (auto const &name :
+       std::vector<std::string>{"TOF", "__TOF", "TOF_" + expectedRunNumber, "__TOF_" + expectedRunNumber}) {
+    if (!ads.doesExist(name)) {
       continue;
     }
-    for (auto index = 0u; index < workspaceGroup->size(); ++index) {
-      auto const groupMember = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(workspaceGroup->getItem(index));
-      if (groupMember && workspaceMatchesRunAndPeriod(*groupMember, plottingWorkspace, expectedRunNumber)) {
-        return groupMember;
-      }
+    if (auto match = matchingTOFWorkspace(ads.retrieve(name), plottingWorkspace, expectedRunNumber)) {
+      return match;
     }
   }
   return nullptr;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Plotting/PlottingModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Plotting/PlottingModelTest.h
@@ -222,15 +222,57 @@ public:
     TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist("__isis_refl_align_IvsQ_22345_profile"));
   }
 
-  void testAlignmentDoesNotCreateWorkspaceForAddedRuns() {
+  void testAlignmentCreatesWorkspaceForAddedRuns() {
     createConstantWorkspace("IvsQ_12345+12346", -100.0);
-    createAlignmentInputWorkspace("summed_raw_input_name", "12345+12346", {1.0, 3.0, 6.0, 3.0, 1.0});
-    createTOFGroup({"summed_raw_input_name"});
+    createAlignmentInputWorkspace("TOF_12345+12346", "12345+12346", alignmentYValues(100, 10.0));
+    createAlignmentInputWorkspace("TOF_12345", "12345", alignmentYValues(100, 3.0));
+    createAlignmentInputWorkspace("TOF_12346", "12346", alignmentYValues(100, 7.0));
+    createTOFGroup({"TOF_12345", "TOF_12346"});
     auto model = PlottingModel{};
     auto const workspaces = std::vector<PlottingWorkspace>{plottingWorkspace("IvsQ_12345+12346", {"12345", "12346"})};
     auto const workspacesForPlotting = model.workspacesForPlotting(workspaces, alignmentOutputSelection());
 
-    TS_ASSERT(workspacesForPlotting.empty());
+    TS_ASSERT_EQUALS(workspacesForPlotting, std::vector<std::string>{"__isis_refl_align_IvsQ_12345+12346"});
+    assertYValue("__isis_refl_align_IvsQ_12345+12346_profile", 10.0, 96);
+  }
+
+  void testAlignmentFindsSummedRunLogOutsideTOFGroup() {
+    createAlignmentInputWorkspace("TOF_12345+12346", "12345+12346", alignmentYValues(100, 10.0));
+    auto const workspaces = std::vector<PlottingWorkspace>{plottingWorkspace("IvsQ_12345+12346", {"12345+12346"})};
+    auto const outputs = PlottingModel{}.workspacesForPlotting(workspaces, alignmentOutputSelection());
+    TS_ASSERT_EQUALS(outputs, std::vector<std::string>{"__isis_refl_align_IvsQ_12345+12346"});
+    assertYValue("__isis_refl_align_IvsQ_12345+12346_profile", 10.0, 96);
+  }
+
+  void testDetectorMapFindsSummedWorkspaceOutsideTOFGroup() {
+    createDetectorMapInputWorkspace("TOF_12345", "12345", 10.0);
+    createDetectorMapInputWorkspace("TOF_12346", "12346", 20.0);
+    createTOFGroup({"TOF_12345", "TOF_12346"});
+    createDetectorMapInputWorkspace("TOF_12345+12346", "12345+12346", 30.0);
+    auto const workspaces = std::vector<PlottingWorkspace>{plottingWorkspace("IvsQ_12345+12346", {"12345+12346"})};
+    auto const outputs = PlottingModel{}.workspacesForPlotting(workspaces, detectorMapOutputSelection());
+    TS_ASSERT_EQUALS(outputs, std::vector<std::string>{"__isis_refl_det_map_IvsQ_12345+12346"});
+    assertYValue("__isis_refl_det_map_IvsQ_12345+12346", 34.0);
+  }
+
+  void testBothPlotTypesFindHiddenSummedWorkspace() {
+    createAlignmentInputWorkspace("__TOF_12345+12346", "12345+12346", alignmentYValues(100, 10.0));
+    auto const workspaces = std::vector<PlottingWorkspace>{plottingWorkspace("IvsQ_12345+12346", {"12345+12346"})};
+    TS_ASSERT_EQUALS(PlottingModel{}.workspacesForPlotting(workspaces, alignmentOutputSelection()).size(), 1);
+    TS_ASSERT_EQUALS(PlottingModel{}.workspacesForPlotting(workspaces, detectorMapOutputSelection()).size(), 1);
+    assertYValue("__isis_refl_align_IvsQ_12345+12346_profile", 10.0, 96);
+    assertYValue("__isis_refl_det_map_IvsQ_12345+12346", 10.0, 0, 96);
+  }
+
+  void testBothPlotTypesFindSelectedPeriodInSummedWorkspaceGroup() {
+    createAlignmentInputWorkspace("TOF_12345+12346_1", "12345+12346", alignmentYValues(100, 3.0), 1);
+    createAlignmentInputWorkspace("TOF_12345+12346_2", "12345+12346", alignmentYValues(100, 10.0), 2);
+    createTOFGroup({"TOF_12345+12346_1", "TOF_12345+12346_2"}, "TOF_12345+12346");
+    auto const workspaces = std::vector<PlottingWorkspace>{plottingWorkspace("IvsQ_12345+12346_2", {"12345+12346"}, 2)};
+    TS_ASSERT_EQUALS(PlottingModel{}.workspacesForPlotting(workspaces, alignmentOutputSelection()).size(), 1);
+    TS_ASSERT_EQUALS(PlottingModel{}.workspacesForPlotting(workspaces, detectorMapOutputSelection()).size(), 1);
+    assertYValue("__isis_refl_align_IvsQ_12345+12346_2_profile", 10.0, 96);
+    assertYValue("__isis_refl_det_map_IvsQ_12345+12346_2", 10.0, 0, 96);
   }
 
   void testAlignmentFindsPeriodSpecificTOFWorkspaceInTOFGroup() {
@@ -481,19 +523,20 @@ private:
     Mantid::API::AnalysisDataService::Instance().addOrReplace(name, workspace);
   }
 
-  void createTOFGroup(std::vector<std::string> const &workspaceNames) {
+  void createTOFGroup(std::vector<std::string> const &workspaceNames, std::string const &groupName = "TOF") {
     auto group = std::make_shared<Mantid::API::WorkspaceGroup>();
     for (auto const &workspaceName : workspaceNames) {
       group->addWorkspace(
           Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName));
     }
-    Mantid::API::AnalysisDataService::Instance().addOrReplace("TOF", group);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(groupName, group);
   }
 
-  void assertYValue(std::string const &workspaceName, double expected, size_t const workspaceIndex = 0) {
+  void assertYValue(std::string const &workspaceName, double expected, size_t const binIndex = 0,
+                    size_t const workspaceIndex = 0) {
     auto workspace =
         Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName);
-    TS_ASSERT_DELTA(workspace->y(0)[workspaceIndex], expected, 1e-12);
+    TS_ASSERT_DELTA(workspace->y(workspaceIndex)[binIndex], expected, 1e-12);
   }
 
   void assertXValue(std::string const &workspaceName, double expected, size_t const workspaceIndex,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Plotting/PlottingWorkspaceTreeTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Plotting/PlottingWorkspaceTreeTest.h
@@ -43,6 +43,20 @@ public:
     TS_ASSERT_EQUALS(plottingWorkspaces[0].runNumbers, std::vector<std::string>{"12345"});
   }
 
+  void testPlottingWorkspaceRetainsSummedRunLog() {
+    addWorkspaceWithRunNumber("IvsQ_12345+12346", "12345+12346");
+    auto row = Row({"12345", "12346"}, 0.5, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
+                   ReductionWorkspaces({}, TransmissionRunPair()));
+    row.setOutputNames({"", "IvsQ_12345+12346", ""});
+    row.setSuccess();
+    auto tree = PlottingWorkspaceTree{};
+    tree.rebuild(runsTableWith(std::move(row)));
+
+    auto const workspaces = tree.plottingWorkspacesForNames({"IvsQ_12345+12346"});
+    TS_ASSERT_EQUALS(workspaces.size(), 1);
+    TS_ASSERT_EQUALS(workspaces[0].runNumbers, std::vector<std::string>{"12345+12346"});
+  }
+
   void testPlottingWorkspaceRecordsContainingWorkspaceGroupAndPeriodNumber() {
     addWorkspaceWithRunNumberAndPeriod("IvsQ_binned_12345_2", "12345", 2, 2);
     auto workspaceGroup = std::make_shared<Mantid::API::WorkspaceGroup>();


### PR DESCRIPTION
### Description of work

This PR adds support for summed TOF workspace in the ISIS Reflectometry plotting tab, something that was previously intentionally excluded.

Closes #42140

<!-- If issue raised by user. Do not leak email addresses.
**Report to:** [user name]
-->

### To test:
1) In `Runs` tab of reflectometry interface, set instrument to `POLREF`, create a new group called `test`.
2) for runs, input `47041+47042` (or equivalent), type in an angle as required (0.4).
3) Run reduction
4) Go to the plotting tab. Test the `detector map` and `alignment` plots (the others will be meaningless due to lack of inputs).
5) See that the associated summed TOF workspace is found, and a plot is output.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
