### PR TITLE
Add test coverage for helpwindowpresenter

### DIFF
--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -122,6 +122,7 @@ set(PYTHON_WIDGET_WORKBENCH_ONLY_TESTS
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
     mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
     mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+    mantidqt/widgets/helpwindow/test/test_helpwindowpresenter.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -2,28 +2,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-
-try:
-    from mantid.kernel import Logger
-except ImportError:
-    print("Warning: Mantid Logger not found, using basic print for logging.")
-
-    class Logger:
-        def __init__(self, name):
-            self._name = name
-
-        def warning(self, msg):
-            print(f"WARNING [{self._name}]: {msg}")
-
-        def debug(self, msg):
-            print(f"DEBUG [{self._name}]: {msg}")
-
-        def information(self, msg):
-            print(f"INFO [{self._name}]: {msg}")
-
-        def error(self, msg):
-            print(f"ERROR [{self._name}]: {msg}")
-
+from mantid.kernel import Logger
 
 log = Logger("HelpWindowPresenter")
 
@@ -56,19 +35,22 @@ class HelpWindowPresenter:
             return
 
         log.debug(f"Opening help page in system browser: '{relativeUrl}'")
+
         try:
             docUrl = self.model.build_help_url(relativeUrl)
+
             if not QDesktopServices.openUrl(docUrl):
                 log.error(f"Failed to open URL in system browser: {docUrl.toString()}")
+
         except FileNotFoundError as e:
             log.error(f"Documentation file not found: {e}")
+
             # Fallback to online docs if local file not found
-            try:
-                fallback_url = QUrl(f"{self.model.ONLINE_BASE_URL}/{relativeUrl}")
-                log.debug(f"Attempting fallback to online docs: {fallback_url.toString()}")
-                if not QDesktopServices.openUrl(fallback_url):
-                    log.error(f"Failed to open fallback URL: {fallback_url.toString()}")
-            except Exception as fallback_error:
-                log.error(f"Fallback to online docs failed: {fallback_error}")
+            fallback_url = QUrl(f"{self.model.ONLINE_BASE_URL}/{relativeUrl}")
+            log.debug(f"Attempting fallback to online docs: {fallback_url.toString()}")
+
+            if not QDesktopServices.openUrl(fallback_url):
+                log.error(f"Failed to open fallback URL: {fallback_url.toString()}")
+
         except Exception as e:
             log.error(f"Error opening help page '{relativeUrl}': {e}")

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowpresenter.py
@@ -1,0 +1,107 @@
+# Copyright &copy; 2026 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest.mock import call, Mock, patch
+
+from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
+from qtpy.QtCore import QUrl
+
+LOG_PATH = "mantidqt.widgets.helpwindow.helpwindowpresenter.log"
+OPEN_URL_PATH = "mantidqt.widgets.helpwindow.helpwindowpresenter.QDesktopServices.openUrl"
+
+
+class TestHelpWindowModelConfigService(unittest.TestCase):
+    @patch(LOG_PATH)
+    def test_show_help_page_handles_model_failure(self, mock_log):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = None
+        help_presenter.show_help_page("dummy")
+        mock_log.error.assert_called_once_with("Cannot show help page, model is not available.")
+
+    @patch(OPEN_URL_PATH)
+    @patch(LOG_PATH)
+    def test_show_help_page_opens_url(self, mock_log, mock_open_url):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = Mock()
+
+        doc_url = QUrl("file:///path/to/index.html")
+        help_presenter.model.build_help_url.return_value = doc_url
+        mock_open_url.return_value = True
+
+        help_presenter.show_help_page("index.html")
+
+        help_presenter.model.build_help_url.assert_called_once_with("index.html")
+        mock_open_url.assert_called_once_with(doc_url)
+        mock_log.debug.assert_called_once_with("Opening help page in system browser: 'index.html'")
+        mock_log.error.assert_not_called()
+
+    @patch(OPEN_URL_PATH, return_value=False)
+    @patch(LOG_PATH)
+    def test_show_help_page_logs_error_when_open_url_fails(self, mock_log, mock_open_url):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = Mock()
+
+        doc_url = QUrl("file:///path/to/index.html")
+        help_presenter.model.build_help_url.return_value = doc_url
+        help_presenter.show_help_page("index.html")
+
+        mock_log.error.assert_called_once_with(f"Failed to open URL in system browser: {doc_url.toString()}")
+
+    @patch(OPEN_URL_PATH, return_value=True)
+    @patch(LOG_PATH)
+    def test_show_help_page_fallback(self, mock_log, mock_open_url):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = Mock()
+        help_presenter.model.ONLINE_BASE_URL = "https://docs.mantidproject.org"
+
+        error = FileNotFoundError("Local help file not found: file:///path/to/index.html")
+        help_presenter.model.build_help_url.side_effect = error
+        help_presenter.show_help_page("index.html")
+        help_presenter.model.build_help_url.assert_called_once_with("index.html")
+
+        mock_open_url.assert_called_once()
+        fallback_url = mock_open_url.call_args.args[0]
+        self.assertEqual(fallback_url.toString(), "https://docs.mantidproject.org/index.html")
+        mock_log.error.assert_called_once_with(f"Documentation file not found: {error}")
+        mock_log.debug.assert_any_call("Opening help page in system browser: 'index.html'")
+        mock_log.debug.assert_any_call(f"Attempting fallback to online docs: {fallback_url.toString()}")
+
+    @patch(OPEN_URL_PATH, return_value=False)
+    @patch(LOG_PATH)
+    def test_show_help_page_fallback_fails(self, mock_log, mock_open_url):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = Mock()
+        help_presenter.model.ONLINE_BASE_URL = "https://docs.mantidproject.org"
+
+        error = FileNotFoundError("Local help file not found: file:///path/to/index.html")
+        help_presenter.model.build_help_url.side_effect = error
+        help_presenter.show_help_page("index.html")
+        help_presenter.model.build_help_url.assert_called_once_with("index.html")
+
+        mock_open_url.assert_called_once()
+        fallback_url = mock_open_url.call_args.args[0]
+        self.assertEqual(fallback_url.toString(), "https://docs.mantidproject.org/index.html")
+        mock_log.error.assert_has_calls(
+            [call(f"Documentation file not found: {error}"), call(f"Failed to open fallback URL: {fallback_url.toString()}")]
+        )
+        mock_log.debug.assert_any_call("Opening help page in system browser: 'index.html'")
+        mock_log.debug.assert_any_call(f"Attempting fallback to online docs: {fallback_url.toString()}")
+
+    @patch(LOG_PATH)
+    def test_show_help_page_logs_error_on_unexpected_exception(self, mock_log):
+        help_presenter = HelpWindowPresenter()
+        help_presenter.model = Mock()
+
+        error = RuntimeError("Something unexpected happened")
+        help_presenter.model.build_help_url.side_effect = error
+
+        help_presenter.show_help_page("index.html")
+
+        help_presenter.model.build_help_url.assert_called_once_with("index.html")
+        mock_log.error.assert_called_once_with(f"Error opening help page 'index.html': {error}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of work
During the review of #42168, it was spotted that I broke the fallback functionality for when a local help file isn't found. Although that was fixed before the PR was merged, it was realised that there was no test coverage for the `helpwindowpresenter`. This adds test coverage to prevent similar problems. I also removed some redundant code.

### To test:
Review the code, and hope that CI passes the new tests. No functional testing required.

<!-- REMEMBER:
- Add labels, milestones, etc.
- Ensure the base of this PR is correct (e.g. release-next or main)
- Add release notes in separate file as per ([guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)), or justify their absence:
  *This does not require release notes* because <fill in an explanation of why>
-->

<!--  GATEKEEPER: When squashing, remove the section from HERE...  -->

______________________________________________________________________

### Reviewer

**Your comments will be used as part of the gatekeeper process.** Comment clearly on what you have checked and tested during your review. Provide an audit trail for any changes requested.

As per the [review guidelines](http://developer.mantidproject.org/ReviewingAPullRequest.html):

- Is the code of an acceptable quality? ([Code standards](http://developer.mantidproject.org/Standards/)/[GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html))
- Has a thorough functional test been performed? Do the changes handle unexpected input/situations?
- Are appropriately scoped unit and/or system tests provided?
- Do the release notes conform to the [guidelines](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html) and describe the changes appropriately?
- Has the relevant (user and developer) documentation been added/updated?
- If the PR author isn’t in the `mantid-developers` or `mantid-contributors` teams, add a review comment `rerun ci` to authorize/rerun the CI

### Gatekeeper

As per the [gatekeeping guidelines](https://developer.mantidproject.org/Gatekeeping.html):

- Has a thorough first line review been conducted, including functional testing?
- At a high-level, is the code quality sufficient?
- Are the base, milestone and labels correct?

<!--  GATEKEEPER: ...To HERE  -->
